### PR TITLE
Allow `include_presences` to be False when GUILD_PRESENCES isn't declared

### DIFF
--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -529,7 +529,7 @@ class GatewayShardImpl(shard.GatewayShard):
         if not query and not limit and not self._intents & intents_.Intents.GUILD_MEMBERS:
             raise errors.MissingIntentError(intents_.Intents.GUILD_MEMBERS)
 
-        if include_presences is not undefined.UNDEFINED and not self._intents & intents_.Intents.GUILD_PRESENCES:
+        if include_presences and not self._intents & intents_.Intents.GUILD_PRESENCES:
             raise errors.MissingIntentError(intents_.Intents.GUILD_PRESENCES)
 
         if users is not undefined.UNDEFINED and (query or limit):

--- a/hikari/impl/stateful_guild_chunker.py
+++ b/hikari/impl/stateful_guild_chunker.py
@@ -66,7 +66,7 @@ class ChunkStream(event_stream.EventStream[shard_events.MemberChunkEvent]):
 
     See Also
     --------
-    Event Stream: `hikari.utilities.event_stream.EventStream`
+    Event Stream: `hikari.event_stream.EventStream`
     """
 
     __slots__: typing.Sequence[str] = (

--- a/hikari/internal/enums.pyi
+++ b/hikari/internal/enums.pyi
@@ -19,7 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-"""Typehints for `hikari.utilities.enums`."""
+"""Typehints for `hikari.internal.enums`."""
 
 # Enums use a lot of internal voodoo that will not type check nicely, so we
 # skip that module with MyPy and just accept that "here be dragons".

--- a/tests/hikari/impl/test_shard.py
+++ b/tests/hikari/impl/test_shard.py
@@ -706,6 +706,19 @@ class TestGatewayShardImpl:
         with pytest.raises(errors.MissingIntentError):
             await client.request_guild_members(123, query="test", limit=1, include_presences=True)
 
+    async def test_request_guild_members_when_presences_false_and_GUILD_PRESENCES_not_enabled(self, client):
+        client._intents = intents.Intents.GUILD_INTEGRATIONS
+        client._ws = mock.Mock(send_json=mock.AsyncMock())
+
+        await client.request_guild_members(123, query="test", limit=1, include_presences=False)
+
+        client._ws.send_json.assert_awaited_once_with(
+            {
+                "op": 8,
+                "d": {"guild_id": "123", "query": "test", "presences": False, "limit": 1},
+            }
+        )
+
     @pytest.mark.parametrize("kwargs", [{"query": "some query"}, {"limit": 1}])
     async def test_request_guild_members_when_specifiying_users_with_limit_or_query(self, client, kwargs):
         client._intents = intents.Intents.GUILD_INTEGRATIONS


### PR DESCRIPTION
### Summary
Allow `include_presences` to be False when GUILD_PRESENCES isn't declared for shard.request_guild_members

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
