### PR TITLE
Implement support for inline replies

### DIFF
--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -870,6 +870,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
         tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         nonce: undefined.UndefinedOr[str] = undefined.UNDEFINED,
+        reply_message: undefined.UndefinedOr[snowflakes.SnowflakeishOr[messages_.PartialMessage]] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
             typing.Union[snowflakes.SnowflakeishSequence[users.PartialUser], bool]
@@ -877,6 +878,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         role_mentions: undefined.UndefinedOr[
             typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
         ] = undefined.UNDEFINED,
+        reply_mention: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
     ) -> messages_.Message:
         """Create a message in the given channel.
 
@@ -917,6 +919,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             this must be less than 32 bytes. If not provided, then
             a null value is placed on the message instead. All users can
             see this value.
+        reply_message : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]]
+            If provided, the message to reply to.
         mentions_everyone : hikari.undefined.UndefinedOr[builtins.bool]
             If provided, whether the message should parse @everyone/@here
             mentions.
@@ -936,6 +940,11 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             `hikari.snowflakes.Snowflake`, or
             `hikari.guilds.PartialRole` derivatives to enforce mentioning
             specific roles.
+        reply_mention : hikari.undefined.UndefinedOr[builtins.bool]
+            If provided, whether to mention the author of the message
+            that is being replied to.
+
+            This will not do anything if not being used with `reply_message`.
 
         !!! note
             Attachments can be passed as many different things, to aid in
@@ -983,7 +992,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             limits; too many attachments; attachments that are too large;
             invalid image URLs in embeds; users in `user_mentions` not being
             mentioned in the message content; roles in `role_mentions` not
-            being mentioned in the message content.
+            being mentioned in the message content; if `reply_message` is
+            not found or not in the same channel as `channel`.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.ForbiddenError

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -364,6 +364,7 @@ class TextChannel(PartialChannel, abc.ABC):
         attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
         nonce: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
+        reply_message: undefined.UndefinedOr[snowflakes.SnowflakeishOr[messages.PartialMessage]] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
             typing.Union[snowflakes.SnowflakeishSequence[users.PartialUser], bool]
@@ -371,8 +372,9 @@ class TextChannel(PartialChannel, abc.ABC):
         role_mentions: undefined.UndefinedOr[
             typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
         ] = undefined.UNDEFINED,
+        reply_mention: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
     ) -> messages.Message:
-        """Create a message in the channel this message belongs to.
+        """Create a message in this channel.
 
         Parameters
         ----------
@@ -405,6 +407,8 @@ class TextChannel(PartialChannel, abc.ABC):
         nonce : hikari.undefined.UndefinedOr[builtins.str]
             If provided, a nonce that can be used for optimistic message
             sending.
+        reply_message : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]]
+            If provided, the message to reply to.
         mentions_everyone : hikari.undefined.UndefinedOr[builtins.bool]
             If provided, whether the message should parse @everyone/@here
             mentions.
@@ -422,6 +426,11 @@ class TextChannel(PartialChannel, abc.ABC):
             `hikari.snowflakes.Snowflake`, or
             `hikari.guilds.PartialRole` derivatives to enforce mentioning
             specific roles.
+        reply_mention : hikari.undefined.UndefinedOr[builtins.bool]
+            If provided, whether to mention the author of the message
+            that is being replied to.
+
+            This will not do anything if not being used with `reply_message`.
 
         !!! note
             Attachments can be passed as many different things, to aid in
@@ -464,7 +473,8 @@ class TextChannel(PartialChannel, abc.ABC):
             limits; too many attachments; attachments that are too large;
             invalid image URLs in embeds; users in `user_mentions` not being
             mentioned in the message content; roles in `role_mentions` not
-            being mentioned in the message content.
+            being mentioned in the message content; `reply_message` not found
+            or not in the same channel.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.ForbiddenError
@@ -491,9 +501,11 @@ class TextChannel(PartialChannel, abc.ABC):
             attachments=attachments,
             nonce=nonce,
             tts=tts,
+            reply_message=reply_message,
             mentions_everyone=mentions_everyone,
             user_mentions=user_mentions,
             role_mentions=role_mentions,
+            reply_mention=reply_mention,
         )
 
     def trigger_typing(self) -> special_endpoints.TypingIndicator:

--- a/hikari/urls.py
+++ b/hikari/urls.py
@@ -28,6 +28,13 @@ __all__: typing.List[str] = ["BASE_URL", "REST_API_URL", "OAUTH2_API_URL", "CDN_
 import typing
 
 BASE_URL: typing.Final[str] = "https://discord.com"
+"""The base URL."""
+
 REST_API_URL: typing.Final[str] = f"{BASE_URL}/api/v8"
+"""The REST API URL."""
+
 OAUTH2_API_URL: typing.Final[str] = f"{REST_API_URL}/oauth2"
+"""The OAUTH2 API URL."""
+
 CDN_URL: typing.Final[str] = "https://cdn.discordapp.com"
+"""The CDN URL."""

--- a/pipelines/pdoc3.nox.py
+++ b/pipelines/pdoc3.nox.py
@@ -61,8 +61,11 @@ def pdoc3(session: nox.Session) -> None:
     )
 
     if shutil.which("npm") is None:
-        print("'npm' not installed, won't prebuild index")
-        exit(0 if "CI" not in os.environ else 1)
+        message = "'npm' not installed, can't prebuild index"
+        if "CI" in os.environ:
+            session.error(message)
+
+        session.skip(message)
 
     print("Prebuilding index...")
     session.run("npm", "install", "lunr@2.3.7", external=True)

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -530,25 +530,25 @@ class TestRESTClientImpl:
     @pytest.mark.parametrize(
         ("function_input", "expected_output"),
         [
-            ((True, True, True), {"parse": ["everyone", "users", "roles"]}),
-            ((False, False, False), {"parse": []}),
-            ((undefined.UNDEFINED, undefined.UNDEFINED, undefined.UNDEFINED), {"parse": []}),
-            ((undefined.UNDEFINED, True, True), {"parse": ["roles", "users"]}),
-            ((False, [123], [456]), {"parse": [], "users": ["123"], "roles": ["456"]}),
+            ((True, True, True, True), {"parse": ["everyone", "users", "roles"], "replied_user": True}),
+            ((False, False, False, False), {"parse": []}),
+            ((undefined.UNDEFINED, undefined.UNDEFINED, undefined.UNDEFINED, undefined.UNDEFINED), {"parse": []}),
+            ((undefined.UNDEFINED, True, True, True), {"parse": ["roles", "users"], "replied_user": True}),
+            ((False, [123], [456], False), {"parse": [], "users": ["123"], "roles": ["456"]}),
             (
-                (True, [123, "123", 987], ["213", "456", 456]),
-                {"parse": ["everyone"], "users": ["123", "987"], "roles": ["213", "456"]},
+                (True, [123, "123", 987], ["213", "456", 456], True),
+                {"parse": ["everyone"], "users": ["123", "987"], "roles": ["213", "456"], "replied_user": True},
             ),
         ],
     )
     def test__generate_allowed_mentions(self, rest_client, function_input, expected_output):
         returned = rest_client._generate_allowed_mentions(*function_input)
-        if returned is not undefined.UNDEFINED:
-            for k in returned.keys():
-                returned[k] = sorted(returned[k])
+        for k, v in expected_output.items():
+            if isinstance(v, list):
+                returned[k] = sorted(v)
 
-        if expected_output is not undefined.UNDEFINED:
-            for k in expected_output.keys():
+        for k, v in expected_output.items():
+            if isinstance(v, list):
                 expected_output[k] = sorted(expected_output[k])
 
         assert returned == expected_output

--- a/tests/hikari/test_channels.py
+++ b/tests/hikari/test_channels.py
@@ -218,6 +218,7 @@ class TestTextChannel:
         mock_attachment = object()
         mock_embed = object()
         mock_attachments = [object(), object(), object()]
+        mock_reply_message = object()
 
         await model.send(
             content="test content",
@@ -226,9 +227,11 @@ class TestTextChannel:
             attachment=mock_attachment,
             attachments=mock_attachments,
             embed=mock_embed,
+            reply_message=mock_reply_message,
             mentions_everyone=False,
             user_mentions=[123, 456],
             role_mentions=[789, 567],
+            reply_mention=True,
         )
 
         model.app.rest.create_message.assert_awaited_once_with(
@@ -239,9 +242,11 @@ class TestTextChannel:
             attachment=mock_attachment,
             attachments=mock_attachments,
             embed=mock_embed,
+            reply_message=mock_reply_message,
             mentions_everyone=False,
             user_mentions=[123, 456],
             role_mentions=[789, 567],
+            reply_mention=True,
         )
 
     def test_trigger_typing(self, model):

--- a/tests/hikari/test_messages.py
+++ b/tests/hikari/test_messages.py
@@ -128,6 +128,7 @@ def message():
         message_reference=None,
         flags=None,
         nonce=None,
+        referenced_message=None,
     )
 
 
@@ -203,6 +204,7 @@ class TestAsyncMessage:
         roles = [object()]
         attachment = object()
         attachments = [object()]
+        reference_messsage = object()
         await message.reply(
             content="test content",
             embed=embed,
@@ -210,9 +212,11 @@ class TestAsyncMessage:
             attachments=attachments,
             nonce="nonce",
             tts=True,
+            reply_message=reference_messsage,
             mentions_everyone=True,
             user_mentions=False,
             role_mentions=roles,
+            reply_mention=True,
         )
         message.app.rest.create_message.assert_awaited_once_with(
             channel=456,
@@ -222,9 +226,11 @@ class TestAsyncMessage:
             attachments=attachments,
             nonce="nonce",
             tts=True,
+            reply_message=reference_messsage,
             mentions_everyone=True,
             user_mentions=False,
             role_mentions=roles,
+            reply_mention=True,
         )
 
     async def test_delete(self, message):


### PR DESCRIPTION
### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Closes #263 