### PR TITLE
Switch stateless cache to returning empty resources on getting methods.

### DIFF
--- a/hikari/api/cache.py
+++ b/hikari/api/cache.py
@@ -70,6 +70,10 @@ class Cache(abc.ABC):
     The implementation may choose to use a simple in-memory collection of
     objects, or may decide to use a distributed system such as a Redis cache
     for cross-process bots.
+
+    !!! note
+        For a stateless implementation of this cache getting methods will always
+        return empty resources (e.g `builtins.None` and empty cache views).
     """
 
     __slots__: typing.Sequence[str] = ()
@@ -531,6 +535,12 @@ class MutableCache(Cache, abc.ABC):
 
     This is only exposed to internal components. There is no guarantee the
     user-facing cache will provide these methods or not.
+
+    !!! note
+        For a "stateless" implementation of this getting methods will always
+        return empty resources (e.g `builtins.None` and empty cache views) while
+        modifying methods will always raise `builtins.NotImplementedError` when
+        they are called.
     """
 
     @abc.abstractmethod
@@ -542,6 +552,11 @@ class MutableCache(Cache, abc.ABC):
         CacheView[hikari.snowflakes.Snowflake, hikari.channels.PrivateTextChannel]
             The cache view of user IDs to the private text channel objects that
             were removed from the cache.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -561,6 +576,11 @@ class MutableCache(Cache, abc.ABC):
         typing.Optional[hikari.channels.PrivateTextChannel]
             The object of the private text channel that was removed from the
             cache if found, else `builtins.None`
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -571,6 +591,11 @@ class MutableCache(Cache, abc.ABC):
         ----------
         channel : hikari.channels.PrivateTextChannel
             The object of the private text channel to add to the cache.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -590,6 +615,11 @@ class MutableCache(Cache, abc.ABC):
             A tuple of the old cached private text channel if found
             (else `builtins.None`) and the new cached private text channel if it
             could be cached (else `builtins.None`).
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """  # noqa E501: - Line too long
 
     @abc.abstractmethod
@@ -605,6 +635,11 @@ class MutableCache(Cache, abc.ABC):
         CacheView[hikari.snowflakes.Snowflake, hikari.emojis.KnownCustomEmoji]
             A cache view of emoji IDs to objects of the emojis that were
             removed from the cache.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -628,6 +663,11 @@ class MutableCache(Cache, abc.ABC):
         CacheView[hikari.snowflakes.Snowflake, hikari.emojis.KnownCustomEmoji]
             A view of emoji IDs to objects of the emojis that were removed
             from the cache.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -648,6 +688,11 @@ class MutableCache(Cache, abc.ABC):
         typing.Optional[hikari.emojis.KnownCustomEmoji]
             The object of the emoji that was removed from the cache or
             `builtins.None`.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -658,6 +703,11 @@ class MutableCache(Cache, abc.ABC):
         ----------
         emoji : hikari.emojis.KnownCustomEmoji
             The object of the known custom emoji to add to the cache.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -677,6 +727,11 @@ class MutableCache(Cache, abc.ABC):
             A tuple of the old cached emoji object if found (else `builtins.None`)
             and the new cached emoji object if it could be cached (else
             `builtins.None`).
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """  # noqa E501: - Line too long
 
     @abc.abstractmethod
@@ -688,6 +743,11 @@ class MutableCache(Cache, abc.ABC):
         CacheView[hikari.snowflakes.Snowflake, hikari.guilds.GatewayGuild]
             The cache view of guild IDs to guild objects that were removed from
             the cache.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -704,6 +764,11 @@ class MutableCache(Cache, abc.ABC):
         typing.Optional[hikari.guilds.GatewayGuild]
             The object of the guild that was removed from the cache, will be
             `builtins.None` if not found.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -714,6 +779,11 @@ class MutableCache(Cache, abc.ABC):
         ----------
         guild : hikari.guilds.GatewayGuild
             The object of the guild to add to the cache.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -726,6 +796,11 @@ class MutableCache(Cache, abc.ABC):
             The ID of the guild to set the availability for.
         is_available : builtins.bool
             The availability to set for the guild.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -749,6 +824,11 @@ class MutableCache(Cache, abc.ABC):
             A tuple of the old cached guild object if found (else `builtins.None`)
             and the object of the guild that was added to the cache if it could
             be added (else `builtins.None`).
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """  # noqa E501: - Line too long
 
     @abc.abstractmethod
@@ -760,6 +840,11 @@ class MutableCache(Cache, abc.ABC):
         CacheView[hikari.snowflakes.Snowflake, hikari.channels.GuildChannel]
             A view of channel IDs to objects of the guild channels that were
             removed from the cache.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -778,6 +863,11 @@ class MutableCache(Cache, abc.ABC):
         CacheView[hikari.snowflakes.Snowflake, hikari.channels.GuildChannel]
             A view of channel IDs to objects of the guild channels that were
             removed from the cache.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -793,7 +883,12 @@ class MutableCache(Cache, abc.ABC):
         -------
         typing.Optional[hikari.channels.GuildChannel]
             The object of the guild channel that was removed from the cache if
-            found, else `builtins.None`.ww
+            found, else `builtins.None`.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -804,6 +899,11 @@ class MutableCache(Cache, abc.ABC):
         ----------
         channel : hikari.channels.GuildChannel
             The guild channel based object to add to the cache.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -823,6 +923,11 @@ class MutableCache(Cache, abc.ABC):
             A tuple of the old cached guild channel if found (else `builtins.None`)
             and the new cached guild channel if it could be cached
             (else `builtins.None`).
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """  # noqa E501: - Line too long
 
     @abc.abstractmethod
@@ -834,6 +939,11 @@ class MutableCache(Cache, abc.ABC):
         CacheView[builtins.str, hikari.invites.InviteWithMetadata]
             A view of invite code strings to objects of the invites that were
             removed from the cache.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -850,6 +960,11 @@ class MutableCache(Cache, abc.ABC):
         CacheView[builtins.str, hikari.invites.InviteWithMetadata]
             A view of invite code strings to objects of the invites that were
             removed from the cache for the specified guild.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -870,6 +985,11 @@ class MutableCache(Cache, abc.ABC):
         CacheView[builtins.str, hikari.invites.InviteWithMetadata]
             A view of invite code strings to objects of the invites that were
             removed from the cache for the specified channel.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -886,6 +1006,11 @@ class MutableCache(Cache, abc.ABC):
         typing.Optional[hikari.invites.InviteWithMetaData]
             The object of the invite that was removed from the cache if found,
             else `builtins.None`.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -896,6 +1021,11 @@ class MutableCache(Cache, abc.ABC):
         ----------
         invite : hikari.invites.InviteWithMetadata
             The object of the invite to add to the cache.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -915,6 +1045,11 @@ class MutableCache(Cache, abc.ABC):
             A tuple of the old cached invite object if found (else
             `builtins.None`) and the new cached invite object if it could be
             cached (else `builtins.None`).
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """  # noqa E501: - Line too long
 
     @abc.abstractmethod
@@ -926,6 +1061,11 @@ class MutableCache(Cache, abc.ABC):
         typing.Optional[hikari.users.OwnUser]
             The own user object that was removed from the cache if found,
             else `builtins.None`.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -936,6 +1076,11 @@ class MutableCache(Cache, abc.ABC):
         ----------
         user : hikari.users.OwnUser
             The own user object to set in the cache.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -955,6 +1100,11 @@ class MutableCache(Cache, abc.ABC):
             A tuple of the old cached own user object if found (else
             `builtins.None`) and the new cached own user object if it could be
             cached, else `builtins.None`.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -966,6 +1116,11 @@ class MutableCache(Cache, abc.ABC):
         CacheView[hikari.snowflakes.Snowflake, ICacheView[hikari.snowflakes.Snowflake, hikari.guilds.Member]]
             A view of guild IDs to views of user IDs to objects of the members
             that were removed from the cache.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """  # noqa E501: - Line too long
 
     @abc.abstractmethod
@@ -988,6 +1143,11 @@ class MutableCache(Cache, abc.ABC):
         CacheView[hikari.snowflakes.Snowflake, hikari.guilds.Member]
             The view of user IDs to the member objects that were removed from
             the cache.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -1013,6 +1173,11 @@ class MutableCache(Cache, abc.ABC):
         typing.Optional[hikari.guilds.Member]
             The object of the member that was removed from the cache if found,
             else `builtins.None`.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -1023,6 +1188,11 @@ class MutableCache(Cache, abc.ABC):
         ----------
         member : hikari.guilds.Member
             The object of the member to add to the cache.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -1042,6 +1212,11 @@ class MutableCache(Cache, abc.ABC):
             A tuple of the old cached member object if found (else `builtins.None`)
             and the new cached member object if it could be cached (else
             `builtins.None`)
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -1055,6 +1230,11 @@ class MutableCache(Cache, abc.ABC):
         CacheView[hikari.snowflakes.Snowflake, ICacheView[hikari.snowflakes.Snowflake, hikari.include_presences.MemberPresence]]
             A view of guild IDs to views of user IDs to objects of the include_presences
             that were removed from the cache.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """  # noqa E501: - Line too long
 
     @abc.abstractmethod
@@ -1073,6 +1253,11 @@ class MutableCache(Cache, abc.ABC):
         CacheView[hikari.snowflakes.Snowflake, hikari.presences.MemberPresence]
             A view of user IDs to objects of the include_presences that were removed
             from the cache for the specified guild.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -1093,6 +1278,11 @@ class MutableCache(Cache, abc.ABC):
         typing.Optional[hikari.include_presences.MemberPresence]
             The object of the presence that was removed from the cache if found,
             else `builtins.None`.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -1103,6 +1293,11 @@ class MutableCache(Cache, abc.ABC):
         ----------
         presence : hikari.presences.MemberPresence
             The object of the presence to add to the cache.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -1122,6 +1317,11 @@ class MutableCache(Cache, abc.ABC):
             A tuple of the old cached invite object if found (else `builtins.None`
             and the new cached invite object if it could be cached ( else
             `builtins.None`).
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """  # noqa E501: - Line too long
 
     @abc.abstractmethod
@@ -1133,6 +1333,11 @@ class MutableCache(Cache, abc.ABC):
         CacheView[hikari.snowflakes.Snowflake, hikari.guilds.Role]
             A view of role IDs to objects of the roles that were removed from
             the cache.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -1149,6 +1354,11 @@ class MutableCache(Cache, abc.ABC):
         CacheView[hikari.snowflakes.Snowflake, hikari.guilds.Role]
             A view of role IDs to objects of the roles that were removed from
             the cache for the specific guild.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -1165,6 +1375,11 @@ class MutableCache(Cache, abc.ABC):
         typing.Optional[hikari.guilds.Role]
             The object of the role that was removed from the cache if found,
             else `builtins.None`.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -1175,6 +1390,11 @@ class MutableCache(Cache, abc.ABC):
         ----------
         role : hikari.guilds.Role
             The object of the role to add to the cache.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -1194,6 +1414,11 @@ class MutableCache(Cache, abc.ABC):
             A tuple of the old cached role object if found (else `builtins.None`
             and the new cached role object if it could be cached (else
             `builtins.None`).
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -1210,6 +1435,11 @@ class MutableCache(Cache, abc.ABC):
         CacheView[hikari.snowflakes.Snowflake, hikari.users.User]
             The view of user IDs to the user objects that were removed from the
             cache.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -1231,6 +1461,11 @@ class MutableCache(Cache, abc.ABC):
         typing.Optional[hikari.users.User]
             The object of the user that was removed from the cache if found,
             else `builtins.None`.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -1241,6 +1476,11 @@ class MutableCache(Cache, abc.ABC):
         ----------
         user : hikari.users.User
             The object of the user to add to the cache.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -1259,6 +1499,11 @@ class MutableCache(Cache, abc.ABC):
         typing.Tuple[typing.Optional[hikari.users.User], typing.Optional[hikari.users.User]]
             A tuple of the old cached user if found (else `builtins.None`) and
             the newly cached user if it could be cached (else `builtins.None`).
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -1270,6 +1515,11 @@ class MutableCache(Cache, abc.ABC):
         CacheView[hikari.snowflakes.Snowflake, ICacheView[hikari.snowflakes.Snowflake, hikari.voices.VoiceState]]
             A view of guild IDs to views of user IDs to objects of the voice
             states that were removed from the states.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """  # noqa E501: - Line too long
 
     @abc.abstractmethod
@@ -1288,6 +1538,11 @@ class MutableCache(Cache, abc.ABC):
         CacheView[hikari.snowflakes.Snowflake, hikari.voices.VoiceState]
             A view of user IDs to the voice state objects that were removed from
             the cache.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -1308,6 +1563,11 @@ class MutableCache(Cache, abc.ABC):
         CacheView[hikari.snowflakes.Snowflake, hikari.voices.VoiceState]
             A view of user IDs to objects of the voice state that were removed
             from the cache for the specified channel.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -1328,6 +1588,11 @@ class MutableCache(Cache, abc.ABC):
         typing.Optional[hikari.voices.VoiceState]
             The object of the voice state that was removed from the cache if
             found, else `builtins.None`.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -1338,6 +1603,11 @@ class MutableCache(Cache, abc.ABC):
         ----------
         voice_state : hikari.voices.VoiceState
             The object of the voice state to add to the cache.
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """
 
     @abc.abstractmethod
@@ -1357,4 +1627,9 @@ class MutableCache(Cache, abc.ABC):
             A tuple of the old cached voice state if found (else `builtins.None`)
             and the new cached voice state object if it could be cached
             (else `builtins.None`).
+
+        Raises
+        ------
+        builtins.NotImplementedError
+            When called on a stateless cache implementation.
         """

--- a/hikari/impl/stateful_cache.py
+++ b/hikari/impl/stateful_cache.py
@@ -25,16 +25,10 @@ from __future__ import annotations
 
 __all__: typing.Final[typing.List[str]] = ["StatefulCacheImpl"]
 
-import abc
-import array
-import bisect
 import copy
 import datetime
 import logging
-import reprlib
 import typing
-
-import attr
 
 from hikari import channels
 from hikari import emojis
@@ -42,171 +36,21 @@ from hikari import errors
 from hikari import guilds
 from hikari import intents as intents_
 from hikari import invites
-from hikari import iterators
 from hikari import presences
 from hikari import snowflakes
 from hikari import undefined
 from hikari import users
 from hikari import voices
 from hikari.api import cache
-from hikari.utilities import attr_extensions
-from hikari.utilities import date
+from hikari.utilities import cache as cache_utility
 
 if typing.TYPE_CHECKING:
     from hikari import traits
 
 
-_DataT = typing.TypeVar("_DataT", bound="_BaseData[typing.Any]")
 _KeyT = typing.TypeVar("_KeyT", bound=typing.Hashable)
 _LOGGER: typing.Final[logging.Logger] = logging.getLogger("hikari.cache")
 _ValueT = typing.TypeVar("_ValueT")
-
-
-def _copy_mapping(mapping: typing.Mapping[_KeyT, _ValueT]) -> typing.MutableMapping[_KeyT, _ValueT]:
-    # We use this to cover 2 main cases in the cache, one where we copy a mapping before iterating over it to avoid any
-    # errors that would be raised by it being mutated during this process and the other to make sure that the mappings
-    # we pass through to cache views are snapshots that won't be further modified by the cache.
-
-    # dict.copy ranges from between roughly 2 times to 5 times more efficient than casting to a dict so we want to
-    # try to use this where possible.
-    try:
-        return mapping.copy()  # type: ignore[attr-defined, no-any-return]
-    except (AttributeError, TypeError):
-        raise NotImplementedError("provided mapping doesn't implement a copy method") from None
-
-
-class _IDTable(typing.MutableSet[snowflakes.Snowflake]):
-    """Compact 64-bit integer bisected-array-set of snowflakes."""
-
-    __slots__: typing.Sequence[str] = ("_ids",)
-
-    def __init__(self) -> None:
-        self._ids = array.array("Q")
-
-    def add(self, sf: snowflakes.Snowflake) -> None:
-        if not self._ids:
-            self._ids.append(sf)
-        else:
-            index = bisect.bisect_left(self._ids, sf)
-            if len(self._ids) == index or self._ids[index] != sf:
-                self._ids.insert(index, sf)
-
-    def add_all(self, sfs: typing.Iterable[snowflakes.Snowflake]) -> None:
-        for sf in sfs:
-            self.add(sf)
-
-    def discard(self, sf: snowflakes.Snowflake) -> None:
-        index = self._index_of(sf)
-        if index != -1:
-            del self._ids[index]
-
-    def _index_of(self, sf: int) -> int:
-        index = bisect.bisect_left(self._ids, sf)
-        return index if index < len(self._ids) or self._ids[index] == sf else -1
-
-    def __contains__(self, value: typing.Any) -> bool:
-        if not isinstance(value, int):
-            return False
-
-        return self._index_of(value) != -1
-
-    def __len__(self) -> int:
-        return len(self._ids)
-
-    def __iter__(self) -> typing.Iterator[snowflakes.Snowflake]:
-        return map(snowflakes.Snowflake, self._ids)
-
-    def __repr__(self) -> str:
-        return "SnowflakeTable" + reprlib.repr(self._ids)[5:]
-
-
-class _StatefulCacheMappingView(cache.CacheView[_KeyT, _ValueT], typing.Generic[_KeyT, _ValueT]):
-    __slots__: typing.Sequence[str] = ("_builder", "_data", "_unpack", "_predicate")
-
-    def __init__(
-        self,
-        items: typing.Mapping[_KeyT, typing.Union[_ValueT, _DataT, _GenericRefWrapper[_ValueT]]],
-        *,
-        builder: typing.Optional[typing.Callable[[_DataT], _ValueT]] = None,
-        unpack: bool = False,
-        predicate: typing.Optional[typing.Callable[[typing.Any], bool]] = None,
-    ) -> None:
-        self._builder = builder
-        self._data = items
-        self._unpack = unpack
-        self._predicate = predicate
-
-    @classmethod
-    def _copy(cls, value: _ValueT) -> _ValueT:
-        return copy.copy(value)
-
-    def __contains__(self, key: typing.Any) -> bool:
-        return key in self._data and (self._predicate is None or self._predicate(self._data[key]))
-
-    def __getitem__(self, key: _KeyT) -> _ValueT:
-        entry = self._data[key]
-
-        if self._predicate is not None and not self._predicate(entry):
-            raise KeyError(key)
-
-        if self._builder is not None:
-            entry = self._builder(entry)  # type: ignore[arg-type]
-        elif self._unpack:
-            assert isinstance(entry, _GenericRefWrapper)
-            entry = self._copy(entry.object)
-        else:
-            entry = self._copy(entry)  # type: ignore[arg-type]
-
-        return entry
-
-    def __iter__(self) -> typing.Iterator[_KeyT]:
-        if self._predicate is None:
-            return iter(self._data)
-        else:
-            return (key for key, value in self._data.items() if self._predicate(value))
-
-    def __len__(self) -> int:
-        if self._predicate is None:
-            return len(self._data)
-        else:
-            return sum(1 for value in self._data.values() if self._predicate(value))
-
-    def get_item_at(self, index: int) -> _ValueT:
-        current_index = -1
-
-        for key, value in self._data.items():
-            if self._predicate is None or self._predicate(value):
-                index += 1
-
-            if current_index == index:
-                return self[key]
-
-        raise IndexError(index)
-
-    def iterator(self) -> iterators.LazyIterator[_ValueT]:
-        return iterators.FlatLazyIterator(self.values())
-
-
-class _EmptyCacheView(cache.CacheView[typing.Any, typing.Any]):
-    __slots__: typing.Sequence[str] = ()
-
-    def __contains__(self, _: typing.Any) -> typing.Literal[False]:
-        return False
-
-    def __getitem__(self, key: typing.Any) -> typing.NoReturn:
-        raise KeyError(key)
-
-    def __iter__(self) -> typing.Iterator[typing.Any]:
-        yield from ()
-
-    def __len__(self) -> typing.Literal[0]:
-        return 0
-
-    def get_item_at(self, index: int) -> typing.NoReturn:
-        raise IndexError(index)
-
-    def iterator(self) -> iterators.LazyIterator[_ValueT]:
-        return iterators.FlatLazyIterator(())
 
 
 class _VoidMapping(typing.MutableMapping[_KeyT, _ValueT]):
@@ -238,499 +82,6 @@ _VOID_MAPPING: typing.Final[typing.MutableMapping[typing.Any, typing.Any]] = _Vo
 """A constant instance of `_VoidMapping` used within the cache."""
 
 
-@attr_extensions.with_copy
-@attr.s(slots=True, repr=False, hash=False, weakref_slot=False)
-class _GuildRecord:
-    """An object used for storing guild specific cached information.
-
-    This includes references to the cached entities that "belong" to the guild
-    by ID if it's globally unique or by object if it's only unique within the
-    guild.
-    """
-
-    is_available: typing.Optional[bool] = attr.ib(default=None)
-    guild: typing.Optional[guilds.GatewayGuild] = attr.ib(default=None)
-    channels: typing.Optional[typing.MutableSet[snowflakes.Snowflake]] = attr.ib(default=None)
-    emojis: typing.Optional[typing.MutableSet[snowflakes.Snowflake]] = attr.ib(default=None)
-    invites: typing.Optional[typing.MutableSequence[str]] = attr.ib(default=None)
-    members: typing.Optional[typing.MutableMapping[snowflakes.Snowflake, _MemberData]] = attr.ib(default=None)
-    presences: typing.Optional[typing.MutableMapping[snowflakes.Snowflake, _MemberPresenceData]] = attr.ib(default=None)
-    roles: typing.Optional[typing.MutableSet[snowflakes.Snowflake]] = attr.ib(default=None)
-    voice_states: typing.Optional[typing.MutableMapping[snowflakes.Snowflake, _VoiceStateData]] = attr.ib(default=None)
-
-    def __bool__(self) -> bool:  # TODO: should "is_available" keep this alive?
-        return any(
-            (
-                self.channels,
-                self.emojis,
-                self.guild,
-                self.invites,
-                self.members,
-                self.presences,
-                self.roles,
-                self.voice_states,
-            )
-        )
-
-
-@attr.s(slots=True, repr=False, hash=False, init=True, weakref_slot=False)
-class _BaseData(abc.ABC, typing.Generic[_ValueT]):
-    """A data class used for storing entities in a more primitive form.
-
-    !!! note
-        This base implementation assumes that all the fields it'll handle will
-        be immutable and to handle mutable fields you'll have to override
-        build_entity and build_from_entity to explicitly copy them.
-    """
-
-    __slots__: typing.Sequence[str] = ()
-
-    @classmethod
-    @abc.abstractmethod
-    def get_fields(cls) -> typing.Collection[str]:
-        """Get the fields that should be automatically handled on the target entity.
-
-        !!! note
-            These fields should match up with both the target entity and the
-            data class itself.
-
-        Returns
-        -------
-        typing.Collection[builtins.str]
-            A collection of the names of fields to handle.
-        """
-
-    def build_entity(self, target: typing.Type[_ValueT], **kwargs: typing.Any) -> _ValueT:
-        """Build an entity object from this data object.
-
-        Parameters
-        ----------
-        target
-            The class of the entity object to add attributes to.
-        kwargs
-            Extra fields to pass on to the entity's initialiser. These will take
-            priority over fields on the builder.
-
-        Returns
-        -------
-        The initialised entity object.
-        """
-        for field in self.get_fields():
-            if field not in kwargs:
-                kwargs[field] = getattr(self, field)
-
-        return target(**kwargs)  # type: ignore[call-arg]
-
-    @classmethod
-    def build_from_entity(cls: typing.Type[_DataT], entity: _ValueT, **kwargs: typing.Any) -> _DataT:
-        """Build a data object from an initialised entity.
-
-        Parameters
-        ----------
-        entity
-            The entity object to build a data class from.
-        kwargs
-            Extra fields to add to the data class. Fields here will take
-            priority over fields on `entity`.
-
-        Returns
-        -------
-        The built data class.
-        """
-        for field in cls.get_fields():
-            if field not in kwargs:
-                kwargs[field] = getattr(entity, field)
-
-        return cls(**kwargs)  # type: ignore[call-arg]
-
-    def replace(self: _DataT, **kwargs: typing.Any) -> _DataT:
-        data = copy.copy(self)
-
-        for attribute, value in kwargs.items():
-            setattr(data, attribute, value)
-
-        return data
-
-
-@attr_extensions.with_copy
-@attr.s(kw_only=True, slots=True, repr=False, hash=False, weakref_slot=False)
-class _PrivateTextChannelData(_BaseData[channels.PrivateTextChannel]):
-    """The representation private text channel data stored in the cache.
-
-    !!! note
-        This doesn't cover private group text channels as we won't ever receive
-        those over the gateway.
-    """
-
-    id: snowflakes.Snowflake = attr.ib()
-    name: typing.Optional[str] = attr.ib()
-    last_message_id: typing.Optional[snowflakes.Snowflake] = attr.ib()
-    recipient_id: snowflakes.Snowflake = attr.ib()
-
-    @classmethod
-    def get_fields(cls) -> typing.Collection[str]:
-        return "id", "name", "last_message_id"
-
-    def build_entity(
-        self, target: typing.Type[channels.PrivateTextChannel], **kwargs: typing.Any
-    ) -> channels.PrivateTextChannel:
-        return super().build_entity(target, type=channels.ChannelType.PRIVATE_TEXT, **kwargs)
-
-    @classmethod
-    def build_from_entity(
-        cls: typing.Type[_PrivateTextChannelData], entity: channels.PrivateTextChannel, **kwargs: typing.Any
-    ) -> _PrivateTextChannelData:
-        return super().build_from_entity(entity, **kwargs, recipient_id=entity.recipient.id)
-
-
-@attr_extensions.with_copy
-@attr.s(kw_only=True, slots=True, repr=False, hash=False, weakref_slot=False)
-class _InviteData(_BaseData[invites.InviteWithMetadata]):
-    """The representation of invite data stored in the cache."""
-
-    code: str = attr.ib()
-    guild_id: typing.Optional[snowflakes.Snowflake] = attr.ib()
-    channel_id: snowflakes.Snowflake = attr.ib()
-    inviter_id: typing.Optional[snowflakes.Snowflake] = attr.ib()
-    target_user_id: typing.Optional[snowflakes.Snowflake] = attr.ib()
-    target_user_type: typing.Optional[invites.TargetUserType] = attr.ib()
-    uses: int = attr.ib()
-    max_uses: typing.Optional[int] = attr.ib()
-    max_age: typing.Optional[datetime.timedelta] = attr.ib()
-    is_temporary: bool = attr.ib()
-    created_at: datetime.datetime = attr.ib()
-
-    @classmethod
-    def get_fields(cls) -> typing.Collection[str]:
-        return (
-            "code",
-            "guild_id",
-            "channel_id",
-            "target_user_type",
-            "uses",
-            "max_uses",
-            "max_age",
-            "is_temporary",
-            "created_at",
-        )
-
-    def build_entity(
-        self, target: typing.Type[invites.InviteWithMetadata], **kwargs: typing.Any
-    ) -> invites.InviteWithMetadata:
-        return super().build_entity(
-            target, approximate_member_count=None, approximate_presence_count=None, channel=None, guild=None, **kwargs,
-        )
-
-    @classmethod
-    def build_from_entity(
-        cls: typing.Type[_InviteData], entity: invites.InviteWithMetadata, **kwargs: typing.Any
-    ) -> _InviteData:
-        return super().build_from_entity(
-            entity,
-            **kwargs,
-            inviter_id=entity.inviter.id if entity.inviter is not None else None,
-            target_user_id=entity.target_user.id if entity.target_user is not None else None,
-        )
-
-
-@attr_extensions.with_copy
-@attr.s(kw_only=True, slots=True, repr=False, hash=False, weakref_slot=False)
-class _MemberData(_BaseData[guilds.Member]):
-    """The representation of member data stored in the cache."""
-
-    id: snowflakes.Snowflake = attr.ib()
-    guild_id: snowflakes.Snowflake = attr.ib()
-    nickname: undefined.UndefinedNoneOr[str] = attr.ib()
-    role_ids: typing.Tuple[snowflakes.Snowflake, ...] = attr.ib()
-    joined_at: undefined.UndefinedOr[datetime.datetime] = attr.ib()
-    premium_since: undefined.UndefinedNoneOr[datetime.datetime] = attr.ib()
-    is_deaf: undefined.UndefinedOr[bool] = attr.ib()
-    is_mute: undefined.UndefinedOr[bool] = attr.ib()
-    # meta-attribute
-    has_been_deleted: bool = attr.ib(default=False)
-    ref_count: int = attr.ib(default=0)
-
-    @classmethod
-    def get_fields(cls) -> typing.Collection[str]:
-        return "guild_id", "nickname", "role_ids", "joined_at", "premium_since", "is_deaf", "is_mute"
-
-    @classmethod
-    def build_from_entity(cls: typing.Type[_MemberData], entity: guilds.Member, **kwargs: typing.Any) -> _MemberData:
-        # role_ids is a special case as it may be a mutable sequence so we want to ensure it's immutable when cached.
-        return super().build_from_entity(entity, **kwargs, id=entity.user.id, role_ids=tuple(entity.role_ids))
-
-
-@attr_extensions.with_copy
-@attr.s(kw_only=True, slots=True, repr=False, hash=False, weakref_slot=False)
-class _KnownCustomEmojiData(_BaseData[emojis.KnownCustomEmoji]):
-    """The representation of known custom emoji state data stored in the cache."""
-
-    id: snowflakes.Snowflake = attr.ib()
-    name: typing.Optional[str] = attr.ib()
-    is_animated: typing.Optional[bool] = attr.ib()
-    guild_id: snowflakes.Snowflake = attr.ib()
-    role_ids: typing.Tuple[snowflakes.Snowflake, ...] = attr.ib()
-    user_id: typing.Optional[snowflakes.Snowflake] = attr.ib()
-    is_colons_required: bool = attr.ib()
-    is_managed: bool = attr.ib()
-    is_available: bool = attr.ib()
-    # meta-attributes
-    has_been_deleted: bool = attr.ib(default=False)  # We need test coverage for this systm
-    ref_count: int = attr.ib(default=0)
-
-    @classmethod
-    def get_fields(cls) -> typing.Collection[str]:
-        return "id", "name", "is_animated", "guild_id", "role_ids", "is_colons_required", "is_managed", "is_available"
-
-    @classmethod
-    def build_from_entity(
-        cls: typing.Type[_KnownCustomEmojiData], entity: emojis.KnownCustomEmoji, **kwargs: typing.Any
-    ) -> _KnownCustomEmojiData:
-        # role_ids is a special case as it may be a mutable sequence so we want to ensure it's immutable when cached.
-        return super().build_from_entity(
-            entity, **kwargs, user_id=entity.user.id if entity.user else None, role_ids=tuple(entity.role_ids)
-        )
-
-
-@attr_extensions.with_copy
-@attr.s(kw_only=True, slots=True, repr=False, hash=False, weakref_slot=False)
-class _RichActivityData(_BaseData[presences.RichActivity]):
-    """The representation of rich activity data stored in the cache."""
-
-    name: str = attr.ib()
-    url: str = attr.ib()
-    type: presences.ActivityType = attr.ib()
-    created_at: datetime.datetime = attr.ib()
-    timestamps: typing.Optional[presences.ActivityTimestamps] = attr.ib()
-    application_id: typing.Optional[snowflakes.Snowflake] = attr.ib()
-    details: typing.Optional[str] = attr.ib()
-    state: typing.Optional[str] = attr.ib()
-    emoji_id_or_name: typing.Union[snowflakes.Snowflake, str, None] = attr.ib()
-    party: typing.Optional[presences.ActivityParty] = attr.ib()
-    assets: typing.Optional[presences.ActivityAssets] = attr.ib()
-    secrets: typing.Optional[presences.ActivitySecret] = attr.ib()
-    is_instance: typing.Optional[bool] = attr.ib()
-    flags: typing.Optional[presences.ActivityFlag] = attr.ib()
-
-    @classmethod
-    def get_fields(cls) -> typing.Collection[str]:
-        return "name", "url", "type", "created_at", "application_id", "details", "state", "is_instance", "flags"
-
-    @classmethod
-    def build_from_entity(
-        cls: typing.Type[_RichActivityData], entity: presences.RichActivity, **kwargs: typing.Any
-    ) -> _RichActivityData:
-        emoji_id_or_name: typing.Union[snowflakes.Snowflake, str, None]
-        if entity.emoji is None:
-            emoji_id_or_name = None
-        elif isinstance(entity.emoji, emojis.CustomEmoji):
-            emoji_id_or_name = entity.emoji.id
-        else:
-            emoji_id_or_name = entity.emoji.name
-
-        timestamps = copy.copy(entity.timestamps) if entity.timestamps is not None else None
-        party = copy.copy(entity.party) if entity.party is not None else None
-        assets = copy.copy(entity.assets) if entity.assets is not None else None
-        secrets = copy.copy(entity.secrets) if entity.secrets is not None else None
-        return super().build_from_entity(
-            entity,
-            emoji_id_or_name=emoji_id_or_name,
-            timestamps=timestamps,
-            party=party,
-            assets=assets,
-            secrets=secrets,
-        )
-
-    def build_entity(self, target: typing.Type[presences.RichActivity], **kwargs: typing.Any) -> presences.RichActivity:
-        return super().build_entity(
-            target,
-            timestamps=copy.copy(self.timestamps) if self.timestamps is not None else None,
-            party=copy.copy(self.party) if self.party is not None else None,
-            assets=copy.copy(self.assets) if self.assets is not None else None,
-            secrets=copy.copy(self.secrets) if self.secrets is not None else None,
-            **kwargs,
-        )
-
-
-@attr_extensions.with_copy
-@attr.s(kw_only=True, slots=True, repr=False, hash=False, weakref_slot=False)
-class _MemberPresenceData(_BaseData[presences.MemberPresence]):
-    """The representation of member presence data stored in the cache."""
-
-    user_id: snowflakes.Snowflake = attr.ib()
-    role_ids: typing.Optional[typing.Tuple[snowflakes.Snowflake, ...]] = attr.ib()
-    guild_id: typing.Optional[snowflakes.Snowflake] = attr.ib()
-    visible_status: presences.Status = attr.ib()
-    activities: typing.Tuple[_RichActivityData, ...] = attr.ib()
-    client_status: presences.ClientStatus = attr.ib()
-    premium_since: typing.Optional[datetime.datetime] = attr.ib()
-    nickname: typing.Optional[str] = attr.ib()
-
-    @classmethod
-    def get_fields(cls) -> typing.Collection[str]:
-        return "user_id", "role_ids", "guild_id", "visible_status", "premium_since", "nickname"
-
-    @classmethod
-    def build_from_entity(
-        cls: typing.Type[_MemberPresenceData], entity: presences.MemberPresence, **kwargs: typing.Any
-    ) -> _MemberPresenceData:
-        # role_ids and activities are special cases as may be mutable sequences, therefor we ant to ensure they're
-        # stored in immutable sequences (tuples). Plus activities need to be converted to Data objects.
-        return super().build_from_entity(
-            entity,
-            role_ids=tuple(entity.role_ids) if entity.role_ids is not None else None,
-            activities=tuple(_RichActivityData.build_from_entity(activity) for activity in entity.activities),
-            client_status=copy.copy(entity.client_status),
-        )
-
-    def build_entity(
-        self, target: typing.Type[presences.MemberPresence], **kwargs: typing.Any,
-    ) -> presences.MemberPresence:
-        presence_kwargs = kwargs.pop("presence_kwargs")
-        activities = [
-            activity.build_entity(presences.RichActivity, **kwargs_)
-            for activity, kwargs_ in zip(self.activities, presence_kwargs)
-        ]
-        return super().build_entity(
-            target, activities=activities, client_status=copy.copy(self.client_status), **kwargs
-        )
-
-
-@attr_extensions.with_copy
-@attr.s(kw_only=True, slots=True, repr=False, hash=False, weakref_slot=False)
-class _VoiceStateData(_BaseData[voices.VoiceState]):
-    """The representation of voice state data stored in the cache."""
-
-    channel_id: typing.Optional[snowflakes.Snowflake] = attr.ib()
-    guild_id: snowflakes.Snowflake = attr.ib()
-    is_guild_deafened: bool = attr.ib()
-    is_guild_muted: bool = attr.ib()
-    is_self_deafened: bool = attr.ib()
-    is_self_muted: bool = attr.ib()
-    is_streaming: bool = attr.ib()
-    is_suppressed: bool = attr.ib()
-    is_video_enabled: bool = attr.ib()
-    user_id: snowflakes.Snowflake = attr.ib()
-    session_id: str = attr.ib()
-
-    @classmethod
-    def get_fields(cls) -> typing.Collection[str]:
-        return (
-            "channel_id",
-            "guild_id",
-            "is_guild_deafened",
-            "is_guild_muted",
-            "is_self_deafened",
-            "is_self_muted",
-            "is_streaming",
-            "is_suppressed",
-            "is_video_enabled",
-            "user_id",
-            "session_id",
-        )
-
-
-@attr_extensions.with_copy
-@attr.s(kw_only=True, slots=True, repr=False, hash=False, weakref_slot=False)
-class _GenericRefWrapper(typing.Generic[_ValueT]):
-    """An object used for wrapping cached entities.
-
-    This is intended to enable reference counting for entities that are only kept
-    alive by reference (e.g. the unknown emoji objects attached to presence
-    activities and user objects) without the use of a "Data" object which lowers
-    the time spent building these entities for the objects that reference them.
-    """
-
-    object: _ValueT = attr.ib()
-    ref_count: int = attr.ib(default=0)
-
-
-class _PrivateTextChannelMRUMutableMapping(typing.MutableMapping[snowflakes.Snowflake, _PrivateTextChannelData]):
-    # This allows us to stop the private message cached from growing un-controllably by removing old private channels
-    # rather than waiting for delete events that'll never come or querying every guild the bot is in (which sounds
-    # rather bad as far as scaling goes).
-    __slots__: typing.Sequence[str] = ("_channels", "_expiry")
-
-    def __init__(
-        self,
-        source: typing.Optional[typing.Dict[snowflakes.Snowflake, _PrivateTextChannelData]] = None,
-        /,
-        *,
-        expiry: datetime.timedelta,
-    ) -> None:
-        if expiry <= datetime.timedelta():
-            raise ValueError("expiry time must be greater than 0 microseconds.")
-
-        self._channels: typing.Dict[
-            snowflakes.Snowflake, _PrivateTextChannelData
-        ] = source.copy() if source is not None else {}
-        self._expiry = expiry
-
-    def copy(self) -> typing.Dict[snowflakes.Snowflake, _PrivateTextChannelData]:
-        return self._channels.copy()
-
-    def _garbage_collect(self) -> None:
-        current_time = date.utc_datetime()
-        for channel_id, channel in self._channels.copy().items():
-            if channel.last_message_id and current_time - channel.last_message_id.created_at < self._expiry:
-                break
-
-            del self._channels[channel_id]
-
-    def __delitem__(self, sf: snowflakes.Snowflake) -> None:
-        del self._channels[sf]
-        self._garbage_collect()
-
-    def __getitem__(self, sf: snowflakes.Snowflake) -> _PrivateTextChannelData:
-        return self._channels[sf]
-
-    def __iter__(self) -> typing.Iterator[snowflakes.Snowflake]:
-        return iter(self._channels)
-
-    def __len__(self) -> int:
-        return len(self._channels)
-
-    def __setitem__(self, sf: snowflakes.Snowflake, value: _PrivateTextChannelData) -> None:
-        self._garbage_collect()
-        #  Seeing as we rely on insertion order in _garbage_collect, we have to make sure that each item is added to
-        #  the end of the dict.
-        if value.last_message_id is not None and sf in self:
-            del self[sf]
-
-        self._channels[sf] = value
-
-
-def _copy_guild_channel(channel: channels.GuildChannel) -> channels.GuildChannel:
-    """Logic for handling the copying of guild channel objects.
-
-    This exists account for the permission overwrite objects attached to guild
-    channel objects which need to be copied themselves.
-    """
-    channel = copy.copy(channel)
-    channel.permission_overwrites = {
-        sf: copy.copy(overwrite) for sf, overwrite in _copy_mapping(channel.permission_overwrites).items()
-    }
-    return channel
-
-
-class _GuildChannelCacheMappingView(_StatefulCacheMappingView[snowflakes.Snowflake, channels.GuildChannel]):
-    # This special case of the mapping view implements copy logic that targets guild channels specifically.
-    __slots__: typing.Sequence[str] = ()
-
-    @classmethod
-    def _copy(cls, value: channels.GuildChannel) -> channels.GuildChannel:
-        return _copy_guild_channel(value)
-
-
-class _3DCacheMappingView(_StatefulCacheMappingView[snowflakes.Snowflake, cache.CacheView[_KeyT, _ValueT]]):
-    # This special case of the Mapping View avoids copying the views contained within it as they are already immutable.
-    __slots__: typing.Sequence[str] = ()
-
-    @classmethod
-    def _copy(cls, value: cache.CacheView[_KeyT, _ValueT]) -> cache.CacheView[_KeyT, _ValueT]:
-        return value
-
-
 #  TODO: do we want to hide entities that are marked as "deleted" and being kept alive by references?
 class StatefulCacheImpl(cache.MutableCache):
     """In-memory cache implementation."""
@@ -756,19 +107,21 @@ class StatefulCacheImpl(cache.MutableCache):
         # have to go through all the guilds the app is in to see if it shares any of them with the channel's owner
         # before removing it from the cache so we use a specific MRU implementation to cover private channel de-caching.
         self._private_text_channel_entries: typing.MutableMapping[
-            snowflakes.Snowflake, _PrivateTextChannelData
-        ] = _PrivateTextChannelMRUMutableMapping(expiry=datetime.timedelta(minutes=5))
-        self._emoji_entries: typing.MutableMapping[snowflakes.Snowflake, _KnownCustomEmojiData] = {}
+            snowflakes.Snowflake, cache_utility.PrivateTextChannelData
+        ] = cache_utility.PrivateTextChannelMRUMutableMapping(expiry=datetime.timedelta(minutes=5))
+        self._emoji_entries: typing.MutableMapping[snowflakes.Snowflake, cache_utility.KnownCustomEmojiData] = {}
         self._guild_channel_entries: typing.MutableMapping[snowflakes.Snowflake, channels.GuildChannel] = {}
-        self._guild_entries: typing.MutableMapping[snowflakes.Snowflake, _GuildRecord] = {}
-        self._invite_entries: typing.MutableMapping[str, _InviteData] = {}
+        self._guild_entries: typing.MutableMapping[snowflakes.Snowflake, cache_utility.GuildRecord] = {}
+        self._invite_entries: typing.MutableMapping[str, cache_utility.InviteData] = {}
         self._role_entries: typing.MutableMapping[snowflakes.Snowflake, guilds.Role] = {}
         # This is a purely internal cache used for handling the caching and de-duplicating of the unknown custom emojis
         # found attached to cached presence activities.
         self._unknown_custom_emoji_entries: typing.MutableMapping[
-            snowflakes.Snowflake, _GenericRefWrapper[emojis.CustomEmoji],
+            snowflakes.Snowflake, cache_utility.GenericRefWrapper[emojis.CustomEmoji],
         ] = {}
-        self._user_entries: typing.MutableMapping[snowflakes.Snowflake, _GenericRefWrapper[users.User]] = {}
+        self._user_entries: typing.MutableMapping[
+            snowflakes.Snowflake, cache_utility.GenericRefWrapper[users.User]
+        ] = {}
 
         self._intents = intents
 
@@ -781,8 +134,10 @@ class StatefulCacheImpl(cache.MutableCache):
 
     def _build_private_text_channel(
         self,
-        channel_data: _PrivateTextChannelData,
-        cached_users: typing.Optional[typing.Mapping[snowflakes.Snowflake, _GenericRefWrapper[users.User]]] = None,
+        channel_data: cache_utility.PrivateTextChannelData,
+        cached_users: typing.Optional[
+            typing.Mapping[snowflakes.Snowflake, cache_utility.GenericRefWrapper[users.User]]
+        ] = None,
     ) -> channels.PrivateTextChannel:
         if cached_users:
             recipient = copy.copy(cached_users[channel_data.recipient_id].object)
@@ -793,7 +148,7 @@ class StatefulCacheImpl(cache.MutableCache):
 
     def clear_private_text_channels(self) -> cache.CacheView[snowflakes.Snowflake, channels.PrivateTextChannel]:
         if not self._private_text_channel_entries:
-            return _EmptyCacheView()
+            return cache_utility.EmptyCacheView()
 
         cached_channels = self._private_text_channel_entries
         self._private_text_channel_entries = {}
@@ -803,7 +158,7 @@ class StatefulCacheImpl(cache.MutableCache):
             cached_users[user_id] = self._user_entries[user_id]
             self._garbage_collect_user(user_id, decrement=1)
 
-        return _StatefulCacheMappingView(
+        return cache_utility.StatefulCacheMappingView(
             cached_channels, builder=lambda channel: self._build_private_text_channel(channel, cached_users)
         )
 
@@ -828,11 +183,11 @@ class StatefulCacheImpl(cache.MutableCache):
 
     def get_private_text_channels_view(self) -> cache.CacheView[snowflakes.Snowflake, channels.PrivateTextChannel]:
         if not self._private_text_channel_entries:
-            return _EmptyCacheView()
+            return cache_utility.EmptyCacheView()
 
-        cached_channels = _copy_mapping(self._private_text_channel_entries)
+        cached_channels = cache_utility.copy_mapping(self._private_text_channel_entries)
         cached_users = {user_id: self._user_entries[user_id] for user_id in cached_channels}
-        return _StatefulCacheMappingView(
+        return cache_utility.StatefulCacheMappingView(
             cached_channels, builder=lambda channel: self._build_private_text_channel(channel, cached_users),
         )
 
@@ -842,7 +197,9 @@ class StatefulCacheImpl(cache.MutableCache):
         if channel.recipient.id not in self._private_text_channel_entries:
             self._increment_user_ref_count(channel.recipient.id)
 
-        self._private_text_channel_entries[channel.recipient.id] = _PrivateTextChannelData.build_from_entity(channel)
+        self._private_text_channel_entries[
+            channel.recipient.id
+        ] = cache_utility.PrivateTextChannelData.build_from_entity(channel)
 
     def update_private_text_channel(
         self, channel: channels.PrivateTextChannel, /
@@ -853,8 +210,10 @@ class StatefulCacheImpl(cache.MutableCache):
 
     def _build_emoji(
         self,
-        emoji_data: _KnownCustomEmojiData,
-        cached_users: typing.Optional[typing.Mapping[snowflakes.Snowflake, _GenericRefWrapper[users.User]]] = None,
+        emoji_data: cache_utility.KnownCustomEmojiData,
+        cached_users: typing.Optional[
+            typing.Mapping[snowflakes.Snowflake, cache_utility.GenericRefWrapper[users.User]]
+        ] = None,
     ) -> emojis.KnownCustomEmoji:
         user: typing.Optional[users.User] = None
         if cached_users is not None and emoji_data.user_id is not None:
@@ -879,7 +238,7 @@ class StatefulCacheImpl(cache.MutableCache):
             del self._emoji_entries[emoji_id]
 
     @staticmethod
-    def _can_remove_emoji(emoji: _KnownCustomEmojiData) -> bool:
+    def _can_remove_emoji(emoji: cache_utility.KnownCustomEmojiData) -> bool:
         return emoji.has_been_deleted is True and emoji.ref_count < 1
 
     def _clear_emojis(
@@ -887,12 +246,12 @@ class StatefulCacheImpl(cache.MutableCache):
     ) -> cache.CacheView[snowflakes.Snowflake, emojis.KnownCustomEmoji]:
         emoji_ids: typing.Iterable[snowflakes.Snowflake]
         if guild_id is undefined.UNDEFINED:
-            emoji_ids = _copy_mapping(self._emoji_entries)
+            emoji_ids = cache_utility.copy_mapping(self._emoji_entries)
         else:
             guild_record = self._guild_entries.get(guild_id)
             # TODO: explicit is not None vs implicit if statement consistency.
             if guild_record is None or guild_record.emojis is None:
-                return _EmptyCacheView()
+                return cache_utility.EmptyCacheView()
 
             emoji_ids = guild_record.emojis
             guild_record.emojis = None
@@ -914,14 +273,14 @@ class StatefulCacheImpl(cache.MutableCache):
                 cached_users[emoji_data.user_id] = self._user_entries[emoji_data.user_id]
                 self._garbage_collect_user(emoji_data.user_id, decrement=1)
 
-        return _StatefulCacheMappingView(
+        return cache_utility.StatefulCacheMappingView(
             cached_emojis, builder=lambda emoji: self._build_emoji(emoji, cached_users=cached_users)
         )
 
     def clear_emojis(self) -> cache.CacheView[snowflakes.Snowflake, emojis.KnownCustomEmoji]:
         result = self._clear_emojis()
 
-        for guild_id, guild_record in _copy_mapping(self._guild_entries).items():
+        for guild_id, guild_record in cache_utility.copy_mapping(self._guild_entries).items():
             if guild_record.emojis is not None:  # TODO: add test coverage for this.
                 guild_record.emojis = None
                 self._remove_guild_record_if_empty(guild_id)
@@ -967,11 +326,11 @@ class StatefulCacheImpl(cache.MutableCache):
         emoji_ids: typing.Iterable[snowflakes.Snowflake]
 
         if guild_id is undefined.UNDEFINED:
-            emoji_ids = _copy_mapping(self._emoji_entries)
+            emoji_ids = cache_utility.copy_mapping(self._emoji_entries)
         else:
             guild_record = self._guild_entries.get(guild_id)
             if guild_record is None or not guild_record.emojis:
-                return _EmptyCacheView()
+                return cache_utility.EmptyCacheView()
 
             emoji_ids = tuple(guild_record.emojis)
 
@@ -982,7 +341,7 @@ class StatefulCacheImpl(cache.MutableCache):
             if emoji_data.user_id is not None:
                 cached_users[emoji_data.user_id] = self._user_entries[emoji_data.user_id]
 
-        return _StatefulCacheMappingView(
+        return cache_utility.StatefulCacheMappingView(
             cached_emojis, builder=lambda emoji: self._build_emoji(emoji, cached_users=cached_users)
         )
 
@@ -1000,11 +359,11 @@ class StatefulCacheImpl(cache.MutableCache):
             if emoji.id not in self._emoji_entries:
                 self._increment_user_ref_count(emoji.user.id)
 
-        self._emoji_entries[emoji.id] = _KnownCustomEmojiData.build_from_entity(emoji)
+        self._emoji_entries[emoji.id] = cache_utility.KnownCustomEmojiData.build_from_entity(emoji)
         guild_container = self._get_or_create_guild_record(emoji.guild_id)
 
         if guild_container.emojis is None:  # TODO: add test cases when it is not None?
-            guild_container.emojis = _IDTable()
+            guild_container.emojis = cache_utility.IDTable()
 
         guild_container.emojis.add(emoji.id)
 
@@ -1019,16 +378,16 @@ class StatefulCacheImpl(cache.MutableCache):
         if guild_id in self._guild_entries and not self._guild_entries[guild_id]:
             del self._guild_entries[guild_id]
 
-    def _get_or_create_guild_record(self, guild_id: snowflakes.Snowflake) -> _GuildRecord:
+    def _get_or_create_guild_record(self, guild_id: snowflakes.Snowflake) -> cache_utility.GuildRecord:
         if guild_id not in self._guild_entries:
-            self._guild_entries[guild_id] = _GuildRecord()
+            self._guild_entries[guild_id] = cache_utility.GuildRecord()
 
         return self._guild_entries[guild_id]
 
     def clear_guilds(self) -> cache.CacheView[snowflakes.Snowflake, guilds.GatewayGuild]:
         cached_guilds = {}
 
-        for guild_id, guild_record in _copy_mapping(self._guild_entries).items():
+        for guild_id, guild_record in cache_utility.copy_mapping(self._guild_entries).items():
             if guild_record.guild is None:
                 continue
 
@@ -1037,7 +396,9 @@ class StatefulCacheImpl(cache.MutableCache):
             guild_record.is_available = None
             self._remove_guild_record_if_empty(guild_id)
 
-        return _StatefulCacheMappingView(cached_guilds) if cached_guilds else _EmptyCacheView()
+        return (
+            cache_utility.StatefulCacheMappingView(cached_guilds) if cached_guilds else cache_utility.EmptyCacheView()
+        )
 
     def delete_guild(self, guild_id: snowflakes.Snowflake, /) -> typing.Optional[guilds.GatewayGuild]:
         if guild_id not in self._guild_entries:
@@ -1065,11 +426,11 @@ class StatefulCacheImpl(cache.MutableCache):
 
     def get_guilds_view(self) -> cache.CacheView[snowflakes.Snowflake, guilds.GatewayGuild]:
         # TODO: do we want to include unavailable guilds here or hide them?
-        entries = _copy_mapping(self._guild_entries)
+        entries = cache_utility.copy_mapping(self._guild_entries)
         # We may have a guild record without a guild object in cases where we're caching other entities that belong to
         # the guild therefore we want to make sure record.guild isn't None.
         results = {sf: guild_record.guild for sf, guild_record in entries.items() if guild_record.guild}
-        return _StatefulCacheMappingView(results) if results else _EmptyCacheView()
+        return cache_utility.StatefulCacheMappingView(results) if results else cache_utility.EmptyCacheView()
 
     def set_guild(self, guild: guilds.GatewayGuild, /) -> None:
         guild_record = self._get_or_create_guild_record(guild.id)
@@ -1083,7 +444,7 @@ class StatefulCacheImpl(cache.MutableCache):
     # TODO: is this the best way to handle this?
     def set_initial_unavailable_guilds(self, guild_ids: typing.Collection[snowflakes.Snowflake], /) -> None:
         # Invoked when we receive ON_READY, assume all of these are unavailable on startup.
-        self._guild_entries = {guild_id: _GuildRecord(is_available=False) for guild_id in guild_ids}
+        self._guild_entries = {guild_id: cache_utility.GuildRecord(is_available=False) for guild_id in guild_ids}
 
     def update_guild(
         self, guild: guilds.GatewayGuild, /
@@ -1106,26 +467,26 @@ class StatefulCacheImpl(cache.MutableCache):
         cached_channels = self._guild_channel_entries
         self._guild_channel_entries = {}
 
-        for guild_id, guild_record in _copy_mapping(self._guild_entries).items():
+        for guild_id, guild_record in cache_utility.copy_mapping(self._guild_entries).items():
             if guild_record.channels is not None:
                 guild_record.channels = None
                 self._remove_guild_record_if_empty(guild_id)
 
-        return _StatefulCacheMappingView(cached_channels)
+        return cache_utility.StatefulCacheMappingView(cached_channels)
 
     def clear_guild_channels_for_guild(
         self, guild_id: snowflakes.Snowflake, /
     ) -> cache.CacheView[snowflakes.Snowflake, channels.GuildChannel]:
         guild_record = self._guild_entries.get(guild_id)
         if guild_record is None or guild_record.channels is None:
-            return _EmptyCacheView()
+            return cache_utility.EmptyCacheView()
 
         # Tuple casts like this avoid edge case issues which would be caused by guild_record.channels being modified
         # while we're iterating over it
         cached_channels = {sf: self._guild_channel_entries.pop(sf) for sf in tuple(guild_record.channels)}
         guild_record.channels = None
         self._remove_guild_record_if_empty(guild_id)
-        return _StatefulCacheMappingView(cached_channels)
+        return cache_utility.StatefulCacheMappingView(cached_channels)
 
     def delete_guild_channel(self, channel_id: snowflakes.Snowflake, /) -> typing.Optional[channels.GuildChannel]:
         channel = self._guild_channel_entries.pop(channel_id, None)
@@ -1145,17 +506,17 @@ class StatefulCacheImpl(cache.MutableCache):
 
     def get_guild_channel(self, channel_id: snowflakes.Snowflake, /) -> typing.Optional[channels.GuildChannel]:
         channel = self._guild_channel_entries.get(channel_id)
-        return _copy_guild_channel(channel) if channel is not None else None
+        return cache_utility.copy_guild_channel(channel) if channel is not None else None
 
     def get_guild_channels_view(self) -> cache.CacheView[snowflakes.Snowflake, channels.GuildChannel]:
-        return _GuildChannelCacheMappingView(_copy_mapping(self._guild_channel_entries))
+        return cache_utility.GuildChannelCacheMappingView(cache_utility.copy_mapping(self._guild_channel_entries))
 
     def get_guild_channels_view_for_guild(
         self, guild_id: snowflakes.Snowflake, /
     ) -> cache.CacheView[snowflakes.Snowflake, channels.GuildChannel]:
         guild_record = self._guild_entries.get(guild_id)
         if guild_record is None or not guild_record.channels:
-            return _EmptyCacheView()
+            return cache_utility.EmptyCacheView()
 
         # Tuple casts like this avoids edge case issues which would be caused by arrays being modified while we're
         # iterating over them.
@@ -1174,14 +535,14 @@ class StatefulCacheImpl(cache.MutableCache):
             return parent_position, 1, channel.position
 
         cached_channels = dict(sorted(cached_channels.items(), key=sorter))
-        return _GuildChannelCacheMappingView(cached_channels)
+        return cache_utility.GuildChannelCacheMappingView(cached_channels)
 
     def set_guild_channel(self, channel: channels.GuildChannel, /) -> None:
-        self._guild_channel_entries[channel.id] = _copy_guild_channel(channel)
+        self._guild_channel_entries[channel.id] = cache_utility.copy_guild_channel(channel)
         guild_record = self._get_or_create_guild_record(channel.guild_id)
 
         if guild_record.channels is None:
-            guild_record.channels = _IDTable()
+            guild_record.channels = cache_utility.IDTable()
 
         guild_record.channels.add(channel.id)
 
@@ -1194,9 +555,9 @@ class StatefulCacheImpl(cache.MutableCache):
 
     def _build_invite(
         self,
-        invite_data: _InviteData,
+        invite_data: cache_utility.InviteData,
         cached_users: undefined.UndefinedOr[
-            typing.Mapping[snowflakes.Snowflake, _GenericRefWrapper[users.User]]
+            typing.Mapping[snowflakes.Snowflake, cache_utility.GenericRefWrapper[users.User]]
         ] = undefined.UNDEFINED,
     ) -> invites.InviteWithMetadata:
         inviter: typing.Optional[users.User] = None
@@ -1223,7 +584,7 @@ class StatefulCacheImpl(cache.MutableCache):
             guild_record = self._guild_entries.get(guild_id)
 
             if guild_record is None or guild_record.invites is None:
-                return _EmptyCacheView()
+                return cache_utility.EmptyCacheView()
 
             # Tuple casts like this avoids edge case issues which would be caused by arrays being modified while we're
             # iterating over them.
@@ -1232,7 +593,7 @@ class StatefulCacheImpl(cache.MutableCache):
             self._remove_guild_record_if_empty(guild_id)
 
         else:
-            invite_codes = _copy_mapping(self._invite_entries)
+            invite_codes = cache_utility.copy_mapping(self._invite_entries)
 
         cached_invites = {}
         cached_users = {}
@@ -1249,7 +610,7 @@ class StatefulCacheImpl(cache.MutableCache):
                 cached_users[invite_data.target_user_id] = self._user_entries[invite_data.target_user_id]
                 self._garbage_collect_user(invite_data.target_user_id, decrement=1)
 
-        return _StatefulCacheMappingView(
+        return cache_utility.StatefulCacheMappingView(
             cached_invites, builder=lambda invite_data: self._build_invite(invite_data, cached_users=cached_users)
         )
 
@@ -1266,7 +627,7 @@ class StatefulCacheImpl(cache.MutableCache):
     ) -> cache.CacheView[str, invites.InviteWithMetadata]:
         guild_record = self._guild_entries.get(guild_id)
         if guild_record is None or guild_record.invites is None:
-            return _EmptyCacheView()
+            return cache_utility.EmptyCacheView()
 
         cached_invites = {}
         cached_users = {}
@@ -1294,7 +655,7 @@ class StatefulCacheImpl(cache.MutableCache):
             guild_record.invites = None
             self._remove_guild_record_if_empty(guild_id)
 
-        return _StatefulCacheMappingView(
+        return cache_utility.StatefulCacheMappingView(
             cached_invites, builder=lambda invite_data: self._build_invite(invite_data, cached_users=cached_users)
         )
 
@@ -1329,12 +690,12 @@ class StatefulCacheImpl(cache.MutableCache):
     ) -> cache.CacheView[str, invites.InviteWithMetadata]:
         invite_ids: typing.Iterable[str]
         if guild_id is undefined.UNDEFINED:
-            invite_ids = _copy_mapping(self._invite_entries)
+            invite_ids = cache_utility.copy_mapping(self._invite_entries)
 
         else:
             guild_entry = self._guild_entries.get(guild_id)
             if guild_entry is None or guild_entry.invites is None:
-                return _EmptyCacheView()
+                return cache_utility.EmptyCacheView()
 
             # Tuple casts like this avoids edge case issues which would be caused by arrays being modified while we're
             # iterating over them.
@@ -1353,7 +714,7 @@ class StatefulCacheImpl(cache.MutableCache):
             if invite_data.target_user_id is not None:
                 cached_users[invite_data.target_user_id] = self._user_entries[invite_data.target_user_id]
 
-        return _StatefulCacheMappingView(
+        return cache_utility.StatefulCacheMappingView(
             cached_invites, builder=lambda invite_data: self._build_invite(invite_data, cached_users=cached_users)
         )
 
@@ -1370,7 +731,7 @@ class StatefulCacheImpl(cache.MutableCache):
     ) -> cache.CacheView[str, invites.InviteWithMetadata]:
         guild_entry = self._guild_entries.get(guild_id)
         if guild_entry is None or guild_entry.invites is None:
-            return _EmptyCacheView()
+            return cache_utility.EmptyCacheView()
 
         cached_invites = {}
         cached_users = {}
@@ -1397,7 +758,7 @@ class StatefulCacheImpl(cache.MutableCache):
             guild_entry.channels = None
             self._remove_guild_record_if_empty(guild_id)
 
-        return _StatefulCacheMappingView(
+        return cache_utility.StatefulCacheMappingView(
             cached_invites, builder=lambda invite_data: self._build_invite(invite_data, cached_users=cached_users)
         )
 
@@ -1412,7 +773,7 @@ class StatefulCacheImpl(cache.MutableCache):
             if invite.code not in self._invite_entries:
                 self._increment_user_ref_count(invite.target_user.id)
 
-        self._invite_entries[invite.code] = _InviteData.build_from_entity(invite)
+        self._invite_entries[invite.code] = cache_utility.InviteData.build_from_entity(invite)
         if invite.guild_id:
             guild_entry = self._get_or_create_guild_record(invite.guild_id)
 
@@ -1449,8 +810,10 @@ class StatefulCacheImpl(cache.MutableCache):
 
     def _build_member(
         self,
-        member_data: _MemberData,
-        cached_users: typing.Optional[typing.Mapping[snowflakes.Snowflake, _GenericRefWrapper[users.User]]] = None,
+        member_data: cache_utility.MemberData,
+        cached_users: typing.Optional[
+            typing.Mapping[snowflakes.Snowflake, cache_utility.GenericRefWrapper[users.User]]
+        ] = None,
     ) -> guilds.Member:
         if cached_users is None:
             user = copy.copy(self._user_entries[member_data.id].object)
@@ -1460,13 +823,15 @@ class StatefulCacheImpl(cache.MutableCache):
         return member_data.build_entity(guilds.Member, user=user)
 
     @staticmethod
-    def _can_remove_member(member: _MemberData, guild_record: _GuildRecord) -> bool:
+    def _can_remove_member(member: cache_utility.MemberData, guild_record: cache_utility.GuildRecord) -> bool:
         if member.has_been_deleted is False:
             return False
 
         return bool(not guild_record.voice_states or member.id not in guild_record.voice_states)
 
-    def _garbage_collect_member(self, guild_record: _GuildRecord, member: _MemberData) -> None:
+    def _garbage_collect_member(
+        self, guild_record: cache_utility.GuildRecord, member: cache_utility.MemberData
+    ) -> None:
         if guild_record.members is None or member.id not in guild_record.members:
             return
 
@@ -1478,7 +843,9 @@ class StatefulCacheImpl(cache.MutableCache):
             guild_record.members = None
             self._remove_guild_record_if_empty(member.guild_id)
 
-    def _chainable_remove_member(self, member: _MemberData, guild_record: _GuildRecord) -> typing.Optional[_MemberData]:
+    def _chainable_remove_member(
+        self, member: cache_utility.MemberData, guild_record: cache_utility.GuildRecord
+    ) -> typing.Optional[cache_utility.MemberData]:
         assert guild_record.members is not None
         member.has_been_deleted = True
         if not self._can_remove_member(member, guild_record):
@@ -1497,39 +864,40 @@ class StatefulCacheImpl(cache.MutableCache):
         self,
     ) -> cache.CacheView[snowflakes.Snowflake, cache.CacheView[snowflakes.Snowflake, guilds.Member]]:
         views = {}
-        cached_users = _copy_mapping(self._user_entries)
+        cached_users = cache_utility.copy_mapping(self._user_entries)
 
-        def build_member(member: _MemberData) -> guilds.Member:
+        def build_member(member: cache_utility.MemberData) -> guilds.Member:
             return self._build_member(member, cached_users=cached_users)
 
-        for guild_id, guild_record in _copy_mapping(self._guild_entries).items():
+        for guild_id, guild_record in cache_utility.copy_mapping(self._guild_entries).items():
             if not guild_record.members:
                 continue
 
             #  This takes roughly half the time a two-layered for loop where we
             #  assign to the members dict on every inner-iteration takes.
             members_gen = (
-                self._chainable_remove_member(m, guild_record) for m in _copy_mapping(guild_record.members).values()
+                self._chainable_remove_member(m, guild_record)
+                for m in cache_utility.copy_mapping(guild_record.members).values()
             )
             # _chainable_remove_member will only return the member data object if they could be removed, else None.
             cached_members = {member.id: member for member in members_gen if member is not None}
-            views[guild_id] = _StatefulCacheMappingView(cached_members, builder=build_member)
+            views[guild_id] = cache_utility.StatefulCacheMappingView(cached_members, builder=build_member)
 
-        return _StatefulCacheMappingView(views)
+        return cache_utility.StatefulCacheMappingView(views)
 
     def clear_members_for_guild(
         self, guild_id: snowflakes.Snowflake, /
     ) -> cache.CacheView[snowflakes.Snowflake, guilds.Member]:
         guild_record = self._guild_entries.get(guild_id)
         if guild_record is None or guild_record.members is None:
-            return _EmptyCacheView()
+            return cache_utility.EmptyCacheView()
 
-        cached_members = _copy_mapping(guild_record.members)
+        cached_members = cache_utility.copy_mapping(guild_record.members)
         members_gen = (self._chainable_remove_member(m, guild_record) for m in cached_members.values())
         # _chainable_remove_member will only return the member data object if they could be removed, else None.
         cached_members = {member.id: member for member in members_gen if member is not None}
         cached_users = {user_id: self._user_entries[user_id] for user_id in cached_members}
-        return _StatefulCacheMappingView(
+        return cache_utility.StatefulCacheMappingView(
             cached_members, builder=lambda member: self._build_member(member, cached_users=cached_users)
         )
 
@@ -1561,15 +929,15 @@ class StatefulCacheImpl(cache.MutableCache):
     def get_members_view(
         self,
     ) -> cache.CacheView[snowflakes.Snowflake, cache.CacheView[snowflakes.Snowflake, guilds.Member]]:
-        cached_users = _copy_mapping(self._user_entries)
+        cached_users = cache_utility.copy_mapping(self._user_entries)
 
-        def member_builder(member: _MemberData) -> guilds.Member:
+        def member_builder(member: cache_utility.MemberData) -> guilds.Member:
             return self._build_member(member, cached_users=cached_users)
 
-        return _3DCacheMappingView(
+        return cache_utility.Cache3DMappingView(
             {
-                guild_id: _StatefulCacheMappingView(view.members, builder=member_builder)
-                for guild_id, view in _copy_mapping(self._guild_entries).items()
+                guild_id: cache_utility.StatefulCacheMappingView(view.members, builder=member_builder)
+                for guild_id, view in cache_utility.copy_mapping(self._guild_entries).items()
                 if view.members
             }
         )
@@ -1579,23 +947,23 @@ class StatefulCacheImpl(cache.MutableCache):
     ) -> cache.CacheView[snowflakes.Snowflake, guilds.Member]:
         guild_record = self._guild_entries.get(guild_id)
         if guild_record is None or guild_record.members is None:
-            return _EmptyCacheView()
+            return cache_utility.EmptyCacheView()
 
         cached_members = {
             user_id: member
-            for user_id, member in _copy_mapping(guild_record.members).items()
+            for user_id, member in cache_utility.copy_mapping(guild_record.members).items()
             if not member.has_been_deleted
         }
         cached_users = {user_id: self._user_entries[user_id] for user_id in cached_members}
 
-        return _StatefulCacheMappingView(
+        return cache_utility.StatefulCacheMappingView(
             cached_members, builder=lambda member: self._build_member(member, cached_users=cached_users)
         )
 
     def set_member(self, member: guilds.Member, /) -> None:
         guild_record = self._get_or_create_guild_record(member.guild_id)
         self.set_user(member.user)
-        member_data = _MemberData.build_from_entity(member)
+        member_data = cache_utility.MemberData.build_from_entity(member)
 
         if guild_record.members is None:  # TODO: test when this is not None
             guild_record.members = {}
@@ -1614,13 +982,16 @@ class StatefulCacheImpl(cache.MutableCache):
 
     def _build_presence(
         self,
-        presence_data: _MemberPresenceData,
+        presence_data: cache_utility.MemberPresenceData,
         cached_emojis: typing.Optional[
             typing.Mapping[
-                snowflakes.Snowflake, typing.Union[_GenericRefWrapper[emojis.CustomEmoji], _KnownCustomEmojiData],
+                snowflakes.Snowflake,
+                typing.Union[cache_utility.GenericRefWrapper[emojis.CustomEmoji], cache_utility.KnownCustomEmojiData],
             ]
         ] = None,
-        cached_users: typing.Optional[typing.Mapping[snowflakes.Snowflake, _GenericRefWrapper[users.User]]] = None,
+        cached_users: typing.Optional[
+            typing.Mapping[snowflakes.Snowflake, cache_utility.GenericRefWrapper[users.User]]
+        ] = None,
     ) -> presences.MemberPresence:
         presence_kwargs: typing.MutableSequence[typing.Mapping[str, typing.Optional[emojis.Emoji]]] = []
         for activity_data in presence_data.activities:
@@ -1633,7 +1004,7 @@ class StatefulCacheImpl(cache.MutableCache):
 
             elif cached_emojis:
                 emoji = cached_emojis[identifier]
-                if isinstance(emoji, _KnownCustomEmojiData):
+                if isinstance(emoji, cache_utility.KnownCustomEmojiData):
                     presence_kwargs.append({"emoji": self._build_emoji(emoji, cached_users=cached_users)})
                 else:
                     presence_kwargs.append({"emoji": copy.copy(emoji.object)})
@@ -1659,11 +1030,12 @@ class StatefulCacheImpl(cache.MutableCache):
 
     def _chainable_remove_presence_assets(
         self,
-        presence_data: _MemberPresenceData,
+        presence_data: cache_utility.MemberPresenceData,
         cached_emojis: typing.MutableMapping[
-            snowflakes.Snowflake, typing.Union[_KnownCustomEmojiData, _GenericRefWrapper[emojis.CustomEmoji]],
+            snowflakes.Snowflake,
+            typing.Union[cache_utility.KnownCustomEmojiData, cache_utility.GenericRefWrapper[emojis.CustomEmoji]],
         ],
-        cached_users: typing.MutableMapping[snowflakes.Snowflake, _GenericRefWrapper[users.User]],
+        cached_users: typing.MutableMapping[snowflakes.Snowflake, cache_utility.GenericRefWrapper[users.User]],
     ) -> None:
         for activity_data in presence_data.activities:
             emoji_identifier = activity_data.emoji_id_or_name
@@ -1692,47 +1064,53 @@ class StatefulCacheImpl(cache.MutableCache):
     ) -> cache.CacheView[snowflakes.Snowflake, cache.CacheView[snowflakes.Snowflake, presences.MemberPresence]]:
         views = {}
         cached_emojis: typing.MutableMapping[
-            snowflakes.Snowflake, typing.Union[_GenericRefWrapper[emojis.CustomEmoji], _KnownCustomEmojiData],
+            snowflakes.Snowflake,
+            typing.Union[cache_utility.GenericRefWrapper[emojis.CustomEmoji], cache_utility.KnownCustomEmojiData],
         ] = {}
-        cached_users: typing.MutableMapping[snowflakes.Snowflake, _GenericRefWrapper[users.User]] = {}
+        cached_users: typing.MutableMapping[snowflakes.Snowflake, cache_utility.GenericRefWrapper[users.User]] = {}
 
-        def build_presence(presence: _MemberPresenceData) -> presences.MemberPresence:
+        def build_presence(presence: cache_utility.MemberPresenceData) -> presences.MemberPresence:
             return self._build_presence(presence, cached_users=cached_users, cached_emojis=cached_emojis)
 
-        for guild_id, guild_record in _copy_mapping(self._guild_entries).items():
+        for guild_id, guild_record in cache_utility.copy_mapping(self._guild_entries).items():
             if not guild_record.presences:
                 continue
 
-            cached_presences: typing.MutableMapping[snowflakes.Snowflake, _MemberPresenceData] = guild_record.presences
+            cached_presences: typing.MutableMapping[
+                snowflakes.Snowflake, cache_utility.MemberPresenceData
+            ] = guild_record.presences
             guild_record.presences = None
 
             for presence in cached_presences.values():
                 self._chainable_remove_presence_assets(presence, cached_emojis, cached_users)
 
             self._remove_guild_record_if_empty(guild_id)
-            views[guild_id] = _StatefulCacheMappingView(cached_presences, builder=build_presence)
+            views[guild_id] = cache_utility.StatefulCacheMappingView(cached_presences, builder=build_presence)
 
-        return _StatefulCacheMappingView(views)
+        return cache_utility.StatefulCacheMappingView(views)
 
     def clear_presences_for_guild(
         self, guild_id: snowflakes.Snowflake, /
     ) -> cache.CacheView[snowflakes.Snowflake, presences.MemberPresence]:
         guild_record = self._guild_entries.get(guild_id)
         if guild_record is None or guild_record.presences is None:
-            return _EmptyCacheView()
+            return cache_utility.EmptyCacheView()
 
         cached_emojis: typing.MutableMapping[
-            snowflakes.Snowflake, typing.Union[_GenericRefWrapper[emojis.CustomEmoji], _KnownCustomEmojiData],
+            snowflakes.Snowflake,
+            typing.Union[cache_utility.GenericRefWrapper[emojis.CustomEmoji], cache_utility.KnownCustomEmojiData],
         ] = {}
-        cached_users: typing.MutableMapping[snowflakes.Snowflake, _GenericRefWrapper[users.User]] = {}
-        cached_presences: typing.MutableMapping[snowflakes.Snowflake, _MemberPresenceData] = guild_record.presences
+        cached_users: typing.MutableMapping[snowflakes.Snowflake, cache_utility.GenericRefWrapper[users.User]] = {}
+        cached_presences: typing.MutableMapping[
+            snowflakes.Snowflake, cache_utility.MemberPresenceData
+        ] = guild_record.presences
         guild_record.presences = None
 
         for presence in cached_presences.values():
             self._chainable_remove_presence_assets(presence, cached_emojis, cached_users)
 
         self._remove_guild_record_if_empty(guild_id)
-        return _StatefulCacheMappingView(
+        return cache_utility.StatefulCacheMappingView(
             cached_presences,
             builder=lambda presence_data_: self._build_presence(
                 presence_data_, cached_users=cached_users, cached_emojis=cached_emojis
@@ -1773,11 +1151,12 @@ class StatefulCacheImpl(cache.MutableCache):
 
     def _chainable_get_presence_assets(
         self,
-        presence_data: _MemberPresenceData,
+        presence_data: cache_utility.MemberPresenceData,
         cached_emojis: typing.MutableMapping[
-            snowflakes.Snowflake, typing.Union[_KnownCustomEmojiData, _GenericRefWrapper[emojis.CustomEmoji]],
+            snowflakes.Snowflake,
+            typing.Union[cache_utility.KnownCustomEmojiData, cache_utility.GenericRefWrapper[emojis.CustomEmoji]],
         ],
-        cached_users: typing.MutableMapping[snowflakes.Snowflake, _GenericRefWrapper[users.User]],
+        cached_users: typing.MutableMapping[snowflakes.Snowflake, cache_utility.GenericRefWrapper[users.User]],
     ) -> None:
         for activity_data in presence_data.activities:
             emoji_identifier = activity_data.emoji_id_or_name
@@ -1802,43 +1181,45 @@ class StatefulCacheImpl(cache.MutableCache):
         views = {}
 
         cached_emojis: typing.MutableMapping[
-            snowflakes.Snowflake, typing.Union[_GenericRefWrapper[emojis.CustomEmoji], _KnownCustomEmojiData],
-        ] = _copy_mapping(self._unknown_custom_emoji_entries)
-        cached_users: typing.MutableMapping[snowflakes.Snowflake, _GenericRefWrapper[users.User]] = {}
+            snowflakes.Snowflake,
+            typing.Union[cache_utility.GenericRefWrapper[emojis.CustomEmoji], cache_utility.KnownCustomEmojiData],
+        ] = cache_utility.copy_mapping(self._unknown_custom_emoji_entries)
+        cached_users: typing.MutableMapping[snowflakes.Snowflake, cache_utility.GenericRefWrapper[users.User]] = {}
 
-        def presence_builder(presence: _MemberPresenceData) -> presences.MemberPresence:
+        def presence_builder(presence: cache_utility.MemberPresenceData) -> presences.MemberPresence:
             return self._build_presence(presence, cached_users=cached_users, cached_emojis=cached_emojis)
 
-        for guild_id, guild_record in _copy_mapping(self._guild_entries).items():
+        for guild_id, guild_record in cache_utility.copy_mapping(self._guild_entries).items():
             if not guild_record.presences:
                 continue
 
-            cached_presences = _copy_mapping(guild_record.presences)
+            cached_presences = cache_utility.copy_mapping(guild_record.presences)
 
             for presence in cached_presences.values():
                 self._chainable_get_presence_assets(presence, cached_emojis, cached_users)
 
-            views[guild_id] = _StatefulCacheMappingView(cached_presences, builder=presence_builder)
+            views[guild_id] = cache_utility.StatefulCacheMappingView(cached_presences, builder=presence_builder)
 
-        return _3DCacheMappingView(views)
+        return cache_utility.Cache3DMappingView(views)
 
     def get_presences_view_for_guild(
         self, guild_id: snowflakes.Snowflake, /
     ) -> cache.CacheView[snowflakes.Snowflake, presences.MemberPresence]:
         guild_record = self._guild_entries.get(guild_id)
         if guild_record is None or guild_record.presences is None:
-            return _EmptyCacheView()
+            return cache_utility.EmptyCacheView()
 
         cached_emojis: typing.MutableMapping[
-            snowflakes.Snowflake, typing.Union[_GenericRefWrapper[emojis.CustomEmoji], _KnownCustomEmojiData],
+            snowflakes.Snowflake,
+            typing.Union[cache_utility.GenericRefWrapper[emojis.CustomEmoji], cache_utility.KnownCustomEmojiData],
         ] = {}
-        cached_users: typing.MutableMapping[snowflakes.Snowflake, _GenericRefWrapper[users.User]] = {}
-        cached_presences = _copy_mapping(guild_record.presences)
+        cached_users: typing.MutableMapping[snowflakes.Snowflake, cache_utility.GenericRefWrapper[users.User]] = {}
+        cached_presences = cache_utility.copy_mapping(guild_record.presences)
 
         for presence in cached_presences.values():
             self._chainable_get_presence_assets(presence, cached_emojis, cached_users)
 
-        return _StatefulCacheMappingView(
+        return cache_utility.StatefulCacheMappingView(
             cached_presences,
             builder=lambda presence_data_: self._build_presence(
                 presence_data_, cached_users=cached_users, cached_emojis=cached_emojis
@@ -1846,7 +1227,7 @@ class StatefulCacheImpl(cache.MutableCache):
         )
 
     def set_presence(self, presence: presences.MemberPresence, /) -> None:
-        presence_data = _MemberPresenceData.build_from_entity(presence)
+        presence_data = cache_utility.MemberPresenceData.build_from_entity(presence)
 
         for activity in presence.activities:
             emoji = activity.emoji
@@ -1861,7 +1242,9 @@ class StatefulCacheImpl(cache.MutableCache):
                 self._unknown_custom_emoji_entries[emoji.id].object = copy.copy(emoji)
 
             else:
-                self._unknown_custom_emoji_entries[emoji.id] = _GenericRefWrapper(object=copy.copy(emoji), ref_count=1)
+                self._unknown_custom_emoji_entries[emoji.id] = cache_utility.GenericRefWrapper(
+                    object=copy.copy(emoji), ref_count=1
+                )
 
         guild_record = self._get_or_create_guild_record(presence.guild_id)
         if guild_record.presences is None:
@@ -1878,26 +1261,28 @@ class StatefulCacheImpl(cache.MutableCache):
 
     def clear_roles(self) -> cache.CacheView[snowflakes.Snowflake, guilds.Role]:
         if not self._role_entries:
-            return _EmptyCacheView()
+            return cache_utility.EmptyCacheView()
 
         roles = self._role_entries
         self._role_entries = {}
 
-        for guild_id, guild_record in _copy_mapping(self._guild_entries).items():
+        for guild_id, guild_record in cache_utility.copy_mapping(self._guild_entries).items():
             if guild_record.roles is not None:  # TODO: test coverage for this
                 guild_record.roles = None
                 self._remove_guild_record_if_empty(guild_id)
 
-        return _StatefulCacheMappingView(roles)
+        return cache_utility.StatefulCacheMappingView(roles)
 
     def clear_roles_for_guild(
         self, guild_id: snowflakes.Snowflake, /
     ) -> cache.CacheView[snowflakes.Snowflake, guilds.Role]:
         guild_record = self._guild_entries.get(guild_id)
         if guild_record is None or not guild_record.roles:
-            return _EmptyCacheView()
+            return cache_utility.EmptyCacheView()
 
-        view = _StatefulCacheMappingView({role_id: self._role_entries[role_id] for role_id in guild_record.roles})
+        view = cache_utility.StatefulCacheMappingView(
+            {role_id: self._role_entries[role_id] for role_id in guild_record.roles}
+        )
         guild_record.roles = None
         self._remove_guild_record_if_empty(guild_id)
         return view
@@ -1921,19 +1306,19 @@ class StatefulCacheImpl(cache.MutableCache):
         return self._role_entries.get(role_id)
 
     def get_roles_view(self) -> cache.CacheView[snowflakes.Snowflake, guilds.Role]:
-        cached_roles = _copy_mapping(self._role_entries)
-        return _StatefulCacheMappingView(cached_roles)
+        cached_roles = cache_utility.copy_mapping(self._role_entries)
+        return cache_utility.StatefulCacheMappingView(cached_roles)
 
     def get_roles_view_for_guild(
         self, guild_id: snowflakes.Snowflake, /
     ) -> cache.CacheView[snowflakes.Snowflake, guilds.Role]:
         guild_record = self._guild_entries.get(guild_id)
         if guild_record is None or guild_record.roles is None:
-            return _EmptyCacheView()
+            return cache_utility.EmptyCacheView()
 
         # Tuple casts like this avoids edge case issues which would be caused by arrays being modified while we're
         # iterating over them.
-        return _StatefulCacheMappingView(
+        return cache_utility.StatefulCacheMappingView(
             {role_id: self._role_entries[role_id] for role_id in tuple(guild_record.roles)}
         )
 
@@ -1942,7 +1327,7 @@ class StatefulCacheImpl(cache.MutableCache):
         guild_record = self._get_or_create_guild_record(role.guild_id)
 
         if guild_record.roles is None:  # TODO: test when this is not None
-            guild_record.roles = _IDTable()
+            guild_record.roles = cache_utility.IDTable()
 
         guild_record.roles.add(role.id)
 
@@ -1954,7 +1339,7 @@ class StatefulCacheImpl(cache.MutableCache):
         return cached_role, self.get_role(role.id)
 
     @staticmethod
-    def _can_remove_user(user_data: typing.Optional[_GenericRefWrapper[users.User]]) -> bool:
+    def _can_remove_user(user_data: typing.Optional[cache_utility.GenericRefWrapper[users.User]]) -> bool:
         return bool(user_data and user_data.ref_count == 0)
 
     def _increment_user_ref_count(self, user_id: snowflakes.Snowflake, increment: int = 1) -> None:
@@ -1969,18 +1354,18 @@ class StatefulCacheImpl(cache.MutableCache):
 
     def clear_users(self) -> cache.CacheView[snowflakes.Snowflake, users.User]:
         if not self._user_entries:
-            return _EmptyCacheView()
+            return cache_utility.EmptyCacheView()
 
         cached_users = {}
 
-        for user_id, user in _copy_mapping(self._user_entries).items():
+        for user_id, user in cache_utility.copy_mapping(self._user_entries).items():
             if user.ref_count > 0:
                 continue
 
             cached_users[user_id] = user.object
             del self._user_entries[user_id]
 
-        return _StatefulCacheMappingView(cached_users) if cached_users else _EmptyCacheView()
+        return cache_utility.StatefulCacheMappingView(cached_users) if cached_users else cache_utility.EmptyCacheView()
 
     def delete_user(self, user_id: snowflakes.Snowflake, /) -> typing.Optional[users.User]:
         if self._can_remove_user(self._user_entries.get(user_id)):
@@ -1993,16 +1378,16 @@ class StatefulCacheImpl(cache.MutableCache):
 
     def get_users_view(self) -> cache.CacheView[snowflakes.Snowflake, users.User]:
         if not self._user_entries:
-            return _EmptyCacheView()
+            return cache_utility.EmptyCacheView()
 
-        cached_users = _copy_mapping(self._user_entries)
-        return _StatefulCacheMappingView(cached_users, unpack=True)
+        cached_users = cache_utility.copy_mapping(self._user_entries)
+        return cache_utility.StatefulCacheMappingView(cached_users, unpack=True)
 
     def set_user(self, user: users.User, /) -> None:
         try:
             self._user_entries[user.id].object = copy.copy(user)
         except KeyError:
-            self._user_entries[user.id] = _GenericRefWrapper(object=copy.copy(user), ref_count=0)
+            self._user_entries[user.id] = cache_utility.GenericRefWrapper(object=copy.copy(user), ref_count=0)
 
     def update_user(
         self, user: users.User, /
@@ -2013,9 +1398,11 @@ class StatefulCacheImpl(cache.MutableCache):
 
     def _build_voice_state(
         self,
-        voice_data: _VoiceStateData,
-        cached_members: typing.Optional[typing.Mapping[snowflakes.Snowflake, _MemberData]] = None,
-        cached_users: typing.Optional[typing.Mapping[snowflakes.Snowflake, _GenericRefWrapper[users.User]]] = None,
+        voice_data: cache_utility.VoiceStateData,
+        cached_members: typing.Optional[typing.Mapping[snowflakes.Snowflake, cache_utility.MemberData]] = None,
+        cached_users: typing.Optional[
+            typing.Mapping[snowflakes.Snowflake, cache_utility.GenericRefWrapper[users.User]]
+        ] = None,
     ) -> voices.VoiceState:
         if cached_members:
             member = self._build_member(cached_members[voice_data.user_id], cached_users=cached_users)
@@ -2029,10 +1416,10 @@ class StatefulCacheImpl(cache.MutableCache):
 
     def _chainable_remove_voice_state_assets(
         self,
-        voice_state: _VoiceStateData,
-        guild_record: _GuildRecord,
-        cached_members: typing.MutableMapping[snowflakes.Snowflake, _MemberData],
-        cached_users: typing.MutableMapping[snowflakes.Snowflake, _GenericRefWrapper[users.User]],
+        voice_state: cache_utility.VoiceStateData,
+        guild_record: cache_utility.GuildRecord,
+        cached_members: typing.MutableMapping[snowflakes.Snowflake, cache_utility.MemberData],
+        cached_users: typing.MutableMapping[snowflakes.Snowflake, cache_utility.GenericRefWrapper[users.User]],
     ) -> None:
         assert guild_record.members is not None
         member = guild_record.members[voice_state.user_id]
@@ -2047,44 +1434,46 @@ class StatefulCacheImpl(cache.MutableCache):
         self,
     ) -> cache.CacheView[snowflakes.Snowflake, cache.CacheView[snowflakes.Snowflake, voices.VoiceState]]:
         views: typing.MutableMapping[
-            snowflakes.Snowflake, _StatefulCacheMappingView[snowflakes.Snowflake, voices.VoiceState]
+            snowflakes.Snowflake, cache_utility.StatefulCacheMappingView[snowflakes.Snowflake, voices.VoiceState]
         ] = {}
-        cached_users: typing.MutableMapping[snowflakes.Snowflake, _GenericRefWrapper[users.User]] = {}
+        cached_users: typing.MutableMapping[snowflakes.Snowflake, cache_utility.GenericRefWrapper[users.User]] = {}
 
         def builder_generator(
-            cached_members_: typing.MutableMapping[snowflakes.Snowflake, _MemberData]
-        ) -> typing.Callable[[_VoiceStateData], voices.VoiceState]:
+            cached_members_: typing.MutableMapping[snowflakes.Snowflake, cache_utility.MemberData]
+        ) -> typing.Callable[[cache_utility.VoiceStateData], voices.VoiceState]:
             return lambda voice_data: self._build_voice_state(
                 voice_data, cached_members=cached_members_, cached_users=cached_users
             )
 
-        for guild_id, guild_record in _copy_mapping(self._guild_entries).items():
+        for guild_id, guild_record in cache_utility.copy_mapping(self._guild_entries).items():
             if not guild_record.voice_states:
                 continue
 
             assert guild_record.members is not None
             cached_voice_states = guild_record.voice_states
             guild_record.voice_states = None
-            cached_members: typing.MutableMapping[snowflakes.Snowflake, _MemberData] = {}
+            cached_members: typing.MutableMapping[snowflakes.Snowflake, cache_utility.MemberData] = {}
 
             for voice_state in cached_voice_states.values():
                 self._chainable_remove_voice_state_assets(voice_state, guild_record, cached_members, cached_users)
 
             self._remove_guild_record_if_empty(guild_id)
-            views[guild_id] = _StatefulCacheMappingView(cached_voice_states, builder=builder_generator(cached_members))
+            views[guild_id] = cache_utility.StatefulCacheMappingView(
+                cached_voice_states, builder=builder_generator(cached_members)
+            )
 
-        return _StatefulCacheMappingView(views)
+        return cache_utility.StatefulCacheMappingView(views)
 
     def clear_voice_states_for_channel(
         self, guild_id: snowflakes.Snowflake, channel_id: snowflakes.Snowflake, /
     ) -> cache.CacheView[snowflakes.Snowflake, voices.VoiceState]:
         guild_record = self._guild_entries.get(guild_id)
         if guild_record is None or not guild_record.voice_states:
-            return _EmptyCacheView()
+            return cache_utility.EmptyCacheView()
 
         assert guild_record.members is not None
-        cached_members: typing.MutableMapping[snowflakes.Snowflake, _MemberData] = {}
-        cached_users: typing.MutableMapping[snowflakes.Snowflake, _GenericRefWrapper[users.User]] = {}
+        cached_members: typing.MutableMapping[snowflakes.Snowflake, cache_utility.MemberData] = {}
+        cached_users: typing.MutableMapping[snowflakes.Snowflake, cache_utility.GenericRefWrapper[users.User]] = {}
         cached_voice_states = {}
 
         for user_id, voice_state in guild_record.voice_states.items():
@@ -2096,7 +1485,7 @@ class StatefulCacheImpl(cache.MutableCache):
             guild_record.voice_states = None
             self._remove_guild_record_if_empty(guild_id)
 
-        return _StatefulCacheMappingView(
+        return cache_utility.StatefulCacheMappingView(
             cached_voice_states,
             builder=lambda voice_state: self._build_voice_state(
                 voice_state, cached_members=cached_members, cached_users=cached_users
@@ -2109,19 +1498,19 @@ class StatefulCacheImpl(cache.MutableCache):
         guild_record = self._guild_entries.get(guild_id)
 
         if guild_record is None or guild_record.voice_states is None:
-            return _EmptyCacheView()
+            return cache_utility.EmptyCacheView()
 
         assert guild_record.members is not None
         cached_voice_states = guild_record.voice_states
         guild_record.voice_states = None
-        cached_members: typing.MutableMapping[snowflakes.Snowflake, _MemberData] = {}
-        cached_users: typing.MutableMapping[snowflakes.Snowflake, _GenericRefWrapper[users.User]] = {}
+        cached_members: typing.MutableMapping[snowflakes.Snowflake, cache_utility.MemberData] = {}
+        cached_users: typing.MutableMapping[snowflakes.Snowflake, cache_utility.GenericRefWrapper[users.User]] = {}
 
         for voice_state in cached_voice_states.values():
             self._chainable_remove_voice_state_assets(voice_state, guild_record, cached_members, cached_users)
 
         self._remove_guild_record_if_empty(guild_id)
-        return _StatefulCacheMappingView(
+        return cache_utility.StatefulCacheMappingView(
             cached_voice_states,
             builder=lambda voice_data: self._build_voice_state(
                 voice_data, cached_members=cached_members, cached_users=cached_users
@@ -2156,10 +1545,10 @@ class StatefulCacheImpl(cache.MutableCache):
 
     def _chainable_get_voice_states_assets(
         self,
-        voice_state: _VoiceStateData,
-        guild_record: _GuildRecord,
-        cached_members: typing.MutableMapping[snowflakes.Snowflake, _MemberData],
-        cached_users: typing.MutableMapping[snowflakes.Snowflake, _GenericRefWrapper[users.User]],
+        voice_state: cache_utility.VoiceStateData,
+        guild_record: cache_utility.GuildRecord,
+        cached_members: typing.MutableMapping[snowflakes.Snowflake, cache_utility.MemberData],
+        cached_users: typing.MutableMapping[snowflakes.Snowflake, cache_utility.GenericRefWrapper[users.User]],
     ) -> None:
         assert guild_record.members is not None
         cached_members[voice_state.user_id] = guild_record.members[voice_state.user_id]
@@ -2171,48 +1560,50 @@ class StatefulCacheImpl(cache.MutableCache):
         self,
     ) -> cache.CacheView[snowflakes.Snowflake, cache.CacheView[snowflakes.Snowflake, voices.VoiceState]]:
         views: typing.MutableMapping[
-            snowflakes.Snowflake, _StatefulCacheMappingView[snowflakes.Snowflake, voices.VoiceState]
+            snowflakes.Snowflake, cache_utility.StatefulCacheMappingView[snowflakes.Snowflake, voices.VoiceState]
         ] = {}
-        cached_users: typing.MutableMapping[snowflakes.Snowflake, _GenericRefWrapper[users.User]] = {}
-        cached_members: typing.MutableMapping[snowflakes.Snowflake, _MemberData]
+        cached_users: typing.MutableMapping[snowflakes.Snowflake, cache_utility.GenericRefWrapper[users.User]] = {}
+        cached_members: typing.MutableMapping[snowflakes.Snowflake, cache_utility.MemberData]
 
         def builder_generator(
-            cached_members_: typing.MutableMapping[snowflakes.Snowflake, _MemberData]
-        ) -> typing.Callable[[_VoiceStateData], voices.VoiceState]:
+            cached_members_: typing.MutableMapping[snowflakes.Snowflake, cache_utility.MemberData]
+        ) -> typing.Callable[[cache_utility.VoiceStateData], voices.VoiceState]:
             return lambda voice_state_: self._build_voice_state(
                 voice_state_, cached_members=cached_members_, cached_users=cached_users
             )
 
-        for guild_id, guild_record in _copy_mapping(self._guild_entries).items():
+        for guild_id, guild_record in cache_utility.copy_mapping(self._guild_entries).items():
             if not guild_record.voice_states:
                 continue
 
-            cached_voice_states = _copy_mapping(guild_record.voice_states)
+            cached_voice_states = cache_utility.copy_mapping(guild_record.voice_states)
             cached_members = {}
 
             for voice_state in cached_voice_states.values():
                 self._chainable_get_voice_states_assets(voice_state, guild_record, cached_members, cached_users)
 
-            views[guild_id] = _StatefulCacheMappingView(cached_voice_states, builder=builder_generator(cached_members))
+            views[guild_id] = cache_utility.StatefulCacheMappingView(
+                cached_voice_states, builder=builder_generator(cached_members)
+            )
 
-        return _3DCacheMappingView(views)
+        return cache_utility.Cache3DMappingView(views)
 
     def get_voice_states_view_for_channel(
         self, guild_id: snowflakes.Snowflake, channel_id: snowflakes.Snowflake, /
     ) -> cache.CacheView[snowflakes.Snowflake, voices.VoiceState]:
         guild_record = self._guild_entries.get(guild_id)
         if guild_record is None or guild_record.voice_states is None:
-            return _EmptyCacheView()
+            return cache_utility.EmptyCacheView()
 
-        cached_members: typing.MutableMapping[snowflakes.Snowflake, _MemberData] = {}
-        cached_users: typing.MutableMapping[snowflakes.Snowflake, _GenericRefWrapper[users.User]] = {}
-        cached_voice_states = _copy_mapping(guild_record.voice_states)
+        cached_members: typing.MutableMapping[snowflakes.Snowflake, cache_utility.MemberData] = {}
+        cached_users: typing.MutableMapping[snowflakes.Snowflake, cache_utility.GenericRefWrapper[users.User]] = {}
+        cached_voice_states = cache_utility.copy_mapping(guild_record.voice_states)
 
         for voice_state in cached_voice_states.values():
             if voice_state.channel_id == channel_id:
                 self._chainable_get_voice_states_assets(voice_state, guild_record, cached_members, cached_users)
 
-        return _StatefulCacheMappingView(
+        return cache_utility.StatefulCacheMappingView(
             cached_voice_states,
             builder=lambda voice_data: self._build_voice_state(
                 voice_data, cached_members=cached_members, cached_users=cached_users
@@ -2224,16 +1615,16 @@ class StatefulCacheImpl(cache.MutableCache):
     ) -> cache.CacheView[snowflakes.Snowflake, voices.VoiceState]:
         guild_record = self._guild_entries.get(guild_id)
         if guild_record is None or guild_record.voice_states is None:
-            return _EmptyCacheView()
+            return cache_utility.EmptyCacheView()
 
-        voice_states = _copy_mapping(guild_record.voice_states)
-        cached_members: typing.MutableMapping[snowflakes.Snowflake, _MemberData] = {}
-        cached_users: typing.MutableMapping[snowflakes.Snowflake, _GenericRefWrapper[users.User]] = {}
+        voice_states = cache_utility.copy_mapping(guild_record.voice_states)
+        cached_members: typing.MutableMapping[snowflakes.Snowflake, cache_utility.MemberData] = {}
+        cached_users: typing.MutableMapping[snowflakes.Snowflake, cache_utility.GenericRefWrapper[users.User]] = {}
 
         for voice_state in voice_states.values():
             self._chainable_get_voice_states_assets(voice_state, guild_record, cached_members, cached_users)
 
-        return _StatefulCacheMappingView(
+        return cache_utility.StatefulCacheMappingView(
             voice_states,
             builder=lambda voice_data: self._build_voice_state(
                 voice_data, cached_members=cached_members, cached_users=cached_users
@@ -2250,7 +1641,7 @@ class StatefulCacheImpl(cache.MutableCache):
         self.set_member(voice_state.member)
         assert guild_record.members is not None
         guild_record.members[voice_state.member.id].has_been_deleted = True
-        guild_record.voice_states[voice_state.user_id] = _VoiceStateData.build_from_entity(voice_state)
+        guild_record.voice_states[voice_state.user_id] = cache_utility.VoiceStateData.build_from_entity(voice_state)
 
     def update_voice_state(
         self, voice_state: voices.VoiceState, /

--- a/hikari/impl/stateless_cache.py
+++ b/hikari/impl/stateless_cache.py
@@ -31,6 +31,7 @@ __all__: typing.Final[typing.List[str]] = ["StatelessCacheImpl"]
 import typing
 
 from hikari.api import cache
+from hikari.utilities import cache as cache_utilities
 
 if typing.TYPE_CHECKING:
     from hikari import channels
@@ -62,12 +63,6 @@ class StatelessCacheImpl(cache.MutableCache):
     def __init__(self) -> None:
         self._me: typing.Optional[users.OwnUser] = None
 
-    def get_me(self) -> typing.Optional[users.OwnUser]:
-        return self._me
-
-    def set_me(self, user: users.OwnUser, /) -> None:
-        self._me = user
-
     @staticmethod
     def _no_cache() -> NotImplementedError:
         return NotImplementedError("This application is stateless, cache operations are not implemented.")
@@ -83,10 +78,10 @@ class StatelessCacheImpl(cache.MutableCache):
     def get_private_text_channel(
         self, user_id: snowflakes.Snowflake, /
     ) -> typing.Optional[channels.PrivateTextChannel]:
-        raise self._no_cache()
+        return None
 
     def get_private_text_channels_view(self) -> cache.CacheView[snowflakes.Snowflake, channels.PrivateTextChannel]:
-        raise self._no_cache()
+        return cache_utilities.EmptyCacheView()
 
     def set_private_text_channel(self, channel: channels.PrivateTextChannel, /) -> None:
         raise self._no_cache()
@@ -108,15 +103,15 @@ class StatelessCacheImpl(cache.MutableCache):
         raise self._no_cache()
 
     def get_emoji(self, emoji_id: snowflakes.Snowflake, /) -> typing.Optional[emojis.KnownCustomEmoji]:
-        raise self._no_cache()
+        return None
 
     def get_emojis_view(self) -> cache.CacheView[snowflakes.Snowflake, emojis.KnownCustomEmoji]:
-        raise self._no_cache()
+        return cache_utilities.EmptyCacheView()
 
     def get_emojis_view_for_guild(
         self, guild_id: snowflakes.Snowflake, /
     ) -> cache.CacheView[snowflakes.Snowflake, emojis.KnownCustomEmoji]:
-        raise self._no_cache()
+        return cache_utilities.EmptyCacheView()
 
     def set_emoji(self, emoji: emojis.KnownCustomEmoji, /) -> None:
         raise self._no_cache()
@@ -133,10 +128,10 @@ class StatelessCacheImpl(cache.MutableCache):
         raise self._no_cache()
 
     def get_guild(self, guild_id: snowflakes.Snowflake, /) -> typing.Optional[guilds.GatewayGuild]:
-        raise self._no_cache()
+        return None
 
     def get_guilds_view(self) -> cache.CacheView[snowflakes.Snowflake, guilds.GatewayGuild]:
-        raise self._no_cache()
+        return cache_utilities.EmptyCacheView()
 
     def set_guild(self, guild: guilds.GatewayGuild, /) -> None:
         raise self._no_cache()
@@ -164,15 +159,15 @@ class StatelessCacheImpl(cache.MutableCache):
         raise self._no_cache()
 
     def get_guild_channel(self, channel_id: snowflakes.Snowflake, /) -> typing.Optional[channels.GuildChannel]:
-        raise self._no_cache()
+        return None
 
     def get_guild_channels_view(self) -> cache.CacheView[snowflakes.Snowflake, channels.GuildChannel]:
-        raise self._no_cache()
+        return cache_utilities.EmptyCacheView()
 
     def get_guild_channels_view_for_guild(
         self, guild_id: snowflakes.Snowflake, /
     ) -> cache.CacheView[snowflakes.Snowflake, channels.GuildChannel]:
-        raise self._no_cache()
+        return cache_utilities.EmptyCacheView()
 
     def set_guild_channel(self, channel: channels.GuildChannel, /) -> None:
         raise self._no_cache()
@@ -199,20 +194,20 @@ class StatelessCacheImpl(cache.MutableCache):
         raise self._no_cache()
 
     def get_invite(self, code: str, /) -> typing.Optional[invites.InviteWithMetadata]:
-        raise self._no_cache()
+        return None
 
     def get_invites_view(self) -> cache.CacheView[str, invites.InviteWithMetadata]:
-        raise self._no_cache()
+        return cache_utilities.EmptyCacheView()
 
     def get_invites_view_for_guild(
         self, guild_id: snowflakes.Snowflake, /
     ) -> cache.CacheView[str, invites.InviteWithMetadata]:
-        raise self._no_cache()
+        return cache_utilities.EmptyCacheView()
 
     def get_invites_view_for_channel(
         self, guild_id: snowflakes.Snowflake, channel_id: snowflakes.Snowflake, /
     ) -> cache.CacheView[str, invites.InviteWithMetadata]:
-        raise self._no_cache()
+        return cache_utilities.EmptyCacheView()
 
     def set_invite(self, invite: invites.InviteWithMetadata, /) -> None:
         raise self._no_cache()
@@ -223,12 +218,22 @@ class StatelessCacheImpl(cache.MutableCache):
         raise self._no_cache()
 
     def delete_me(self) -> typing.Optional[users.OwnUser]:
-        raise self._no_cache()
+        cached_me = self._me
+        self._me = None
+        return cached_me
+
+    def get_me(self) -> typing.Optional[users.OwnUser]:
+        return self._me
+
+    def set_me(self, user: users.OwnUser, /) -> None:
+        self._me = user
 
     def update_me(
         self, user: users.OwnUser, /
     ) -> typing.Tuple[typing.Optional[users.OwnUser], typing.Optional[users.OwnUser]]:
-        raise self._no_cache()
+        cached_me = self.get_me()
+        self.set_me(user)
+        return cached_me, self.get_me()
 
     def clear_members(
         self,
@@ -248,17 +253,17 @@ class StatelessCacheImpl(cache.MutableCache):
     def get_member(
         self, guild_id: snowflakes.Snowflake, user_id: snowflakes.Snowflake, /
     ) -> typing.Optional[guilds.Member]:
-        raise self._no_cache()
+        return None
 
     def get_members_view(
         self,
     ) -> cache.CacheView[snowflakes.Snowflake, cache.CacheView[snowflakes.Snowflake, guilds.Member]]:
-        raise self._no_cache()
+        return cache_utilities.EmptyCacheView()
 
     def get_members_view_for_guild(
         self, guild_id: snowflakes.Snowflake, /
     ) -> cache.CacheView[snowflakes.Snowflake, guilds.Member]:
-        raise self._no_cache()
+        return cache_utilities.EmptyCacheView()
 
     def set_member(self, member: guilds.Member, /) -> None:
         raise self._no_cache()
@@ -286,17 +291,17 @@ class StatelessCacheImpl(cache.MutableCache):
     def get_presence(
         self, guild_id: snowflakes.Snowflake, user_id: snowflakes.Snowflake, /
     ) -> typing.Optional[presences.MemberPresence]:
-        raise self._no_cache()
+        return None
 
     def get_presences_view(
         self,
     ) -> cache.CacheView[snowflakes.Snowflake, cache.CacheView[snowflakes.Snowflake, presences.MemberPresence]]:
-        raise self._no_cache()
+        return cache_utilities.EmptyCacheView()
 
     def get_presences_view_for_guild(
         self, guild_id: snowflakes.Snowflake, /
     ) -> cache.CacheView[snowflakes.Snowflake, presences.MemberPresence]:
-        raise self._no_cache()
+        return cache_utilities.EmptyCacheView()
 
     def set_presence(self, presence: presences.MemberPresence, /) -> None:
         raise self._no_cache()
@@ -318,15 +323,15 @@ class StatelessCacheImpl(cache.MutableCache):
         raise self._no_cache()
 
     def get_role(self, role_id: snowflakes.Snowflake, /) -> typing.Optional[guilds.Role]:
-        raise self._no_cache()
+        return None
 
     def get_roles_view(self) -> cache.CacheView[snowflakes.Snowflake, guilds.Role]:
-        raise self._no_cache()
+        return cache_utilities.EmptyCacheView()
 
     def get_roles_view_for_guild(
         self, guild_id: snowflakes.Snowflake, /
     ) -> cache.CacheView[snowflakes.Snowflake, guilds.Role]:
-        raise self._no_cache()
+        return cache_utilities.EmptyCacheView()
 
     def set_role(self, role: guilds.Role, /) -> None:
         raise self._no_cache()
@@ -343,10 +348,10 @@ class StatelessCacheImpl(cache.MutableCache):
         raise self._no_cache()
 
     def get_user(self, user_id: snowflakes.Snowflake, /) -> typing.Optional[users.User]:
-        raise self._no_cache()
+        return None
 
     def get_users_view(self) -> cache.CacheView[snowflakes.Snowflake, users.User]:
-        raise self._no_cache()
+        return cache_utilities.EmptyCacheView()
 
     def set_user(self, user: users.User, /) -> None:
         raise self._no_cache()
@@ -379,22 +384,22 @@ class StatelessCacheImpl(cache.MutableCache):
     def get_voice_state(
         self, guild_id: snowflakes.Snowflake, user_id: snowflakes.Snowflake, /
     ) -> typing.Optional[voices.VoiceState]:
-        raise self._no_cache()
+        return None
 
     def get_voice_states_view(
         self,
     ) -> cache.CacheView[snowflakes.Snowflake, cache.CacheView[snowflakes.Snowflake, voices.VoiceState]]:
-        raise self._no_cache()
+        return cache_utilities.EmptyCacheView()
 
     def get_voice_states_view_for_channel(
         self, guild_id: snowflakes.Snowflake, channel_id: snowflakes.Snowflake, /
     ) -> cache.CacheView[snowflakes.Snowflake, voices.VoiceState]:
-        raise self._no_cache()
+        return cache_utilities.EmptyCacheView()
 
     def get_voice_states_view_for_guild(
         self, guild_id: snowflakes.Snowflake, /
     ) -> cache.CacheView[snowflakes.Snowflake, voices.VoiceState]:
-        raise self._no_cache()
+        return cache_utilities.EmptyCacheView()
 
     def set_voice_state(self, voice_state: voices.VoiceState, /) -> None:
         raise self._no_cache()

--- a/hikari/utilities/cache.py
+++ b/hikari/utilities/cache.py
@@ -1,0 +1,755 @@
+# -*- coding: utf-8 -*-
+# cython: language_level=3
+# Copyright (c) 2020 Nekokatt
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Various utilities that may be used in a cache-impl."""
+from __future__ import annotations
+
+__all__: typing.Final[typing.List[str]] = [
+    "copy_mapping",
+    "IDTable",
+    "StatefulCacheMappingView",
+    "EmptyCacheView",
+    "GuildRecord",
+    "BaseData",
+    "PrivateTextChannelData",
+    "InviteData",
+    "MemberData",
+    "KnownCustomEmojiData",
+    "RichActivityData",
+    "MemberPresenceData",
+    "VoiceStateData",
+    "GenericRefWrapper",
+    "PrivateTextChannelMRUMutableMapping",
+    "copy_guild_channel",
+    "GuildChannelCacheMappingView",
+    "Cache3DMappingView",
+    "DataT",
+    "KeyT",
+    "ValueT",
+]
+
+import abc
+import array
+import bisect
+import copy
+import datetime
+import reprlib
+import typing
+
+import attr
+
+from hikari import channels
+from hikari import emojis
+from hikari import guilds
+from hikari import invites
+from hikari import iterators
+from hikari import presences
+from hikari import snowflakes
+from hikari import undefined
+from hikari import voices
+from hikari.api import cache
+from hikari.utilities import attr_extensions
+from hikari.utilities import date
+
+DataT = typing.TypeVar("DataT", bound="BaseData[typing.Any]")
+"""Type-hint for "data" objects used for storing and building entities."""
+KeyT = typing.TypeVar("KeyT", bound=typing.Hashable)
+"""Type-hint for mapping keys."""
+ValueT = typing.TypeVar("ValueT")
+"""Type-hint for mapping values."""
+
+
+def copy_mapping(mapping: typing.Mapping[KeyT, ValueT]) -> typing.MutableMapping[KeyT, ValueT]:
+    """Logic for copying mappings that targets impl specific copy impls (e.g. dict.copy).
+
+    We use this to cover 2 main cases in the cache, one where we copy a mapping
+    before iterating over it to avoid any errors that would be raised by it
+    being mutated during this process and the other to make sure that the
+    mappings we pass through to cache views are snapshots that won't be further
+    modified by the cache.
+    """
+    # dict.copy ranges from between roughly 2 times to 5 times more efficient than casting to a dict so we want to
+    # try to use this where possible.
+    try:
+        return mapping.copy()  # type: ignore[attr-defined, no-any-return]
+    except (AttributeError, TypeError):
+        raise NotImplementedError("provided mapping doesn't implement a copy method") from None
+
+
+class IDTable(typing.MutableSet[snowflakes.Snowflake]):
+    """Compact 64-bit integer bisected-array-set of snowflakes."""
+
+    __slots__: typing.Sequence[str] = ("_ids",)
+
+    def __init__(self) -> None:
+        self._ids = array.array("Q")
+
+    def add(self, sf: snowflakes.Snowflake) -> None:
+        """Add a snowflake to this set."""
+        if not self._ids:
+            self._ids.append(sf)
+        else:
+            index = bisect.bisect_left(self._ids, sf)
+            if len(self._ids) == index or self._ids[index] != sf:
+                self._ids.insert(index, sf)
+
+    def add_all(self, sfs: typing.Iterable[snowflakes.Snowflake]) -> None:
+        """Add a collection of snowflakes to this set."""
+        for sf in sfs:
+            self.add(sf)
+
+    def discard(self, sf: snowflakes.Snowflake) -> None:
+        """Remove a snowflake from this set if it's present."""
+        index = self._index_of(sf)
+        if index != -1:
+            del self._ids[index]
+
+    def _index_of(self, sf: int) -> int:
+        index = bisect.bisect_left(self._ids, sf)
+        return index if index < len(self._ids) or self._ids[index] == sf else -1
+
+    def __contains__(self, value: typing.Any) -> bool:
+        if not isinstance(value, int):
+            return False
+
+        return self._index_of(value) != -1
+
+    def __len__(self) -> int:
+        return len(self._ids)
+
+    def __iter__(self) -> typing.Iterator[snowflakes.Snowflake]:
+        return map(snowflakes.Snowflake, self._ids)
+
+    def __repr__(self) -> str:
+        return "SnowflakeTable" + reprlib.repr(self._ids)[5:]
+
+
+class StatefulCacheMappingView(cache.CacheView[KeyT, ValueT], typing.Generic[KeyT, ValueT]):
+    """A cache mapping view implementation used for representing cached data.
+
+    Parameters
+    ----------
+    items : typing.Mapping[KeyT, ValueT or DataT or GenericRefWrapper[ValueT]
+        A mapping of keys to the values in their raw forms, wrapped by a ref
+        wrapper or in a data form.
+    builder : typing.Callable[[DataT], ValueT] or builtins.None
+        The callable used to build entities before they're returned by the
+        mapping. This is used to cover the case when items stores `DataT` objects.
+    unpack : bool
+        Whether to unpack items from their ref wrappers or not before returning
+        them. This accounts for when `items` is `GenericRefWrapper[ValueT]`.
+    predicate : typing.Callable[[typing.Any], bool] or builtins.None
+        A callable to use to determine whether entries should be returned or hidden,
+        this should take in whatever raw type was passed for the value in `items`.
+        This may be `builtins.None` if all entries should be exposed.
+    """
+
+    __slots__: typing.Sequence[str] = ("_builder", "_data", "_unpack", "_predicate")
+
+    def __init__(
+        self,
+        items: typing.Mapping[KeyT, typing.Union[ValueT, DataT, GenericRefWrapper[ValueT]]],
+        *,
+        builder: typing.Optional[typing.Callable[[DataT], ValueT]] = None,
+        unpack: bool = False,
+        predicate: typing.Optional[typing.Callable[[typing.Any], bool]] = None,
+    ) -> None:
+        self._builder = builder
+        self._data = items
+        self._unpack = unpack
+        self._predicate = predicate
+
+    @classmethod
+    def _copy(cls, value: ValueT) -> ValueT:
+        return copy.copy(value)
+
+    def __contains__(self, key: typing.Any) -> bool:
+        return key in self._data and (self._predicate is None or self._predicate(self._data[key]))
+
+    def __getitem__(self, key: KeyT) -> ValueT:
+        entry = self._data[key]
+
+        if self._predicate is not None and not self._predicate(entry):
+            raise KeyError(key)
+
+        if self._builder is not None:
+            entry = self._builder(entry)  # type: ignore[arg-type]
+        elif self._unpack:
+            assert isinstance(entry, GenericRefWrapper)
+            entry = self._copy(entry.object)
+        else:
+            entry = self._copy(entry)  # type: ignore[arg-type]
+
+        return entry
+
+    def __iter__(self) -> typing.Iterator[KeyT]:
+        if self._predicate is None:
+            return iter(self._data)
+        else:
+            return (key for key, value in self._data.items() if self._predicate(value))
+
+    def __len__(self) -> int:
+        if self._predicate is None:
+            return len(self._data)
+        else:
+            return sum(1 for value in self._data.values() if self._predicate(value))
+
+    def get_item_at(self, index: int) -> ValueT:
+        current_index = -1
+
+        for key, value in self._data.items():
+            if self._predicate is None or self._predicate(value):
+                index += 1
+
+            if current_index == index:
+                return self[key]
+
+        raise IndexError(index)
+
+    def iterator(self) -> iterators.LazyIterator[ValueT]:
+        return iterators.FlatLazyIterator(self.values())
+
+
+class EmptyCacheView(cache.CacheView[typing.Any, typing.Any]):
+    """An empty cache view implementation."""
+
+    __slots__: typing.Sequence[str] = ()
+
+    def __contains__(self, _: typing.Any) -> typing.Literal[False]:
+        return False
+
+    def __getitem__(self, key: typing.Any) -> typing.NoReturn:
+        raise KeyError(key)
+
+    def __iter__(self) -> typing.Iterator[typing.Any]:
+        yield from ()
+
+    def __len__(self) -> typing.Literal[0]:
+        return 0
+
+    def get_item_at(self, index: int) -> typing.NoReturn:
+        raise IndexError(index)
+
+    def iterator(self) -> iterators.LazyIterator[ValueT]:
+        return iterators.FlatLazyIterator(())
+
+
+@attr_extensions.with_copy
+@attr.s(slots=True, repr=False, hash=False, weakref_slot=False)
+class GuildRecord:
+    """An object used for storing guild specific cached information in-memory.
+
+    This includes references to the cached entities that "belong" to the guild
+    by ID if it's globally unique or by object if it's only unique within the
+    guild.
+    """
+
+    is_available: typing.Optional[bool] = attr.ib(default=None)
+    guild: typing.Optional[guilds.GatewayGuild] = attr.ib(default=None)
+    channels: typing.Optional[typing.MutableSet[snowflakes.Snowflake]] = attr.ib(default=None)
+    emojis: typing.Optional[typing.MutableSet[snowflakes.Snowflake]] = attr.ib(default=None)
+    invites: typing.Optional[typing.MutableSequence[str]] = attr.ib(default=None)
+    members: typing.Optional[typing.MutableMapping[snowflakes.Snowflake, MemberData]] = attr.ib(default=None)
+    presences: typing.Optional[typing.MutableMapping[snowflakes.Snowflake, MemberPresenceData]] = attr.ib(default=None)
+    roles: typing.Optional[typing.MutableSet[snowflakes.Snowflake]] = attr.ib(default=None)
+    voice_states: typing.Optional[typing.MutableMapping[snowflakes.Snowflake, VoiceStateData]] = attr.ib(default=None)
+
+    def __bool__(self) -> bool:  # TODO: should "is_available" keep this alive?
+        return any(
+            (
+                self.channels,
+                self.emojis,
+                self.guild,
+                self.invites,
+                self.members,
+                self.presences,
+                self.roles,
+                self.voice_states,
+            )
+        )
+
+
+@attr.s(slots=True, repr=False, hash=False, init=True, weakref_slot=False)
+class BaseData(abc.ABC, typing.Generic[ValueT]):
+    """A data class used for in-memory storage of entities in a more primitive form.
+
+    !!! note
+        This base implementation assumes that all the fields it'll handle will
+        be immutable and to handle mutable fields you'll have to override
+        build_entity and build_from_entity to explicitly copy them.
+    """
+
+    __slots__: typing.Sequence[str] = ()
+
+    @classmethod
+    @abc.abstractmethod
+    def get_fields(cls) -> typing.Collection[str]:
+        """Get the fields that should be automatically handled on the target entity.
+
+        !!! note
+            These fields should match up with both the target entity and the
+            data class itself.
+
+        Returns
+        -------
+        typing.Collection[builtins.str]
+            A collection of the names of fields to handle.
+        """
+
+    def build_entity(self, target: typing.Type[ValueT], **kwargs: typing.Any) -> ValueT:
+        """Build an entity object from this data object.
+
+        Parameters
+        ----------
+        target
+            The class of the entity object to build.
+        kwargs
+            Extra fields to pass on to the entity's initialiser. These will take
+            priority over fields on the builder.
+
+        Returns
+        -------
+        The initialised entity object.
+        """
+        for field in self.get_fields():
+            if field not in kwargs:
+                kwargs[field] = getattr(self, field)
+
+        return target(**kwargs)  # type: ignore[call-arg]
+
+    @classmethod
+    def build_from_entity(cls: typing.Type[DataT], entity: ValueT, **kwargs: typing.Any) -> DataT:
+        """Build a data object from an initialised entity.
+
+        Parameters
+        ----------
+        entity
+            The entity object to build a data class from.
+        kwargs
+            Extra fields to add to the data class. Fields here will take
+            priority over fields on `entity`.
+
+        Returns
+        -------
+        The built data class.
+        """
+        for field in cls.get_fields():
+            if field not in kwargs:
+                kwargs[field] = getattr(entity, field)
+
+        return cls(**kwargs)  # type: ignore[call-arg]
+
+    def replace(self: DataT, **kwargs: typing.Any) -> DataT:
+        data = copy.copy(self)
+
+        for attribute, value in kwargs.items():
+            setattr(data, attribute, value)
+
+        return data
+
+
+@attr_extensions.with_copy
+@attr.s(kw_only=True, slots=True, repr=False, hash=False, weakref_slot=False)
+class PrivateTextChannelData(BaseData[channels.PrivateTextChannel]):
+    """A data model for storing private text channel data in an in-memory cache.
+
+    !!! note
+        This doesn't cover private group text channels as we won't ever receive
+        those over the gateway.
+    """
+
+    id: snowflakes.Snowflake = attr.ib()
+    name: typing.Optional[str] = attr.ib()
+    last_message_id: typing.Optional[snowflakes.Snowflake] = attr.ib()
+    recipient_id: snowflakes.Snowflake = attr.ib()
+
+    @classmethod
+    def get_fields(cls) -> typing.Collection[str]:
+        return "id", "name", "last_message_id"
+
+    def build_entity(
+        self, target: typing.Type[channels.PrivateTextChannel], **kwargs: typing.Any
+    ) -> channels.PrivateTextChannel:
+        return super().build_entity(target, type=channels.ChannelType.PRIVATE_TEXT, **kwargs)
+
+    @classmethod
+    def build_from_entity(
+        cls: typing.Type[PrivateTextChannelData], entity: channels.PrivateTextChannel, **kwargs: typing.Any
+    ) -> PrivateTextChannelData:
+        return super().build_from_entity(entity, **kwargs, recipient_id=entity.recipient.id)
+
+
+@attr_extensions.with_copy
+@attr.s(kw_only=True, slots=True, repr=False, hash=False, weakref_slot=False)
+class InviteData(BaseData[invites.InviteWithMetadata]):
+    """A data model for storing invite data in an in-memory cache."""
+
+    code: str = attr.ib()
+    guild_id: typing.Optional[snowflakes.Snowflake] = attr.ib()
+    channel_id: snowflakes.Snowflake = attr.ib()
+    inviter_id: typing.Optional[snowflakes.Snowflake] = attr.ib()
+    target_user_id: typing.Optional[snowflakes.Snowflake] = attr.ib()
+    target_user_type: typing.Optional[invites.TargetUserType] = attr.ib()
+    uses: int = attr.ib()
+    max_uses: typing.Optional[int] = attr.ib()
+    max_age: typing.Optional[datetime.timedelta] = attr.ib()
+    is_temporary: bool = attr.ib()
+    created_at: datetime.datetime = attr.ib()
+
+    @classmethod
+    def get_fields(cls) -> typing.Collection[str]:
+        return (
+            "code",
+            "guild_id",
+            "channel_id",
+            "target_user_type",
+            "uses",
+            "max_uses",
+            "max_age",
+            "is_temporary",
+            "created_at",
+        )
+
+    def build_entity(
+        self, target: typing.Type[invites.InviteWithMetadata], **kwargs: typing.Any
+    ) -> invites.InviteWithMetadata:
+        return super().build_entity(
+            target, approximate_member_count=None, approximate_presence_count=None, channel=None, guild=None, **kwargs,
+        )
+
+    @classmethod
+    def build_from_entity(
+        cls: typing.Type[InviteData], entity: invites.InviteWithMetadata, **kwargs: typing.Any
+    ) -> InviteData:
+        return super().build_from_entity(
+            entity,
+            **kwargs,
+            inviter_id=entity.inviter.id if entity.inviter is not None else None,
+            target_user_id=entity.target_user.id if entity.target_user is not None else None,
+        )
+
+
+@attr_extensions.with_copy
+@attr.s(kw_only=True, slots=True, repr=False, hash=False, weakref_slot=False)
+class MemberData(BaseData[guilds.Member]):
+    """A data model for storing member data in an in-memory cache."""
+
+    id: snowflakes.Snowflake = attr.ib()
+    guild_id: snowflakes.Snowflake = attr.ib()
+    nickname: undefined.UndefinedNoneOr[str] = attr.ib()
+    role_ids: typing.Tuple[snowflakes.Snowflake, ...] = attr.ib()
+    joined_at: undefined.UndefinedOr[datetime.datetime] = attr.ib()
+    premium_since: undefined.UndefinedNoneOr[datetime.datetime] = attr.ib()
+    is_deaf: undefined.UndefinedOr[bool] = attr.ib()
+    is_mute: undefined.UndefinedOr[bool] = attr.ib()
+    # meta-attribute
+    has_been_deleted: bool = attr.ib(default=False)
+    ref_count: int = attr.ib(default=0)
+
+    @classmethod
+    def get_fields(cls) -> typing.Collection[str]:
+        return "guild_id", "nickname", "role_ids", "joined_at", "premium_since", "is_deaf", "is_mute"
+
+    @classmethod
+    def build_from_entity(cls: typing.Type[MemberData], entity: guilds.Member, **kwargs: typing.Any) -> MemberData:
+        # role_ids is a special case as it may be a mutable sequence so we want to ensure it's immutable when cached.
+        return super().build_from_entity(entity, **kwargs, id=entity.user.id, role_ids=tuple(entity.role_ids))
+
+
+@attr_extensions.with_copy
+@attr.s(kw_only=True, slots=True, repr=False, hash=False, weakref_slot=False)
+class KnownCustomEmojiData(BaseData[emojis.KnownCustomEmoji]):
+    """A data model for storing known custom emoji data in an in-memory cache."""
+
+    id: snowflakes.Snowflake = attr.ib()
+    name: typing.Optional[str] = attr.ib()
+    is_animated: typing.Optional[bool] = attr.ib()
+    guild_id: snowflakes.Snowflake = attr.ib()
+    role_ids: typing.Tuple[snowflakes.Snowflake, ...] = attr.ib()
+    user_id: typing.Optional[snowflakes.Snowflake] = attr.ib()
+    is_colons_required: bool = attr.ib()
+    is_managed: bool = attr.ib()
+    is_available: bool = attr.ib()
+    # meta-attributes
+    has_been_deleted: bool = attr.ib(default=False)  # We need test coverage for this systm
+    ref_count: int = attr.ib(default=0)
+
+    @classmethod
+    def get_fields(cls) -> typing.Collection[str]:
+        return "id", "name", "is_animated", "guild_id", "role_ids", "is_colons_required", "is_managed", "is_available"
+
+    @classmethod
+    def build_from_entity(
+        cls: typing.Type[KnownCustomEmojiData], entity: emojis.KnownCustomEmoji, **kwargs: typing.Any
+    ) -> KnownCustomEmojiData:
+        # role_ids is a special case as it may be a mutable sequence so we want to ensure it's immutable when cached.
+        return super().build_from_entity(
+            entity, **kwargs, user_id=entity.user.id if entity.user else None, role_ids=tuple(entity.role_ids)
+        )
+
+
+@attr_extensions.with_copy
+@attr.s(kw_only=True, slots=True, repr=False, hash=False, weakref_slot=False)
+class RichActivityData(BaseData[presences.RichActivity]):
+    """A data model for storing rich activity data in an in-memory cache."""
+
+    name: str = attr.ib()
+    url: str = attr.ib()
+    type: presences.ActivityType = attr.ib()
+    created_at: datetime.datetime = attr.ib()
+    timestamps: typing.Optional[presences.ActivityTimestamps] = attr.ib()
+    application_id: typing.Optional[snowflakes.Snowflake] = attr.ib()
+    details: typing.Optional[str] = attr.ib()
+    state: typing.Optional[str] = attr.ib()
+    emoji_id_or_name: typing.Union[snowflakes.Snowflake, str, None] = attr.ib()
+    party: typing.Optional[presences.ActivityParty] = attr.ib()
+    assets: typing.Optional[presences.ActivityAssets] = attr.ib()
+    secrets: typing.Optional[presences.ActivitySecret] = attr.ib()
+    is_instance: typing.Optional[bool] = attr.ib()
+    flags: typing.Optional[presences.ActivityFlag] = attr.ib()
+
+    @classmethod
+    def get_fields(cls) -> typing.Collection[str]:
+        return "name", "url", "type", "created_at", "application_id", "details", "state", "is_instance", "flags"
+
+    @classmethod
+    def build_from_entity(
+        cls: typing.Type[RichActivityData], entity: presences.RichActivity, **kwargs: typing.Any
+    ) -> RichActivityData:
+        emoji_id_or_name: typing.Union[snowflakes.Snowflake, str, None]
+        if entity.emoji is None:
+            emoji_id_or_name = None
+        elif isinstance(entity.emoji, emojis.CustomEmoji):
+            emoji_id_or_name = entity.emoji.id
+        else:
+            emoji_id_or_name = entity.emoji.name
+
+        timestamps = copy.copy(entity.timestamps) if entity.timestamps is not None else None
+        party = copy.copy(entity.party) if entity.party is not None else None
+        assets = copy.copy(entity.assets) if entity.assets is not None else None
+        secrets = copy.copy(entity.secrets) if entity.secrets is not None else None
+        return super().build_from_entity(
+            entity,
+            emoji_id_or_name=emoji_id_or_name,
+            timestamps=timestamps,
+            party=party,
+            assets=assets,
+            secrets=secrets,
+        )
+
+    def build_entity(self, target: typing.Type[presences.RichActivity], **kwargs: typing.Any) -> presences.RichActivity:
+        return super().build_entity(
+            target,
+            timestamps=copy.copy(self.timestamps) if self.timestamps is not None else None,
+            party=copy.copy(self.party) if self.party is not None else None,
+            assets=copy.copy(self.assets) if self.assets is not None else None,
+            secrets=copy.copy(self.secrets) if self.secrets is not None else None,
+            **kwargs,
+        )
+
+
+@attr_extensions.with_copy
+@attr.s(kw_only=True, slots=True, repr=False, hash=False, weakref_slot=False)
+class MemberPresenceData(BaseData[presences.MemberPresence]):
+    """A data model for storing presence data in an in-memory cache."""
+
+    user_id: snowflakes.Snowflake = attr.ib()
+    role_ids: typing.Optional[typing.Tuple[snowflakes.Snowflake, ...]] = attr.ib()
+    guild_id: typing.Optional[snowflakes.Snowflake] = attr.ib()
+    visible_status: presences.Status = attr.ib()
+    activities: typing.Tuple[RichActivityData, ...] = attr.ib()
+    client_status: presences.ClientStatus = attr.ib()
+    premium_since: typing.Optional[datetime.datetime] = attr.ib()
+    nickname: typing.Optional[str] = attr.ib()
+
+    @classmethod
+    def get_fields(cls) -> typing.Collection[str]:
+        return "user_id", "role_ids", "guild_id", "visible_status", "premium_since", "nickname"
+
+    @classmethod
+    def build_from_entity(
+        cls: typing.Type[MemberPresenceData], entity: presences.MemberPresence, **kwargs: typing.Any
+    ) -> MemberPresenceData:
+        # role_ids and activities are special cases as may be mutable sequences, therefor we ant to ensure they're
+        # stored in immutable sequences (tuples). Plus activities need to be converted to Data objects.
+        return super().build_from_entity(
+            entity,
+            role_ids=tuple(entity.role_ids) if entity.role_ids is not None else None,
+            activities=tuple(RichActivityData.build_from_entity(activity) for activity in entity.activities),
+            client_status=copy.copy(entity.client_status),
+        )
+
+    def build_entity(
+        self, target: typing.Type[presences.MemberPresence], **kwargs: typing.Any,
+    ) -> presences.MemberPresence:
+        presence_kwargs = kwargs.pop("presence_kwargs")
+        activities = [
+            activity.build_entity(presences.RichActivity, **kwargs_)
+            for activity, kwargs_ in zip(self.activities, presence_kwargs)
+        ]
+        return super().build_entity(
+            target, activities=activities, client_status=copy.copy(self.client_status), **kwargs
+        )
+
+
+@attr_extensions.with_copy
+@attr.s(kw_only=True, slots=True, repr=False, hash=False, weakref_slot=False)
+class VoiceStateData(BaseData[voices.VoiceState]):
+    """A data model for storing voice state data in an in-memory cache."""
+
+    channel_id: typing.Optional[snowflakes.Snowflake] = attr.ib()
+    guild_id: snowflakes.Snowflake = attr.ib()
+    is_guild_deafened: bool = attr.ib()
+    is_guild_muted: bool = attr.ib()
+    is_self_deafened: bool = attr.ib()
+    is_self_muted: bool = attr.ib()
+    is_streaming: bool = attr.ib()
+    is_suppressed: bool = attr.ib()
+    is_video_enabled: bool = attr.ib()
+    user_id: snowflakes.Snowflake = attr.ib()
+    session_id: str = attr.ib()
+
+    @classmethod
+    def get_fields(cls) -> typing.Collection[str]:
+        return (
+            "channel_id",
+            "guild_id",
+            "is_guild_deafened",
+            "is_guild_muted",
+            "is_self_deafened",
+            "is_self_muted",
+            "is_streaming",
+            "is_suppressed",
+            "is_video_enabled",
+            "user_id",
+            "session_id",
+        )
+
+
+@attr_extensions.with_copy
+@attr.s(kw_only=True, slots=True, repr=False, hash=False, weakref_slot=False)
+class GenericRefWrapper(typing.Generic[ValueT]):
+    """An object used for wrapping entities in an in-memory cache.
+
+    This is intended to enable reference counting for entities that are only kept
+    alive by reference (e.g. the unknown emoji objects attached to presence
+    activities and user objects) without the use of a "Data" object which lowers
+    the time spent building these entities for the objects that reference them.
+    """
+
+    object: ValueT = attr.ib()
+    ref_count: int = attr.ib(default=0)
+
+
+class PrivateTextChannelMRUMutableMapping(typing.MutableMapping[snowflakes.Snowflake, PrivateTextChannelData]):
+    """A specialised Most-recently-used limited mapping for private text channels.
+
+    This allows us to stop the private message cached from growing
+    un-controllably by removing old private channels rather than waiting for
+    delete events that'll never come or querying every guild the bot is in
+    (which sounds rather bad as far as scaling goes).
+
+    Parameters
+    ----------
+    expiry : datetime.timedelta
+        The timedelta of how long this should keep private channels for before
+        deleting them.
+
+    Raises
+    ------
+    ValueError
+        If `expiry` is a negative timedelta.
+    """
+
+    __slots__: typing.Sequence[str] = ("_channels", "_expiry")
+
+    def __init__(self, *, expiry: datetime.timedelta) -> None:
+        if expiry <= datetime.timedelta():
+            raise ValueError("expiry time must be greater than 0 microseconds.")
+
+        self._channels: typing.Dict[snowflakes.Snowflake, PrivateTextChannelData] = {}
+        self._expiry = expiry
+
+    def copy(self) -> typing.Dict[snowflakes.Snowflake, PrivateTextChannelData]:
+        return self._channels.copy()
+
+    def _garbage_collect(self) -> None:
+        current_time = date.utc_datetime()
+        for channel_id, channel in self._channels.copy().items():
+            if channel.last_message_id and current_time - channel.last_message_id.created_at < self._expiry:
+                break
+
+            del self._channels[channel_id]
+
+    def __delitem__(self, sf: snowflakes.Snowflake) -> None:
+        del self._channels[sf]
+        self._garbage_collect()
+
+    def __getitem__(self, sf: snowflakes.Snowflake) -> PrivateTextChannelData:
+        return self._channels[sf]
+
+    def __iter__(self) -> typing.Iterator[snowflakes.Snowflake]:
+        return iter(self._channels)
+
+    def __len__(self) -> int:
+        return len(self._channels)
+
+    def __setitem__(self, sf: snowflakes.Snowflake, value: PrivateTextChannelData) -> None:
+        self._garbage_collect()
+        #  Seeing as we rely on insertion order in _garbage_collect, we have to make sure that each item is added to
+        #  the end of the dict.
+        if value.last_message_id is not None and sf in self:
+            del self[sf]
+
+        self._channels[sf] = value
+
+
+def copy_guild_channel(channel: channels.GuildChannel) -> channels.GuildChannel:
+    """Logic for handling the copying of guild channel objects.
+
+    This exists account for the permission overwrite objects attached to guild
+    channel objects which need to be copied themselves.
+    """
+    channel = copy.copy(channel)
+    channel.permission_overwrites = {
+        sf: copy.copy(overwrite) for sf, overwrite in copy_mapping(channel.permission_overwrites).items()
+    }
+    return channel
+
+
+class GuildChannelCacheMappingView(StatefulCacheMappingView[snowflakes.Snowflake, channels.GuildChannel]):
+    """A special case of the mapping view implements copy logic that targets guild channels specifically."""
+
+    __slots__: typing.Sequence[str] = ()
+
+    @classmethod
+    def _copy(cls, value: channels.GuildChannel) -> channels.GuildChannel:
+        return copy_guild_channel(value)
+
+
+class Cache3DMappingView(StatefulCacheMappingView[snowflakes.Snowflake, cache.CacheView[KeyT, ValueT]]):
+    """A special case of the Mapping View which avoids copying the already immutable views contained within it."""
+
+    __slots__: typing.Sequence[str] = ()
+
+    @classmethod
+    def _copy(cls, value: cache.CacheView[KeyT, ValueT]) -> cache.CacheView[KeyT, ValueT]:
+        return value

--- a/tests/hikari/impl/test_stateless_cache.py
+++ b/tests/hikari/impl/test_stateless_cache.py
@@ -26,12 +26,169 @@ import pytest
 from hikari import users
 from hikari.api import cache
 from hikari.impl import stateless_cache
+from tests.hikari import hikari_test_helpers
 
 
 class TestStatelessCache:
     @pytest.fixture
     def component(self):
         return stateless_cache.StatelessCacheImpl()
+
+    def test_clear_private_text_channels(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.clear_private_text_channels()
+
+    def test_delete_private_text_channel(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.delete_private_text_channel(123)
+
+    def test_get_private_text_channel(self, component):
+        assert component.get_private_text_channel(123) is None
+
+    def test_get_private_text_channels_view(self, component):
+        assert component.get_private_text_channels_view() == {}
+
+    def test_set_private_text_channel(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.set_private_text_channel(object())
+
+    def test_update_private_text_channel(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.update_private_text_channel(object())
+
+    def test_clear_emojis(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.clear_emojis()
+
+    def test_clear_emojis_for_guild(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.clear_emojis_for_guild(123432)
+
+    def test_delete_emoji(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.delete_emoji(34123)
+
+    def test_get_emoji(self, component):
+        assert component.get_emoji(532134) is None
+
+    def test_get_emojis_view(self, component):
+        assert component.get_emojis_view() == {}
+
+    def test_get_emojis_view_for_guild(self, component):
+        assert component.get_emojis_view_for_guild(234123) == {}
+
+    def test_set_emoji(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.set_emoji(object())
+
+    def test_update_emoji(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.update_emoji(object())
+
+    def test_clear_guilds(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.clear_guilds()
+
+    def test_delete_guild(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.delete_guild(123123)
+
+    def test_get_guild(self, component):
+        assert component.get_guild(1234123) is None
+
+    def test_get_guilds_view(self, component):
+        assert component.get_guilds_view() == {}
+
+    def test_set_guild(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.set_guild(object())
+
+    def test_set_guild_availability(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.set_guild_availability(123123, True)
+
+    def test_set_initial_unavailable_guilds(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.set_initial_unavailable_guilds([123])
+
+    def test_update_guild(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.update_guild(object())
+
+    def test_clear_guild_channels(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.clear_guild_channels()
+
+    def test_clear_guild_channels_for_guild(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.clear_guild_channels_for_guild(123123123)
+
+    def test_delete_guild_channel(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.delete_guild_channel(652341234)
+
+    def test_get_guild_channel(self, component):
+        assert component.get_guild_channel(3234243) is None
+
+    def test_get_guild_channels_view(self, component):
+        assert component.get_guild_channels_view() == {}
+
+    def test_get_guild_channels_view_for_guild(self, component):
+        assert component.get_guild_channels_view_for_guild(1234123) == {}
+
+    def test_set_guild_channel(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.set_guild_channel(object())
+
+    def test_update_guild_channel(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.update_guild_channel(object())
+
+    def test_clear_invites(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.clear_invites()
+
+    def test_clear_invites_for_guild(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.clear_invites_for_guild(123123)
+
+    def test_clear_invites_for_channel(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.clear_invites_for_channel(12354234, 753245234)
+
+    def test_delete_invite(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.delete_invite("OKOKOKOKLKOK")
+
+    def test_get_invite(self, component):
+        assert component.get_invite("Okokok") is None
+
+    def test_get_invites_view(self, component):
+        assert component.get_invites_view() == {}
+
+    def test_get_invites_view_for_guild(self, component):
+        assert component.get_invites_view_for_guild(1342234123) == {}
+
+    def test_get_invites_view_for_channel(self, component):
+        assert component.get_invites_view_for_channel(123123, 542341234) == {}
+
+    def test_set_invite(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.set_invite(object())
+
+    def test_update_invite(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.update_invite(object())
+
+    def test_delete_me_for_cached_me(self, component):
+        me = object()
+        component._me = me
+        assert component.delete_me() is me
+        assert component._me is None
+
+    def test_delete_me_for_uncached_me(self, component):
+        assert component.delete_me() is None
+        assert component._me is None
 
     def test_get_me(self, component):
         me = mock.Mock(spec_set=users.OwnUser)
@@ -44,10 +201,160 @@ class TestStatelessCache:
         component.set_me(me)
         assert component._me is me
 
-    @pytest.mark.parametrize("method", sorted(cache.MutableCache.__abstractmethods__ - {"get_me", "set_me", "app"}))
-    def test_stateless_method_raises_NotImplementedError(self, component, method):
+    def test_update_me(self):
+        old_cached_me = object()
+        new_cached_me = object()
+        me = object()
+        component_ = hikari_test_helpers.mock_class_namespace(
+            stateless_cache.StatelessCacheImpl,
+            set_me=mock.Mock(),
+            get_me=mock.Mock(side_effect=[old_cached_me, new_cached_me]),
+        )()
+        assert component_.update_me(me) == (old_cached_me, new_cached_me)
+        component_.set_me.assert_called_once_with(me)
+        component_.get_me.assert_has_calls([mock.call(), mock.call()])
+
+    def test_clear_members(self, component):
         with pytest.raises(NotImplementedError):
-            method_impl = getattr(component, method)
-            arg_count = len(inspect.signature(method_impl).parameters)
-            args = [object()] * arg_count
-            method_impl(*args)
+            assert component.clear_members()
+
+    def test_clear_members_for_guild(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.clear_members_for_guild(123123)
+
+    def test_delete_member(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.delete_member(45234, 123123132)
+
+    def test_get_member(self, component):
+        assert component.get_member(345123, 5632452134) is None
+
+    def test_get_members_view(self, component):
+        assert component.get_members_view() == {}
+
+    def test_get_members_view_for_guild(self, component):
+        assert component.get_members_view_for_guild(354123) == {}
+
+    def test_set_member(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.set_member(object())
+
+    def test_update_member(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.update_member(object())
+
+    def test_clear_presences(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.clear_presences()
+
+    def test_clear_presences_for_guild(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.clear_presences_for_guild(1234123)
+
+    def test_delete_presence(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.delete_presence(123, 54234)
+
+    def test_get_presence(self, component):
+        assert component.get_presence(123, 54234) is None
+
+    def test_get_presences_view(self, component):
+        assert component.get_presences_view() == {}
+
+    def test_get_presences_view_for_guild(self, component):
+        assert component.get_presences_view_for_guild(34123) == {}
+
+    def test_set_presence(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.set_presence(object())
+
+    def test_update_presence(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.update_presence(object())
+
+    def test_clear_roles(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.clear_roles() == {}
+
+    def test_clear_roles_for_guild(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.clear_roles_for_guild(43123123)
+
+    def test_delete_role(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.delete_role(12353123)
+
+    def test_get_role(self, component):
+        assert component.get_role(351234) is None
+
+    def test_get_roles_view(self, component):
+        assert component.get_roles_view() == {}
+
+    def test_get_roles_view_for_guild(self, component):
+        assert component.get_roles_view_for_guild(43234) == {}
+
+    def test_set_role(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.set_role(object())
+
+    def test_update_role(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.update_role(object())
+
+    def test_clear_users(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.clear_users()
+
+    def test_delete_user(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.delete_user(312312)
+
+    def test_get_user(self, component):
+        assert component.get_user(123123) is None
+
+    def test_get_users_view(self, component):
+        assert component.get_users_view() == {}
+
+    def test_set_user(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.set_user(object())
+
+    def test_update_user(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.update_user(object())
+
+    def test_clear_voice_states(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.clear_voice_states()
+
+    def test_clear_voice_states_for_guild(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.clear_voice_states_for_guild(1223123)
+
+    def test_clear_voice_states_for_channel(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.clear_voice_states_for_channel(1236543, 43123)
+
+    def test_delete_voice_state(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.delete_voice_state(3123, 6542134123)
+
+    def test_get_voice_state(self, component):
+        assert component.get_voice_state(123, 6234) is None
+
+    def test_get_voice_states_view(self, component):
+        assert component.get_voice_states_view() == {}
+
+    def test_get_voice_states_view_for_channel(self, component):
+        assert component.get_voice_states_view_for_channel(2123, 5234) == {}
+
+    def test_get_voice_states_view_for_guild(self, component):
+        assert component.get_voice_states_view_for_guild(54231324) == {}
+
+    def test_set_voice_state(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.set_voice_state(object())
+
+    def test_update_voice_state(self, component):
+        with pytest.raises(NotImplementedError):
+            assert component.update_voice_state(object())


### PR DESCRIPTION
### Summary
Switch stateless cache to returning empty resources on getting methods.
* Document that modifying methods raise NotImplementedError on a stateless guild impl.
* Extract cache utilities to separate module.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x ] I have run `nox` and all the pipelines have passed.
- [ x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Close #63