### PR TITLE
Fix usage/setting of bot._is_alive and invalid channel type assertions

### DIFF
--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -179,7 +179,7 @@ class ChannelFollow:
         return await self.app.rest.fetch_webhook(self.webhook_id)
 
     @property
-    def channel(self) -> typing.Union[GuildNewsChannel, GuildTextChannel]:
+    def channel(self) -> typing.Union[GuildNewsChannel, GuildTextChannel, None]:
         """Get the channel being followed from the cache.
 
         !!! warning
@@ -195,7 +195,7 @@ class ChannelFollow:
             status then this will return a `GuildTextChannel`.
         """
         channel = self.app.cache.get_guild_channel(self.channel_id)
-        assert isinstance(channel, (GuildNewsChannel, GuildTextChannel))
+        assert channel is None or isinstance(channel, (GuildNewsChannel, GuildTextChannel))
         return channel
 
 

--- a/hikari/events/channel_events.py
+++ b/hikari/events/channel_events.py
@@ -438,7 +438,7 @@ class GuildPinsUpdateEvent(PinsUpdateEvent, GuildChannelEvent):
             will return `builtins.None` instead.
         """
         channel = self.app.cache.get_guild_channel(self.channel_id)
-        assert isinstance(channel, channels.GuildTextChannel)
+        assert channel is None or isinstance(channel, channels.GuildTextChannel)
         return channel
 
     async def fetch_channel(self) -> channels.GuildTextChannel:

--- a/hikari/events/message_events.py
+++ b/hikari/events/message_events.py
@@ -243,8 +243,8 @@ class GuildMessageCreateEvent(MessageCreateEvent):
             otherwise, `builtins.None`.
         """
         channel = self.app.cache.get_guild_channel(self.channel_id)
-        assert isinstance(
-            channel, (channels.GuildNewsChannel, channels.GuildTextChannel, type(None))
+        assert channel is None or isinstance(
+            channel, (channels.GuildNewsChannel, channels.GuildTextChannel)
         ), f"Cached channel ID is not a GuildNewsChannel or a GuildTextChannel, but a {type(channel).__name__}!"
         return channel
 
@@ -508,7 +508,7 @@ class GuildMessageUpdateEvent(MessageUpdateEvent):
             otherwise, `builtins.None`.
         """
         channel = self.app.cache.get_guild_channel(self.channel_id)
-        assert isinstance(
+        assert channel is None or isinstance(
             channel, (channels.GuildNewsChannel, channels.GuildTextChannel)
         ), f"Cached channel ID is not a GuildNewsChannel or a GuildTextChannel, but a {type(channel).__name__}!"
         return channel

--- a/hikari/events/typing_events.py
+++ b/hikari/events/typing_events.py
@@ -171,7 +171,7 @@ class GuildTypingEvent(TypingEvent):
     """
 
     @property
-    def channel(self) -> typing.Union[channels.GuildTextChannel, channels.GuildNewsChannel]:
+    def channel(self) -> typing.Union[channels.GuildTextChannel, channels.GuildNewsChannel, None]:
         """Get the cached channel object this typing event occurred in.
 
         Returns
@@ -180,7 +180,7 @@ class GuildTypingEvent(TypingEvent):
             The channel.
         """
         channel = self.app.cache.get_guild_channel(self.channel_id)
-        assert isinstance(
+        assert channel is None or isinstance(
             channel, (channels.GuildTextChannel, channels.GuildNewsChannel)
         ), f"expected GuildTextChannel or GuildNewsChannel from cache, got {channel}"
         return channel

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -779,7 +779,7 @@ class BotApp(traits.BotAware, event_dispatcher.EventDispatcher):
                 ux.check_for_updates(self._http_settings, self._proxy_settings),
                 name="check for package updates",
             )
-        self._is_alive = False
+
         requirements_task = asyncio.create_task(self._rest.fetch_gateway_bot(), name="fetch gateway sharding settings")
         await self.dispatch(lifetime_events.StartingEvent(app=self))
         requirements = await requirements_task
@@ -802,6 +802,7 @@ class BotApp(traits.BotAware, event_dispatcher.EventDispatcher):
             )
             raise errors.GatewayError("Attempted to start more sessions than were allowed in the given time-window")
 
+        self._is_alive = True
         _LOGGER.info(
             "planning to start %s session%s... you can start %s session%s before the next window starts at %s",
             len(shard_ids),
@@ -876,7 +877,7 @@ class BotApp(traits.BotAware, event_dispatcher.EventDispatcher):
         _LOGGER.info("application started successfully in approx %.2f seconds", time.monotonic() - start_time)
 
     def _check_if_alive(self) -> None:
-        if self._is_alive:
+        if not self._is_alive:
             raise errors.ComponentNotRunningError("bot is not running so it cannot be interacted with")
 
     def stream(


### PR DESCRIPTION
### Summary
Fix usage/setting of bot._is_alive and invalid channel type assertions

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
