### PR TITLE
Dont suppress errors raised by run_once

### DIFF
--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -976,7 +976,7 @@ class BotApp(traits.BotAware, event_dispatcher.EventDispatcher):
             _LOGGER.debug("Shard %s started successfully in %.1fms", shard_id, (end - start) * 1_000)
             return new_shard
 
-        raise errors.GatewayError(f"Shard {shard_id} shut down immediately when starting")
+        raise errors.GatewayError(f"shard {shard_id} shut down immediately when starting")
 
     @staticmethod
     def _destroy_loop(loop: asyncio.AbstractEventLoop) -> None:

--- a/tests/hikari/impl/test_shard.py
+++ b/tests/hikari/impl/test_shard.py
@@ -777,7 +777,7 @@ class TestGatewayShardImpl:
         create_task = stack.enter_context(mock.patch.object(asyncio, "create_task", side_effect=[run_task, waiter]))
         wait = stack.enter_context(mock.patch.object(asyncio, "wait", return_value=([run_task], [waiter])))
         stack.enter_context(
-            pytest.raises(asyncio.CancelledError, match="Shard 20 was closed before it could start successfully")
+            pytest.raises(asyncio.CancelledError, match="shard 20 was closed before it could start successfully")
         )
 
         with stack:


### PR DESCRIPTION
### Summary
Errors raised by `run_once` were being suppressed causing server gateway closure errors from not propagating 

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Fixes #330
