### PR TITLE
Fix bot.heartbeat_latency to return the average instead of the sum

### DIFF
--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -363,7 +363,7 @@ class BotApp(traits.BotAware, event_dispatcher.EventDispatcher):
     @property
     def heartbeat_latency(self) -> float:
         latencies = [s.heartbeat_latency for s in self._shards.values() if not math.isnan(s.heartbeat_latency)]
-        return sum(latencies) if latencies else float("nan")
+        return sum(latencies) / len(latencies) if latencies else float("nan")
 
     @property
     def http_settings(self) -> config.HTTPSettings:


### PR DESCRIPTION
### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
