### PR TITLE
Seperate `reply` and `respond` in message

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ async def ping(event: hikari.GuildMessageCreateEvent) -> None:
         return
 
     if event.content.startswith("hk.ping"):
-        await event.message.reply("Pong!")
+        await event.message.respond("Pong!")
 
 bot.run()
 ```

--- a/examples/hello_world/hello_world.py
+++ b/examples/hello_world/hello_world.py
@@ -36,7 +36,7 @@ async def on_message(event: hikari.MessageCreateEvent) -> None:
         return
 
     if event.content == "!ping":
-        await event.message.reply(f"Pong! {bot.heartbeat_latency * 1_000:.0f}ms")
+        await event.message.respond(f"Pong! {bot.heartbeat_latency * 1_000:.0f}ms")
 
 
 bot.run()

--- a/examples/image_resources/image_resources.py
+++ b/examples/image_resources/image_resources.py
@@ -60,28 +60,30 @@ async def inspect_image(event: hikari.GuildMessageCreateEvent, what: str) -> Non
     if user_match := re.match(r"<@!?(\d+)>", what):
         user_id = hikari.Snowflake(user_match.group(1))
         user = bot.cache.get_user(user_id) or await bot.rest.fetch_user(user_id)
-        await event.message.reply("User avatar", attachment=user.avatar_url or user.default_avatar_url)
+        await event.message.respond("User avatar", attachment=user.avatar_url or user.default_avatar_url)
 
     # Show the guild icon:
     elif what.casefold() in ("guild", "server", "here", "this"):
         if event.guild is None:
-            await event.message.reply("Guild is missing from the cache :(")
+            await event.message.respond("Guild is missing from the cache :(")
             return
 
         icon = event.guild.icon_url
         if icon is None:
-            await event.message.reply("This guild doesn't have an icon")
+            await event.message.respond("This guild doesn't have an icon")
         else:
-            await event.message.reply("Guild icon", attachment=icon)
+            await event.message.respond("Guild icon", attachment=icon)
 
     # Show the image for the given emoji if there is some content present:
     elif what:
         emoji = hikari.Emoji.parse(what)
-        await event.message.reply(emoji.name, attachment=emoji)
+        await event.message.respond(emoji.name, attachment=emoji)
 
     # If nothing was given, we should just return the avatar of the person who ran the command:
     else:
-        await event.message.reply("Your avatar", attachment=event.author.avatar_url or event.author.default_avatar_url)
+        await event.message.respond(
+            "Your avatar", attachment=event.author.avatar_url or event.author.default_avatar_url
+        )
 
 
 bot.run()

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -872,15 +872,15 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
         tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         nonce: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-        reply_message: undefined.UndefinedOr[snowflakes.SnowflakeishOr[messages_.PartialMessage]] = undefined.UNDEFINED,
+        reply_to: undefined.UndefinedOr[snowflakes.SnowflakeishOr[messages_.PartialMessage]] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
+        mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
             typing.Union[snowflakes.SnowflakeishSequence[users.PartialUser], bool]
         ] = undefined.UNDEFINED,
         role_mentions: undefined.UndefinedOr[
             typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
         ] = undefined.UNDEFINED,
-        reply_mention: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
     ) -> messages_.Message:
         """Create a message in the given channel.
 
@@ -921,11 +921,16 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             this must be less than 32 bytes. If not provided, then
             a null value is placed on the message instead. All users can
             see this value.
-        reply_message : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]]
+        reply_to : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]]
             If provided, the message to reply to.
         mentions_everyone : hikari.undefined.UndefinedOr[builtins.bool]
             If provided, whether the message should parse @everyone/@here
             mentions.
+        mentions_reply : hikari.undefined.UndefinedOr[builtins.bool]
+            If provided, whether to mention the author of the message
+            that is being replied to.
+
+            This will not do anything if not being used with `reply_to`.
         user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], builtins.bool]]
             If provided, and `builtins.True`, all user mentions will be detected.
             If provided, and `builtins.False`, all user mentions will be ignored
@@ -942,11 +947,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             `hikari.snowflakes.Snowflake`, or
             `hikari.guilds.PartialRole` derivatives to enforce mentioning
             specific roles.
-        reply_mention : hikari.undefined.UndefinedOr[builtins.bool]
-            If provided, whether to mention the author of the message
-            that is being replied to.
-
-            This will not do anything if not being used with `reply_message`.
 
         !!! note
             Attachments can be passed as many different things, to aid in
@@ -994,7 +994,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             limits; too many attachments; attachments that are too large;
             invalid image URLs in embeds; users in `user_mentions` not being
             mentioned in the message content; roles in `role_mentions` not
-            being mentioned in the message content; if `reply_message` is
+            being mentioned in the message content; if `reply_to` is
             not found or not in the same channel as `channel`.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
@@ -1079,6 +1079,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         *,
         embed: undefined.UndefinedNoneOr[embeds_.Embed] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
+        mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
             typing.Union[snowflakes.SnowflakeishSequence[users.PartialUser], bool]
         ] = undefined.UNDEFINED,
@@ -1122,6 +1123,11 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             not changed. If `builtins.True`, then `@everyone`/`@here` mentions
             in the message content will show up as mentioning everyone that can
             view the chat.
+        mentions_reply : hikari.undefined.UndefinedOr[builtins.bool]
+            If provided, whether to mention the author of the message
+            that is being replied to.
+
+            This will not do anything if `message` is not a reply message.
         user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], builtins.bool]]
             If provided, sanitation for user mentions. If
             `hikari.undefined.UNDEFINED`, then the previous setting is

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -365,15 +365,15 @@ class TextChannel(PartialChannel, abc.ABC):
         attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
         nonce: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-        reply_message: undefined.UndefinedOr[snowflakes.SnowflakeishOr[messages.PartialMessage]] = undefined.UNDEFINED,
+        reply_to: undefined.UndefinedOr[snowflakes.SnowflakeishOr[messages.PartialMessage]] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
+        mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
             typing.Union[snowflakes.SnowflakeishSequence[users.PartialUser], bool]
         ] = undefined.UNDEFINED,
         role_mentions: undefined.UndefinedOr[
             typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
         ] = undefined.UNDEFINED,
-        reply_mention: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
     ) -> messages.Message:
         """Create a message in this channel.
 
@@ -408,11 +408,16 @@ class TextChannel(PartialChannel, abc.ABC):
         nonce : hikari.undefined.UndefinedOr[builtins.str]
             If provided, a nonce that can be used for optimistic message
             sending.
-        reply_message : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]]
+        reply_to : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]]
             If provided, the message to reply to.
         mentions_everyone : hikari.undefined.UndefinedOr[builtins.bool]
             If provided, whether the message should parse @everyone/@here
             mentions.
+        mentions_reply : hikari.undefined.UndefinedOr[builtins.bool]
+            If provided, whether to mention the author of the message
+            that is being replied to.
+
+            This will not do anything if not being used with `reply_to`.
         user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], builtins.bool]]
             If provided, and `builtins.True`, all mentions will be parsed.
             If provided, and `builtins.False`, no mentions will be parsed.
@@ -427,11 +432,6 @@ class TextChannel(PartialChannel, abc.ABC):
             `hikari.snowflakes.Snowflake`, or
             `hikari.guilds.PartialRole` derivatives to enforce mentioning
             specific roles.
-        reply_mention : hikari.undefined.UndefinedOr[builtins.bool]
-            If provided, whether to mention the author of the message
-            that is being replied to.
-
-            This will not do anything if not being used with `reply_message`.
 
         !!! note
             Attachments can be passed as many different things, to aid in
@@ -474,7 +474,7 @@ class TextChannel(PartialChannel, abc.ABC):
             limits; too many attachments; attachments that are too large;
             invalid image URLs in embeds; users in `user_mentions` not being
             mentioned in the message content; roles in `role_mentions` not
-            being mentioned in the message content; `reply_message` not found
+            being mentioned in the message content; `reply_to` not found
             or not in the same channel.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
@@ -502,11 +502,11 @@ class TextChannel(PartialChannel, abc.ABC):
             attachments=attachments,
             nonce=nonce,
             tts=tts,
-            reply_message=reply_message,
+            reply_to=reply_to,
             mentions_everyone=mentions_everyone,
             user_mentions=user_mentions,
             role_mentions=role_mentions,
-            reply_mention=reply_mention,
+            mentions_reply=mentions_reply,
         )
 
     def trigger_typing(self) -> special_endpoints.TypingIndicator:

--- a/hikari/emojis.py
+++ b/hikari/emojis.py
@@ -255,7 +255,7 @@ class CustomEmoji(snowflakes.Unique, Emoji):
 
         >>> emojis = await bot.rest.fetch_guild_emojis(12345)
         >>> picks = random.choices(emojis, 5)
-        >>> await event.reply(files=picks)
+        >>> await event.respond(files=picks)
 
     !!! warning
         Discord will not provide information on whether these emojis are

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -735,9 +735,9 @@ class RESTClientImpl(rest_api.RESTClient):
     @typing.final
     def _generate_allowed_mentions(
         mentions_everyone: undefined.UndefinedOr[bool],
+        mentions_reply: undefined.UndefinedOr[bool],
         user_mentions: undefined.UndefinedOr[typing.Union[snowflakes.SnowflakeishSequence[users.PartialUser], bool]],
         role_mentions: undefined.UndefinedOr[typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]],
-        reply_mention: undefined.UndefinedOr[bool],
     ) -> data_binding.JSONObject:
         parsed_mentions: typing.List[str] = []
         allowed_mentions: typing.Dict[str, typing.Any] = {"parse": parsed_mentions}
@@ -745,7 +745,7 @@ class RESTClientImpl(rest_api.RESTClient):
         if mentions_everyone is True:
             parsed_mentions.append("everyone")
 
-        if reply_mention is True:
+        if mentions_reply is True:
             allowed_mentions["replied_user"] = True
 
         if user_mentions is True:
@@ -997,15 +997,15 @@ class RESTClientImpl(rest_api.RESTClient):
         attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
         tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         nonce: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-        reply_message: undefined.UndefinedOr[snowflakes.SnowflakeishOr[messages_.PartialMessage]] = undefined.UNDEFINED,
+        reply_to: undefined.UndefinedOr[snowflakes.SnowflakeishOr[messages_.PartialMessage]] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
+        mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
             typing.Union[snowflakes.SnowflakeishSequence[users.PartialUser], bool]
         ] = undefined.UNDEFINED,
         role_mentions: undefined.UndefinedOr[
             typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
         ] = undefined.UNDEFINED,
-        reply_mention: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
     ) -> messages_.Message:
         if not undefined.count(attachment, attachments):
             raise ValueError("You may only specify one of 'attachment' or 'attachments', not both")
@@ -1038,12 +1038,12 @@ class RESTClientImpl(rest_api.RESTClient):
         body = data_binding.JSONObjectBuilder()
         body.put(
             "allowed_mentions",
-            self._generate_allowed_mentions(mentions_everyone, user_mentions, role_mentions, reply_mention),
+            self._generate_allowed_mentions(mentions_everyone, mentions_reply, user_mentions, role_mentions),
         )
         body.put("content", content, conversion=str)
         body.put("nonce", nonce)
         body.put("tts", tts)
-        body.put("message_reference", reply_message, conversion=lambda m: {"message_id": str(int(m))})
+        body.put("message_reference", reply_to, conversion=lambda m: {"message_id": str(int(m))})
 
         final_attachments: typing.List[files.Resource[files.AsyncReader]] = []
         if attachment is not undefined.UNDEFINED:
@@ -1096,6 +1096,7 @@ class RESTClientImpl(rest_api.RESTClient):
         *,
         embed: undefined.UndefinedNoneOr[embeds_.Embed] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
+        mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
             typing.Union[snowflakes.SnowflakeishSequence[users.PartialUser], bool]
         ] = undefined.UNDEFINED,
@@ -1107,10 +1108,10 @@ class RESTClientImpl(rest_api.RESTClient):
         route = routes.PATCH_CHANNEL_MESSAGE.compile(channel=channel, message=message)
         body = data_binding.JSONObjectBuilder()
         body.put("flags", flags)
-        if undefined.count(mentions_everyone, user_mentions, role_mentions) != 3:
+        if undefined.count(mentions_everyone, mentions_reply, user_mentions, role_mentions) != 4:
             body.put(
                 "allowed_mentions",
-                self._generate_allowed_mentions(mentions_everyone, user_mentions, role_mentions, undefined.UNDEFINED),
+                self._generate_allowed_mentions(mentions_everyone, mentions_reply, user_mentions, role_mentions),
             )
 
         if embed is undefined.UNDEFINED and isinstance(content, embeds_.Embed):
@@ -1459,7 +1460,7 @@ class RESTClientImpl(rest_api.RESTClient):
         body = data_binding.JSONObjectBuilder()
         body.put(
             "mentions",
-            self._generate_allowed_mentions(mentions_everyone, user_mentions, role_mentions, undefined.UNDEFINED),
+            self._generate_allowed_mentions(mentions_everyone, undefined.UNDEFINED, user_mentions, role_mentions),
         )
         body.put("content", content, conversion=str)
         body.put("embeds", serialized_embeds)
@@ -1526,7 +1527,7 @@ class RESTClientImpl(rest_api.RESTClient):
         if undefined.count(mentions_everyone, user_mentions, role_mentions) != 3:
             body.put(
                 "allowed_mentions",
-                self._generate_allowed_mentions(mentions_everyone, user_mentions, role_mentions, undefined.UNDEFINED),
+                self._generate_allowed_mentions(mentions_everyone, undefined.UNDEFINED, user_mentions, role_mentions),
             )
 
         if content is not None:

--- a/hikari/messages.py
+++ b/hikari/messages.py
@@ -607,6 +607,7 @@ class PartialMessage(snowflakes.Unique):
         *,
         embed: undefined.UndefinedNoneOr[embeds_.Embed] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
+        mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
             typing.Union[snowflakes.SnowflakeishSequence[users_.PartialUser], bool]
         ] = undefined.UNDEFINED,
@@ -644,6 +645,11 @@ class PartialMessage(snowflakes.Unique):
             not changed. If `builtins.True`, then `@everyone`/`@here` mentions
             in the message content will show up as mentioning everyone that can
             view the chat.
+        mentions_reply : hikari.undefined.UndefinedOr[builtins.bool]
+            If provided, whether to mention the author of the message
+            that is being replied to.
+
+            This will not do anything if this is not a reply message.
         user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], builtins.bool]]
             Sanitation for user mentions. If
             `hikari.undefined.UNDEFINED`, then the previous setting is
@@ -721,12 +727,13 @@ class PartialMessage(snowflakes.Unique):
             content=content,
             embed=embed,
             mentions_everyone=mentions_everyone,
+            mentions_reply=mentions_reply,
             user_mentions=user_mentions,
             role_mentions=role_mentions,
             flags=flags,
         )
 
-    async def reply(
+    async def respond(
         self,
         content: undefined.UndefinedOr[typing.Any] = undefined.UNDEFINED,
         *,
@@ -735,17 +742,20 @@ class PartialMessage(snowflakes.Unique):
         attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
         nonce: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-        reply_message: undefined.UndefinedOr[snowflakes.SnowflakeishOr[PartialMessage]] = undefined.UNDEFINED,
+        reply_to: undefined.UndefinedOr[snowflakes.SnowflakeishOr[PartialMessage]] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
+        mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
             typing.Union[snowflakes.SnowflakeishSequence[users_.PartialUser], bool]
         ] = undefined.UNDEFINED,
         role_mentions: undefined.UndefinedOr[
             typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
         ] = undefined.UNDEFINED,
-        reply_mention: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
     ) -> Message:
         """Create a message in the channel this message belongs to.
+
+        !!! note
+            To reply to the message, please use `reply`.
 
         Parameters
         ----------
@@ -778,11 +788,16 @@ class PartialMessage(snowflakes.Unique):
         nonce : hikari.undefined.UndefinedOr[builtins.str]
             If provided, a nonce that can be used for optimistic message
             sending.
-        reply_message : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]]
+        reply_to : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]]
             If provided, the message to reply to.
         mentions_everyone : hikari.undefined.UndefinedOr[builtins.bool]
             If provided, whether the message should parse @everyone/@here
             mentions.
+        mentions_reply : hikari.undefined.UndefinedOr[builtins.bool]
+            If provided, whether to mention the author of the message
+            that is being replied to.
+
+            This will not do anything if not being used with `reply_to`.
         user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], builtins.bool]]
             If provided, and `builtins.True`, all mentions will be parsed.
             If provided, and `builtins.False`, no mentions will be parsed.
@@ -796,11 +811,6 @@ class PartialMessage(snowflakes.Unique):
             `hikari.snowflakes.Snowflake`, or
             `hikari.guilds.PartialRole` derivatives to enforce mentioning
             specific roles.
-        reply_mention : hikari.undefined.UndefinedOr[builtins.bool]
-            If provided, whether to mention the author of the message
-            that is being replied to.
-
-            This will not do anything if not being used with `reply_message`.
 
         !!! note
             Attachments can be passed as many different things, to aid in
@@ -843,7 +853,7 @@ class PartialMessage(snowflakes.Unique):
             limits; too many attachments; attachments that are too large;
             invalid image URLs in embeds; users in `user_mentions` not being
             mentioned in the message content; roles in `role_mentions` not
-            being mentioned in the message content; `reply_message` not found
+            being mentioned in the message content; `reply_to` not found
             or not in the same channel.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
@@ -871,11 +881,164 @@ class PartialMessage(snowflakes.Unique):
             attachments=attachments,
             nonce=nonce,
             tts=tts,
-            reply_message=reply_message,
+            reply_to=reply_to,
             mentions_everyone=mentions_everyone,
             user_mentions=user_mentions,
             role_mentions=role_mentions,
-            reply_mention=reply_mention,
+            mentions_reply=mentions_reply,
+        )
+
+    async def reply(
+        self,
+        content: undefined.UndefinedOr[typing.Any] = undefined.UNDEFINED,
+        *,
+        embed: undefined.UndefinedOr[embeds_.Embed] = undefined.UNDEFINED,
+        attachment: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
+        attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
+        nonce: undefined.UndefinedOr[str] = undefined.UNDEFINED,
+        tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
+        mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
+        mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
+        user_mentions: undefined.UndefinedOr[
+            typing.Union[snowflakes.SnowflakeishSequence[users_.PartialUser], bool]
+        ] = undefined.UNDEFINED,
+        role_mentions: undefined.UndefinedOr[
+            typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
+        ] = undefined.UNDEFINED,
+    ) -> Message:
+        """Reply to this message.
+
+        !!! note
+            To create a message in the same channel as this message without
+            actually replying to it, use `respond`.
+
+        Parameters
+        ----------
+        content : hikari.undefined.UndefinedOr[typing.Any]
+            If provided, the message contents. If
+            `hikari.undefined.UNDEFINED`, then nothing will be sent
+            in the content. Any other value here will be cast to a
+            `builtins.str`.
+
+            If this is a `hikari.embeds.Embed` and no `embed` kwarg is
+            provided, then this will instead update the embed. This allows for
+            simpler syntax when sending an embed alone.
+
+            Likewise, if this is a `hikari.files.Resource`, then the
+            content is instead treated as an attachment if no `attachment` and
+            no `attachments` kwargs are provided.
+
+        Other Parameters
+        ----------------
+        embed : hikari.undefined.UndefinedOr[hikari.embeds.Embed]
+            If provided, the message embed.
+        attachment : hikari.undefined.UndefinedOr[hikari.files.Resourceish],
+            If provided, the message attachment. This can be a resource,
+            or string of a path on your computer or a URL.
+        attachments : hikari.undefined.UndefinedOr[typing.Sequence[hikari.files.Resourceish]],
+            If provided, the message attachments. These can be resources, or
+            strings consisting of paths on your computer or URLs.
+        tts : hikari.undefined.UndefinedOr[builtins.bool]
+            If provided, whether the message will be TTS (Text To Speech).
+        nonce : hikari.undefined.UndefinedOr[builtins.str]
+            If provided, a nonce that can be used for optimistic message
+            sending.
+        mentions_everyone : hikari.undefined.UndefinedOr[builtins.bool]
+            If provided, whether the message should parse @everyone/@here
+            mentions.
+        mentions_reply : hikari.undefined.UndefinedOr[builtins.bool]
+            If provided, whether to mention the author of the message
+            that is being replied to.
+
+            This will not do anything if not being used with `reply_to`.
+        user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], builtins.bool]]
+            If provided, and `builtins.True`, all mentions will be parsed.
+            If provided, and `builtins.False`, no mentions will be parsed.
+            Alternatively this may be a collection of
+            `hikari.snowflakes.Snowflake`, or `hikari.users.PartialUser`
+            derivatives to enforce mentioning specific users.
+        role_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole], builtins.bool]]
+            If provided, and `builtins.True`, all mentions will be parsed.
+            If provided, and `builtins.False`, no mentions will be parsed.
+            Alternatively this may be a collection of
+            `hikari.snowflakes.Snowflake`, or
+            `hikari.guilds.PartialRole` derivatives to enforce mentioning
+            specific roles.
+
+        !!! note
+            Attachments can be passed as many different things, to aid in
+            convenience.
+
+            - If a `pathlib.PurePath` or `builtins.str` to a valid URL, the
+                resource at the given URL will be streamed to Discord when
+                sending the message. Subclasses of
+                `hikari.files.WebResource` such as
+                `hikari.files.URL`,
+                `hikari.messages.Attachment`,
+                `hikari.emojis.Emoji`,
+                `EmbedResource`, etc will also be uploaded this way.
+                This will use bit-inception, so only a small percentage of the
+                resource will remain in memory at any one time, thus aiding in
+                scalability.
+            - If a `hikari.files.Bytes` is passed, or a `builtins.str`
+                that contains a valid data URI is passed, then this is uploaded
+                with a randomized file name if not provided.
+            - If a `hikari.files.File`, `pathlib.PurePath` or
+                `builtins.str` that is an absolute or relative path to a file
+                on your file system is passed, then this resource is uploaded
+                as an attachment using non-blocking code internally and streamed
+                using bit-inception where possible. This depends on the
+                type of `concurrent.futures.Executor` that is being used for
+                the application (default is a thread pool which supports this
+                behaviour).
+
+        Returns
+        -------
+        hikari.messages.Message
+            The created message.
+
+        Raises
+        ------
+        hikari.errors.BadRequestError
+            This may be raised in several discrete situations, such as messages
+            being empty with no attachments or embeds; messages with more than
+            2000 characters in them, embeds that exceed one of the many embed
+            limits; too many attachments; attachments that are too large;
+            invalid image URLs in embeds; users in `user_mentions` not being
+            mentioned in the message content; roles in `role_mentions` not
+            being mentioned in the message content; `reply_to` not found
+            or not in the same channel.
+        hikari.errors.UnauthorizedError
+            If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.ForbiddenError
+            If you lack permissions to send messages in the given channel.
+        hikari.errors.NotFoundError
+            If the channel is not found.
+        hikari.errors.InternalServerError
+            If an internal error occurs on Discord while handling the request.
+        builtins.ValueError
+            If more than 100 unique objects/entities are passed for
+            `role_mentions` or `user_mentions`.
+        builtins.TypeError
+            If both `attachment` and `attachments` are specified.
+
+        !!! warning
+            You are expected to make a connection to the gateway and identify
+            once before being able to use this endpoint for a bot.
+        """  # noqa: E501 - Line too long
+        return await self.app.rest.create_message(
+            channel=self.channel_id,
+            content=content,
+            embed=embed,
+            attachment=attachment,
+            attachments=attachments,
+            nonce=nonce,
+            tts=tts,
+            reply_to=self,
+            mentions_everyone=mentions_everyone,
+            user_mentions=user_mentions,
+            role_mentions=role_mentions,
+            mentions_reply=mentions_reply,
         )
 
     async def delete(self) -> None:

--- a/hikari/users.py
+++ b/hikari/users.py
@@ -222,15 +222,15 @@ class PartialUser(snowflakes.Unique, abc.ABC):
         attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
         nonce: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-        reply_message: undefined.UndefinedOr[snowflakes.SnowflakeishOr[messages.PartialMessage]] = undefined.UNDEFINED,
+        reply_to: undefined.UndefinedOr[snowflakes.SnowflakeishOr[messages.PartialMessage]] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
+        mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
             typing.Union[snowflakes.SnowflakeishSequence[PartialUser], bool]
         ] = undefined.UNDEFINED,
         role_mentions: undefined.UndefinedOr[
             typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
         ] = undefined.UNDEFINED,
-        reply_mention: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
     ) -> messages.Message:
         """Send a message to this user in DM's.
 
@@ -269,11 +269,16 @@ class PartialUser(snowflakes.Unique, abc.ABC):
             this must be less than 32 bytes. If not provided, then
             a null value is placed on the message instead. All users can
             see this value.
-        reply_message : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]]
+        reply_to : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]]
             If provided, the message to reply to.
         mentions_everyone : hikari.undefined.UndefinedOr[builtins.bool]
             If provided, whether the message should parse @everyone/@here
             mentions.
+        mentions_reply : hikari.undefined.UndefinedOr[builtins.bool]
+            If provided, whether to mention the author of the message
+            that is being replied to.
+
+            This will not do anything if not being used with `reply_to`.
         user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], builtins.bool]]
             If provided, and `builtins.True`, all user mentions will be detected.
             If provided, and `builtins.False`, all user mentions will be ignored
@@ -290,11 +295,6 @@ class PartialUser(snowflakes.Unique, abc.ABC):
             `hikari.snowflakes.Snowflake`, or
             `hikari.guilds.PartialRole` derivatives to enforce mentioning
             specific roles.
-        reply_mention : hikari.undefined.UndefinedOr[builtins.bool]
-            If provided, whether to mention the author of the message
-            that is being replied to.
-
-            This will not do anything if not being used with `reply_message`.
 
         !!! note
             Attachments can be passed as many different things, to aid in
@@ -342,7 +342,7 @@ class PartialUser(snowflakes.Unique, abc.ABC):
             limits; too many attachments; attachments that are too large;
             invalid image URLs in embeds; users in `user_mentions` not being
             mentioned in the message content; roles in `role_mentions` not
-            being mentioned in the message content; `reply_message` not found
+            being mentioned in the message content; `reply_to` not found
             or not in the same channel.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
@@ -379,11 +379,11 @@ class PartialUser(snowflakes.Unique, abc.ABC):
             attachments=attachments,
             nonce=nonce,
             tts=tts,
-            reply_message=reply_message,
+            reply_to=reply_to,
             mentions_everyone=mentions_everyone,
             user_mentions=user_mentions,
             role_mentions=role_mentions,
-            reply_mention=reply_mention,
+            mentions_reply=mentions_reply,
         )
 
 
@@ -663,14 +663,14 @@ class OwnUser(UserImpl):
         attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
         nonce: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-        reply_message: undefined.UndefinedOr[snowflakes.SnowflakeishOr[messages.PartialMessage]] = undefined.UNDEFINED,
+        reply_to: undefined.UndefinedOr[snowflakes.SnowflakeishOr[messages.PartialMessage]] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
+        mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
             typing.Union[snowflakes.SnowflakeishSequence[PartialUser], bool]
         ] = undefined.UNDEFINED,
         role_mentions: undefined.UndefinedOr[
             typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
         ] = undefined.UNDEFINED,
-        reply_mention: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
     ) -> typing.NoReturn:
         raise TypeError("Unable to send a DM to yourself")

--- a/pages/index.html
+++ b/pages/index.html
@@ -65,7 +65,7 @@
             @bot.listen()
             @command("hk.ping")
             async def ping(event: hikari.MessageCreateEvent) -> None:
-                await event.message.reply("Pong!")
+                await event.message.respond("Pong!")
 
 
             @bot.listen()
@@ -79,13 +79,13 @@
                     )
 
                 try:
-                    await event.message.reply("Please enter the first number")
+                    await event.message.respond("Please enter the first number")
                     e1 = await bot.wait_for(hikari.MessageCreateEvent, predicate=is_number_check, timeout=30)
-                    await event.message.reply("Please enter the second number")
+                    await event.message.respond("Please enter the second number")
                     e2 = await bot.wait_for(hikari.MessageCreateEvent, predicate=is_number_check, timeout=30)
 
                 except asyncio.TimeoutError:
-                    await event.message.reply("You took too long...")
+                    await event.message.respond("You took too long...")
 
                 else:
                     val1 = int(e1.message.content)
@@ -93,7 +93,7 @@
 
                     embed = hikari.Embed(title="Result!", description=f"{val1} + {val2} = {val1 + val2}", color="#3f3")
 
-                    await event.message.reply(embed=embed)
+                    await event.message.respond(embed=embed)
 
 
             bot.run()

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -535,9 +535,9 @@ class TestRESTClientImpl:
             ((False, False, False, False), {"parse": []}),
             ((undefined.UNDEFINED, undefined.UNDEFINED, undefined.UNDEFINED, undefined.UNDEFINED), {"parse": []}),
             ((undefined.UNDEFINED, True, True, True), {"parse": ["roles", "users"], "replied_user": True}),
-            ((False, [123], [456], False), {"parse": [], "users": ["123"], "roles": ["456"]}),
+            ((False, False, [123], [456]), {"parse": [], "users": ["123"], "roles": ["456"]}),
             (
-                (True, [123, "123", 987], ["213", "456", 456], True),
+                (True, True, [123, "123", 987], ["213", "456", 456]),
                 {"parse": ["everyone"], "users": ["123", "987"], "roles": ["213", "456"], "replied_user": True},
             ),
         ],

--- a/tests/hikari/test_channels.py
+++ b/tests/hikari/test_channels.py
@@ -219,7 +219,7 @@ class TestTextChannel:
         mock_attachment = object()
         mock_embed = object()
         mock_attachments = [object(), object(), object()]
-        mock_reply_message = object()
+        mock_reply_to = object()
 
         await model.send(
             content="test content",
@@ -228,11 +228,11 @@ class TestTextChannel:
             attachment=mock_attachment,
             attachments=mock_attachments,
             embed=mock_embed,
-            reply_message=mock_reply_message,
+            reply_to=mock_reply_to,
             mentions_everyone=False,
             user_mentions=[123, 456],
             role_mentions=[789, 567],
-            reply_mention=True,
+            mentions_reply=True,
         )
 
         model.app.rest.create_message.assert_awaited_once_with(
@@ -243,11 +243,11 @@ class TestTextChannel:
             attachment=mock_attachment,
             attachments=mock_attachments,
             embed=mock_embed,
-            reply_message=mock_reply_message,
+            reply_to=mock_reply_to,
             mentions_everyone=False,
             user_mentions=[123, 456],
             role_mentions=[789, 567],
-            reply_mention=True,
+            mentions_reply=True,
         )
 
     def test_trigger_typing(self, model):

--- a/tests/hikari/test_messages.py
+++ b/tests/hikari/test_messages.py
@@ -182,6 +182,7 @@ class TestAsyncMessage:
             content="test content",
             embed=embed,
             mentions_everyone=True,
+            mentions_reply=False,
             user_mentions=False,
             role_mentions=roles,
             flags=messages.MessageFlag.URGENT,
@@ -192,9 +193,47 @@ class TestAsyncMessage:
             content="test content",
             embed=embed,
             mentions_everyone=True,
+            mentions_reply=False,
             user_mentions=False,
             role_mentions=roles,
             flags=messages.MessageFlag.URGENT,
+        )
+
+    async def test_respond(self, message):
+        message.app = mock.AsyncMock()
+        message.id = 123
+        message.channel_id = 456
+        embed = object()
+        roles = [object()]
+        attachment = object()
+        attachments = [object()]
+        reference_messsage = object()
+        await message.respond(
+            content="test content",
+            embed=embed,
+            attachment=attachment,
+            attachments=attachments,
+            nonce="nonce",
+            tts=True,
+            reply_to=reference_messsage,
+            mentions_everyone=True,
+            user_mentions=False,
+            role_mentions=roles,
+            mentions_reply=True,
+        )
+        message.app.rest.create_message.assert_awaited_once_with(
+            channel=456,
+            content="test content",
+            embed=embed,
+            attachment=attachment,
+            attachments=attachments,
+            nonce="nonce",
+            tts=True,
+            reply_to=reference_messsage,
+            mentions_everyone=True,
+            user_mentions=False,
+            role_mentions=roles,
+            mentions_reply=True,
         )
 
     async def test_reply(self, message):
@@ -205,7 +244,6 @@ class TestAsyncMessage:
         roles = [object()]
         attachment = object()
         attachments = [object()]
-        reference_messsage = object()
         await message.reply(
             content="test content",
             embed=embed,
@@ -213,11 +251,10 @@ class TestAsyncMessage:
             attachments=attachments,
             nonce="nonce",
             tts=True,
-            reply_message=reference_messsage,
             mentions_everyone=True,
             user_mentions=False,
             role_mentions=roles,
-            reply_mention=True,
+            mentions_reply=True,
         )
         message.app.rest.create_message.assert_awaited_once_with(
             channel=456,
@@ -227,11 +264,11 @@ class TestAsyncMessage:
             attachments=attachments,
             nonce="nonce",
             tts=True,
-            reply_message=reference_messsage,
+            reply_to=message,
             mentions_everyone=True,
             user_mentions=False,
             role_mentions=roles,
-            reply_mention=True,
+            mentions_reply=True,
         )
 
     async def test_delete(self, message):

--- a/tests/hikari/test_users.py
+++ b/tests/hikari/test_users.py
@@ -65,8 +65,8 @@ class TestPartialUser:
         role_mentions = [object(), object()]
         mock_channel = mock.Mock(id=456)
         mock_message = object()
-        reply_message = object()
-        reply_mention = object()
+        reply_to = object()
+        mentions_reply = object()
 
         obj.app = mock.Mock()
         obj.fetch_dm_channel = mock.AsyncMock(return_value=mock_channel)
@@ -80,11 +80,11 @@ class TestPartialUser:
             attachments=attachments,
             nonce="nonce",
             tts=True,
-            reply_message=reply_message,
+            reply_to=reply_to,
             mentions_everyone=False,
             user_mentions=user_mentions,
             role_mentions=role_mentions,
-            reply_mention=reply_mention,
+            mentions_reply=mentions_reply,
         )
 
         assert returned == mock_message
@@ -99,10 +99,10 @@ class TestPartialUser:
             nonce="nonce",
             tts=True,
             mentions_everyone=False,
-            reply_message=reply_message,
+            reply_to=reply_to,
             user_mentions=user_mentions,
             role_mentions=role_mentions,
-            reply_mention=reply_mention,
+            mentions_reply=mentions_reply,
         )
 
 


### PR DESCRIPTION
   - Rename `reply_message` arg to `reply_to`
   - Rename `reply_metion` arg to `mentions_reply` for consistency
   - Add `mentions_reply` to `edit_message`

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Closes #418 
