### PR TITLE
Allow the event manager to run stateless-ly

### DIFF
--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -262,7 +262,7 @@ class BotApp(traits.BotAware, event_dispatcher.EventDispatcher):
         self._cache = cache_impl.CacheImpl(self, cache_settings)
 
         # Event handling
-        self._events = event_manager.EventManagerImpl(self, self._cache)
+        self._events = event_manager.EventManagerImpl(self, cache=self._cache)
 
         # Entity creation
         self._entity_factory = entity_factory_impl.EntityFactoryImpl(self)


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
