### PR TITLE
Mediate random socket closures caused by aiohttp

### DIFF
--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -194,14 +194,13 @@ class _GatewayTransport(aiohttp.ClientWebSocketResponse):
                     errors.ShardCloseCode.RATE_LIMITED,
                 )
 
-                # Assume we can always resume first.
                 raise errors.GatewayServerClosedConnectionError(reason, close_code, can_reconnect)
 
             elif message.type == aiohttp.WSMsgType.CLOSING or message.type == aiohttp.WSMsgType.CLOSED:
                 # May be caused by the server shutting us down.
                 # May be caused by Windows injecting an EOF if something disconnects, as some
                 # network drivers appear to do this.
-                raise errors.GatewayError("Socket has closed")
+                raise errors.GatewayConnectionError("Socket has closed")
 
             elif len(buff) != 0 and message.type != aiohttp.WSMsgType.BINARY:
                 raise errors.GatewayError(f"Unexpected message type received {message.type.name}, expected BINARY")


### PR DESCRIPTION
- Instead of raising `GatewayError` we raise `GatewayConnectionError` to cause a reconnect.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Fixes #391
