### PR TITLE
Switch to using `x-ratelimit-reset-after` as reset_after

### DIFF
--- a/hikari/applications.py
+++ b/hikari/applications.py
@@ -383,12 +383,8 @@ class Application(guilds.PartialApplication):
     Will be `builtins.None` if this application doesn't have a bot.
     """
 
-    owner: typing.Optional[users.User] = attr.ib(eq=False, hash=False, repr=True)
-    """The application's owner.
-
-    This should always be `builtins.None` in application objects retrieved outside
-    Discord's oauth2 flow.
-    """
+    owner: users.User = attr.ib(eq=False, hash=False, repr=True)
+    """The application's owner."""
 
     rpc_origins: typing.Optional[typing.Sequence[str]] = attr.ib(eq=False, hash=False, repr=False)
     """A collection of this application's RPC origin URLs, if RPC is enabled."""

--- a/hikari/impl/buckets.py
+++ b/hikari/impl/buckets.py
@@ -119,9 +119,6 @@ Once you have received your response, you are expected to extract the values of
 the vital rate limit headers manually and parse them to the correct data types.
 These headers are:
 
-* `Date`:
-    the response date on the server. This should be parsed to a
-    `datetime.datetime` using `email.utils.parsedate_to_datetime`.
 * `X-RateLimit-Limit`:
     an `builtins.int` describing the max requests in the bucket from empty to
     being rate limited.
@@ -130,12 +127,9 @@ These headers are:
     limiting occurs in the current window.
 * `X-RateLimit-Bucket`:
     a `builtins.str` containing the initial bucket hash.
-* `X-RateLimit-Reset`:
-    a `builtins.float` containing the number of seconds since
-    1st January 1970 at 0:00:00 UTC at which the current ratelimit window
-    resets. This should be parsed to a `datetime.datetime` using
-    `datetime.datetime.fromtimestamp`, passing `datetime.timezone.utc`
-    as `tz`.
+* `x-ratelimit-reset-after`:
+    a `builtins.float` containing the number of seconds when the current rate
+    limit bucket will reset with decimal millisecond precision.
 
 Each of the above values should be passed to the `update_rate_limits` method to
 ensure that the bucket you acquired time from is correctly updated should
@@ -171,7 +165,7 @@ on what attributes you send in a JSON or form data payload.
 No information is sent in headers about these specific limits. You will only
 be made aware that they exist once you get ratelimited. In the 429 ratelimited
 response, you will have the `"global"` attribute set to `builtins.False`, and a
-`"reset_after"` attribute that differs entirely to the `X-RateLimit-Reset`
+`"reset_after"` attribute that differs entirely to the `x-ratelimit-reset-after`
 header. Thus, it is important to not assume the value in the 429 response
 for the reset time is the same as the one in the bucket headers. Hikari's
 `hikari.api.rest.RESTClient` implementation specifically uses the value furthest

--- a/hikari/impl/buckets.py
+++ b/hikari/impl/buckets.py
@@ -205,7 +205,6 @@ from __future__ import annotations
 __all__: typing.List[str] = ["UNKNOWN_HASH", "RESTBucket", "RESTBucketManager"]
 
 import asyncio
-import datetime
 import logging
 import typing
 
@@ -563,8 +562,7 @@ class RESTBucketManager:
         bucket_header: str,
         remaining_header: int,
         limit_header: int,
-        date_header: datetime.datetime,
-        reset_at_header: datetime.datetime,
+        reset_after: float,
     ) -> None:
         """Update the rate limits for a bucket using info from a response.
 
@@ -578,16 +576,13 @@ class RESTBucketManager:
             The `X-RateLimit-Remaining` header cast to an `builtins.int`.
         limit_header : builtins.int
             The `X-RateLimit-Limit`header cast to an `builtins.int`.
-        date_header : datetime.datetime
-            The `Date` header value as a `datetime.datetime`.
-        reset_at_header : datetime.datetime
-            The `X-RateLimit-Reset` header value as a `datetime.datetime`.
+        reset_after : builtins.float
+            The `x-ratelimit-reset-after` cast to a `builtins.float`.
         """
         self.routes_to_hashes[compiled_route.route] = bucket_header
 
         real_bucket_hash = compiled_route.create_real_bucket_hash(bucket_header)
 
-        reset_after = (reset_at_header - date_header).total_seconds()
         reset_at_monotonic = time.monotonic() + reset_after
 
         if real_bucket_hash in self.real_hashes_to_buckets:

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -301,7 +301,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             description=payload["description"],
             is_bot_public=payload.get("bot_public"),
             is_bot_code_grant_required=payload.get("bot_require_code_grant"),
-            owner=self.deserialize_user(payload["owner"]) if "owner" in payload else None,
+            owner=self.deserialize_user(payload["owner"]),
             rpc_origins=payload["rpc_origins"] if "rpc_origins" in payload else None,
             summary=payload["summary"],
             verify_key=bytes(payload["verify_key"], "utf-8") if "verify_key" in payload else None,

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -654,18 +654,14 @@ class RESTClientImpl(rest_api.RESTClient):
         limit = int(resp_headers.get(_X_RATELIMIT_LIMIT_HEADER, "1"))
         remaining = int(resp_headers.get(_X_RATELIMIT_REMAINING_HEADER, "1"))
         bucket = resp_headers.get(_X_RATELIMIT_BUCKET_HEADER, "None")
-        reset_at = float(resp_headers.get(_X_RATELIMIT_RESET_HEADER, "0"))
         reset_after = float(resp_headers.get(_X_RATELIMIT_RESET_AFTER_HEADER, "0"))
-        reset_date = datetime.datetime.fromtimestamp(reset_at, tz=datetime.timezone.utc)
-        now_date = time.rfc7231_datetime_string_to_datetime(resp_headers[_DATE_HEADER])
 
         self.buckets.update_rate_limits(
             compiled_route=compiled_route,
             bucket_header=bucket,
             remaining_header=remaining,
             limit_header=limit,
-            date_header=now_date,
-            reset_at_header=reset_date,
+            reset_after=reset_after,
         )
 
         if response.status != http.HTTPStatus.TOO_MANY_REQUESTS:

--- a/hikari/internal/time.py
+++ b/hikari/internal/time.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 __all__: typing.List[str] = [
     "DISCORD_EPOCH",
-    "rfc7231_datetime_string_to_datetime",
     "datetime_to_discord_epoch",
     "discord_epoch_to_datetime",
     "unix_epoch_to_datetime",
@@ -39,7 +38,6 @@ __all__: typing.List[str] = [
 ]
 
 import datetime
-import email.utils
 import time
 import typing
 import uuid as uuid_
@@ -65,28 +63,6 @@ References
 """
 
 _ISO_8601_FORMAT: typing.Final[str] = "%Y-%m-%dT%H:%M:%s"
-
-
-def rfc7231_datetime_string_to_datetime(date_str: str, /) -> datetime.datetime:
-    """Return the HTTP date as a datetime object.
-
-    Parameters
-    ----------
-    date_str : builtins.str
-        The RFC-2822 (section 3.3) compliant date string to parse.
-
-    Returns
-    -------
-    datetime.datetime
-        The HTTP date as a datetime object.
-
-    References
-    ----------
-    * [RFC-2822](https://www.ietf.org/rfc/rfc2822.txt)
-    * [Mozilla documentation for `Date` HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date)
-    """
-    # According to Mozilla, these are always going to be GMT (which is UTC).
-    return email.utils.parsedate_to_datetime(date_str).replace(tzinfo=datetime.timezone.utc)
 
 
 # Default to the standard lib parser, that isn't really ISO compliant but seems

--- a/tests/hikari/impl/test_buckets.py
+++ b/tests/hikari/impl/test_buckets.py
@@ -19,7 +19,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import asyncio
-import datetime
 import time
 
 import mock
@@ -285,7 +284,7 @@ class TestRESTBucketManager:
             route = mock.Mock()
             route.create_real_bucket_hash = mock.Mock(wraps=lambda intial_hash: intial_hash + ";bobs")
             mgr.routes_to_hashes[route.route] = "123"
-            mgr.update_rate_limits(route, "blep", 22, 23, datetime.datetime.now(), datetime.datetime.now())
+            mgr.update_rate_limits(route, "blep", 22, 23, 3.56)
             assert mgr.routes_to_hashes[route.route] == "blep"
             assert isinstance(mgr.real_hashes_to_buckets["blep;bobs"], buckets.RESTBucket)
 
@@ -297,7 +296,7 @@ class TestRESTBucketManager:
             mgr.routes_to_hashes[route.route] = "123"
             bucket = mock.Mock(reset_at=time.perf_counter() + 999999999999999999999999999)
             mgr.real_hashes_to_buckets["123;bobs"] = bucket
-            mgr.update_rate_limits(route, "123", 22, 23, datetime.datetime.now(), datetime.datetime.now())
+            mgr.update_rate_limits(route, "123", 22, 23, 7.65)
             assert mgr.routes_to_hashes[route.route] == "123"
             assert mgr.real_hashes_to_buckets["123;bobs"] is bucket
 
@@ -309,13 +308,10 @@ class TestRESTBucketManager:
             mgr.routes_to_hashes[route.route] = "123"
             bucket = mock.Mock(reset_at=time.perf_counter() + 999999999999999999999999999)
             mgr.real_hashes_to_buckets["123;bobs"] = bucket
-            date = datetime.datetime.now().replace(year=2004)
-            reset_at = datetime.datetime.now()
 
             with mock.patch.object(hikari_date, "monotonic", return_value=27):
-                expect_reset_at_monotonic = 27 + (reset_at - date).total_seconds()
-                mgr.update_rate_limits(route, "123", 22, 23, date, reset_at)
-                bucket.update_rate_limit.assert_called_once_with(22, 23, expect_reset_at_monotonic)
+                mgr.update_rate_limits(route, "123", 22, 23, 5.32)
+                bucket.update_rate_limit.assert_called_once_with(22, 23, 27 + 5.32)
 
     @pytest.mark.parametrize(("gc_task", "is_started"), [(None, False), (mock.Mock(spec_set=asyncio.Task), True)])
     def test_is_started(self, gc_task, is_started):

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -245,11 +245,11 @@ class TestEntityFactoryImpl:
                 "icon": "3123123",
                 "description": "I am an application",
                 "summary": "not a blank string",
+                "owner": owner_payload,
             }
         )
         assert application.is_bot_public is None
         assert application.is_bot_code_grant_required is None
-        assert application.owner is None
         assert application.rpc_origins is None
         assert application.verify_key is None
         assert application.team is None
@@ -267,6 +267,7 @@ class TestEntityFactoryImpl:
                 "description": "I am an application",
                 "summary": "not a blank string",
                 "team": None,
+                "owner": owner_payload,
             }
         )
         assert application.icon_hash is None

--- a/tests/hikari/internal/test_time.py
+++ b/tests/hikari/internal/test_time.py
@@ -92,12 +92,6 @@ def test_parse_iso_8601_date_with_no_fraction():
     assert date.microsecond == 0
 
 
-def test_parse_http_date():
-    rfc_timestamp = "Mon, 03 Jun 2019 17:54:26 GMT"
-    expected_timestamp = datetime.datetime(2019, 6, 3, 17, 54, 26, tzinfo=datetime.timezone.utc)
-    assert time.rfc7231_datetime_string_to_datetime(rfc_timestamp) == expected_timestamp
-
-
 def test_parse_discord_epoch_to_datetime():
     discord_timestamp = 37921278956
     expected_timestamp = datetime.datetime(2016, 3, 14, 21, 41, 18, 956000, tzinfo=datetime.timezone.utc)


### PR DESCRIPTION
### Summary
Switch to using `x-ratelimit-reset-after` as reset_after
* This is generally speaking more accurate than calculating this value from the `Date` header
  and `X-RateLimit-Reset` headers as these seem to drift away and on add reaction endpoints
  were seen to by almost a second larger than `x-ratelimit-reset-after` in some cases
  (e.g 0.25 vs 0.403, 0.25 vs 0.425, 0.25 vs 1.098, 0.25 vs 0.361 and 0.25 vs 0.634)
* Make owner mandatory on application

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
