### PR TITLE
Make nickname optional if not available

### DIFF
--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -281,18 +281,16 @@ class Member(users.User):
     is_pending: undefined.UndefinedOr[bool] = attr.ib(repr=False)
     """Whether the user has passed the guild's membership screening requirements.
 
-    This will be `hikari.undefined.UNDEFINED` if it's state is unknown."""
+    This will be `hikari.undefined.UNDEFINED` if it's state is unknown.
+    """
 
     joined_at: datetime.datetime = attr.ib(repr=True)
     """The datetime of when this member joined the guild they belong to."""
 
-    nickname: undefined.UndefinedNoneOr[str] = attr.ib(repr=True)
+    nickname: typing.Optional[str] = attr.ib(repr=True)
     """This member's nickname.
 
     This will be `builtins.None` if not set.
-
-    On member update events, this may not be included at all.
-    In this case, this will be undefined.
     """
 
     premium_since: typing.Optional[datetime.datetime] = attr.ib(repr=False)

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -1048,7 +1048,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             guild_id=guild_id,
             role_ids=role_ids,
             joined_at=joined_at,
-            nickname=payload["nick"] if "nick" in payload else undefined.UNDEFINED,
+            nickname=payload.get("nick"),
             premium_since=premium_since,
             is_deaf=payload["deaf"] if "deaf" in payload else undefined.UNDEFINED,
             is_mute=payload["mute"] if "mute" in payload else undefined.UNDEFINED,

--- a/hikari/internal/cache.py
+++ b/hikari/internal/cache.py
@@ -400,7 +400,7 @@ class MemberData(BaseData[guilds.Member]):
 
     user: RefCell[users_.User] = attr.ib()
     guild_id: snowflakes.Snowflake = attr.ib()
-    nickname: undefined.UndefinedNoneOr[str] = attr.ib()
+    nickname: typing.Optional[str] = attr.ib()
     role_ids: typing.Tuple[snowflakes.Snowflake, ...] = attr.ib()
     joined_at: datetime.datetime = attr.ib()
     premium_since: typing.Optional[datetime.datetime] = attr.ib()

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -1612,7 +1612,7 @@ class TestEntityFactoryImpl:
                 "premium_since": "2019-05-17T06:26:56.936000+00:00",
             }
         )
-        assert member.nickname is undefined.UNDEFINED
+        assert member.nickname is None
         assert member.is_deaf is undefined.UNDEFINED
         assert member.is_mute is undefined.UNDEFINED
         assert member.is_pending is undefined.UNDEFINED


### PR DESCRIPTION
Nickname seems to be missing from gateway events if it is not set. This means we can safely set it to `None` when Discord doesn't send it

Reference: https://github.com/discord/discord-api-docs/pull/2209

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

