### PR TITLE
Several bugfixes

### DIFF
--- a/hikari/errors.py
+++ b/hikari/errors.py
@@ -27,6 +27,7 @@ __all__: typing.List[str] = [
     "HikariError",
     "HikariWarning",
     "HikariInterrupt",
+    "ComponentNotRunningError",
     "NotFoundError",
     "RateLimitedError",
     "RateLimitTooLongError",
@@ -98,6 +99,17 @@ class HikariInterrupt(KeyboardInterrupt, HikariError):
 
     signame: str = attr.ib()
     """The signal name that was raised."""
+
+
+@attr.s(auto_exc=True, slots=True, repr=False, weakref_slot=False)
+class ComponentNotRunningError(HikariError):
+    """An exception thrown if trying to interact with a component that is not running."""
+
+    reason: str = attr.ib()
+    """A string to explain the issue."""
+
+    def __str__(self) -> str:
+        return self.reason
 
 
 @attr.s(auto_exc=True, slots=True, repr=False, weakref_slot=False)

--- a/hikari/events/lifetime_events.py
+++ b/hikari/events/lifetime_events.py
@@ -115,7 +115,7 @@ class StoppedEvent(base_events.Event):
     closed within a coroutine function.
 
     !!! warning
-        The application will not proceed to leave the `_rest.run` call until all
+        The application will not proceed to leave the `bot.run` call until all
         event handlers for this event have completed/terminated. This
         prevents the risk of race conditions occurring where a script may
         terminate the process before a callback can occur.

--- a/hikari/traits.py
+++ b/hikari/traits.py
@@ -447,6 +447,21 @@ class BotAware(RESTAware, ShardAware, EventFactoryAware, DispatcherAware, typing
 
     __slots__: typing.Sequence[str] = ()
 
+    @property
+    def is_alive(self) -> bool:
+        """Check whether the bot is running or not.
+
+        This is useful as some functions might raise
+        `hikari.errors.ComponentNotRunningError` if this is
+        `builtins.False`.
+
+        Returns
+        -------
+        builtins.bool
+            Whether the bot is running or not.
+        """
+        raise NotImplementedError
+
     async def join(self, until_close: bool = True) -> None:
         """Wait indefinitely until the application closes.
 

--- a/tests/hikari/test_errors.py
+++ b/tests/hikari/test_errors.py
@@ -33,6 +33,15 @@ class TestShardCloseCode:
         assert errors.ShardCloseCode(code).is_standard is expected
 
 
+class TestComponentNotRunningError:
+    @pytest.fixture()
+    def error(self):
+        return errors.ComponentNotRunningError("some reason")
+
+    def test_str(self, error):
+        assert str(error) == "some reason"
+
+
 class TestGatewayError:
     @pytest.fixture()
     def error(self):


### PR DESCRIPTION
  - New error `ComponentNotRunningError` that will be raised when trying to interact with a component that is not running
  - Actually closing when one of the shards has been manually shut down
  - `sent_close` not being set when calling `send_close`
  - Unused ratelimiter now hoocked up to prevent getting disconnected on too many requests
  - `_shards` is now populated as soon as the shard object is created to be able to be used through `bot.x` on shard events

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
