### PR TITLE
Reply cleanups

### DIFF
--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -872,7 +872,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
         tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         nonce: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-        reply_to: undefined.UndefinedOr[snowflakes.SnowflakeishOr[messages_.PartialMessage]] = undefined.UNDEFINED,
+        reply: undefined.UndefinedOr[snowflakes.SnowflakeishOr[messages_.PartialMessage]] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
@@ -921,7 +921,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             this must be less than 32 bytes. If not provided, then
             a null value is placed on the message instead. All users can
             see this value.
-        reply_to : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]]
+        reply : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]]
             If provided, the message to reply to.
         mentions_everyone : hikari.undefined.UndefinedOr[builtins.bool]
             If provided, whether the message should parse @everyone/@here
@@ -930,7 +930,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If provided, whether to mention the author of the message
             that is being replied to.
 
-            This will not do anything if not being used with `reply_to`.
+            This will not do anything if not being used with `reply`.
         user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], builtins.bool]]
             If provided, and `builtins.True`, all user mentions will be detected.
             If provided, and `builtins.False`, all user mentions will be ignored
@@ -994,7 +994,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             limits; too many attachments; attachments that are too large;
             invalid image URLs in embeds; users in `user_mentions` not being
             mentioned in the message content; roles in `role_mentions` not
-            being mentioned in the message content; if `reply_to` is
+            being mentioned in the message content; if `reply` is
             not found or not in the same channel as `channel`.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -365,7 +365,7 @@ class TextChannel(PartialChannel, abc.ABC):
         attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
         nonce: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-        reply_to: undefined.UndefinedOr[snowflakes.SnowflakeishOr[messages.PartialMessage]] = undefined.UNDEFINED,
+        reply: undefined.UndefinedOr[snowflakes.SnowflakeishOr[messages.PartialMessage]] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
@@ -408,7 +408,7 @@ class TextChannel(PartialChannel, abc.ABC):
         nonce : hikari.undefined.UndefinedOr[builtins.str]
             If provided, a nonce that can be used for optimistic message
             sending.
-        reply_to : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]]
+        reply : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]]
             If provided, the message to reply to.
         mentions_everyone : hikari.undefined.UndefinedOr[builtins.bool]
             If provided, whether the message should parse @everyone/@here
@@ -417,7 +417,7 @@ class TextChannel(PartialChannel, abc.ABC):
             If provided, whether to mention the author of the message
             that is being replied to.
 
-            This will not do anything if not being used with `reply_to`.
+            This will not do anything if not being used with `reply`.
         user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], builtins.bool]]
             If provided, and `builtins.True`, all mentions will be parsed.
             If provided, and `builtins.False`, no mentions will be parsed.
@@ -474,7 +474,7 @@ class TextChannel(PartialChannel, abc.ABC):
             limits; too many attachments; attachments that are too large;
             invalid image URLs in embeds; users in `user_mentions` not being
             mentioned in the message content; roles in `role_mentions` not
-            being mentioned in the message content; `reply_to` not found
+            being mentioned in the message content; `reply` not found
             or not in the same channel.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
@@ -502,7 +502,7 @@ class TextChannel(PartialChannel, abc.ABC):
             attachments=attachments,
             nonce=nonce,
             tts=tts,
-            reply_to=reply_to,
+            reply=reply,
             mentions_everyone=mentions_everyone,
             user_mentions=user_mentions,
             role_mentions=role_mentions,

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -997,7 +997,7 @@ class RESTClientImpl(rest_api.RESTClient):
         attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
         tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         nonce: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-        reply_to: undefined.UndefinedOr[snowflakes.SnowflakeishOr[messages_.PartialMessage]] = undefined.UNDEFINED,
+        reply: undefined.UndefinedOr[snowflakes.SnowflakeishOr[messages_.PartialMessage]] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
@@ -1043,7 +1043,7 @@ class RESTClientImpl(rest_api.RESTClient):
         body.put("content", content, conversion=str)
         body.put("nonce", nonce)
         body.put("tts", tts)
-        body.put("message_reference", reply_to, conversion=lambda m: {"message_id": str(int(m))})
+        body.put("message_reference", reply, conversion=lambda m: {"message_id": str(int(m))})
 
         final_attachments: typing.List[files.Resource[files.AsyncReader]] = []
         if attachment is not undefined.UNDEFINED:

--- a/hikari/messages.py
+++ b/hikari/messages.py
@@ -742,7 +742,9 @@ class PartialMessage(snowflakes.Unique):
         attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
         nonce: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-        reply_to: undefined.UndefinedOr[snowflakes.SnowflakeishOr[PartialMessage]] = undefined.UNDEFINED,
+        reply: typing.Union[
+            undefined.UndefinedType, snowflakes.SnowflakeishOr[PartialMessage], bool
+        ] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
@@ -754,9 +756,6 @@ class PartialMessage(snowflakes.Unique):
     ) -> Message:
         """Create a message in the channel this message belongs to.
 
-        !!! note
-            To reply to the message, please use `reply`.
-
         Parameters
         ----------
         content : hikari.undefined.UndefinedOr[typing.Any]
@@ -788,8 +787,9 @@ class PartialMessage(snowflakes.Unique):
         nonce : hikari.undefined.UndefinedOr[builtins.str]
             If provided, a nonce that can be used for optimistic message
             sending.
-        reply_to : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]]
-            If provided, the message to reply to.
+        reply : typing.Union[hikari.undefined.UndefinedType, hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage], builtins.bool]
+            If provided and `builtins.True`, reply to this message.
+            If provided and not `builtins.bool`, the message to reply to.
         mentions_everyone : hikari.undefined.UndefinedOr[builtins.bool]
             If provided, whether the message should parse @everyone/@here
             mentions.
@@ -797,7 +797,7 @@ class PartialMessage(snowflakes.Unique):
             If provided, whether to mention the author of the message
             that is being replied to.
 
-            This will not do anything if not being used with `reply_to`.
+            This will not do anything if not being used with `reply`.
         user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], builtins.bool]]
             If provided, and `builtins.True`, all mentions will be parsed.
             If provided, and `builtins.False`, no mentions will be parsed.
@@ -853,7 +853,7 @@ class PartialMessage(snowflakes.Unique):
             limits; too many attachments; attachments that are too large;
             invalid image URLs in embeds; users in `user_mentions` not being
             mentioned in the message content; roles in `role_mentions` not
-            being mentioned in the message content; `reply_to` not found
+            being mentioned in the message content; `reply` not found
             or not in the same channel.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
@@ -873,6 +873,9 @@ class PartialMessage(snowflakes.Unique):
             You are expected to make a connection to the gateway and identify
             once before being able to use this endpoint for a bot.
         """  # noqa: E501 - Line too long
+        if reply is True:
+            reply = self
+
         return await self.app.rest.create_message(
             channel=self.channel_id,
             content=content,
@@ -881,160 +884,7 @@ class PartialMessage(snowflakes.Unique):
             attachments=attachments,
             nonce=nonce,
             tts=tts,
-            reply_to=reply_to,
-            mentions_everyone=mentions_everyone,
-            user_mentions=user_mentions,
-            role_mentions=role_mentions,
-            mentions_reply=mentions_reply,
-        )
-
-    async def reply(
-        self,
-        content: undefined.UndefinedOr[typing.Any] = undefined.UNDEFINED,
-        *,
-        embed: undefined.UndefinedOr[embeds_.Embed] = undefined.UNDEFINED,
-        attachment: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
-        attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
-        nonce: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-        tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-        mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-        mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-        user_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[users_.PartialUser], bool]
-        ] = undefined.UNDEFINED,
-        role_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
-        ] = undefined.UNDEFINED,
-    ) -> Message:
-        """Reply to this message.
-
-        !!! note
-            To create a message in the same channel as this message without
-            actually replying to it, use `respond`.
-
-        Parameters
-        ----------
-        content : hikari.undefined.UndefinedOr[typing.Any]
-            If provided, the message contents. If
-            `hikari.undefined.UNDEFINED`, then nothing will be sent
-            in the content. Any other value here will be cast to a
-            `builtins.str`.
-
-            If this is a `hikari.embeds.Embed` and no `embed` kwarg is
-            provided, then this will instead update the embed. This allows for
-            simpler syntax when sending an embed alone.
-
-            Likewise, if this is a `hikari.files.Resource`, then the
-            content is instead treated as an attachment if no `attachment` and
-            no `attachments` kwargs are provided.
-
-        Other Parameters
-        ----------------
-        embed : hikari.undefined.UndefinedOr[hikari.embeds.Embed]
-            If provided, the message embed.
-        attachment : hikari.undefined.UndefinedOr[hikari.files.Resourceish],
-            If provided, the message attachment. This can be a resource,
-            or string of a path on your computer or a URL.
-        attachments : hikari.undefined.UndefinedOr[typing.Sequence[hikari.files.Resourceish]],
-            If provided, the message attachments. These can be resources, or
-            strings consisting of paths on your computer or URLs.
-        tts : hikari.undefined.UndefinedOr[builtins.bool]
-            If provided, whether the message will be TTS (Text To Speech).
-        nonce : hikari.undefined.UndefinedOr[builtins.str]
-            If provided, a nonce that can be used for optimistic message
-            sending.
-        mentions_everyone : hikari.undefined.UndefinedOr[builtins.bool]
-            If provided, whether the message should parse @everyone/@here
-            mentions.
-        mentions_reply : hikari.undefined.UndefinedOr[builtins.bool]
-            If provided, whether to mention the author of the message
-            that is being replied to.
-
-            This will not do anything if not being used with `reply_to`.
-        user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], builtins.bool]]
-            If provided, and `builtins.True`, all mentions will be parsed.
-            If provided, and `builtins.False`, no mentions will be parsed.
-            Alternatively this may be a collection of
-            `hikari.snowflakes.Snowflake`, or `hikari.users.PartialUser`
-            derivatives to enforce mentioning specific users.
-        role_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole], builtins.bool]]
-            If provided, and `builtins.True`, all mentions will be parsed.
-            If provided, and `builtins.False`, no mentions will be parsed.
-            Alternatively this may be a collection of
-            `hikari.snowflakes.Snowflake`, or
-            `hikari.guilds.PartialRole` derivatives to enforce mentioning
-            specific roles.
-
-        !!! note
-            Attachments can be passed as many different things, to aid in
-            convenience.
-
-            - If a `pathlib.PurePath` or `builtins.str` to a valid URL, the
-                resource at the given URL will be streamed to Discord when
-                sending the message. Subclasses of
-                `hikari.files.WebResource` such as
-                `hikari.files.URL`,
-                `hikari.messages.Attachment`,
-                `hikari.emojis.Emoji`,
-                `EmbedResource`, etc will also be uploaded this way.
-                This will use bit-inception, so only a small percentage of the
-                resource will remain in memory at any one time, thus aiding in
-                scalability.
-            - If a `hikari.files.Bytes` is passed, or a `builtins.str`
-                that contains a valid data URI is passed, then this is uploaded
-                with a randomized file name if not provided.
-            - If a `hikari.files.File`, `pathlib.PurePath` or
-                `builtins.str` that is an absolute or relative path to a file
-                on your file system is passed, then this resource is uploaded
-                as an attachment using non-blocking code internally and streamed
-                using bit-inception where possible. This depends on the
-                type of `concurrent.futures.Executor` that is being used for
-                the application (default is a thread pool which supports this
-                behaviour).
-
-        Returns
-        -------
-        hikari.messages.Message
-            The created message.
-
-        Raises
-        ------
-        hikari.errors.BadRequestError
-            This may be raised in several discrete situations, such as messages
-            being empty with no attachments or embeds; messages with more than
-            2000 characters in them, embeds that exceed one of the many embed
-            limits; too many attachments; attachments that are too large;
-            invalid image URLs in embeds; users in `user_mentions` not being
-            mentioned in the message content; roles in `role_mentions` not
-            being mentioned in the message content; `reply_to` not found
-            or not in the same channel.
-        hikari.errors.UnauthorizedError
-            If you are unauthorized to make the request (invalid/missing token).
-        hikari.errors.ForbiddenError
-            If you lack permissions to send messages in the given channel.
-        hikari.errors.NotFoundError
-            If the channel is not found.
-        hikari.errors.InternalServerError
-            If an internal error occurs on Discord while handling the request.
-        builtins.ValueError
-            If more than 100 unique objects/entities are passed for
-            `role_mentions` or `user_mentions`.
-        builtins.TypeError
-            If both `attachment` and `attachments` are specified.
-
-        !!! warning
-            You are expected to make a connection to the gateway and identify
-            once before being able to use this endpoint for a bot.
-        """  # noqa: E501 - Line too long
-        return await self.app.rest.create_message(
-            channel=self.channel_id,
-            content=content,
-            embed=embed,
-            attachment=attachment,
-            attachments=attachments,
-            nonce=nonce,
-            tts=tts,
-            reply_to=self,
+            reply=reply,
             mentions_everyone=mentions_everyone,
             user_mentions=user_mentions,
             role_mentions=role_mentions,

--- a/hikari/users.py
+++ b/hikari/users.py
@@ -222,7 +222,7 @@ class PartialUser(snowflakes.Unique, abc.ABC):
         attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
         nonce: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-        reply_to: undefined.UndefinedOr[snowflakes.SnowflakeishOr[messages.PartialMessage]] = undefined.UNDEFINED,
+        reply: undefined.UndefinedOr[snowflakes.SnowflakeishOr[messages.PartialMessage]] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
@@ -269,7 +269,7 @@ class PartialUser(snowflakes.Unique, abc.ABC):
             this must be less than 32 bytes. If not provided, then
             a null value is placed on the message instead. All users can
             see this value.
-        reply_to : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]]
+        reply : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]]
             If provided, the message to reply to.
         mentions_everyone : hikari.undefined.UndefinedOr[builtins.bool]
             If provided, whether the message should parse @everyone/@here
@@ -278,7 +278,7 @@ class PartialUser(snowflakes.Unique, abc.ABC):
             If provided, whether to mention the author of the message
             that is being replied to.
 
-            This will not do anything if not being used with `reply_to`.
+            This will not do anything if not being used with `reply`.
         user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], builtins.bool]]
             If provided, and `builtins.True`, all user mentions will be detected.
             If provided, and `builtins.False`, all user mentions will be ignored
@@ -342,7 +342,7 @@ class PartialUser(snowflakes.Unique, abc.ABC):
             limits; too many attachments; attachments that are too large;
             invalid image URLs in embeds; users in `user_mentions` not being
             mentioned in the message content; roles in `role_mentions` not
-            being mentioned in the message content; `reply_to` not found
+            being mentioned in the message content; `reply` not found
             or not in the same channel.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
@@ -379,7 +379,7 @@ class PartialUser(snowflakes.Unique, abc.ABC):
             attachments=attachments,
             nonce=nonce,
             tts=tts,
-            reply_to=reply_to,
+            reply=reply,
             mentions_everyone=mentions_everyone,
             user_mentions=user_mentions,
             role_mentions=role_mentions,
@@ -663,7 +663,7 @@ class OwnUser(UserImpl):
         attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
         nonce: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-        reply_to: undefined.UndefinedOr[snowflakes.SnowflakeishOr[messages.PartialMessage]] = undefined.UNDEFINED,
+        reply: undefined.UndefinedOr[snowflakes.SnowflakeishOr[messages.PartialMessage]] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[

--- a/tests/hikari/test_channels.py
+++ b/tests/hikari/test_channels.py
@@ -219,7 +219,7 @@ class TestTextChannel:
         mock_attachment = object()
         mock_embed = object()
         mock_attachments = [object(), object(), object()]
-        mock_reply_to = object()
+        mock_reply = object()
 
         await model.send(
             content="test content",
@@ -228,7 +228,7 @@ class TestTextChannel:
             attachment=mock_attachment,
             attachments=mock_attachments,
             embed=mock_embed,
-            reply_to=mock_reply_to,
+            reply=mock_reply,
             mentions_everyone=False,
             user_mentions=[123, 456],
             role_mentions=[789, 567],
@@ -243,7 +243,7 @@ class TestTextChannel:
             attachment=mock_attachment,
             attachments=mock_attachments,
             embed=mock_embed,
-            reply_to=mock_reply_to,
+            reply=mock_reply,
             mentions_everyone=False,
             user_mentions=[123, 456],
             role_mentions=[789, 567],

--- a/tests/hikari/test_messages.py
+++ b/tests/hikari/test_messages.py
@@ -215,7 +215,7 @@ class TestAsyncMessage:
             attachments=attachments,
             nonce="nonce",
             tts=True,
-            reply_to=reference_messsage,
+            reply=reference_messsage,
             mentions_everyone=True,
             user_mentions=False,
             role_mentions=roles,
@@ -229,14 +229,14 @@ class TestAsyncMessage:
             attachments=attachments,
             nonce="nonce",
             tts=True,
-            reply_to=reference_messsage,
+            reply=reference_messsage,
             mentions_everyone=True,
             user_mentions=False,
             role_mentions=roles,
             mentions_reply=True,
         )
 
-    async def test_reply(self, message):
+    async def test_respond_when_reply_is_True(self, message):
         message.app = mock.AsyncMock()
         message.id = 123
         message.channel_id = 456
@@ -244,13 +244,14 @@ class TestAsyncMessage:
         roles = [object()]
         attachment = object()
         attachments = [object()]
-        await message.reply(
+        await message.respond(
             content="test content",
             embed=embed,
             attachment=attachment,
             attachments=attachments,
             nonce="nonce",
             tts=True,
+            reply=True,
             mentions_everyone=True,
             user_mentions=False,
             role_mentions=roles,
@@ -264,7 +265,7 @@ class TestAsyncMessage:
             attachments=attachments,
             nonce="nonce",
             tts=True,
-            reply_to=message,
+            reply=message,
             mentions_everyone=True,
             user_mentions=False,
             role_mentions=roles,

--- a/tests/hikari/test_users.py
+++ b/tests/hikari/test_users.py
@@ -65,7 +65,7 @@ class TestPartialUser:
         role_mentions = [object(), object()]
         mock_channel = mock.Mock(id=456)
         mock_message = object()
-        reply_to = object()
+        reply = object()
         mentions_reply = object()
 
         obj.app = mock.Mock()
@@ -80,7 +80,7 @@ class TestPartialUser:
             attachments=attachments,
             nonce="nonce",
             tts=True,
-            reply_to=reply_to,
+            reply=reply,
             mentions_everyone=False,
             user_mentions=user_mentions,
             role_mentions=role_mentions,
@@ -99,7 +99,7 @@ class TestPartialUser:
             nonce="nonce",
             tts=True,
             mentions_everyone=False,
-            reply_to=reply_to,
+            reply=reply,
             user_mentions=user_mentions,
             role_mentions=role_mentions,
             mentions_reply=mentions_reply,


### PR DESCRIPTION
  - Rename `reply_to` to `reply`
  - Remove `PartialMessage.reply`
  - Allow `PartialMessage.respond(reply=...)` to take in a bool to reply to self.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
