### PR TITLE
Remove include_applications from fetch_integrations as it's always true on v8

### DIFF
--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -4581,12 +4581,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             The guild to fetch the integrations for. This may be the object
             or the ID of an existing guild.
 
-        Other Parameters
-        ----------------
-        include_applications : hikari.undefined.UndefinedOr[builtins.bool]
-            If specified, whether to include bot and webhook integrations as
-            well as the Youtube and Twitch integrations.
-
         Returns
         -------
         typing.Sequence[hikari.guilds.Integration]

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -2270,12 +2270,9 @@ class RESTClientImpl(rest_api.RESTClient):
     async def fetch_integrations(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        include_applications: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
     ) -> typing.Sequence[guilds.Integration]:
         route = routes.GET_GUILD_INTEGRATIONS.compile(guild=guild)
-        query = data_binding.StringMapBuilder()
-        query.put("include_applications", include_applications)
-        raw_response = await self._request(route, query=query)
+        raw_response = await self._request(route)
         response = typing.cast(data_binding.JSONArray, raw_response)
         return data_binding.cast_json_array(response, self._entity_factory.deserialize_integration)
 

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -2552,11 +2552,11 @@ class TestRESTClientImplAsync:
         rest_client._request = mock.AsyncMock(return_value=[{"id": "456"}, {"id": "789"}])
         rest_client._entity_factory.deserialize_integration = mock.Mock(side_effect=[integration1, integration2])
 
-        assert await rest_client.fetch_integrations(StubModel(123), include_applications=True) == [
+        assert await rest_client.fetch_integrations(StubModel(123)) == [
             integration1,
             integration2,
         ]
-        rest_client._request.assert_awaited_once_with(expected_route, query={"include_applications": "true"})
+        rest_client._request.assert_awaited_once_with(expected_route)
         assert rest_client._entity_factory.deserialize_integration.call_count == 2
         rest_client._entity_factory.deserialize_integration.assert_has_calls(
             [mock.call({"id": "456"}), mock.call({"id": "789"})]


### PR DESCRIPTION
# Summary
Remove include_applications from fetch_integrations as it's always true on v8

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
