### PR TITLE
Add proxy resource to EmbedVideo and fix handling of None in embed resources.

### DIFF
--- a/hikari/embeds.py
+++ b/hikari/embeds.py
@@ -69,10 +69,24 @@ class EmbedResource(files.Resource[AsyncReaderT]):
     @property
     @typing.final
     def url(self) -> str:
+        """URL of this embed resource.
+
+        Returns
+        -------
+        typing.Optional[builtins.str]
+            The URL of this embed resource.
+        """
         return self.resource.url
 
     @property
     def filename(self) -> str:
+        """File name of this embed resource.
+
+        Returns
+        -------
+        typing.Optional[builtins.str]
+            The file name of this embed resource.
+        """
         return self.resource.filename
 
     def stream(
@@ -109,6 +123,32 @@ class EmbedResourceWithProxy(EmbedResource[AsyncReaderT]):
         and will be ignored during serialization. Expect this to be
         populated on any received embed attached to a message event.
     """
+
+    @property
+    @typing.final
+    def proxy_url(self) -> typing.Optional[str]:
+        """Proxied URL of this embed resource if applicable.
+
+        Returns
+        -------
+        typing.Optional[builtins.str]
+            The proxied URL of this embed resource if applicable, else
+            `builtins.None`.
+        """
+        return self.proxy_resource.url if self.proxy_resource else None
+
+    @property
+    @typing.final
+    def proxy_filename(self) -> typing.Optional[str]:
+        """File name of the proxied version of this embed resource if applicable.
+
+        Returns
+        -------
+        typing.Optional[builtins.str]
+            The file name of the proxied version of this embed resource if
+            applicable, else `builtins.None`.
+        """
+        return self.proxy_resource.filename if self.proxy_resource else None
 
 
 @attr_extensions.with_copy
@@ -149,7 +189,7 @@ class EmbedImage(EmbedResourceWithProxy[AsyncReaderT]):
 
 
 @attr.s(eq=True, hash=False, init=True, kw_only=True, slots=True, weakref_slot=False)
-class EmbedVideo(EmbedResource[AsyncReaderT]):
+class EmbedVideo(EmbedResourceWithProxy[AsyncReaderT]):
     """Represents an embed video.
 
     !!! note

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -711,27 +711,31 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         fields: typing.Optional[typing.MutableSequence[embed_models.EmbedField]] = None
 
         image: typing.Optional[embed_models.EmbedImage[files.AsyncReader]] = None
-        if image_payload := payload.get("image"):
+        if (image_payload := payload.get("image")) and "url" in image_payload:
+            proxy = files.ensure_resource(image_payload["proxy_url"]) if "proxy_url" in image_payload else None
             image = embed_models.EmbedImage(
-                resource=files.ensure_resource(image_payload.get("url")),
-                proxy_resource=files.ensure_resource(image_payload.get("proxy_url")),
+                resource=files.ensure_resource(image_payload["url"]),
+                proxy_resource=proxy,
                 height=image_payload.get("height"),
                 width=image_payload.get("width"),
             )
 
         thumbnail: typing.Optional[embed_models.EmbedImage[files.AsyncReader]] = None
-        if thumbnail_payload := payload.get("thumbnail"):
+        if (thumbnail_payload := payload.get("thumbnail")) and "url" in thumbnail_payload:
+            proxy = files.ensure_resource(thumbnail_payload["proxy_url"]) if "proxy_url" in thumbnail_payload else None
             thumbnail = embed_models.EmbedImage(
-                resource=files.ensure_resource(thumbnail_payload.get("url")),
-                proxy_resource=files.ensure_resource(thumbnail_payload.get("proxy_url")),
+                resource=files.ensure_resource(thumbnail_payload["url"]),
+                proxy_resource=proxy,
                 height=thumbnail_payload.get("height"),
                 width=thumbnail_payload.get("width"),
             )
 
         video: typing.Optional[embed_models.EmbedVideo[files.AsyncReader]] = None
-        if video_payload := payload.get("video"):
+        if (video_payload := payload.get("video")) and "url" in video_payload:
+            raw_proxy_url = video_payload.get("proxy_url")
             video = embed_models.EmbedVideo(
-                resource=files.ensure_resource(video_payload.get("url")),
+                resource=files.ensure_resource(video_payload["url"]),
+                proxy_resource=files.ensure_resource(raw_proxy_url) if raw_proxy_url else None,
                 height=video_payload.get("height"),
                 width=video_payload.get("width"),
             )
@@ -745,9 +749,10 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         if author_payload := payload.get("author"):
             icon = None
             if "icon_url" in author_payload:
+                raw_proxy_url = author_payload.get("proxy_icon_url")
                 icon = embed_models.EmbedResourceWithProxy(
-                    resource=files.ensure_resource(author_payload.get("icon_url")),
-                    proxy_resource=files.ensure_resource(author_payload.get("proxy_icon_url")),
+                    resource=files.ensure_resource(author_payload["icon_url"]),
+                    proxy_resource=files.ensure_resource(raw_proxy_url) if raw_proxy_url else None,
                 )
 
             author = embed_models.EmbedAuthor(
@@ -760,9 +765,10 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         if footer_payload := payload.get("footer"):
             icon = None
             if "icon_url" in footer_payload:
+                raw_proxy_url = footer_payload.get("proxy_icon_url")
                 icon = embed_models.EmbedResourceWithProxy(
-                    resource=files.ensure_resource(footer_payload.get("icon_url")),
-                    proxy_resource=files.ensure_resource(footer_payload.get("proxy_icon_url")),
+                    resource=files.ensure_resource(footer_payload["icon_url"]),
+                    proxy_resource=files.ensure_resource(raw_proxy_url) if raw_proxy_url else None,
                 )
 
             footer = embed_models.EmbedFooter(text=footer_payload.get("text"), icon=icon)

--- a/tests/hikari/test_embeds.py
+++ b/tests/hikari/test_embeds.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Nekokatt
+# Copyright (c) 2021 davfsa
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import mock
+import pytest
+
+from hikari import embeds
+
+
+class TestEmbedResource:
+    @pytest.fixture()
+    def resource(self):
+        return embeds.EmbedResource(resource=mock.Mock())
+
+    def test_url(self, resource):
+        assert resource.url is resource.resource.url
+
+    def test_filename(self, resource):
+        assert resource.filename is resource.resource.filename
+
+    def test_stream(self, resource):
+        mock_executor = object()
+
+        assert resource.stream(executor=mock_executor, head_only=True) is resource.resource.stream.return_value
+
+        resource.resource.stream.assert_called_once_with(executor=mock_executor, head_only=True)
+
+
+class TestEmbedResourceWithProxy:
+    @pytest.fixture()
+    def resource_with_proxy(self):
+        return embeds.EmbedResourceWithProxy(resource=mock.Mock(), proxy_resource=mock.Mock())
+
+    def test_proxy_url(self, resource_with_proxy):
+        assert resource_with_proxy.proxy_url is resource_with_proxy.proxy_resource.url
+
+    def test_proxy_url_when_resource_is_none(self, resource_with_proxy):
+        resource_with_proxy.proxy_resource = None
+        assert resource_with_proxy.proxy_url is None
+
+    def test_proxy_filename(self, resource_with_proxy):
+        assert resource_with_proxy.proxy_filename is resource_with_proxy.proxy_resource.filename
+
+    def test_proxy_filename_when_resource_is_none(self, resource_with_proxy):
+        resource_with_proxy.proxy_resource = None
+        assert resource_with_proxy.proxy_filename is None


### PR DESCRIPTION
### Summary
Add proxy resource to EmbedVideo and fix handling of None in embed resources.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
