### PR TITLE
Modify traits to remove useless inheritance

### DIFF
--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -49,6 +49,7 @@ import attr
 from hikari import files
 from hikari import permissions
 from hikari import snowflakes
+from hikari import traits
 from hikari import undefined
 from hikari import urls
 from hikari import users
@@ -63,7 +64,6 @@ if typing.TYPE_CHECKING:
     from hikari import guilds
     from hikari import iterators
     from hikari import messages
-    from hikari import traits
     from hikari import webhooks
     from hikari.api import special_endpoints
 
@@ -178,7 +178,7 @@ class ChannelFollow:
         return await self.app.rest.fetch_webhook(self.webhook_id)
 
     @property
-    def channel(self) -> typing.Union[GuildNewsChannel, GuildTextChannel]:
+    def channel(self) -> typing.Union[GuildNewsChannel, GuildTextChannel, None]:
         """Get the channel being followed from the cache.
 
         !!! warning
@@ -187,12 +187,15 @@ class ChannelFollow:
 
         Returns
         -------
-        typing.Optional[hikari.channels.GuildNewsChannel, hikari.channels.GuildTextChannel]
+        typing.Union[hikari.channels.GuildNewsChannel, hikari.channels.GuildTextChannel, builtins.None]
             The object of the guild channel that was found in the cache or
             `builtins.None`. While this will usually be `GuildNewsChannel` or
             `builtins.None`, if the channel referenced has since lost it's news
             status then this will return a `GuildTextChannel`.
         """
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
         channel = self.app.cache.get_guild_channel(self.channel_id)
         assert isinstance(channel, (GuildNewsChannel, GuildTextChannel))
         return channel

--- a/hikari/events/channel_events.py
+++ b/hikari/events/channel_events.py
@@ -128,6 +128,9 @@ class GuildChannelEvent(ChannelEvent, abc.ABC):
             The gateway guild this event relates to, if known. Otherwise
             this will return `builtins.None`.
         """
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
         return self.app.cache.get_available_guild(self.guild_id) or self.app.cache.get_unavailable_guild(self.guild_id)
 
     async def fetch_guild(self) -> guilds.RESTGuild:
@@ -152,6 +155,9 @@ class GuildChannelEvent(ChannelEvent, abc.ABC):
             The cached channel this event relates to. If not known, this
             will return `builtins.None` instead.
         """
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
         return self.app.cache.get_guild_channel(self.channel_id)
 
     async def fetch_channel(self) -> channels.GuildChannel:
@@ -436,6 +442,9 @@ class GuildPinsUpdateEvent(PinsUpdateEvent, GuildChannelEvent):
             The cached channel this event relates to. If not known, this
             will return `builtins.None` instead.
         """
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
         channel = self.app.cache.get_guild_channel(self.channel_id)
         assert isinstance(channel, channels.GuildTextChannel)
         return channel

--- a/hikari/events/guild_events.py
+++ b/hikari/events/guild_events.py
@@ -92,6 +92,9 @@ class GuildEvent(shard_events.ShardEvent, abc.ABC):
         typing.Optional[hikari.guilds.GatewayGuild]
             The guild this event relates to, or `builtins.None` if not known.
         """
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
         return self.app.cache.get_available_guild(self.guild_id) or self.app.cache.get_unavailable_guild(self.guild_id)
 
     async def fetch_guild(self) -> guilds.RESTGuild:
@@ -630,17 +633,6 @@ class PresenceUpdateEvent(shard_events.ShardEvent):
             ID of the guild the event occurred in.
         """
         return self.presence.guild_id
-
-    # TODO: make this nicer, as it is inconsistent with stuff elsewhere I guess.
-    def get_cached_user(self) -> typing.Optional[users.User]:
-        """Get the full cached user, if it is available.
-
-        Returns
-        -------
-        typing.Optional[hikari.users.User]
-            The full cached user, or `builtins.None` if not cached.
-        """
-        return self.app.cache.get_user(self.user_id)
 
     async def fetch_user(self) -> users.User:
         """Perform an API call to fetch the user this event concerns.

--- a/hikari/events/member_events.py
+++ b/hikari/events/member_events.py
@@ -97,6 +97,9 @@ class MemberEvent(shard_events.ShardEvent, abc.ABC):
             The guild that this event occurred in, if known, else
             `builtins.None`.
         """
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
         return self.app.cache.get_available_guild(self.guild_id) or self.app.cache.get_unavailable_guild(self.guild_id)
 
 

--- a/hikari/events/message_events.py
+++ b/hikari/events/message_events.py
@@ -44,6 +44,7 @@ import attr
 from hikari import channels
 from hikari import intents
 from hikari import snowflakes
+from hikari import traits
 from hikari import undefined
 from hikari import users
 from hikari.events import base_events
@@ -54,7 +55,6 @@ if typing.TYPE_CHECKING:
     from hikari import embeds as embeds_
     from hikari import guilds
     from hikari import messages
-    from hikari import traits
     from hikari.api import shard as shard_
 
 
@@ -241,10 +241,11 @@ class GuildMessageCreateEvent(MessageCreateEvent):
             The channel that the message was sent in, if known and cached,
             otherwise, `builtins.None`.
         """
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
         channel = self.app.cache.get_guild_channel(self.channel_id)
-        assert isinstance(
-            channel, (channels.GuildNewsChannel, channels.GuildTextChannel, type(None))
-        ), f"Cached channel ID is not a GuildNewsChannel or a GuildTextChannel, but a {type(channel).__name__}!"
+        assert isinstance(channel, (channels.GuildNewsChannel, channels.GuildTextChannel))
         return channel
 
     @property
@@ -261,6 +262,9 @@ class GuildMessageCreateEvent(MessageCreateEvent):
             The guild that this event occurred in, if cached. Otherwise,
             `builtins.None` instead.
         """
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
         return self.app.cache.get_guild(self.guild_id)
 
     @property
@@ -488,7 +492,7 @@ class GuildMessageUpdateEvent(MessageUpdateEvent):
 
         author = self.message.author
 
-        if author is not None:
+        if author is not None and isinstance(self.app, traits.CacheAware):
             member = self.app.cache.get_member(self.guild_id, author.id)
 
             if member is not None:
@@ -506,10 +510,11 @@ class GuildMessageUpdateEvent(MessageUpdateEvent):
             The channel that the message was sent in, if known and cached,
             otherwise, `builtins.None`.
         """
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
         channel = self.app.cache.get_guild_channel(self.channel_id)
-        assert isinstance(
-            channel, (channels.GuildNewsChannel, channels.GuildTextChannel)
-        ), f"Cached channel ID is not a GuildNewsChannel or a GuildTextChannel, but a {type(channel).__name__}!"
+        assert isinstance(channel, (channels.GuildNewsChannel, channels.GuildTextChannel))
         return channel
 
     @property
@@ -526,6 +531,9 @@ class GuildMessageUpdateEvent(MessageUpdateEvent):
             The guild that this event occurred in, if cached. Otherwise,
             `builtins.None` instead.
         """
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
         return self.app.cache.get_guild(self.guild_id)
 
     @property
@@ -597,10 +605,11 @@ class MessageDeleteEvent(MessageEvent, abc.ABC):
             if it is a normal message, or `hikari.channels.GuildNewsChannel` if
             sent in an announcement channel.
         """
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
         channel = self.app.cache.get_guild_channel(self.channel_id)
-        assert channel is None or isinstance(
-            channel, (channels.GuildTextChannel, channels.GuildNewsChannel)
-        ), f"expected cached channel to be None or a GuildTextChannel/GuildNewsChannel, not {channel}"
+        assert isinstance(channel, (channels.GuildTextChannel, channels.GuildNewsChannel))
         return channel
 
     @property
@@ -698,6 +707,9 @@ class GuildMessageDeleteEvent(MessageDeleteEvent):
             The gateway guild that this event corresponds to, if known and
             cached.
         """
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
         return self.app.cache.get_guild(self.guild_id)
 
 

--- a/hikari/events/typing_events.py
+++ b/hikari/events/typing_events.py
@@ -35,6 +35,7 @@ import attr
 
 from hikari import channels
 from hikari import intents
+from hikari import traits
 from hikari import users
 from hikari.api import special_endpoints
 from hikari.events import base_events
@@ -46,7 +47,6 @@ if typing.TYPE_CHECKING:
 
     from hikari import guilds
     from hikari import snowflakes
-    from hikari import traits
     from hikari.api import shard as gateway_shard
 
 
@@ -170,18 +170,19 @@ class GuildTypingEvent(TypingEvent):
     """
 
     @property
-    def channel(self) -> typing.Union[channels.GuildTextChannel, channels.GuildNewsChannel]:
+    def channel(self) -> typing.Union[channels.GuildTextChannel, channels.GuildNewsChannel, None]:
         """Get the cached channel object this typing event occurred in.
 
         Returns
         -------
-        typing.Union[hikari.channels.GuildTextChannel, hikari.channels.GuildNewsChannel]
+        typing.Union[hikari.channels.GuildTextChannel, hikari.channels.GuildNewsChannel, builtins.None]
             The channel.
         """
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
         channel = self.app.cache.get_guild_channel(self.channel_id)
-        assert isinstance(
-            channel, (channels.GuildTextChannel, channels.GuildNewsChannel)
-        ), f"expected GuildTextChannel or GuildNewsChannel from cache, got {channel}"
+        assert isinstance(channel, (channels.GuildTextChannel, channels.GuildNewsChannel))
         return channel
 
     @property
@@ -195,6 +196,9 @@ class GuildTypingEvent(TypingEvent):
         typing.Optional[hikari.guilds.GatewayGuild]
             The object of the gateway guild if found else `builtins.None`.
         """
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
         return self.app.cache.get_available_guild(self.guild_id) or self.app.cache.get_unavailable_guild(self.guild_id)
 
     @property
@@ -271,6 +275,9 @@ class DMTypingEvent(TypingEvent):
     @property
     def user(self) -> typing.Optional[users.User]:
         # <<inherited docstring from TypingEvent>>.
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
         return self.app.cache.get_user(self.user_id)
 
     async def fetch_channel(self) -> channels.DMChannel:

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -57,6 +57,7 @@ import attr
 
 from hikari import files
 from hikari import snowflakes
+from hikari import traits
 from hikari import undefined
 from hikari import urls
 from hikari import users
@@ -73,7 +74,6 @@ if typing.TYPE_CHECKING:
     from hikari import emojis as emojis_
     from hikari import permissions as permissions_
     from hikari import presences as presences_
-    from hikari import traits
     from hikari import voices as voices_
 
 
@@ -405,7 +405,10 @@ class Member(users.User):
         typing.Optional[hikari.presences.MemberPresence]
             The member presence, or `builtins.None` if not known.
         """
-        return self.app.cache.get_presence(self.guild_id, self.id)
+        if not isinstance(self.user.app, traits.CacheAware):
+            return None
+
+        return self.user.app.cache.get_presence(self.guild_id, self.user.id)
 
     @property
     def roles(self) -> typing.Sequence[Role]:
@@ -418,7 +421,10 @@ class Member(users.User):
         typing.Sequence[hikari.guilds.Role]
             The roles the users has.
         """
-        roles_view = self.app.cache.get_roles_view_for_guild(self.guild_id)
+        if not isinstance(self.user.app, traits.CacheAware):
+            return []
+
+        roles_view = self.user.app.cache.get_roles_view_for_guild(self.guild_id)
 
         return [r for r in roles_view.values() if r.id in self.role_ids]
 
@@ -454,7 +460,7 @@ class Member(users.User):
         hikari.guilds.Member
             An up-to-date view of this member.
         """
-        return await self.app.rest.fetch_member(self.guild_id, self.id)
+        return await self.user.app.rest.fetch_member(self.guild_id, self.user.id)
 
     async def fetch_dm_channel(self) -> channels_.DMChannel:
         return await self.user.fetch_dm_channel()
@@ -500,7 +506,9 @@ class Member(users.User):
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
         """
-        await self.app.rest.ban_user(self.guild_id, self.id, delete_message_days=delete_message_days, reason=reason)
+        await self.user.app.rest.ban_user(
+            self.guild_id, self.user.id, delete_message_days=delete_message_days, reason=reason
+        )
 
     def __str__(self) -> str:
         return str(self.user)
@@ -1365,11 +1373,17 @@ class GatewayGuild(Guild):
             A mapping of channel IDs to objects of the channels cached for the
             guild.
         """
+        if not isinstance(self.app, traits.CacheAware):
+            return {}
+
         return self.app.cache.get_guild_channels_view_for_guild(self.id)
 
     @property
     def emojis(self) -> typing.Mapping[snowflakes.Snowflake, emojis_.KnownCustomEmoji]:
         # <<inherited docstring from Guild>>.
+        if not isinstance(self.app, traits.CacheAware):
+            return {}
+
         return self.app.cache.get_emojis_view_for_guild(self.id)
 
     @property
@@ -1379,6 +1393,9 @@ class GatewayGuild(Guild):
         typing.Mapping[hikari.snowflakes.Snowflake, Member]
             A mapping of user IDs to objects of the members cached for the guild.
         """
+        if not isinstance(self.app, traits.CacheAware):
+            return {}
+
         return self.app.cache.get_members_view_for_guild(self.id)
 
     @property
@@ -1389,11 +1406,17 @@ class GatewayGuild(Guild):
             A mapping of user IDs to objects of the presences cached for the
             guild.
         """
+        if not isinstance(self.app, traits.CacheAware):
+            return {}
+
         return self.app.cache.get_presences_view_for_guild(self.id)
 
     @property
     def roles(self) -> typing.Mapping[snowflakes.Snowflake, Role]:
         # <<inherited docstring from Guild>>.
+        if not isinstance(self.app, traits.CacheAware):
+            return {}
+
         return self.app.cache.get_roles_view_for_guild(self.id)
 
     @property
@@ -1406,6 +1429,9 @@ class GatewayGuild(Guild):
             A mapping of user IDs to objects of the voice states cached for the
             guild.
         """
+        if not isinstance(self.app, traits.CacheAware):
+            return {}
+
         return self.app.cache.get_voice_states_view_for_guild(self.id)
 
     def get_channel(
@@ -1424,6 +1450,9 @@ class GatewayGuild(Guild):
         typing.Optional[hikari.channels.GuildChannel]
             The object of the guild channel found in cache or `builtins.None.
         """
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
         return self.app.cache.get_guild_channel(snowflakes.Snowflake(channel))
 
     def get_emoji(
@@ -1442,6 +1471,9 @@ class GatewayGuild(Guild):
             The object of the custom emoji if found in cache, else
             `builtins.None`.
         """
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
         return self.app.cache.get_emoji(snowflakes.Snowflake(emoji))
 
     def get_member(self, user: snowflakes.SnowflakeishOr[users.User]) -> typing.Optional[Member]:
@@ -1457,6 +1489,9 @@ class GatewayGuild(Guild):
         typing.Optional[Member]
             The cached member object if found, else `builtins.None`.
         """
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
         return self.app.cache.get_member(self.id, snowflakes.Snowflake(user))
 
     def get_my_member(self) -> typing.Optional[Member]:
@@ -1469,6 +1504,9 @@ class GatewayGuild(Guild):
             This will be sent on each `hikari.events.guild_events.GuildAvailableEvent`,
             as well as any presence updates if you have opted into them.
         """
+        if not isinstance(self.app, traits.ShardAware):
+            return None
+
         me = self.app.me
         if me is None:
             return None
@@ -1488,6 +1526,9 @@ class GatewayGuild(Guild):
         typing.Optional[hikari.presences.MemberPresence]
             The cached presence object if found, else `builtins.None`.
         """
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
         return self.app.cache.get_presence(self.id, snowflakes.Snowflake(user))
 
     def get_role(self, role: snowflakes.SnowflakeishOr[Role]) -> typing.Optional[Role]:
@@ -1503,6 +1544,9 @@ class GatewayGuild(Guild):
         typing.Optional[Role]
             The object of the role found in cache, else `builtins.None`.
         """
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
         return self.app.cache.get_role(snowflakes.Snowflake(role))
 
     def get_voice_state(self, user: snowflakes.SnowflakeishOr[users.User]) -> typing.Optional[voices_.VoiceState]:
@@ -1518,4 +1562,7 @@ class GatewayGuild(Guild):
         typing.Optional[hikari.voices.VoiceState]
             The cached voice state object if found, else `builtins.None`.
         """
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
         return self.app.cache.get_voice_state(self.id, snowflakes.Snowflake(user))

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -64,13 +64,11 @@ from hikari import traits
 from hikari import undefined
 from hikari import urls
 from hikari import users
-from hikari.api import cache as cache_
 from hikari.api import rest as rest_api
 from hikari.impl import buckets as buckets_
 from hikari.impl import entity_factory as entity_factory_impl
 from hikari.impl import rate_limits
 from hikari.impl import special_endpoints
-from hikari.impl import stateless_cache
 from hikari.internal import data_binding
 from hikari.internal import net
 from hikari.internal import routes
@@ -141,12 +139,10 @@ class _RESTProvider(traits.RESTAware):
         self,
         entity_factory: typing.Callable[[], entity_factory_.EntityFactory],
         executor: typing.Optional[concurrent.futures.Executor],
-        cache: typing.Callable[[], cache_.Cache],
         rest: typing.Callable[[], rest_api.RESTClient],
     ) -> None:
         self._entity_factory = entity_factory
         self._executor = executor
-        self._cache = cache
         self._rest = rest
 
     @property
@@ -156,14 +152,6 @@ class _RESTProvider(traits.RESTAware):
     @property
     def executor(self) -> typing.Optional[concurrent.futures.Executor]:
         return self._executor
-
-    @property
-    def cache(self) -> cache_.Cache:
-        return self._cache()
-
-    @property
-    def me(self) -> typing.Optional[users.OwnUser]:
-        return self._cache().get_me()
 
     @property
     def rest(self) -> rest_api.RESTClient:
@@ -305,11 +293,9 @@ class RESTApp(traits.ExecutorAware):
         # Since we essentially mimic a fake App instance, we need to make a circular provider.
         # We can achieve this using a lambda. This allows the entity factory to build models that
         # are also REST-aware
-        cache = stateless_cache.StatelessCacheImpl()
         provider = _RESTProvider(
             lambda: entity_factory,
             self._executor,
-            lambda: cache,
             lambda: rest_client,
         )
         entity_factory = entity_factory_impl.EntityFactoryImpl(provider)

--- a/hikari/messages.py
+++ b/hikari/messages.py
@@ -559,6 +559,8 @@ class PartialMessage(snowflakes.Unique):
         if self._guild_id:
             return self._guild_id
 
+        if not isinstance(self.app, traits.CacheAware):
+            return None
         # Don't check the member, as if the guild_id is missing, the member
         # will always be missing too.
         channel = self.app.cache.get_guild_channel(self.channel_id)

--- a/hikari/traits.py
+++ b/hikari/traits.py
@@ -32,6 +32,7 @@ __all__: typing.List[str] = [
     "EntityFactoryAware",
     "EventFactoryAware",
     "ExecutorAware",
+    "IntentsAware",
     "ChunkerAware",
     "NetworkSettingsAware",
     "RESTAware",
@@ -123,38 +124,23 @@ class NetworkSettingsAware(typing.Protocol):
 
 
 @typing.runtime_checkable
-class CacheAware(typing.Protocol):
-    """Structural supertype for a cache-aware object.
+class ChunkerAware(typing.Protocol):
+    """Structural supertype for a guild chunker-aware object.
 
-    Any cache-aware objects are able to access the Discord application cache.
+    These are able to request member chunks for guilds via the gateway to
+    retrieve mass member and presence information in bulk.
     """
 
     __slots__: typing.Sequence[str] = ()
 
     @property
-    def cache(self) -> cache_.Cache:
-        """Return the immutable cache implementation for this object.
+    def chunker(self) -> chunker_.GuildChunker:
+        """Return the guild chunker component.
 
         Returns
         -------
-        hikari.api.cache.Cache
-            The cache component for this object.
-        """
-        raise NotImplementedError
-
-    @property
-    def me(self) -> typing.Optional[users.OwnUser]:
-        """Return the bot user, if known.
-
-        This should be available as soon as the bot has fired the
-        `hikari.events.lifetime_events.StartingEvent`.
-
-        Until then, this may or may not be `builtins.None`.
-
-        Returns
-        -------
-        typing.Optional[hikari.users.OwnUser]
-            The bot user, if known, otherwise `builtins.None`.
+        hikari.api.chunker.GuildChunker
+            The guild chunker component.
         """
         raise NotImplementedError
 
@@ -251,29 +237,25 @@ class EventFactoryAware(typing.Protocol):
 
 
 @typing.runtime_checkable
-class ChunkerAware(typing.Protocol):
-    """Structural supertype for a guild chunker-aware object.
-
-    These are able to request member chunks for guilds via the gateway to
-    retrieve mass member and presence information in bulk.
-    """
+class IntentsAware(typing.Protocol):
+    """A component that is aware of the application intents."""
 
     __slots__: typing.Sequence[str] = ()
 
     @property
-    def chunker(self) -> chunker_.GuildChunker:
-        """Return the guild chunker component.
+    def intents(self) -> intents_.Intents:
+        """Return the intents registered for the application.
 
         Returns
         -------
-        hikari.api.chunker.GuildChunker
-            The guild chunker component.
+        hikari.intents.Intents
+            The intents registered on this application.
         """
         raise NotImplementedError
 
 
 @typing.runtime_checkable
-class RESTAware(EntityFactoryAware, NetworkSettingsAware, ExecutorAware, CacheAware, typing.Protocol):
+class RESTAware(EntityFactoryAware, NetworkSettingsAware, ExecutorAware, typing.Protocol):
     """Structural supertype for a REST-aware object.
 
     These are able to perform REST API calls.
@@ -316,7 +298,7 @@ class VoiceAware(typing.Protocol):
 
 
 @typing.runtime_checkable
-class ShardAware(NetworkSettingsAware, ExecutorAware, CacheAware, ChunkerAware, VoiceAware, typing.Protocol):
+class ShardAware(IntentsAware, NetworkSettingsAware, ExecutorAware, VoiceAware, typing.Protocol):
     """Structural supertype for a shard-aware object.
 
     These will expose a mapping of shards, the intents in use
@@ -355,13 +337,18 @@ class ShardAware(NetworkSettingsAware, ExecutorAware, CacheAware, ChunkerAware, 
         raise NotImplementedError
 
     @property
-    def intents(self) -> intents_.Intents:
-        """Return the intents registered for the application.
+    def me(self) -> typing.Optional[users.OwnUser]:
+        """Return the bot user, if known.
+
+        This should be available as soon as the bot has fired the
+        `hikari.events.lifetime_events.StartingEvent`.
+
+        Until then, this may or may not be `builtins.None`.
 
         Returns
         -------
-        hikari.intents.Intents
-            The intents registered on this application.
+        typing.Optional[hikari.users.OwnUser]
+            The bot user, if known, otherwise `builtins.None`.
         """
         raise NotImplementedError
 
@@ -442,7 +429,28 @@ class ShardAware(NetworkSettingsAware, ExecutorAware, CacheAware, ChunkerAware, 
 
 
 @typing.runtime_checkable
-class BotAware(RESTAware, ShardAware, EventFactoryAware, DispatcherAware, typing.Protocol):
+class CacheAware(typing.Protocol):
+    """Structural supertype for a cache-aware object.
+
+    Any cache-aware objects are able to access the Discord application cache.
+    """
+
+    __slots__: typing.Sequence[str] = ()
+
+    @property
+    def cache(self) -> cache_.Cache:
+        """Return the immutable cache implementation for this object.
+
+        Returns
+        -------
+        hikari.api.cache.Cache
+            The cache component for this object.
+        """
+        raise NotImplementedError
+
+
+@typing.runtime_checkable
+class BotAware(RESTAware, ShardAware, EventFactoryAware, DispatcherAware, ChunkerAware, CacheAware, typing.Protocol):
     """Structural supertype for a component that is aware of all internals."""
 
     __slots__: typing.Sequence[str] = ()

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -118,10 +118,6 @@ class TestRestProvider:
         return StubRestClient()
 
     @pytest.fixture()
-    def cache(self):
-        return mock.Mock()
-
-    @pytest.fixture()
     def executor(self):
         return mock.Mock()
 
@@ -130,8 +126,8 @@ class TestRestProvider:
         return mock.Mock()
 
     @pytest.fixture()
-    def rest_provider(self, rest_client, cache, executor, entity_factory):
-        return rest._RESTProvider(lambda: entity_factory, executor, lambda: cache, lambda: rest_client)
+    def rest_provider(self, rest_client, executor, entity_factory):
+        return rest._RESTProvider(lambda: entity_factory, executor, lambda: rest_client)
 
     def test_rest_property(self, rest_provider, rest_client):
         assert rest_provider.rest == rest_client
@@ -145,14 +141,8 @@ class TestRestProvider:
     def test_entity_factory_property(self, rest_provider, entity_factory):
         assert rest_provider.entity_factory == entity_factory
 
-    def test_cache_property(self, rest_provider, cache):
-        assert rest_provider.cache == cache
-
     def test_executor_property(self, rest_provider, executor):
         assert rest_provider.executor == executor
-
-    def test_me_property(self, rest_provider, cache):
-        assert rest_provider.me == cache.get_me()
 
 
 ###########
@@ -250,7 +240,6 @@ class TestRESTApp:
         assert _entity_factory.call_count == 1
         factory = _entity_factory.call_args_list[0][0][0]
         factory.entity_factory
-        factory.cache
         factory.rest
 
     def test_acquire_when__event_loop_and_loop_do_not_equal(self, rest_app):

--- a/tests/hikari/test_channels.py
+++ b/tests/hikari/test_channels.py
@@ -28,13 +28,12 @@ from hikari import files
 from hikari import permissions
 from hikari import snowflakes
 from hikari import users
-from hikari.impl import bot
 from tests.hikari import hikari_test_helpers
 
 
 @pytest.fixture()
 def mock_app():
-    return mock.Mock(spec_set=bot.BotApp)
+    return mock.Mock()
 
 
 class TestChannelType:
@@ -70,8 +69,7 @@ class TestChannelFollow:
         assert result is mock_webhook
         mock_app.rest.fetch_webhook.assert_awaited_once_with(54123123)
 
-    @pytest.mark.asyncio
-    async def test_channel(self, mock_app):
+    def test_channel(self, mock_app):
         mock_channel = mock.Mock(spec=channels.GuildNewsChannel)
         mock_app.cache.get_guild_channel = mock.Mock(return_value=mock_channel)
         follow = channels.ChannelFollow(
@@ -82,6 +80,13 @@ class TestChannelFollow:
 
         assert result is mock_channel
         mock_app.cache.get_guild_channel.assert_called_once_with(696969)
+
+    def test_channel_when_no_cache_trait(self):
+        follow = channels.ChannelFollow(
+            webhook_id=snowflakes.Snowflake(993883), app=object(), channel_id=snowflakes.Snowflake(696969)
+        )
+
+        assert follow.channel is None
 
 
 class TestPermissionOverwrite:


### PR DESCRIPTION
  - Removes CacheAware from RestAware

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
