### PR TITLE
Add a member object return to rest.edit_member

### DIFF
--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -3857,7 +3857,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             snowflakes.SnowflakeishOr[channels.GuildVoiceChannel]
         ] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-    ) -> None:
+    ) -> guilds.Member:
         """Edit a guild member.
 
         Parameters
@@ -3903,6 +3903,11 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         reason : hikari.undefined.UndefinedOr[builtins.str]
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
+
+        Returns
+        -------
+        hikari.guilds.Member
+            Object of the member that was updated.
 
         Raises
         ------

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -2094,7 +2094,7 @@ class RESTClientImpl(rest_api.RESTClient):
             snowflakes.SnowflakeishOr[channels.GuildVoiceChannel]
         ] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-    ) -> None:
+    ) -> guilds.Member:
         route = routes.PATCH_GUILD_MEMBER.compile(guild=guild, user=user)
         body = data_binding.JSONObjectBuilder()
         body.put("nick", nick)
@@ -2107,7 +2107,9 @@ class RESTClientImpl(rest_api.RESTClient):
         elif voice_channel is not undefined.UNDEFINED:
             body.put_snowflake("channel_id", voice_channel)
 
-        await self._request(route, json=body, reason=reason)
+        raw_response = await self._request(route, json=body, reason=reason)
+        response = typing.cast(data_binding.JSONObject, raw_response)
+        return self._entity_factory.deserialize_member(response, guild_id=snowflakes.Snowflake(guild))
 
     async def edit_my_nick(
         self,

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -2248,7 +2248,7 @@ class TestRESTClientImplAsync:
         expected_json = {"nick": "test", "roles": ["654", "321"], "mute": True, "deaf": False, "channel_id": "987"}
         rest_client._request = mock.AsyncMock(return_value={"id": "789"})
 
-        await rest_client.edit_member(
+        result = await rest_client.edit_member(
             StubModel(123),
             StubModel(456),
             nick="test",
@@ -2258,6 +2258,11 @@ class TestRESTClientImplAsync:
             voice_channel=StubModel(987),
             reason="because i can",
         )
+
+        assert result is rest_client._entity_factory.deserialize_member.return_value
+        rest_client._entity_factory.deserialize_member.assert_called_once_with(
+            rest_client._request.return_value, guild_id=123
+        )
         rest_client._request.assert_awaited_once_with(expected_route, json=expected_json, reason="because i can")
 
     async def test_edit_member_when_voice_channel_is_None(self, rest_client):
@@ -2265,7 +2270,7 @@ class TestRESTClientImplAsync:
         expected_json = {"nick": "test", "roles": ["654", "321"], "mute": True, "deaf": False, "channel_id": None}
         rest_client._request = mock.AsyncMock(return_value={"id": "789"})
 
-        await rest_client.edit_member(
+        result = await rest_client.edit_member(
             StubModel(123),
             StubModel(456),
             nick="test",
@@ -2274,6 +2279,11 @@ class TestRESTClientImplAsync:
             deaf=False,
             voice_channel=None,
             reason="because i can",
+        )
+
+        assert result is rest_client._entity_factory.deserialize_member.return_value
+        rest_client._entity_factory.deserialize_member.assert_called_once_with(
+            rest_client._request.return_value, guild_id=123
         )
         rest_client._request.assert_awaited_once_with(
             expected_route,
@@ -2285,7 +2295,12 @@ class TestRESTClientImplAsync:
         expected_route = routes.PATCH_GUILD_MEMBER.compile(guild=123, user=456)
         rest_client._request = mock.AsyncMock(return_value={"id": "789"})
 
-        await rest_client.edit_member(StubModel(123), StubModel(456))
+        result = await rest_client.edit_member(StubModel(123), StubModel(456))
+
+        assert result is rest_client._entity_factory.deserialize_member.return_value
+        rest_client._entity_factory.deserialize_member.assert_called_once_with(
+            rest_client._request.return_value, guild_id=123
+        )
         rest_client._request.assert_awaited_once_with(expected_route, json={}, reason=undefined.UNDEFINED)
 
     async def test_edit_my_nick(self, rest_client):


### PR DESCRIPTION
### Summary
Add a member object return to rest.edit_member

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
