### PR TITLE
Allow models to be used in cache calls in place of IDs.

### DIFF
--- a/hikari/api/cache.py
+++ b/hikari/api/cache.py
@@ -79,13 +79,15 @@ class Cache(abc.ABC):
     __slots__: typing.Sequence[str] = ()
 
     @abc.abstractmethod
-    def get_emoji(self, emoji_id: snowflakes.Snowflakeish, /) -> typing.Optional[emojis.KnownCustomEmoji]:
+    def get_emoji(
+        self, emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji], /
+    ) -> typing.Optional[emojis.KnownCustomEmoji]:
         """Get a known custom emoji from the cache.
 
         Parameters
         ----------
-        emoji_id : hikari.snowflakes.Snowflakeish
-            The ID of the emoji to get from the cache.
+        emoji : hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]
+            Object or ID of the emoji to get from the cache.
 
         Returns
         -------
@@ -106,14 +108,14 @@ class Cache(abc.ABC):
 
     @abc.abstractmethod
     def get_emojis_view_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> CacheView[snowflakes.Snowflake, emojis.KnownCustomEmoji]:
         """Get a view of the known custom emojis cached for a specific guild.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to get the cached emoji objects for.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to get the cached emoji objects for.
 
         Returns
         -------
@@ -123,7 +125,9 @@ class Cache(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_guild(self, guild_id: snowflakes.Snowflakeish, /) -> typing.Optional[guilds.GatewayGuild]:
+    def get_guild(
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
+    ) -> typing.Optional[guilds.GatewayGuild]:
         """Get a guild from the cache.
 
         !!! warning
@@ -134,8 +138,8 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to get from the cache.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to get from the cache.
 
         Returns
         -------
@@ -144,13 +148,15 @@ class Cache(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_available_guild(self, guild_id: snowflakes.Snowflakeish, /) -> typing.Optional[guilds.GatewayGuild]:
+    def get_available_guild(
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
+    ) -> typing.Optional[guilds.GatewayGuild]:
         """Get the object of an available guild from the cache.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to get from the cache.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to get from the cache.
 
         Returns
         -------
@@ -159,7 +165,9 @@ class Cache(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_unavailable_guild(self, guild_id: snowflakes.Snowflakeish) -> typing.Optional[guilds.GatewayGuild]:
+    def get_unavailable_guild(
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
+    ) -> typing.Optional[guilds.GatewayGuild]:
         """Get the object of a unavailable guild from the cache.
 
         !!! note
@@ -170,8 +178,8 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to get from the cache.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to get from the cache.
 
         Returns
         -------
@@ -206,13 +214,15 @@ class Cache(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_guild_channel(self, channel_id: snowflakes.Snowflakeish, /) -> typing.Optional[channels.GuildChannel]:
+    def get_guild_channel(
+        self, channel: snowflakes.SnowflakeishOr[channels.PartialChannel], /
+    ) -> typing.Optional[channels.GuildChannel]:
         """Get a guild channel from the cache.
 
         Parameters
         ----------
-        channel_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild channel to get from the cache.
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+            Object or ID of the guild channel to get from the cache.
 
         Returns
         -------
@@ -234,13 +244,14 @@ class Cache(abc.ABC):
 
     @abc.abstractmethod
     def get_guild_channels_view_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> CacheView[snowflakes.Snowflake, channels.GuildChannel]:
         """Get a view of the guild channels in the cache for a specific guild.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to get the cached channels for.
 
         Returns
         -------
@@ -250,13 +261,13 @@ class Cache(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_invite(self, code: str, /) -> typing.Optional[invites.InviteWithMetadata]:
+    def get_invite(self, code: invites.Inviteish, /) -> typing.Optional[invites.InviteWithMetadata]:
         """Get an invite object from the cache.
 
         Parameters
         ----------
-        code : str
-            The string code of the invite to get from the cache.
+        code : hikari.invites.Inviteish
+            The object or string code of the invite to get from the cache.
 
         Returns
         -------
@@ -277,14 +288,14 @@ class Cache(abc.ABC):
 
     @abc.abstractmethod
     def get_invites_view_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> CacheView[str, invites.InviteWithMetadata]:
         """Get a view of the invite objects in the cache for a specific guild.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to get invite objects for.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to get invite objects for.
 
         Returns
         -------
@@ -296,18 +307,18 @@ class Cache(abc.ABC):
     @abc.abstractmethod
     def get_invites_view_for_channel(
         self,
-        guild_id: snowflakes.Snowflakeish,
-        channel_id: snowflakes.Snowflakeish,
+        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        channel: snowflakes.SnowflakeishOr[channels.PartialChannel],
         /,
     ) -> CacheView[str, invites.InviteWithMetadata]:
         """Get a view of the invite objects in the cache for a specified channel.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to get invite objects for.
-        channel_id : hikari.snowflakes.Snowflakeish
-            The ID of the channel to get invite objects for.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to get invite objects for.
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+            Object or ID of the channel to get invite objects for.
 
         Returns
         -------
@@ -328,14 +339,19 @@ class Cache(abc.ABC):
 
     @abc.abstractmethod
     def get_member(
-        self, guild_id: snowflakes.Snowflakeish, user_id: snowflakes.Snowflakeish, /
+        self,
+        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        user: snowflakes.SnowflakeishOr[users.PartialUser],
+        /,
     ) -> typing.Optional[guilds.Member]:
         """Get a member object from the cache.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-        user_id : hikari.snowflakes.Snowflakeish
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to get a cached member for.
+        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+            Object or ID of the user to get a cached member for.
 
         Returns
         -------
@@ -372,13 +388,15 @@ class Cache(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_message(self, message_id: snowflakes.Snowflakeish, /) -> typing.Optional[messages.Message]:
+    def get_message(
+        self, message: snowflakes.SnowflakeishOr[messages.PartialMessage], /
+    ) -> typing.Optional[messages.Message]:
         """Get a message object from the cache.
 
         Parameters
         ----------
-        message_id : hikari.snowflakes.Snowflakeish
-            The ID of the message to get from the cache.
+        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+            Object or ID of the message to get from the cache.
 
         Returns
         -------
@@ -398,16 +416,19 @@ class Cache(abc.ABC):
 
     @abc.abstractmethod
     def get_presence(
-        self, guild_id: snowflakes.Snowflakeish, user_id: snowflakes.Snowflakeish, /
+        self,
+        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        user: snowflakes.SnowflakeishOr[users.PartialUser],
+        /,
     ) -> typing.Optional[presences.MemberPresence]:
         """Get a presence object from the cache.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to get a presence for.
-        user_id : hikari.snowflakes.Snowflakeish
-            The ID of the user to get a presence for.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to get a presence for.
+        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+            Object or ID of the user to get a presence for.
 
         Returns
         -------
@@ -431,14 +452,14 @@ class Cache(abc.ABC):
 
     @abc.abstractmethod
     def get_presences_view_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> CacheView[snowflakes.Snowflake, presences.MemberPresence]:
         """Get a view of the presence objects in the cache for a specific guild.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to get the cached presence objects for.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to get the cached presence objects for.
 
         Returns
         -------
@@ -448,13 +469,13 @@ class Cache(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_role(self, role_id: snowflakes.Snowflakeish, /) -> typing.Optional[guilds.Role]:
+    def get_role(self, role: snowflakes.SnowflakeishOr[guilds.PartialRole], /) -> typing.Optional[guilds.Role]:
         """Get a role object from the cache.
 
         Parameters
         ----------
-        role_id : hikari.snowflakes.Snowflakeish
-            The ID of the role to get from the cache.
+        role : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialRole]
+            Object or ID of the role to get from the cache.
 
         Returns
         -------
@@ -474,14 +495,14 @@ class Cache(abc.ABC):
 
     @abc.abstractmethod
     def get_roles_view_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> CacheView[snowflakes.Snowflake, guilds.Role]:
         """Get a view of the roles in the cache for a specific guild.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to get the cached roles for.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to get the cached roles for.
 
         Returns
         -------
@@ -491,13 +512,13 @@ class Cache(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_user(self, user_id: snowflakes.Snowflakeish, /) -> typing.Optional[users.User]:
+    def get_user(self, user: snowflakes.SnowflakeishOr[users.PartialUser], /) -> typing.Optional[users.User]:
         """Get a user object from the cache.
 
         Parameters
         ----------
-        user_id : hikari.snowflakes.Snowflakeish
-            The ID of the user to get from the cache.
+        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+            Object or ID of the user to get from the cache.
 
         Returns
         -------
@@ -518,16 +539,19 @@ class Cache(abc.ABC):
 
     @abc.abstractmethod
     def get_voice_state(
-        self, guild_id: snowflakes.Snowflakeish, user_id: snowflakes.Snowflakeish, /
+        self,
+        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        user: snowflakes.SnowflakeishOr[users.PartialUser],
+        /,
     ) -> typing.Optional[voices.VoiceState]:
         """Get a voice state object from the cache.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to get a voice state for.
-        user_id :hikari.snowflakes.Snowflakeish
-            The ID of the user to get a voice state for.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to get a voice state for.
+        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+            Object or ID of the user to get a voice state for.
 
         Returns
         -------
@@ -551,16 +575,19 @@ class Cache(abc.ABC):
 
     @abc.abstractmethod
     def get_voice_states_view_for_channel(
-        self, guild_id: snowflakes.Snowflakeish, channel_id: snowflakes.Snowflakeish, /
+        self,
+        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        channel: snowflakes.SnowflakeishOr[channels.PartialChannel],
+        /,
     ) -> CacheView[snowflakes.Snowflake, voices.VoiceState]:
         """Get a view of the voice states cached for a specific channel.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to get the cached voice states for.
-        channel_id : hikari.snowflakes.Snowflakeish
-            The ID of the channel to get the cached voice states for.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to get the cached voice states for.
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+            Object or ID of the channel to get the cached voice states for.
 
         Returns
         -------
@@ -571,14 +598,14 @@ class Cache(abc.ABC):
 
     @abc.abstractmethod
     def get_voice_states_view_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> CacheView[snowflakes.Snowflake, voices.VoiceState]:
         """Get a view of the voice states cached for a specific guild.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to get the cached voice states for.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to get the cached voice states for.
 
         Returns
         -------
@@ -618,14 +645,14 @@ class MutableCache(Cache, abc.ABC):
 
     @abc.abstractmethod
     def clear_emojis_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> CacheView[snowflakes.Snowflake, emojis.KnownCustomEmoji]:
         """Remove the known custom emoji objects cached for a specific guild.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to remove the cached emoji objects for.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to remove the cached emoji objects for.
 
         !!! note
             This will skip emojis that are being kept alive by a reference
@@ -639,13 +666,15 @@ class MutableCache(Cache, abc.ABC):
         """
 
     @abc.abstractmethod
-    def delete_emoji(self, emoji_id: snowflakes.Snowflakeish, /) -> typing.Optional[emojis.KnownCustomEmoji]:
+    def delete_emoji(
+        self, emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji], /
+    ) -> typing.Optional[emojis.KnownCustomEmoji]:
         """Remove a known custom emoji from the cache.
 
         Parameters
         ----------
-        emoji_id : hikari.snowflakes.Snowflakeish
-            The ID of the emoji to remove from the cache.
+        emoji : hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]
+            Object or ID of the emoji to remove from the cache.
 
         !!! note
             This will not delete emojis that are being kept alive by a reference
@@ -699,13 +728,15 @@ class MutableCache(Cache, abc.ABC):
         """
 
     @abc.abstractmethod
-    def delete_guild(self, guild_id: snowflakes.Snowflakeish, /) -> typing.Optional[guilds.GatewayGuild]:
+    def delete_guild(
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
+    ) -> typing.Optional[guilds.GatewayGuild]:
         """Remove a guild object from the cache.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to remove from the cache.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to remove from the cache.
 
         Returns
         -------
@@ -725,13 +756,15 @@ class MutableCache(Cache, abc.ABC):
         """
 
     @abc.abstractmethod
-    def set_guild_availability(self, guild_id: snowflakes.Snowflakeish, is_available: bool, /) -> None:
+    def set_guild_availability(
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], is_available: bool, /
+    ) -> None:
         """Set whether a cached guild is available or not.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to set the availability for.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to set the availability for.
         is_available : builtins.bool
             The availability to set for the guild.
         """
@@ -768,14 +801,14 @@ class MutableCache(Cache, abc.ABC):
 
     @abc.abstractmethod
     def clear_guild_channels_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> CacheView[snowflakes.Snowflake, channels.GuildChannel]:
         """Remove guild channels from the cache for a specific guild.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to remove cached channels for.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to remove cached channels for.
 
         Returns
         -------
@@ -785,13 +818,15 @@ class MutableCache(Cache, abc.ABC):
         """
 
     @abc.abstractmethod
-    def delete_guild_channel(self, channel_id: snowflakes.Snowflakeish, /) -> typing.Optional[channels.GuildChannel]:
+    def delete_guild_channel(
+        self, channel: snowflakes.SnowflakeishOr[channels.PartialChannel], /
+    ) -> typing.Optional[channels.GuildChannel]:
         """Remove a guild channel from the cache.
 
         Parameters
         ----------
-        channel_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild channel to remove from the cache.
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+            Object or ID of the guild channel to remove from the cache.
 
         Returns
         -------
@@ -842,14 +877,14 @@ class MutableCache(Cache, abc.ABC):
 
     @abc.abstractmethod
     def clear_invites_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> CacheView[str, invites.InviteWithMetadata]:
         """Remove the invite objects in the cache for a specific guild.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to remove invite objects for.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to remove invite objects for.
 
         Returns
         -------
@@ -860,16 +895,19 @@ class MutableCache(Cache, abc.ABC):
 
     @abc.abstractmethod
     def clear_invites_for_channel(
-        self, guild_id: snowflakes.Snowflakeish, channel_id: snowflakes.Snowflakeish, /
+        self,
+        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        channel: snowflakes.SnowflakeishOr[channels.PartialChannel],
+        /,
     ) -> CacheView[str, invites.InviteWithMetadata]:
         """Remove the invite objects in the cache for a specific channel.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to remove invite objects for.
-        channel_id : hikari.snowflakes.Snowflakeish
-            The ID of the channel to remove invite objects for.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to remove invite objects for.
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+            Object or ID of the channel to remove invite objects for.
 
         Returns
         -------
@@ -879,13 +917,13 @@ class MutableCache(Cache, abc.ABC):
         """
 
     @abc.abstractmethod
-    def delete_invite(self, code: str, /) -> typing.Optional[invites.InviteWithMetadata]:
+    def delete_invite(self, code: invites.Inviteish, /) -> typing.Optional[invites.InviteWithMetadata]:
         """Remove an invite object from the cache.
 
         Parameters
         ----------
-        code : str
-            The string code of the invite to remove from the cache.
+        code : hikari.invites.Inviteish
+            Object or string code of the invite to remove from the cache.
 
         Returns
         -------
@@ -976,14 +1014,14 @@ class MutableCache(Cache, abc.ABC):
 
     @abc.abstractmethod
     def clear_members_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> CacheView[snowflakes.Snowflake, guilds.Member]:
         """Remove the members for a specific guild from the cache.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to remove cached members for.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to remove cached members for.
 
         !!! note
             This will skip members that are being referenced by other entries in
@@ -998,16 +1036,19 @@ class MutableCache(Cache, abc.ABC):
 
     @abc.abstractmethod
     def delete_member(
-        self, guild_id: snowflakes.Snowflakeish, user_id: snowflakes.Snowflakeish, /
+        self,
+        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        user: snowflakes.SnowflakeishOr[users.PartialUser],
+        /,
     ) -> typing.Optional[guilds.Member]:
         """Remove a member object from the cache.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to remove a member from the cache for.
-        user_id : hikari.snowflakes.Snowflakeish
-            The ID of the user to remove a member from the cache for.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to remove a member from the cache for.
+        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+            Object or ID of the user to remove a member from the cache for.
 
         !!! note
             You cannot delete a member entry that's being referenced by other
@@ -1065,14 +1106,14 @@ class MutableCache(Cache, abc.ABC):
 
     @abc.abstractmethod
     def clear_presences_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> CacheView[snowflakes.Snowflake, presences.MemberPresence]:
         """Remove the presences in the cache for a specific guild.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to remove presences for.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to remove presences for.
 
         Returns
         -------
@@ -1083,16 +1124,19 @@ class MutableCache(Cache, abc.ABC):
 
     @abc.abstractmethod
     def delete_presence(
-        self, guild_id: snowflakes.Snowflakeish, user_id: snowflakes.Snowflakeish, /
+        self,
+        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        user: snowflakes.SnowflakeishOr[users.PartialUser],
+        /,
     ) -> typing.Optional[presences.MemberPresence]:
         """Remove a presence from the cache.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to remove a presence for.
-        user_id : hikari.snowflakes.Snowflakeish
-            The ID of the user to remove a presence for.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to remove a presence for.
+        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+            Object or ID of the user to remove a presence for.
 
         Returns
         -------
@@ -1143,14 +1187,14 @@ class MutableCache(Cache, abc.ABC):
 
     @abc.abstractmethod
     def clear_roles_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> CacheView[snowflakes.Snowflake, guilds.Role]:
         """Remove role objects from the cache for a specific guild.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to remove roles for.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to remove roles for.
 
         Returns
         -------
@@ -1160,13 +1204,13 @@ class MutableCache(Cache, abc.ABC):
         """
 
     @abc.abstractmethod
-    def delete_role(self, role_id: snowflakes.Snowflakeish, /) -> typing.Optional[guilds.Role]:
+    def delete_role(self, role: snowflakes.SnowflakeishOr[guilds.PartialRole], /) -> typing.Optional[guilds.Role]:
         """Remove a role object form the cache.
 
         Parameters
         ----------
-        role_id : hikari.snowflakes.Snowflakeish
-            The ID of the role to remove from the cache.
+        role : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialRole]
+            Object or ID of the role to remove from the cache.
 
         Returns
         -------
@@ -1217,14 +1261,14 @@ class MutableCache(Cache, abc.ABC):
 
     @abc.abstractmethod
     def clear_voice_states_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> CacheView[snowflakes.Snowflake, voices.VoiceState]:
         """Clear the voice state objects cached for a specific guild.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to remove cached voice states for.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to remove cached voice states for.
 
         Returns
         -------
@@ -1236,17 +1280,18 @@ class MutableCache(Cache, abc.ABC):
     @abc.abstractmethod
     def clear_voice_states_for_channel(
         self,
-        guild_id: snowflakes.Snowflakeish,
-        channel_id: snowflakes.Snowflakeish,
+        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        channel: snowflakes.SnowflakeishOr[channels.PartialChannel],
+        /,
     ) -> CacheView[snowflakes.Snowflake, voices.VoiceState]:
         """Remove the voice state objects cached for a specific channel.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild to remove voice states for.
-        channel_id : hikari.snowflakes.Snowflakeish
-            The ID of the channel to remove voice states for.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild to remove voice states for.
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+            Object or ID of the channel to remove voice states for.
 
         Returns
         -------
@@ -1257,16 +1302,19 @@ class MutableCache(Cache, abc.ABC):
 
     @abc.abstractmethod
     def delete_voice_state(
-        self, guild_id: snowflakes.Snowflakeish, user_id: snowflakes.Snowflakeish, /
+        self,
+        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        user: snowflakes.SnowflakeishOr[users.PartialUser],
+        /,
     ) -> typing.Optional[voices.VoiceState]:
         """Remove a voice state object from the cache.
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
-            The ID of the guild the voice state to remove is related to.
-        user_id : hikari.snowflakes.Snowflakeish
-            The ID of the user who the voice state to remove belongs to.
+        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+            Object or ID of the guild the voice state to remove is related to.
+        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+            Object or ID of the user who the voice state to remove belongs to.
 
         Returns
         -------
@@ -1315,13 +1363,15 @@ class MutableCache(Cache, abc.ABC):
         """
 
     @abc.abstractmethod
-    def delete_message(self, message_id: snowflakes.Snowflakeish, /) -> typing.Optional[messages.Message]:
+    def delete_message(
+        self, message: snowflakes.SnowflakeishOr[messages.PartialMessage], /
+    ) -> typing.Optional[messages.Message]:
         """Remove a message object from the cache.
 
         Parameters
         ----------
-        message_id : hikari.snowflakes.Snowflakeish
-            The ID of the messages to remove the cache.
+        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+            Object or ID of the messages to remove the cache.
 
         Returns
         -------

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -1353,7 +1353,7 @@ class Guild(PartialGuild, abc.ABC):
         """Get an emoji from the cache by it's ID."""
 
     @abc.abstractmethod
-    def get_role(self, role: snowflakes.SnowflakeishOr[Role]) -> typing.Optional[Role]:
+    def get_role(self, role: snowflakes.SnowflakeishOr[PartialRole]) -> typing.Optional[Role]:
         """Get a role from the cache by it's ID."""
 
 
@@ -1403,7 +1403,7 @@ class RESTGuild(Guild):
         # <<inherited docstring from Guild>>.
         return self._emojis.get(snowflakes.Snowflake(emoji))
 
-    def get_role(self, role: snowflakes.SnowflakeishOr[Role]) -> typing.Optional[Role]:
+    def get_role(self, role: snowflakes.SnowflakeishOr[PartialRole]) -> typing.Optional[Role]:
         # <<inherited docstring from Guild>>.
         return self._roles.get(snowflakes.Snowflake(role))
 
@@ -1512,13 +1512,13 @@ class GatewayGuild(Guild):
 
     def get_channel(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.GuildChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.PartialChannel],
     ) -> typing.Optional[channels_.GuildChannel]:
         """Get a cached channel that belongs to the guild by it's ID or object.
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
             The object or ID of the guild channel to get from the cache.
 
         Returns
@@ -1529,7 +1529,7 @@ class GatewayGuild(Guild):
         if not isinstance(self.app, traits.CacheAware):
             return None
 
-        return self.app.cache.get_guild_channel(snowflakes.Snowflake(channel))
+        return self.app.cache.get_guild_channel(channel)
 
     def get_emoji(
         self, emoji: snowflakes.SnowflakeishOr[emojis_.CustomEmoji]
@@ -1550,14 +1550,14 @@ class GatewayGuild(Guild):
         if not isinstance(self.app, traits.CacheAware):
             return None
 
-        return self.app.cache.get_emoji(snowflakes.Snowflake(emoji))
+        return self.app.cache.get_emoji(emoji)
 
-    def get_member(self, user: snowflakes.SnowflakeishOr[users.User]) -> typing.Optional[Member]:
+    def get_member(self, user: snowflakes.SnowflakeishOr[users.PartialUser]) -> typing.Optional[Member]:
         """Get a cached member that belongs to the guild by it's user ID or object.
 
         Parameters
         ----------
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.User]
+        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
             The object or ID of the user to get the cached member for.
 
         Returns
@@ -1568,7 +1568,7 @@ class GatewayGuild(Guild):
         if not isinstance(self.app, traits.CacheAware):
             return None
 
-        return self.app.cache.get_member(self.id, snowflakes.Snowflake(user))
+        return self.app.cache.get_member(self.id, user)
 
     def get_my_member(self) -> typing.Optional[Member]:
         """Return the cached member for the bot user in this guild, if known.
@@ -1589,12 +1589,14 @@ class GatewayGuild(Guild):
 
         return self.get_member(me.id)
 
-    def get_presence(self, user: snowflakes.SnowflakeishOr[users.User]) -> typing.Optional[presences_.MemberPresence]:
+    def get_presence(
+        self, user: snowflakes.SnowflakeishOr[users.PartialUser]
+    ) -> typing.Optional[presences_.MemberPresence]:
         """Get a cached presence that belongs to the guild by it's user ID or object.
 
         Parameters
         ----------
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.User]
+        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
             The object or ID of the user to get the cached presence for.
 
         Returns
@@ -1605,14 +1607,14 @@ class GatewayGuild(Guild):
         if not isinstance(self.app, traits.CacheAware):
             return None
 
-        return self.app.cache.get_presence(self.id, snowflakes.Snowflake(user))
+        return self.app.cache.get_presence(self.id, user)
 
-    def get_role(self, role: snowflakes.SnowflakeishOr[Role]) -> typing.Optional[Role]:
+    def get_role(self, role: snowflakes.SnowflakeishOr[PartialRole]) -> typing.Optional[Role]:
         """Get a cached role that belongs to the guild by it's ID or object.
 
         Parameters
         ----------
-        role : hikari.snowflakes.SnowflakeishOr[Role]
+        role : hikari.snowflakes.SnowflakeishOr[PartialRole]
             The object or ID of the role to get for this guild from the cache.
 
         Returns
@@ -1623,14 +1625,16 @@ class GatewayGuild(Guild):
         if not isinstance(self.app, traits.CacheAware):
             return None
 
-        return self.app.cache.get_role(snowflakes.Snowflake(role))
+        return self.app.cache.get_role(role)
 
-    def get_voice_state(self, user: snowflakes.SnowflakeishOr[users.User]) -> typing.Optional[voices_.VoiceState]:
+    def get_voice_state(
+        self, user: snowflakes.SnowflakeishOr[users.PartialUser]
+    ) -> typing.Optional[voices_.VoiceState]:
         """Get a cached voice state that belongs to the guild by it's user.
 
         Parameters
         ----------
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.User]
+        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
             The object or ID of the user to get the cached voice state for.
 
         Returns
@@ -1641,4 +1645,4 @@ class GatewayGuild(Guild):
         if not isinstance(self.app, traits.CacheAware):
             return None
 
-        return self.app.cache.get_voice_state(self.id, snowflakes.Snowflake(user))
+        return self.app.cache.get_voice_state(self.id, user)

--- a/hikari/impl/cache.py
+++ b/hikari/impl/cache.py
@@ -193,12 +193,12 @@ class CacheImpl(cache.MutableCache):
         return cache_utility.CacheMappingView(cached_emojis, builder=self._build_emoji)
 
     def clear_emojis_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> cache.CacheView[snowflakes.Snowflake, emojis.KnownCustomEmoji]:
         if not self._is_cache_enabled_for(EMOJIS):
             return cache_utility.EmptyCacheView()
 
-        guild_id = snowflakes.Snowflake(guild_id)
+        guild_id = snowflakes.Snowflake(guild)
         guild_record = self._guild_entries.get(guild_id)
         if not guild_record or not guild_record.emojis:
             return cache_utility.EmptyCacheView()
@@ -213,11 +213,13 @@ class CacheImpl(cache.MutableCache):
 
         return cache_utility.CacheMappingView(cached_emojis, builder=self._build_emoji)
 
-    def delete_emoji(self, emoji_id: snowflakes.Snowflakeish, /) -> typing.Optional[emojis.KnownCustomEmoji]:
+    def delete_emoji(
+        self, emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji], /
+    ) -> typing.Optional[emojis.KnownCustomEmoji]:
         if not self._is_cache_enabled_for(EMOJIS):
             return None
 
-        emoji_id = snowflakes.Snowflake(emoji_id)
+        emoji_id = snowflakes.Snowflake(emoji)
         emoji_data = self._emoji_entries.pop(emoji_id, None)
         if not emoji_data:
             return None
@@ -234,11 +236,13 @@ class CacheImpl(cache.MutableCache):
 
         return self._build_emoji(emoji_data)
 
-    def get_emoji(self, emoji_id: snowflakes.Snowflakeish, /) -> typing.Optional[emojis.KnownCustomEmoji]:
+    def get_emoji(
+        self, emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji], /
+    ) -> typing.Optional[emojis.KnownCustomEmoji]:
         if not self._is_cache_enabled_for(EMOJIS):
             return None
 
-        emoji_data = self._emoji_entries.get(snowflakes.Snowflake(emoji_id))
+        emoji_data = self._emoji_entries.get(snowflakes.Snowflake(emoji))
         return self._build_emoji(emoji_data) if emoji_data else None
 
     def get_emojis_view(self) -> cache.CacheView[snowflakes.Snowflake, emojis.KnownCustomEmoji]:
@@ -248,13 +252,12 @@ class CacheImpl(cache.MutableCache):
         return cache_utility.CacheMappingView(self._emoji_entries.freeze(), builder=self._build_emoji)
 
     def get_emojis_view_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> cache.CacheView[snowflakes.Snowflake, emojis.KnownCustomEmoji]:
         if not self._is_cache_enabled_for(EMOJIS):
             return cache_utility.EmptyCacheView()
 
-        guild_id = snowflakes.Snowflake(guild_id)
-        guild_record = self._guild_entries.get(guild_id)
+        guild_record = self._guild_entries.get(snowflakes.Snowflake(guild))
         if not guild_record or not guild_record.emojis:
             return cache_utility.EmptyCacheView()
 
@@ -317,11 +320,13 @@ class CacheImpl(cache.MutableCache):
 
         return cache_utility.CacheMappingView(cached_guilds) if cached_guilds else cache_utility.EmptyCacheView()
 
-    def delete_guild(self, guild_id: snowflakes.Snowflakeish, /) -> typing.Optional[guilds.GatewayGuild]:
+    def delete_guild(
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
+    ) -> typing.Optional[guilds.GatewayGuild]:
         if not self._is_cache_enabled_for(GUILDS):
             return None
 
-        guild_id = snowflakes.Snowflake(guild_id)
+        guild_id = snowflakes.Snowflake(guild)
         guild_record = self._guild_entries.get(guild_id)
         if not guild_record:
             return None
@@ -336,33 +341,38 @@ class CacheImpl(cache.MutableCache):
         return guild
 
     def _get_guild(
-        self, guild_id: snowflakes.Snowflakeish, /, *, availability: bool
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /, *, availability: bool
     ) -> typing.Optional[guilds.GatewayGuild]:
-        guild_id = snowflakes.Snowflake(guild_id)
-        guild_record = self._guild_entries.get(guild_id)
+        guild_record = self._guild_entries.get(snowflakes.Snowflake(guild))
         if not guild_record or not guild_record.guild or guild_record.is_available is not availability:
             return None
 
         return copy.copy(guild_record.guild)
 
-    def get_guild(self, guild_id: snowflakes.Snowflakeish, /) -> typing.Optional[guilds.GatewayGuild]:
+    def get_guild(
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
+    ) -> typing.Optional[guilds.GatewayGuild]:
         if not self._is_cache_enabled_for(GUILDS):
             return None
 
-        guild_record = self._guild_entries.get(snowflakes.Snowflake(guild_id))
+        guild_record = self._guild_entries.get(snowflakes.Snowflake(guild))
         return copy.copy(guild_record.guild) if guild_record and guild_record.guild else None
 
-    def get_available_guild(self, guild_id: snowflakes.Snowflakeish, /) -> typing.Optional[guilds.GatewayGuild]:
+    def get_available_guild(
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
+    ) -> typing.Optional[guilds.GatewayGuild]:
         if not self._is_cache_enabled_for(GUILDS):
             return None
 
-        return self._get_guild(guild_id, availability=True)
+        return self._get_guild(guild, availability=True)
 
-    def get_unavailable_guild(self, guild_id: snowflakes.Snowflakeish) -> typing.Optional[guilds.GatewayGuild]:
+    def get_unavailable_guild(
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
+    ) -> typing.Optional[guilds.GatewayGuild]:
         if not self._is_cache_enabled_for(GUILDS):
             return None
 
-        return self._get_guild(guild_id, availability=False)
+        return self._get_guild(guild, availability=False)
 
     def _get_guilds_view(self, *, availability: bool) -> cache.CacheView[snowflakes.Snowflake, guilds.GatewayGuild]:
         # We may have a guild record without a guild object in cases where we're caching other entities that belong to
@@ -394,11 +404,13 @@ class CacheImpl(cache.MutableCache):
         guild_record.guild = copy.copy(guild)
         guild_record.is_available = True
 
-    def set_guild_availability(self, guild_id: snowflakes.Snowflakeish, is_available: bool, /) -> None:
+    def set_guild_availability(
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], is_available: bool, /
+    ) -> None:
         if not self._is_cache_enabled_for(GUILDS):
             return None
 
-        guild_record = self._guild_entries.get(snowflakes.Snowflake(guild_id))
+        guild_record = self._guild_entries.get(snowflakes.Snowflake(guild))
         if guild_record and guild_record.guild:
             guild_record.is_available = is_available
 
@@ -435,12 +447,12 @@ class CacheImpl(cache.MutableCache):
         return cache_utility.CacheMappingView(cached_channels)
 
     def clear_guild_channels_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> cache.CacheView[snowflakes.Snowflake, channels.GuildChannel]:
         if not self._is_cache_enabled_for(GUILD_CHANNELS):
             return cache_utility.EmptyCacheView()
 
-        guild_id = snowflakes.Snowflake(guild_id)
+        guild_id = snowflakes.Snowflake(guild)
         guild_record = self._guild_entries.get(guild_id)
         if not guild_record or not guild_record.channels:
             return cache_utility.EmptyCacheView()
@@ -450,11 +462,13 @@ class CacheImpl(cache.MutableCache):
         self._remove_guild_record_if_empty(guild_id, guild_record)
         return cache_utility.CacheMappingView(cached_channels)
 
-    def delete_guild_channel(self, channel_id: snowflakes.Snowflakeish, /) -> typing.Optional[channels.GuildChannel]:
+    def delete_guild_channel(
+        self, channel: snowflakes.SnowflakeishOr[channels.PartialChannel], /
+    ) -> typing.Optional[channels.GuildChannel]:
         if not self._is_cache_enabled_for(GUILD_CHANNELS):
             return None
 
-        channel_id = snowflakes.Snowflake(channel_id)
+        channel_id = snowflakes.Snowflake(channel)
         channel = self._guild_channel_entries.pop(channel_id, None)
 
         if not channel:
@@ -469,11 +483,13 @@ class CacheImpl(cache.MutableCache):
 
         return channel
 
-    def get_guild_channel(self, channel_id: snowflakes.Snowflakeish, /) -> typing.Optional[channels.GuildChannel]:
+    def get_guild_channel(
+        self, channel: snowflakes.SnowflakeishOr[channels.PartialChannel], /
+    ) -> typing.Optional[channels.GuildChannel]:
         if not self._is_cache_enabled_for(GUILD_CHANNELS):
             return None
 
-        channel = self._guild_channel_entries.get(snowflakes.Snowflake(channel_id))
+        channel = self._guild_channel_entries.get(snowflakes.Snowflake(channel))
         return cache_utility.copy_guild_channel(channel) if channel else None
 
     def get_guild_channels_view(self) -> cache.CacheView[snowflakes.Snowflake, channels.GuildChannel]:
@@ -482,13 +498,12 @@ class CacheImpl(cache.MutableCache):
         )
 
     def get_guild_channels_view_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> cache.CacheView[snowflakes.Snowflake, channels.GuildChannel]:
         if not self._is_cache_enabled_for(GUILD_CHANNELS):
             return cache_utility.EmptyCacheView()
 
-        guild_id = snowflakes.Snowflake(guild_id)
-        guild_record = self._guild_entries.get(guild_id)
+        guild_record = self._guild_entries.get(snowflakes.Snowflake(guild))
         if not guild_record or not guild_record.channels:
             return cache_utility.EmptyCacheView()
 
@@ -564,12 +579,12 @@ class CacheImpl(cache.MutableCache):
         return cache_utility.CacheMappingView(cached_invites, builder=self._build_invite)
 
     def clear_invites_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> cache.CacheView[str, invites.InviteWithMetadata]:
         if not self._is_cache_enabled_for(INVITES):
             return cache_utility.EmptyCacheView()
 
-        guild_id = snowflakes.Snowflake(guild_id)
+        guild_id = snowflakes.Snowflake(guild)
         guild_record = self._guild_entries.get(guild_id)
 
         if not guild_record or not guild_record.invites:
@@ -585,13 +600,16 @@ class CacheImpl(cache.MutableCache):
         return cache_utility.CacheMappingView(cached_invites, builder=self._build_invite)
 
     def clear_invites_for_channel(
-        self, guild_id: snowflakes.Snowflakeish, channel_id: snowflakes.Snowflakeish, /
+        self,
+        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        channel: snowflakes.SnowflakeishOr[channels.PartialChannel],
+        /,
     ) -> cache.CacheView[str, invites.InviteWithMetadata]:
         if not self._is_cache_enabled_for(INVITES):
             return cache_utility.EmptyCacheView()
 
-        guild_id = snowflakes.Snowflake(guild_id)
-        channel_id = snowflakes.Snowflake(channel_id)
+        guild_id = snowflakes.Snowflake(guild)
+        channel_id = snowflakes.Snowflake(channel)
         guild_record = self._guild_entries.get(guild_id)
         if not guild_record or not guild_record.invites:
             return cache_utility.EmptyCacheView()
@@ -614,10 +632,11 @@ class CacheImpl(cache.MutableCache):
 
         return cache_utility.CacheMappingView(cached_invites, builder=self._build_invite)
 
-    def delete_invite(self, code: str, /) -> typing.Optional[invites.InviteWithMetadata]:
+    def delete_invite(self, code: invites.Inviteish, /) -> typing.Optional[invites.InviteWithMetadata]:
         if not self._is_cache_enabled_for(INVITES):
             return None
 
+        code = code if isinstance(code, str) else code.code
         invite_data = self._invite_entries.pop(code, None)
         if not invite_data:
             return None
@@ -635,10 +654,11 @@ class CacheImpl(cache.MutableCache):
 
         return self._build_invite(invite_data)
 
-    def get_invite(self, code: str, /) -> typing.Optional[invites.InviteWithMetadata]:
+    def get_invite(self, code: invites.Inviteish, /) -> typing.Optional[invites.InviteWithMetadata]:
         if not self._is_cache_enabled_for(INVITES):
             return None
 
+        code = code if isinstance(code, str) else code.code
         invite_data = self._invite_entries.get(code)
         return self._build_invite(invite_data) if invite_data else None
 
@@ -649,12 +669,12 @@ class CacheImpl(cache.MutableCache):
         return cache_utility.CacheMappingView(self._invite_entries.freeze(), builder=self._build_invite)
 
     def get_invites_view_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> cache.CacheView[str, invites.InviteWithMetadata]:
         if not self._is_cache_enabled_for(INVITES):
             return cache_utility.EmptyCacheView()
 
-        guild_id = snowflakes.Snowflake(guild_id)
+        guild_id = snowflakes.Snowflake(guild)
         guild_entry = self._guild_entries.get(guild_id)
         if not guild_entry or not guild_entry.invites:
             return cache_utility.EmptyCacheView()
@@ -664,15 +684,15 @@ class CacheImpl(cache.MutableCache):
 
     def get_invites_view_for_channel(
         self,
-        guild_id: snowflakes.Snowflakeish,
-        channel_id: snowflakes.Snowflakeish,
+        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        channel: snowflakes.SnowflakeishOr[channels.PartialChannel],
         /,
     ) -> cache.CacheView[str, invites.InviteWithMetadata]:
         if not self._is_cache_enabled_for(INVITES):
             return cache_utility.EmptyCacheView()
 
-        guild_id = snowflakes.Snowflake(guild_id)
-        channel_id = snowflakes.Snowflake(channel_id)
+        guild_id = snowflakes.Snowflake(guild)
+        channel_id = snowflakes.Snowflake(channel)
         guild_entry = self._guild_entries.get(guild_id)
         if not guild_entry or not guild_entry.invites:
             return cache_utility.EmptyCacheView()
@@ -792,12 +812,12 @@ class CacheImpl(cache.MutableCache):
         return cache_utility.CacheMappingView({guild_id: view for guild_id, view in views if view})
 
     def clear_members_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> cache.CacheView[snowflakes.Snowflake, guilds.Member]:
         if not self._is_cache_enabled_for(MEMBERS):
             return cache_utility.EmptyCacheView()
 
-        guild_id = snowflakes.Snowflake(guild_id)
+        guild_id = snowflakes.Snowflake(guild)
         guild_record = self._guild_entries.get(guild_id)
         if not guild_record or not guild_record.members:
             return cache_utility.EmptyCacheView()
@@ -810,13 +830,16 @@ class CacheImpl(cache.MutableCache):
         return cache_utility.CacheMappingView(cached_members, builder=self._build_member)  # type: ignore[type-var]
 
     def delete_member(
-        self, guild_id: snowflakes.Snowflakeish, user_id: snowflakes.Snowflakeish, /
+        self,
+        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        user: snowflakes.SnowflakeishOr[users.PartialUser],
+        /,
     ) -> typing.Optional[guilds.Member]:
         if not self._is_cache_enabled_for(MEMBERS):
             return None
 
-        guild_id = snowflakes.Snowflake(guild_id)
-        user_id = snowflakes.Snowflake(user_id)
+        guild_id = snowflakes.Snowflake(guild)
+        user_id = snowflakes.Snowflake(user)
         guild_record = self._guild_entries.get(guild_id)
         if not guild_record or not guild_record.members:
             return None
@@ -834,13 +857,16 @@ class CacheImpl(cache.MutableCache):
         return self._build_member(member_data) if garbage_collected else None
 
     def get_member(
-        self, guild_id: snowflakes.Snowflakeish, user_id: snowflakes.Snowflakeish, /
+        self,
+        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        user: snowflakes.SnowflakeishOr[users.PartialUser],
+        /,
     ) -> typing.Optional[guilds.Member]:
         if not self._is_cache_enabled_for(MEMBERS):
             return None
 
-        guild_id = snowflakes.Snowflake(guild_id)
-        user_id = snowflakes.Snowflake(user_id)
+        guild_id = snowflakes.Snowflake(guild)
+        user_id = snowflakes.Snowflake(user)
         guild_record = self._guild_entries.get(guild_id)
         if not guild_record or not guild_record.members:
             return None
@@ -955,12 +981,12 @@ class CacheImpl(cache.MutableCache):
         return cache_utility.CacheMappingView({guild_id: view for guild_id, view in views if view})
 
     def clear_presences_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> cache.CacheView[snowflakes.Snowflake, presences.MemberPresence]:
         if not self._is_cache_enabled_for(PRESENCES):
             return cache_utility.EmptyCacheView()
 
-        guild_id = snowflakes.Snowflake(guild_id)
+        guild_id = snowflakes.Snowflake(guild)
         guild_record = self._guild_entries.get(guild_id)
         if not guild_record or not guild_record.presences:
             return cache_utility.EmptyCacheView()
@@ -975,13 +1001,16 @@ class CacheImpl(cache.MutableCache):
         return cache_utility.CacheMappingView(cached_presences, builder=self._build_presence)
 
     def delete_presence(
-        self, guild_id: snowflakes.Snowflakeish, user_id: snowflakes.Snowflakeish, /
+        self,
+        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        user: snowflakes.SnowflakeishOr[users.PartialUser],
+        /,
     ) -> typing.Optional[presences.MemberPresence]:
         if not self._is_cache_enabled_for(PRESENCES):
             return None
 
-        guild_id = snowflakes.Snowflake(guild_id)
-        user_id = snowflakes.Snowflake(user_id)
+        guild_id = snowflakes.Snowflake(guild)
+        user_id = snowflakes.Snowflake(user)
         guild_record = self._guild_entries.get(guild_id)
         if not guild_record or not guild_record.presences:
             return None
@@ -1000,13 +1029,16 @@ class CacheImpl(cache.MutableCache):
         return self._build_presence(presence_data)
 
     def get_presence(
-        self, guild_id: snowflakes.Snowflakeish, user_id: snowflakes.Snowflakeish, /
+        self,
+        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        user: snowflakes.SnowflakeishOr[users.PartialUser],
+        /,
     ) -> typing.Optional[presences.MemberPresence]:
         if not self._is_cache_enabled_for(PRESENCES):
             return None
 
-        guild_id = snowflakes.Snowflake(guild_id)
-        user_id = snowflakes.Snowflake(user_id)
+        guild_id = snowflakes.Snowflake(guild)
+        user_id = snowflakes.Snowflake(user)
         guild_record = self._guild_entries.get(guild_id)
         if not guild_record or not guild_record.presences:
             return None
@@ -1027,13 +1059,12 @@ class CacheImpl(cache.MutableCache):
         return cache_utility.Cache3DMappingView(views)
 
     def get_presences_view_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> cache.CacheView[snowflakes.Snowflake, presences.MemberPresence]:
         if not self._is_cache_enabled_for(PRESENCES):
             return cache_utility.EmptyCacheView()
 
-        guild_id = snowflakes.Snowflake(guild_id)
-        guild_record = self._guild_entries.get(guild_id)
+        guild_record = self._guild_entries.get(snowflakes.Snowflake(guild))
         if not guild_record or not guild_record.presences:
             return cache_utility.EmptyCacheView()
 
@@ -1091,12 +1122,12 @@ class CacheImpl(cache.MutableCache):
         return cache_utility.CacheMappingView(roles)
 
     def clear_roles_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> cache.CacheView[snowflakes.Snowflake, guilds.Role]:
         if not self._is_cache_enabled_for(ROLES):
             return cache_utility.EmptyCacheView()
 
-        guild_id = snowflakes.Snowflake(guild_id)
+        guild_id = snowflakes.Snowflake(guild)
         guild_record = self._guild_entries.get(guild_id)
         if not guild_record or not guild_record.roles:
             return cache_utility.EmptyCacheView()
@@ -1108,11 +1139,11 @@ class CacheImpl(cache.MutableCache):
         self._remove_guild_record_if_empty(guild_id, guild_record)
         return view
 
-    def delete_role(self, role_id: snowflakes.Snowflakeish, /) -> typing.Optional[guilds.Role]:
+    def delete_role(self, role: snowflakes.SnowflakeishOr[guilds.PartialRole], /) -> typing.Optional[guilds.Role]:
         if not self._is_cache_enabled_for(ROLES):
             return None
 
-        role_id = snowflakes.Snowflake(role_id)
+        role_id = snowflakes.Snowflake(role)
         role = self._role_entries.pop(role_id, None)
         if not role:
             return None
@@ -1127,11 +1158,11 @@ class CacheImpl(cache.MutableCache):
 
         return role
 
-    def get_role(self, role_id: snowflakes.Snowflakeish, /) -> typing.Optional[guilds.Role]:
+    def get_role(self, role: snowflakes.SnowflakeishOr[guilds.PartialRole], /) -> typing.Optional[guilds.Role]:
         if not self._is_cache_enabled_for(ROLES):
             return None
 
-        role = self._role_entries.get(snowflakes.Snowflake(role_id))
+        role = self._role_entries.get(snowflakes.Snowflake(role))
         return copy.copy(role) if role else None
 
     def get_roles_view(self) -> cache.CacheView[snowflakes.Snowflake, guilds.Role]:
@@ -1141,13 +1172,12 @@ class CacheImpl(cache.MutableCache):
         return cache_utility.CacheMappingView(self._role_entries.freeze())
 
     def get_roles_view_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> cache.CacheView[snowflakes.Snowflake, guilds.Role]:
         if not self._is_cache_enabled_for(ROLES):
             return cache_utility.EmptyCacheView()
 
-        guild_id = snowflakes.Snowflake(guild_id)
-        guild_record = self._guild_entries.get(guild_id)
+        guild_record = self._guild_entries.get(snowflakes.Snowflake(guild))
         if not guild_record or not guild_record.roles:
             return cache_utility.EmptyCacheView()
 
@@ -1188,8 +1218,8 @@ class CacheImpl(cache.MutableCache):
         if self._can_remove_user(user) and user.object.id in self._user_entries:
             del self._user_entries[user.object.id]
 
-    def get_user(self, user_id: snowflakes.Snowflakeish, /) -> typing.Optional[users.User]:
-        user = self._user_entries.get(snowflakes.Snowflake(user_id))
+    def get_user(self, user: snowflakes.SnowflakeishOr[users.PartialUser], /) -> typing.Optional[users.User]:
+        user = self._user_entries.get(snowflakes.Snowflake(user))
         return user.copy() if user else None
 
     def get_users_view(self) -> cache.CacheView[snowflakes.Snowflake, users.User]:
@@ -1230,13 +1260,16 @@ class CacheImpl(cache.MutableCache):
         return cache_utility.CacheMappingView({guild_id: view for guild_id, view in views if view})
 
     def clear_voice_states_for_channel(
-        self, guild_id: snowflakes.Snowflakeish, channel_id: snowflakes.Snowflakeish, /
+        self,
+        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        channel: snowflakes.SnowflakeishOr[channels.PartialChannel],
+        /,
     ) -> cache.CacheView[snowflakes.Snowflake, voices.VoiceState]:
         if not self._is_cache_enabled_for(VOICE_STATES):
             return cache_utility.EmptyCacheView()
 
-        guild_id = snowflakes.Snowflake(guild_id)
-        channel_id = snowflakes.Snowflake(channel_id)
+        guild_id = snowflakes.Snowflake(guild)
+        channel_id = snowflakes.Snowflake(channel)
         guild_record = self._guild_entries.get(guild_id)
         if not guild_record or not guild_record.voice_states:
             return cache_utility.EmptyCacheView()
@@ -1255,12 +1288,12 @@ class CacheImpl(cache.MutableCache):
         return cache_utility.CacheMappingView(cached_voice_states, builder=self._build_voice_state)
 
     def clear_voice_states_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> cache.CacheView[snowflakes.Snowflake, voices.VoiceState]:
         if not self._is_cache_enabled_for(VOICE_STATES):
             return cache_utility.EmptyCacheView()
 
-        guild_id = snowflakes.Snowflake(guild_id)
+        guild_id = snowflakes.Snowflake(guild)
         guild_record = self._guild_entries.get(guild_id)
 
         if not guild_record or not guild_record.voice_states:
@@ -1276,13 +1309,16 @@ class CacheImpl(cache.MutableCache):
         return cache_utility.CacheMappingView(cached_voice_states, builder=self._build_voice_state)
 
     def delete_voice_state(
-        self, guild_id: snowflakes.Snowflakeish, user_id: snowflakes.Snowflakeish, /
+        self,
+        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        user: snowflakes.SnowflakeishOr[users.PartialUser],
+        /,
     ) -> typing.Optional[voices.VoiceState]:
         if not self._is_cache_enabled_for(VOICE_STATES):
             return None
 
-        guild_id = snowflakes.Snowflake(guild_id)
-        user_id = snowflakes.Snowflake(user_id)
+        guild_id = snowflakes.Snowflake(guild)
+        user_id = snowflakes.Snowflake(user)
         guild_record = self._guild_entries.get(guild_id)
         if not guild_record or not guild_record.voice_states:
             return None
@@ -1299,13 +1335,16 @@ class CacheImpl(cache.MutableCache):
         return self._build_voice_state(voice_state_data)
 
     def get_voice_state(
-        self, guild_id: snowflakes.Snowflakeish, user_id: snowflakes.Snowflakeish, /
+        self,
+        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        user: snowflakes.SnowflakeishOr[users.PartialUser],
+        /,
     ) -> typing.Optional[voices.VoiceState]:
         if not self._is_cache_enabled_for(VOICE_STATES):
             return None
 
-        guild_id = snowflakes.Snowflake(guild_id)
-        user_id = snowflakes.Snowflake(user_id)
+        guild_id = snowflakes.Snowflake(guild)
+        user_id = snowflakes.Snowflake(user)
         guild_record = self._guild_entries.get(guild_id)
         voice_data = guild_record.voice_states.get(user_id) if guild_record and guild_record.voice_states else None
         return self._build_voice_state(voice_data) if voice_data else None
@@ -1326,13 +1365,16 @@ class CacheImpl(cache.MutableCache):
         return cache_utility.Cache3DMappingView(views)
 
     def get_voice_states_view_for_channel(
-        self, guild_id: snowflakes.Snowflakeish, channel_id: snowflakes.Snowflakeish, /
+        self,
+        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        channel: snowflakes.SnowflakeishOr[channels.PartialChannel],
+        /,
     ) -> cache.CacheView[snowflakes.Snowflake, voices.VoiceState]:
         if not self._is_cache_enabled_for(VOICE_STATES):
             return cache_utility.EmptyCacheView()
 
-        guild_id = snowflakes.Snowflake(guild_id)
-        channel_id = snowflakes.Snowflake(channel_id)
+        guild_id = snowflakes.Snowflake(guild)
+        channel_id = snowflakes.Snowflake(channel)
         guild_record = self._guild_entries.get(guild_id)
         if not guild_record or not guild_record.voice_states:
             return cache_utility.EmptyCacheView()
@@ -1346,13 +1388,12 @@ class CacheImpl(cache.MutableCache):
         return cache_utility.CacheMappingView(cached_voice_states, builder=self._build_voice_state)
 
     def get_voice_states_view_for_guild(
-        self, guild_id: snowflakes.Snowflakeish, /
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
     ) -> cache.CacheView[snowflakes.Snowflake, voices.VoiceState]:
         if not self._is_cache_enabled_for(VOICE_STATES):
             return cache_utility.EmptyCacheView()
 
-        guild_id = snowflakes.Snowflake(guild_id)
-        guild_record = self._guild_entries.get(guild_id)
+        guild_record = self._guild_entries.get(snowflakes.Snowflake(guild))
         if not guild_record or not guild_record.voice_states:
             return cache_utility.EmptyCacheView()
 
@@ -1444,11 +1485,13 @@ class CacheImpl(cache.MutableCache):
 
         return cache_utility.CacheMappingView(cached_messages, builder=self._build_message)  # type: ignore[type-var]
 
-    def delete_message(self, message_id: snowflakes.Snowflakeish, /) -> typing.Optional[messages.Message]:
+    def delete_message(
+        self, message: snowflakes.SnowflakeishOr[messages.PartialMessage], /
+    ) -> typing.Optional[messages.Message]:
         if not self._is_cache_enabled_for(MESSAGES):
             return None
 
-        message_id = snowflakes.Snowflake(message_id)
+        message_id = snowflakes.Snowflake(message)
         message_data = self._message_entries.pop(message_id, None)
 
         if not message_data:
@@ -1460,11 +1503,13 @@ class CacheImpl(cache.MutableCache):
 
         return self._build_message(message_data)
 
-    def get_message(self, message_id: snowflakes.Snowflakeish, /) -> typing.Optional[messages.Message]:
+    def get_message(
+        self, message: snowflakes.SnowflakeishOr[messages.PartialMessage], /
+    ) -> typing.Optional[messages.Message]:
         if not self._is_cache_enabled_for(MESSAGES):
             return None
 
-        message_id = snowflakes.Snowflake(message_id)
+        message_id = snowflakes.Snowflake(message)
         message_data = self._message_entries.get(message_id) or self._referenced_messages.get(message_id)
         return self._build_message(message_data) if message_data else None
 

--- a/tests/hikari/impl/test_cache.py
+++ b/tests/hikari/impl/test_cache.py
@@ -40,6 +40,13 @@ from hikari.internal import collections
 from tests.hikari import hikari_test_helpers
 
 
+class StubModel(snowflakes.Unique):
+    id = None
+
+    def __init__(self, id=0):
+        self.id = snowflakes.Snowflake(id)
+
+
 class TestCacheImpl:
     @pytest.fixture()
     def app_impl(self):
@@ -97,7 +104,9 @@ class TestCacheImpl:
             is_managed=False,
             is_available=True,
         )
+
         emoji = cache_impl._build_emoji(emoji_data)
+
         assert emoji.app is cache_impl._app
         assert emoji.id == snowflakes.Snowflake(1233534234)
         assert emoji.name == "OKOKOKOKOK"
@@ -122,7 +131,9 @@ class TestCacheImpl:
             is_available=True,
         )
         cache_impl._build_user = mock.Mock()
+
         emoji = cache_impl._build_emoji(emoji_data)
+
         cache_impl._build_user.assert_not_called()
         assert emoji.user is None
 
@@ -144,7 +155,9 @@ class TestCacheImpl:
         )
         cache_impl._build_emoji = mock.Mock(side_effect=[mock_emoji_1, mock_emoji_2, mock_emoji_3])
         cache_impl._garbage_collect_user = mock.Mock()
+
         view = cache_impl.clear_emojis()
+
         assert view == {
             snowflakes.Snowflake(43123123): mock_emoji_1,
             snowflakes.Snowflake(87643523): mock_emoji_2,
@@ -190,7 +203,9 @@ class TestCacheImpl:
         cache_impl._build_emoji = mock.Mock(side_effect=[mock_emoji_1, mock_emoji_2, mock_emoji_3])
         cache_impl._remove_guild_record_if_empty = mock.Mock()
         cache_impl._garbage_collect_user = mock.Mock()
-        emoji_mapping = cache_impl.clear_emojis_for_guild(snowflakes.Snowflake(432123123))
+
+        emoji_mapping = cache_impl.clear_emojis_for_guild(StubModel(432123123))
+
         cache_impl._garbage_collect_user.assert_has_calls(
             [mock.call(mock_user_1, decrement=1), mock.call(mock_user_2, decrement=1)]
         )
@@ -219,7 +234,9 @@ class TestCacheImpl:
         cache_impl._build_emoji = mock.Mock()
         cache_impl._remove_guild_record_if_empty = mock.Mock()
         cache_impl._garbage_collect_user = mock.Mock()
-        emoji_mapping = cache_impl.clear_emojis_for_guild(snowflakes.Snowflake(432123123))
+
+        emoji_mapping = cache_impl.clear_emojis_for_guild(StubModel(432123123))
+
         cache_impl._garbage_collect_user.assert_not_called()
         cache_impl._remove_guild_record_if_empty.assert_not_called()
         assert emoji_mapping == {}
@@ -233,7 +250,9 @@ class TestCacheImpl:
         cache_impl._build_emoji = mock.Mock()
         cache_impl._remove_guild_record_if_empty = mock.Mock()
         cache_impl._garbage_collect_user = mock.Mock()
-        emoji_mapping = cache_impl.clear_emojis_for_guild(snowflakes.Snowflake(432123123))
+
+        emoji_mapping = cache_impl.clear_emojis_for_guild(StubModel(432123123))
+
         cache_impl._garbage_collect_user.assert_not_called()
         cache_impl._remove_guild_record_if_empty.assert_not_called()
         assert emoji_mapping == {}
@@ -256,7 +275,10 @@ class TestCacheImpl:
         )
         cache_impl._garbage_collect_user = mock.Mock()
         cache_impl._build_emoji = mock.Mock(return_value=mock_emoji)
-        assert cache_impl.delete_emoji(snowflakes.Snowflake(12354123)) is mock_emoji
+
+        result = cache_impl.delete_emoji(StubModel(12354123))
+
+        assert result is mock_emoji
         assert cache_impl._emoji_entries == {snowflakes.Snowflake(999): mock_other_emoji_data}
         assert cache_impl._guild_entries[snowflakes.Snowflake(123333)].emojis == {snowflakes.Snowflake(432123)}
         cache_impl._build_emoji.assert_called_once_with(mock_emoji_data)
@@ -278,7 +300,10 @@ class TestCacheImpl:
         )
         cache_impl._garbage_collect_user = mock.Mock()
         cache_impl._build_emoji = mock.Mock(return_value=mock_emoji)
-        assert cache_impl.delete_emoji(snowflakes.Snowflake(12354123)) is mock_emoji
+
+        result = cache_impl.delete_emoji(StubModel(12354123))
+
+        assert result is mock_emoji
         assert cache_impl._emoji_entries == {snowflakes.Snowflake(999): mock_other_emoji_data}
         assert cache_impl._guild_entries[snowflakes.Snowflake(123333)].emojis == {snowflakes.Snowflake(432123)}
         cache_impl._build_emoji.assert_called_once_with(mock_emoji_data)
@@ -287,7 +312,10 @@ class TestCacheImpl:
     def test_delete_emoji_for_unknown_emoji(self, cache_impl):
         cache_impl._garbage_collect_user = mock.Mock()
         cache_impl._build_emoji = mock.Mock()
-        assert cache_impl.delete_emoji(snowflakes.Snowflake(12354123)) is None
+
+        result = cache_impl.delete_emoji(StubModel(12354123))
+
+        assert result is None
         cache_impl._build_emoji.assert_not_called()
         cache_impl._garbage_collect_user.assert_not_called()
 
@@ -296,12 +324,18 @@ class TestCacheImpl:
         mock_emoji = mock.Mock(emojis.KnownCustomEmoji)
         cache_impl._build_emoji = mock.Mock(return_value=mock_emoji)
         cache_impl._emoji_entries = collections.FreezableDict({snowflakes.Snowflake(3422123): mock_emoji_data})
-        assert cache_impl.get_emoji(snowflakes.Snowflake(3422123)) is mock_emoji
+
+        result = cache_impl.get_emoji(StubModel(3422123))
+
+        assert result is mock_emoji
         cache_impl._build_emoji.assert_called_once_with(mock_emoji_data)
 
     def test_get_emoji_with_unknown_emoji(self, cache_impl):
         cache_impl._build_emoji = mock.Mock()
-        assert cache_impl.get_emoji(snowflakes.Snowflake(3422123)) is None
+
+        result = cache_impl.get_emoji(StubModel(3422123))
+
+        assert result is None
         cache_impl._build_emoji.assert_not_called()
 
     def test_get_emojis_view(self, cache_impl):
@@ -313,7 +347,10 @@ class TestCacheImpl:
             {snowflakes.Snowflake(123123123): mock_emoji_data_1, snowflakes.Snowflake(43156234): mock_emoji_data_2}
         )
         cache_impl._build_emoji = mock.Mock(side_effect=[mock_emoji_1, mock_emoji_2])
-        assert cache_impl.get_emojis_view() == {
+
+        result = cache_impl.get_emojis_view()
+
+        assert result == {
             snowflakes.Snowflake(123123123): mock_emoji_1,
             snowflakes.Snowflake(43156234): mock_emoji_2,
         }
@@ -340,7 +377,10 @@ class TestCacheImpl:
             }
         )
         cache_impl._build_emoji = mock.Mock(side_effect=[mock_emoji_1, mock_emoji_2])
-        assert cache_impl.get_emojis_view_for_guild(snowflakes.Snowflake(9342123)) == {
+
+        result = cache_impl.get_emojis_view_for_guild(StubModel(9342123))
+
+        assert result == {
             snowflakes.Snowflake(65123): mock_emoji_1,
             snowflakes.Snowflake(43156234): mock_emoji_2,
         }
@@ -357,7 +397,10 @@ class TestCacheImpl:
             }
         )
         cache_impl._build_emoji = mock.Mock()
-        assert cache_impl.get_emojis_view_for_guild(snowflakes.Snowflake(9342123)) == {}
+
+        result = cache_impl.get_emojis_view_for_guild(StubModel(9342123))
+
+        assert result == {}
         cache_impl._build_emoji.assert_not_called()
 
     def test_get_emojis_view_for_guild_for_unknown_record(self, cache_impl):
@@ -368,7 +411,10 @@ class TestCacheImpl:
             {snowflakes.Snowflake(9342123): cache_utilities.GuildRecord()}
         )
         cache_impl._build_emoji = mock.Mock()
-        assert cache_impl.get_emojis_view_for_guild(snowflakes.Snowflake(9342123)) == {}
+
+        result = cache_impl.get_emojis_view_for_guild(StubModel(9342123))
+
+        assert result == {}
         cache_impl._build_emoji.assert_not_called()
 
     def test_set_emoji(self, cache_impl):
@@ -388,7 +434,9 @@ class TestCacheImpl:
         )
         cache_impl._set_user = mock.Mock(return_value=mock_reffed_user)
         cache_impl._increment_ref_count = mock.Mock()
-        assert cache_impl.set_emoji(emoji) is None
+
+        cache_impl.set_emoji(emoji)
+
         assert 65234 in cache_impl._guild_entries
         assert cache_impl._guild_entries[snowflakes.Snowflake(65234)].emojis
         assert 5123123 in cache_impl._guild_entries[snowflakes.Snowflake(65234)].emojis
@@ -426,7 +474,9 @@ class TestCacheImpl:
         )
         cache_impl._set_user = mock.Mock()
         cache_impl._increment_user_ref_count = mock.Mock()
-        assert cache_impl.set_emoji(emoji) is None
+
+        cache_impl.set_emoji(emoji)
+
         assert 5123123 in cache_impl._emoji_entries
         cache_impl._set_user.assert_called_once_with(mock_user)
         cache_impl._increment_user_ref_count.assert_not_called()
@@ -437,7 +487,10 @@ class TestCacheImpl:
         mock_emoji = mock.Mock(emojis.KnownCustomEmoji, id=snowflakes.Snowflake(54123123))
         cache_impl.get_emoji = mock.Mock(side_effect=[mock_cached_emoji_1, mock_cached_emoji_2])
         cache_impl.set_emoji = mock.Mock()
-        assert cache_impl.update_emoji(mock_emoji) == (mock_cached_emoji_1, mock_cached_emoji_2)
+
+        result = cache_impl.update_emoji(mock_emoji)
+
+        assert result == (mock_cached_emoji_1, mock_cached_emoji_2)
         cache_impl.get_emoji.assert_has_calls(
             [mock.call(snowflakes.Snowflake(54123123)), mock.call(snowflakes.Snowflake(54123123))]
         )
@@ -450,7 +503,10 @@ class TestCacheImpl:
                 snowflakes.Snowflake(675345): cache_utilities.GuildRecord(),
             }
         )
-        assert cache_impl.clear_guilds() == {}
+
+        result = cache_impl.clear_guilds()
+
+        assert result == {}
         assert cache_impl._guild_entries == {
             snowflakes.Snowflake(423123): cache_utilities.GuildRecord(),
             snowflakes.Snowflake(675345): cache_utilities.GuildRecord(),
@@ -473,7 +529,10 @@ class TestCacheImpl:
                 snowflakes.Snowflake(321132): cache_utilities.GuildRecord(),
             }
         )
-        assert cache_impl.clear_guilds() == {675345: mock_guild_1, 32142: mock_guild_2, 765345: mock_guild_3}
+
+        result = cache_impl.clear_guilds()
+
+        assert result == {675345: mock_guild_1, 32142: mock_guild_2, 765345: mock_guild_3}
         assert cache_impl._guild_entries == {
             snowflakes.Snowflake(423123): cache_utilities.GuildRecord(),
             snowflakes.Snowflake(32142): cache_utilities.GuildRecord(
@@ -495,7 +554,10 @@ class TestCacheImpl:
                 ),
             }
         )
-        assert cache_impl.delete_guild(snowflakes.Snowflake(543123)) is mock_guild
+
+        result = cache_impl.delete_guild(StubModel(543123))
+
+        assert result is mock_guild
         assert cache_impl._guild_entries == {
             snowflakes.Snowflake(354123): cache_utilities.GuildRecord(),
             snowflakes.Snowflake(543123): cache_utilities.GuildRecord(
@@ -511,7 +573,10 @@ class TestCacheImpl:
                 snowflakes.Snowflake(543123): cache_utilities.GuildRecord(guild=mock_guild, is_available=True),
             }
         )
-        assert cache_impl.delete_guild(snowflakes.Snowflake(543123)) is mock_guild
+
+        result = cache_impl.delete_guild(StubModel(543123))
+
+        assert result is mock_guild
         assert cache_impl._guild_entries == {snowflakes.Snowflake(354123): cache_utilities.GuildRecord()}
 
     def test_delete_guild_for_unknown_guild(self, cache_impl):
@@ -521,7 +586,10 @@ class TestCacheImpl:
                 snowflakes.Snowflake(543123): cache_utilities.GuildRecord(),
             }
         )
-        assert cache_impl.delete_guild(snowflakes.Snowflake(543123)) is None
+
+        result = cache_impl.delete_guild(StubModel(543123))
+
+        assert result is None
         assert cache_impl._guild_entries == {
             snowflakes.Snowflake(354123): cache_utilities.GuildRecord(),
             snowflakes.Snowflake(543123): cache_utilities.GuildRecord(),
@@ -531,7 +599,10 @@ class TestCacheImpl:
         cache_impl._guild_entries = collections.FreezableDict(
             {snowflakes.Snowflake(354123): cache_utilities.GuildRecord()}
         )
-        assert cache_impl.delete_guild(snowflakes.Snowflake(543123)) is None
+
+        result = cache_impl.delete_guild(StubModel(543123))
+
+        assert result is None
         assert cache_impl._guild_entries == {snowflakes.Snowflake(354123): cache_utilities.GuildRecord()}
 
     def test_get_guild_first_tries_get_available_guilds(self, cache_impl):
@@ -542,7 +613,9 @@ class TestCacheImpl:
                 snowflakes.Snowflake(543123): cache_utilities.GuildRecord(guild=mock_guild, is_available=True),
             }
         )
-        cached_guild = cache_impl.get_guild(snowflakes.Snowflake(543123))
+
+        cached_guild = cache_impl.get_guild(StubModel(543123))
+
         assert cached_guild == mock_guild
         assert cache_impl is not mock_guild
 
@@ -554,7 +627,9 @@ class TestCacheImpl:
                 snowflakes.Snowflake(54234123): cache_utilities.GuildRecord(guild=mock_guild, is_available=False),
             }
         )
-        cached_guild = cache_impl.get_guild(snowflakes.Snowflake(54234123))
+
+        cached_guild = cache_impl.get_guild(StubModel(54234123))
+
         assert cached_guild == mock_guild
         assert cache_impl is not mock_guild
 
@@ -566,7 +641,9 @@ class TestCacheImpl:
                 snowflakes.Snowflake(543123): cache_utilities.GuildRecord(guild=mock_guild, is_available=True),
             }
         )
-        cached_guild = cache_impl.get_available_guild(snowflakes.Snowflake(543123))
+
+        cached_guild = cache_impl.get_available_guild(StubModel(543123))
+
         assert cached_guild == mock_guild
         assert cache_impl is not mock_guild
 
@@ -579,7 +656,7 @@ class TestCacheImpl:
             }
         )
 
-        result = cache_impl.get_available_guild(snowflakes.Snowflake(543123))
+        result = cache_impl.get_available_guild(StubModel(543123))
 
         assert result is None
 
@@ -590,13 +667,19 @@ class TestCacheImpl:
                 snowflakes.Snowflake(543123): cache_utilities.GuildRecord(),
             }
         )
-        assert cache_impl.get_available_guild(snowflakes.Snowflake(543123)) is None
+
+        result = cache_impl.get_available_guild(StubModel(543123))
+
+        assert result is None
 
     def test_get_available_guild_for_unknown_guild_record(self, cache_impl):
         cache_impl._guild_entries = collections.FreezableDict(
             {snowflakes.Snowflake(54234123): cache_utilities.GuildRecord()}
         )
-        assert cache_impl.get_available_guild(snowflakes.Snowflake(543123)) is None
+
+        result = cache_impl.get_available_guild(StubModel(543123))
+
+        assert result is None
 
     def test_get_unavailable_guild_for_known_guild_when_unavailable(self, cache_impl):
         mock_guild = mock.MagicMock(guilds.GatewayGuild)
@@ -606,7 +689,9 @@ class TestCacheImpl:
                 snowflakes.Snowflake(452131): cache_utilities.GuildRecord(guild=mock_guild, is_available=False),
             }
         )
-        cached_guild = cache_impl.get_unavailable_guild(snowflakes.Snowflake(452131))
+
+        cached_guild = cache_impl.get_unavailable_guild(StubModel(452131))
+
         assert cached_guild == mock_guild
         assert cache_impl is not mock_guild
 
@@ -619,7 +704,7 @@ class TestCacheImpl:
             }
         )
 
-        result = cache_impl.get_unavailable_guild(snowflakes.Snowflake(654234))
+        result = cache_impl.get_unavailable_guild(StubModel(654234))
 
         assert result is None
 
@@ -630,13 +715,19 @@ class TestCacheImpl:
                 snowflakes.Snowflake(543123): cache_utilities.GuildRecord(),
             }
         )
-        assert cache_impl.get_unavailable_guild(snowflakes.Snowflake(543123)) is None
+
+        result = cache_impl.get_unavailable_guild(StubModel(543123))
+
+        assert result is None
 
     def test_get_unavailable_guild_for_unknown_guild_record(self, cache_impl):
         cache_impl._guild_entries = collections.FreezableDict(
             {snowflakes.Snowflake(54234123): cache_utilities.GuildRecord()}
         )
-        assert cache_impl.get_unavailable_guild(snowflakes.Snowflake(543123)) is None
+
+        result = cache_impl.get_unavailable_guild(StubModel(543123))
+
+        assert result is None
 
     def test_get_available_guilds_view(self, cache_impl):
         mock_guild_1 = mock.MagicMock(guilds.GatewayGuild)
@@ -649,7 +740,10 @@ class TestCacheImpl:
                 snowflakes.Snowflake(6554234): cache_utilities.GuildRecord(guild=object(), is_available=False),
             }
         )
-        assert cache_impl.get_available_guilds_view() == {
+
+        result = cache_impl.get_available_guilds_view()
+
+        assert result == {
             snowflakes.Snowflake(4312312): mock_guild_1,
             snowflakes.Snowflake(73453): mock_guild_2,
         }
@@ -662,7 +756,10 @@ class TestCacheImpl:
                 snowflakes.Snowflake(73453): cache_utilities.GuildRecord(),
             }
         )
-        assert cache_impl.get_available_guilds_view() == {}
+
+        result = cache_impl.get_available_guilds_view()
+
+        assert result == {}
 
     def test_get_unavailable_guilds_view(self, cache_impl):
         mock_guild_1 = mock.MagicMock(guilds.GatewayGuild)
@@ -675,7 +772,10 @@ class TestCacheImpl:
                 snowflakes.Snowflake(6554234): cache_utilities.GuildRecord(guild=object(), is_available=True),
             }
         )
-        assert cache_impl.get_unavailable_guilds_view() == {
+
+        result = cache_impl.get_unavailable_guilds_view()
+
+        assert result == {
             snowflakes.Snowflake(4312312): mock_guild_1,
             snowflakes.Snowflake(73453): mock_guild_2,
         }
@@ -688,11 +788,16 @@ class TestCacheImpl:
                 snowflakes.Snowflake(73453): cache_utilities.GuildRecord(),
             }
         )
-        assert cache_impl.get_unavailable_guilds_view() == {}
+
+        result = cache_impl.get_unavailable_guilds_view()
+
+        assert result == {}
 
     def test_set_guild(self, cache_impl):
         mock_guild = mock.MagicMock(guilds.GatewayGuild, id=snowflakes.Snowflake(5123123))
-        assert cache_impl.set_guild(mock_guild) is None
+
+        cache_impl.set_guild(mock_guild)
+
         assert 5123123 in cache_impl._guild_entries
         assert cache_impl._guild_entries[snowflakes.Snowflake(5123123)].guild == mock_guild
         assert cache_impl._guild_entries[snowflakes.Snowflake(5123123)].guild is not mock_guild
@@ -700,11 +805,14 @@ class TestCacheImpl:
 
     def test_set_guild_availability_for_cached_guild(self, cache_impl):
         cache_impl._guild_entries = {snowflakes.Snowflake(43123): cache_utilities.GuildRecord(guild=object())}
-        assert cache_impl.set_guild_availability(snowflakes.Snowflake(43123), True) is None
+
+        cache_impl.set_guild_availability(StubModel(43123), True)
+
         assert cache_impl._guild_entries[snowflakes.Snowflake(43123)].is_available is True
 
     def test_set_guild_availability_for_uncached_guild(self, cache_impl):
-        assert cache_impl.set_guild_availability(snowflakes.Snowflake(452234123), True) is None
+        cache_impl.set_guild_availability(StubModel(452234123), True)
+
         assert 452234123 not in cache_impl._guild_entries
 
     @pytest.mark.skip(reason="TODO")
@@ -759,7 +867,9 @@ class TestCacheImpl:
             is_temporary=True,
             created_at=datetime.datetime(2020, 7, 30, 7, 22, 9, 550233, tzinfo=datetime.timezone.utc),
         )
+
         invite = cache_impl._build_invite(invite_data)
+
         assert invite.app is cache_impl._app
         assert invite.code == "okokok"
         assert invite.guild is None
@@ -793,7 +903,9 @@ class TestCacheImpl:
             is_temporary=True,
             created_at=datetime.datetime(2020, 7, 30, 7, 22, 9, 550233, tzinfo=datetime.timezone.utc),
         )
+
         invite = cache_impl._build_invite(invite_data)
+
         assert invite.inviter is None
         assert invite.target_user is None
 
@@ -809,7 +921,10 @@ class TestCacheImpl:
         )
         cache_impl._build_invite = mock.Mock(side_effect=[mock_invite_1, mock_invite_2])
         cache_impl._garbage_collect_user = mock.Mock()
-        assert cache_impl.clear_invites() == {"hiBye": mock_invite_1, "Lblalbla": mock_invite_2}
+
+        result = cache_impl.clear_invites()
+
+        assert result == {"hiBye": mock_invite_1, "Lblalbla": mock_invite_2}
         assert cache_impl._invite_entries == {}
         cache_impl._garbage_collect_user.assert_has_calls(
             [mock.call(mock_target_user, decrement=1), mock.call(mock_inviter, decrement=1)], any_order=True
@@ -841,7 +956,10 @@ class TestCacheImpl:
         )
         cache_impl._garbage_collect_user = mock.Mock()
         cache_impl._build_invite = mock.Mock(side_effect=[mock_invite_1, mock_invite_2])
-        assert cache_impl.clear_invites_for_guild(snowflakes.Snowflake(999888777)) == {
+
+        result = cache_impl.clear_invites_for_guild(StubModel(999888777))
+
+        assert result == {
             "oeoeoeoeooe": mock_invite_1,
             "owowowowoowowow": mock_invite_2,
         }
@@ -861,7 +979,10 @@ class TestCacheImpl:
             }
         )
         cache_impl._build_invite = mock.Mock()
-        assert cache_impl.clear_invites_for_guild(snowflakes.Snowflake(765234123)) == {}
+
+        result = cache_impl.clear_invites_for_guild(StubModel(765234123))
+
+        assert result == {}
         assert cache_impl._invite_entries == {"oeoeoeoeoeoeoe": mock_other_invite_data}
         cache_impl._build_invite.assert_not_called()
 
@@ -872,7 +993,10 @@ class TestCacheImpl:
             {snowflakes.Snowflake(54123): mock.Mock(cache_utilities.GuildRecord)}
         )
         cache_impl._build_invite = mock.Mock()
-        assert cache_impl.clear_invites_for_guild(snowflakes.Snowflake(765234123)) == {}
+
+        result = cache_impl.clear_invites_for_guild(StubModel(765234123))
+
+        assert result == {}
         assert cache_impl._invite_entries == {"oeoeoeoeoeoeoe": mock_other_invite_data}
         cache_impl._build_invite.assert_not_called()
 
@@ -910,9 +1034,13 @@ class TestCacheImpl:
         )
         cache_impl._build_invite = mock.Mock(side_effect=[mock_invite_1, mock_invite_2])
         cache_impl._garbage_collect_user = mock.Mock()
-        assert cache_impl.clear_invites_for_channel(
-            snowflakes.Snowflake(999888777), snowflakes.Snowflake(34123123)
-        ) == {"oeoeoeoeooe": mock_invite_1, "owowowowoowowow": mock_invite_2}
+
+        result = cache_impl.clear_invites_for_channel(StubModel(999888777), StubModel(34123123))
+
+        assert result == {
+            "oeoeoeoeooe": mock_invite_1,
+            "owowowowoowowow": mock_invite_2,
+        }
         cache_impl._garbage_collect_user.assert_has_calls(
             [mock.call(mock_target_user, decrement=1), mock.call(mock_inviter, decrement=1)], any_order=True
         )
@@ -934,9 +1062,10 @@ class TestCacheImpl:
             }
         )
         cache_impl._build_invite = mock.Mock()
-        assert (
-            cache_impl.clear_invites_for_channel(snowflakes.Snowflake(765234123), snowflakes.Snowflake(12365345)) == {}
-        )
+
+        result = cache_impl.clear_invites_for_channel(StubModel(765234123), StubModel(12365345))
+
+        assert result == {}
         assert cache_impl._invite_entries == {"oeoeoeoeoeoeoe": mock_other_invite_data}
         cache_impl._build_invite.assert_not_called()
 
@@ -950,9 +1079,10 @@ class TestCacheImpl:
             {snowflakes.Snowflake(54123): mock.Mock(cache_utilities.GuildRecord)}
         )
         cache_impl._build_invite = mock.Mock()
-        assert (
-            cache_impl.clear_invites_for_channel(snowflakes.Snowflake(765234123), snowflakes.Snowflake(76234123)) == {}
-        )
+
+        result = cache_impl.clear_invites_for_channel(StubModel(765234123), StubModel(76234123))
+
+        assert result == {}
         assert cache_impl._invite_entries == {"oeoeoeoeoeoeoe": mock_other_invite_data}
         cache_impl._build_invite.assert_not_called()
 
@@ -978,14 +1108,34 @@ class TestCacheImpl:
         )
         cache_impl._build_invite = mock.Mock(return_value=mock_invite)
         cache_impl._garbage_collect_user = mock.Mock()
+        # TODO: test when this is called
         cache_impl._remove_guild_record_if_empty = mock.Mock()
-        assert cache_impl.delete_invite("oooooooooooooo") is mock_invite
+
+        result = cache_impl.delete_invite("oooooooooooooo")
+
+        assert result is mock_invite
         cache_impl._build_invite.assert_called_once_with(mock_invite_data)
         cache_impl._garbage_collect_user.assert_has_calls(
             [mock.call(mock_inviter, decrement=1), mock.call(mock_target_user, decrement=1)]
         )
         assert cache_impl._invite_entries == {"blamSpat": mock_other_invite_data}
         assert cache_impl._guild_entries[snowflakes.Snowflake(999999999)].invites == ["ok", "blat"]
+
+    def test_delete_invite_with_invite_object(self, cache_impl):
+        mock_invite_data = mock.Mock(cache_utilities.InviteData)
+        mock_other_invite_data = mock.Mock(cache_utilities.InviteData)
+        mock_invite = mock.Mock(invites.InviteWithMetadata, inviter=None, target_user=None, guild_id=None)
+        cache_impl._invite_entries = collections.FreezableDict(
+            {"blamSpat": mock_other_invite_data, "oooooooooooooos": mock_invite_data}
+        )
+        cache_impl._build_invite = mock.Mock(return_value=mock_invite)
+        cache_impl._garbage_collect_user = mock.Mock()
+
+        result = cache_impl.delete_invite(mock.Mock(code="oooooooooooooos"))
+
+        assert result is mock_invite
+        cache_impl._build_invite.assert_called_once_with(mock_invite_data)
+        assert cache_impl._invite_entries == {"blamSpat": mock_other_invite_data}
 
     def test_delete_invite_when_guild_id_is_None(self, cache_impl):
         mock_invite_data = mock.Mock(cache_utilities.InviteData)
@@ -996,9 +1146,11 @@ class TestCacheImpl:
         )
         cache_impl._build_invite = mock.Mock(return_value=mock_invite)
         cache_impl._garbage_collect_user = mock.Mock()
-        # TODO: test this is called
         cache_impl._remove_guild_record_if_empty = mock.Mock()
-        assert cache_impl.delete_invite("oooooooooooooo") is mock_invite
+
+        result = cache_impl.delete_invite("oooooooooooooo")
+
+        assert result is mock_invite
         cache_impl._build_invite.assert_called_once_with(mock_invite_data)
         cache_impl._remove_guild_record_if_empty.assert_not_called()
         assert cache_impl._invite_entries == {"blamSpat": mock_other_invite_data}
@@ -1020,9 +1172,11 @@ class TestCacheImpl:
         )
         cache_impl._build_invite = mock.Mock(return_value=mock_invite)
         cache_impl._garbage_collect_user = mock.Mock()
-        # TODO: test this is called
         cache_impl._remove_guild_record_if_empty = mock.Mock()
-        assert cache_impl.delete_invite("oooooooooooooo") is mock_invite
+
+        result = cache_impl.delete_invite("oooooooooooooo")
+
+        assert result is mock_invite
         cache_impl._build_invite.assert_called_once_with(mock_invite_data)
         cache_impl._garbage_collect_user.assert_not_called()
         assert cache_impl._invite_entries == {
@@ -1035,7 +1189,10 @@ class TestCacheImpl:
         cache_impl._garbage_collect_user = mock.Mock()
         # TODO: test this is called
         cache_impl._remove_guild_record_if_empty = mock.Mock()
-        assert cache_impl.delete_invite("oooooooooooooo") is None
+
+        result = cache_impl.delete_invite("oooooooooooooo")
+
+        assert result is None
         cache_impl._build_invite.assert_not_called()
         cache_impl._garbage_collect_user.assert_not_called()
 
@@ -1046,7 +1203,23 @@ class TestCacheImpl:
         cache_impl._invite_entries = collections.FreezableDict(
             {"blam": mock.Mock(cache_utilities.InviteData), "okokok": mock_invite_data}
         )
-        assert cache_impl.get_invite("okokok") is mock_invite
+
+        result = cache_impl.get_invite("okokok")
+
+        assert result is mock_invite
+        cache_impl._build_invite.assert_called_once_with(mock_invite_data)
+
+    def test_get_invite_with_invite_object(self, cache_impl):
+        mock_invite_data = mock.Mock(cache_utilities.InviteData)
+        mock_invite = mock.Mock(invites.InviteWithMetadata)
+        cache_impl._build_invite = mock.Mock(return_value=mock_invite)
+        cache_impl._invite_entries = collections.FreezableDict(
+            {"blam": mock.Mock(cache_utilities.InviteData), "okokoks": mock_invite_data}
+        )
+
+        result = cache_impl.get_invite(mock.Mock(code="okokoks"))
+
+        assert result is mock_invite
         cache_impl._build_invite.assert_called_once_with(mock_invite_data)
 
     def test_get_invite_for_unknown_invite(self, cache_impl):
@@ -1064,7 +1237,10 @@ class TestCacheImpl:
             {"okok": mock_invite_data_1, "blamblam": mock_invite_data_2}
         )
         cache_impl._build_invite = mock.Mock(side_effect=[mock_invite_1, mock_invite_2])
-        assert cache_impl.get_invites_view() == {"okok": mock_invite_1, "blamblam": mock_invite_2}
+
+        result = cache_impl.get_invites_view()
+
+        assert result == {"okok": mock_invite_1, "blamblam": mock_invite_2}
         cache_impl._build_invite.assert_has_calls([mock.call(mock_invite_data_1), mock.call(mock_invite_data_2)])
 
     def test_get_invites_view_for_guild(self, cache_impl):
@@ -1086,7 +1262,10 @@ class TestCacheImpl:
             }
         )
         cache_impl._build_invite = mock.Mock(side_effect=[mock_invite_1, mock_invite_2])
-        assert cache_impl.get_invites_view_for_guild(snowflakes.Snowflake(4444444)) == {
+
+        result = cache_impl.get_invites_view_for_guild(StubModel(4444444))
+
+        assert result == {
             "okok": mock_invite_1,
             "dsaytert": mock_invite_2,
         }
@@ -1103,7 +1282,10 @@ class TestCacheImpl:
             }
         )
         cache_impl._build_invite = mock.Mock()
-        assert cache_impl.get_invites_view_for_guild(snowflakes.Snowflake(4444444)) == {}
+
+        result = cache_impl.get_invites_view_for_guild(StubModel(4444444))
+
+        assert result == {}
         cache_impl._build_invite.assert_not_called()
 
     def test_get_invites_view_for_guild_unknown_record(self, cache_impl):
@@ -1114,7 +1296,10 @@ class TestCacheImpl:
             {snowflakes.Snowflake(9544994): mock.Mock(cache_utilities.GuildRecord)}
         )
         cache_impl._build_invite = mock.Mock()
-        assert cache_impl.get_invites_view_for_guild(snowflakes.Snowflake(4444444)) == {}
+
+        result = cache_impl.get_invites_view_for_guild(StubModel(4444444))
+
+        assert result == {}
         cache_impl._build_invite.assert_not_called()
 
     def test_get_invites_view_for_channel(self, cache_impl):
@@ -1137,9 +1322,10 @@ class TestCacheImpl:
             }
         )
         cache_impl._build_invite = mock.Mock(side_effect=[mock_invite_1, mock_invite_2])
-        assert cache_impl.get_invites_view_for_channel(
-            snowflakes.Snowflake(83452134), snowflakes.Snowflake(987987)
-        ) == {"blamBang": mock_invite_1, "bingBong": mock_invite_2}
+
+        result = cache_impl.get_invites_view_for_channel(StubModel(83452134), StubModel(987987))
+
+        assert result == {"blamBang": mock_invite_1, "bingBong": mock_invite_2}
         cache_impl._build_invite.assert_has_calls([mock.call(mock_invite_data_1), mock.call(mock_invite_data_2)])
 
     def test_get_invites_view_for_channel_unknown_emoji_cache(self, cache_impl):
@@ -1153,7 +1339,9 @@ class TestCacheImpl:
             }
         )
         cache_impl._build_invite = mock.Mock()
-        result = cache_impl.get_invites_view_for_channel(snowflakes.Snowflake(4444444), snowflakes.Snowflake(942123))
+
+        result = cache_impl.get_invites_view_for_channel(StubModel(4444444), StubModel(942123))
+
         assert result == {}
         cache_impl._build_invite.assert_not_called()
 
@@ -1165,7 +1353,9 @@ class TestCacheImpl:
             {snowflakes.Snowflake(9544994): mock.Mock(cache_utilities.GuildRecord)}
         )
         cache_impl._build_invite = mock.Mock()
-        result = cache_impl.get_invites_view_for_channel(snowflakes.Snowflake(4444444), snowflakes.Snowflake(9543123))
+
+        result = cache_impl.get_invites_view_for_channel(StubModel(4444444), StubModel(9543123))
+
         assert result == {}
         cache_impl._build_invite.assert_not_called()
 
@@ -1175,24 +1365,34 @@ class TestCacheImpl:
         mock_invite = mock.Mock(invites.InviteWithMetadata, code="biggieSmall")
         cache_impl.get_invite = mock.Mock(side_effect=[mock_old_invite, mock_new_invite])
         cache_impl.set_invite = mock.Mock()
-        assert cache_impl.update_invite(mock_invite) == (mock_old_invite, mock_new_invite)
+
+        result = cache_impl.update_invite(mock_invite)
+
+        assert result == (mock_old_invite, mock_new_invite)
         cache_impl.get_invite.assert_has_calls([mock.call("biggieSmall"), mock.call("biggieSmall")])
         cache_impl.set_invite.assert_called_once_with(mock_invite)
 
     def test_delete_me_for_known_me(self, cache_impl):
         mock_own_user = mock.Mock(users.OwnUser)
         cache_impl._me = mock_own_user
-        assert cache_impl.delete_me() is mock_own_user
+
+        result = cache_impl.delete_me()
+
+        assert result is mock_own_user
         assert cache_impl._me is None
 
     def test_delete_me_for_unknown_me(self, cache_impl):
-        assert cache_impl.delete_me() is None
+        result = cache_impl.delete_me()
+
+        assert result is None
         assert cache_impl._me is None
 
     def test_get_me_for_known_me(self, cache_impl):
         mock_own_user = mock.MagicMock(users.OwnUser)
         cache_impl._me = mock_own_user
+
         cached_me = cache_impl.get_me()
+
         assert cached_me == mock_own_user
         assert cached_me is not mock_own_user
 
@@ -1201,7 +1401,9 @@ class TestCacheImpl:
 
     def test_set_me(self, cache_impl):
         mock_own_user = mock.MagicMock(users.OwnUser)
-        assert cache_impl.set_me(mock_own_user) is None
+
+        cache_impl.set_me(mock_own_user)
+
         assert cache_impl._me == mock_own_user
         assert cache_impl._me is not mock_own_user
 
@@ -1209,12 +1411,18 @@ class TestCacheImpl:
         mock_cached_own_user = mock.MagicMock(users.OwnUser)
         mock_own_user = mock.MagicMock(users.OwnUser)
         cache_impl._me = mock_cached_own_user
-        assert cache_impl.update_me(mock_own_user) == (mock_cached_own_user, mock_own_user)
+
+        result = cache_impl.update_me(mock_own_user)
+
+        assert result == (mock_cached_own_user, mock_own_user)
         assert cache_impl._me == mock_own_user
 
     def test_update_me_for_uncached_me(self, cache_impl):
         mock_own_user = mock.MagicMock(users.OwnUser)
-        assert cache_impl.update_me(mock_own_user) == (None, mock_own_user)
+
+        result = cache_impl.update_me(mock_own_user)
+
+        assert result == (None, mock_own_user)
         assert cache_impl._me == mock_own_user
 
     def test__build_member(self, cache_impl):
@@ -1230,7 +1438,9 @@ class TestCacheImpl:
             is_mute=True,
             is_pending=False,
         )
+
         member = cache_impl._build_member(cache_utilities.RefCell(member_data))
+
         assert member.user == mock_user
         assert member.user is not mock_user
         assert member.guild_id == 6434435234
@@ -1321,7 +1531,9 @@ class TestCacheImpl:
         cache_impl._garbage_collect_user = mock.Mock()
         cache_impl._remove_guild_record_if_empty = mock.Mock()
 
-        assert cache_impl.clear_members() == {
+        result = cache_impl.clear_members()
+
+        assert result == {
             snowflakes.Snowflake(43123123): {
                 snowflakes.Snowflake(2123123): mock_member_1,
                 snowflakes.Snowflake(212314423): mock_member_2,
@@ -1332,7 +1544,6 @@ class TestCacheImpl:
                 snowflakes.Snowflake(212399999123): mock_member_5,
             },
         }
-
         cache_impl._garbage_collect_user.assert_has_calls(
             [
                 mock.call(mock_user_1, decrement=1),
@@ -1363,11 +1574,16 @@ class TestCacheImpl:
         ...
 
     def test_delete_member_for_unknown_guild_record(self, cache_impl):
-        assert cache_impl.delete_member(snowflakes.Snowflake(42123), snowflakes.Snowflake(67876)) is None
+        result = cache_impl.delete_member(StubModel(42123), StubModel(67876))
+
+        assert result is None
 
     def test_delete_member_for_unknown_member_cache(self, cache_impl):
         cache_impl._guild_entries = {snowflakes.Snowflake(42123): cache_utilities.GuildRecord()}
-        assert cache_impl.delete_member(snowflakes.Snowflake(42123), snowflakes.Snowflake(67876)) is None
+
+        result = cache_impl.delete_member(StubModel(42123), StubModel(67876))
+
+        assert result is None
 
     def test_delete_member_for_known_member(self, cache_impl):
         mock_member = mock.Mock(guilds.Member)
@@ -1382,7 +1598,9 @@ class TestCacheImpl:
         cache_impl._garbage_collect_user = mock.Mock()
         cache_impl._build_member = mock.Mock(return_value=mock_member)
 
-        assert cache_impl.delete_member(snowflakes.Snowflake(42123), snowflakes.Snowflake(67876)) is mock_member
+        result = cache_impl.delete_member(StubModel(42123), StubModel(67876))
+
+        assert result is mock_member
         assert cache_impl._guild_entries[snowflakes.Snowflake(42123)].members is None
         cache_impl._build_member.assert_called_once_with(mock_reffed_member)
         cache_impl._garbage_collect_user.assert_called_once_with(mock_user, decrement=1)
@@ -1397,14 +1615,20 @@ class TestCacheImpl:
                 )
             }
         )
-        assert cache_impl.delete_member(snowflakes.Snowflake(42123), snowflakes.Snowflake(67876)) is None
+
+        result = cache_impl.delete_member(StubModel(42123), StubModel(67876))
+
+        assert result is None
         assert mock_member.object.has_been_deleted is True
 
     def test_get_member_for_unknown_member_cache(self, cache_impl):
         cache_impl._guild_entries = collections.FreezableDict(
             {snowflakes.Snowflake(1234213): cache_utilities.GuildRecord()}
         )
-        assert cache_impl.get_member(snowflakes.Snowflake(1234213), snowflakes.Snowflake(512312354)) is None
+
+        result = cache_impl.get_member(StubModel(1234213), StubModel(512312354))
+
+        assert result is None
 
     def test_get_member_for_unknown_member(self, cache_impl):
         cache_impl._guild_entries = collections.FreezableDict(
@@ -1414,10 +1638,15 @@ class TestCacheImpl:
                 )
             }
         )
-        assert cache_impl.get_member(snowflakes.Snowflake(1234213), snowflakes.Snowflake(512312354)) is None
+
+        result = cache_impl.get_member(StubModel(1234213), StubModel(512312354))
+
+        assert result is None
 
     def test_get_member_for_unknown_guild_record(self, cache_impl):
-        assert cache_impl.get_member(snowflakes.Snowflake(1234213), snowflakes.Snowflake(512312354)) is None
+        result = cache_impl.get_member(StubModel(1234213), StubModel(512312354))
+
+        assert result is None
 
     def test_get_member_for_known_member(self, cache_impl):
         mock_member_data = mock.Mock(cache_utilities.MemberData)
@@ -1436,7 +1665,10 @@ class TestCacheImpl:
         )
         cache_impl._user_entries = collections.FreezableDict({})
         cache_impl._build_member = mock.Mock(return_value=mock_member)
-        assert cache_impl.get_member(snowflakes.Snowflake(1234213), snowflakes.Snowflake(512312354)) is mock_member
+
+        result = cache_impl.get_member(StubModel(1234213), StubModel(512312354))
+
+        assert result is mock_member
         cache_impl._build_member.assert_called_once_with(mock_member_data)
 
     def test_get_members_view(self, cache_impl):
@@ -1474,7 +1706,9 @@ class TestCacheImpl:
             }
         )
 
-        assert cache_impl.get_members_view() == {
+        result = cache_impl.get_members_view()
+
+        assert result == {
             snowflakes.Snowflake(54123123): {
                 snowflakes.Snowflake(321): mock_member_1,
                 snowflakes.Snowflake(6324): mock_member_2,
@@ -1485,7 +1719,6 @@ class TestCacheImpl:
                 snowflakes.Snowflake(86545463): mock_member_5,
             },
         }
-
         cache_impl._build_member.assert_has_calls(
             [
                 mock.call(mock_member_data_1),
@@ -1497,14 +1730,17 @@ class TestCacheImpl:
         )
 
     def test_get_members_view_for_guild_unknown_record(self, cache_impl):
-        members_mapping = cache_impl.get_members_view_for_guild(snowflakes.Snowflake(42334))
+        members_mapping = cache_impl.get_members_view_for_guild(StubModel(42334))
+
         assert members_mapping == {}
 
     def test_get_members_view_for_guild_unknown_member_cache(self, cache_impl):
         cache_impl._guild_entries = collections.FreezableDict(
             {snowflakes.Snowflake(42334): cache_utilities.GuildRecord()}
         )
-        members_mapping = cache_impl.get_members_view_for_guild(snowflakes.Snowflake(42334))
+
+        members_mapping = cache_impl.get_members_view_for_guild(StubModel(42334))
+
         assert members_mapping == {}
 
     def test_get_members_view_for_guild(self, cache_impl):
@@ -1525,7 +1761,10 @@ class TestCacheImpl:
         )
         cache_impl._guild_entries = collections.FreezableDict({snowflakes.Snowflake(42334): guild_record})
         cache_impl._build_member = mock.Mock(side_effect=[mock_member_1, mock_member_2])
-        assert cache_impl.get_members_view_for_guild(snowflakes.Snowflake(42334)) == {
+
+        result = cache_impl.get_members_view_for_guild(StubModel(42334))
+
+        assert result == {
             snowflakes.Snowflake(3214321): mock_member_1,
             snowflakes.Snowflake(53224): mock_member_2,
         }
@@ -1547,7 +1786,9 @@ class TestCacheImpl:
         )
         cache_impl._set_user = mock.Mock(return_value=mock_user_ref)
         cache_impl._increment_ref_count = mock.Mock()
+
         cache_impl.set_member(member_model)
+
         cache_impl._set_user.assert_called_once_with(mock_user)
         cache_impl._increment_ref_count.assert_called_once_with(mock_user_ref)
         assert 67345234 in cache_impl._guild_entries
@@ -1585,7 +1826,9 @@ class TestCacheImpl:
                 )
             }
         )
+
         cache_impl.set_member(member_model)
+
         cache_impl._set_user.assert_called_once_with(mock_user)
         cache_impl._increment_user_ref_count.assert_not_called()
 
@@ -1599,7 +1842,10 @@ class TestCacheImpl:
         )
         cache_impl.get_member = mock.Mock(side_effect=[mock_old_cached_member, mock_new_cached_member])
         cache_impl.set_member = mock.Mock()
-        assert cache_impl.update_member(mock_member) == (mock_old_cached_member, mock_new_cached_member)
+
+        result = cache_impl.update_member(mock_member)
+
+        assert result == (mock_old_cached_member, mock_new_cached_member)
         cache_impl.get_member.assert_has_calls([mock.call(123123, 65234123), mock.call(123123, 65234123)])
         cache_impl.set_member.assert_called_once_with(mock_member)
 
@@ -1676,7 +1922,9 @@ class TestCacheImpl:
                 snowflakes.Snowflake(645234): mock_other_user,
             }
         )
-        assert cache_impl._garbage_collect_user(mock_user, decrement=1) is None
+
+        cache_impl._garbage_collect_user(mock_user, decrement=1)
+
         assert dict(cache_impl._user_entries) == {snowflakes.Snowflake(645234): mock_other_user}
 
     def test_garbage_collect_user_for_referenced_user(self, cache_impl):
@@ -1685,7 +1933,9 @@ class TestCacheImpl:
         cache_impl._user_entries = collections.FreezableDict(
             {snowflakes.Snowflake(21231234): mock_user, snowflakes.Snowflake(645234): mock_other_user}
         )
-        assert cache_impl._garbage_collect_user(mock_user, decrement=1) is None
+
+        cache_impl._garbage_collect_user(mock_user, decrement=1)
+
         assert cache_impl._user_entries == {
             snowflakes.Snowflake(21231234): mock_user,
             snowflakes.Snowflake(645234): mock_other_user,
@@ -1695,7 +1945,9 @@ class TestCacheImpl:
     def test_garbage_collect_user_for_unknown_user(self, cache_impl):
         mock_user = cache_utilities.RefCell(mock.Mock(id=snowflakes.Snowflake(21235432), ref_count=0))
         cache_impl._user_entries = collections.FreezableDict({snowflakes.Snowflake(21231234): mock_user})
-        assert cache_impl._garbage_collect_user(mock_user) is None
+
+        cache_impl._garbage_collect_user(mock_user)
+
         assert cache_impl._user_entries == {snowflakes.Snowflake(21231234): mock_user}
 
     def test_get_user_for_known_user(self, cache_impl):
@@ -1707,7 +1959,10 @@ class TestCacheImpl:
             }
         )
         cache_impl._build_user = mock.Mock(return_value=mock_user)
-        assert cache_impl.get_user(snowflakes.Snowflake(21231234)) == mock_user
+
+        result = cache_impl.get_user(StubModel(21231234))
+
+        assert result == mock_user
 
     def test_get_users_view_for_filled_user_cache(self, cache_impl):
         mock_user_1 = mock.MagicMock(users.User)
@@ -1718,7 +1973,10 @@ class TestCacheImpl:
                 snowflakes.Snowflake(76345): cache_utilities.RefCell(mock_user_2),
             }
         )
-        assert cache_impl.get_users_view() == {
+
+        result = cache_impl.get_users_view()
+
+        assert result == {
             snowflakes.Snowflake(54123): mock_user_1,
             snowflakes.Snowflake(76345): mock_user_2,
         }
@@ -1731,7 +1989,10 @@ class TestCacheImpl:
         cache_impl._user_entries = collections.FreezableDict(
             {snowflakes.Snowflake(542143): mock.Mock(cache_utilities.RefCell)}
         )
-        assert cache_impl._set_user(mock_user) is cache_impl._user_entries[snowflakes.Snowflake(6451234123)]
+
+        result = cache_impl._set_user(mock_user)
+
+        assert result is cache_impl._user_entries[snowflakes.Snowflake(6451234123)]
         assert 6451234123 in cache_impl._user_entries
         assert cache_impl._user_entries[snowflakes.Snowflake(6451234123)].object == mock_user
         assert cache_impl._user_entries[snowflakes.Snowflake(6451234123)].object is not mock_user
@@ -1744,7 +2005,10 @@ class TestCacheImpl:
                 snowflakes.Snowflake(6451234123): mock.Mock(cache_utilities.RefCell, ref_count=42),
             }
         )
-        assert cache_impl._set_user(mock_user) is cache_impl._user_entries[snowflakes.Snowflake(6451234123)]
+
+        result = cache_impl._set_user(mock_user)
+
+        assert result is cache_impl._user_entries[snowflakes.Snowflake(6451234123)]
         assert 6451234123 in cache_impl._user_entries
         assert cache_impl._user_entries[snowflakes.Snowflake(6451234123)].object == mock_user
         assert cache_impl._user_entries[snowflakes.Snowflake(6451234123)].object is not mock_user
@@ -1766,7 +2030,9 @@ class TestCacheImpl:
             member=cache_utilities.RefCell(mock_member_data),
             session_id="lkmdfslkmfdskjlfsdkjlsfdkjldsf",
         )
+
         current_voice_state = cache_impl._build_voice_state(voice_state_data)
+
         mock_member_data.build_entity.assert_called_once()
         assert current_voice_state.app is cache_impl._app
         assert current_voice_state.channel_id == snowflakes.Snowflake(4651234123)
@@ -1808,7 +2074,10 @@ class TestCacheImpl:
         cache_impl._garbage_collect_member = mock.Mock()
         cache_impl._guild_entries = collections.FreezableDict({snowflakes.Snowflake(54123123): record})
         cache_impl._build_voice_state = mock.Mock(side_effect=[mock_voice_state_1, mock_voice_state_2])
-        assert cache_impl.clear_voice_states_for_guild(snowflakes.Snowflake(54123123)) == {
+
+        result = cache_impl.clear_voice_states_for_guild(StubModel(54123123))
+
+        assert result == {
             snowflakes.Snowflake(7512312): mock_voice_state_1,
             snowflakes.Snowflake(43123123): mock_voice_state_2,
         }
@@ -1822,10 +2091,15 @@ class TestCacheImpl:
 
     def test_clear_voice_states_for_guild_unknown_voice_state_cache(self, cache_impl):
         cache_impl._guild_entries[snowflakes.Snowflake(24123)] = cache_utilities.GuildRecord()
-        assert cache_impl.clear_voice_states_for_guild(snowflakes.Snowflake(24123)) == {}
+
+        result = cache_impl.clear_voice_states_for_guild(StubModel(24123))
+
+        assert result == {}
 
     def test_clear_voice_states_for_guild_unknown_record(self, cache_impl):
-        assert cache_impl.clear_voice_states_for_guild(snowflakes.Snowflake(24123)) == {}
+        result = cache_impl.clear_voice_states_for_guild(StubModel(24123))
+
+        assert result == {}
 
     def test_delete_voice_state(self, cache_impl):
         mock_member_data = object()
@@ -1856,7 +2130,8 @@ class TestCacheImpl:
         cache_impl._remove_guild_record_if_empty = mock.Mock()
         cache_impl._garbage_collect_member = mock.Mock()
 
-        result = cache_impl.delete_voice_state(snowflakes.Snowflake(43123), snowflakes.Snowflake(12354345))
+        result = cache_impl.delete_voice_state(StubModel(43123), StubModel(12354345))
+
         assert result is mock_voice_state
         cache_impl._garbage_collect_member.assert_called_once_with(guild_record, mock_member_data, decrement=1)
         cache_impl._remove_guild_record_if_empty.assert_called_once_with(snowflakes.Snowflake(43123), guild_record)
@@ -1878,7 +2153,9 @@ class TestCacheImpl:
         )
         cache_impl._remove_guild_record_if_empty = mock.Mock()
 
-        assert cache_impl.delete_voice_state(snowflakes.Snowflake(43123), snowflakes.Snowflake(12354345)) is None
+        result = cache_impl.delete_voice_state(StubModel(43123), StubModel(12354345))
+
+        assert result is None
         cache_impl._remove_guild_record_if_empty.assert_not_called()
         assert cache_impl._guild_entries[snowflakes.Snowflake(43123)].voice_states == {
             snowflakes.Snowflake(6541234): mock_other_voice_state_data
@@ -1895,7 +2172,9 @@ class TestCacheImpl:
         )
         cache_impl._remove_guild_record_if_empty = mock.Mock()
 
-        assert cache_impl.delete_voice_state(snowflakes.Snowflake(43123), snowflakes.Snowflake(12354345)) is None
+        result = cache_impl.delete_voice_state(StubModel(43123), StubModel(12354345))
+
+        assert result is None
         cache_impl._remove_guild_record_if_empty.assert_not_called()
 
     def test_delete_voice_state_unknown_record(self, cache_impl):
@@ -1905,7 +2184,9 @@ class TestCacheImpl:
         )
         cache_impl._remove_guild_record_if_empty = mock.Mock()
 
-        assert cache_impl.delete_voice_state(snowflakes.Snowflake(43123), snowflakes.Snowflake(12354345)) is None
+        result = cache_impl.delete_voice_state(StubModel(43123), StubModel(12354345))
+
+        assert result is None
         cache_impl._remove_guild_record_if_empty.assert_not_called()
 
     def test_get_voice_state_for_known_voice_state(self, cache_impl):
@@ -1920,7 +2201,8 @@ class TestCacheImpl:
             }
         )
 
-        result = cache_impl.get_voice_state(snowflakes.Snowflake(1235123), snowflakes.Snowflake(43124))
+        result = cache_impl.get_voice_state(StubModel(1235123), StubModel(43124))
+
         assert result is mock_voice_state
         cache_impl._build_voice_state.assert_called_once_with(mock_voice_state_data)
 
@@ -1935,7 +2217,10 @@ class TestCacheImpl:
                 snowflakes.Snowflake(73245): mock.Mock(cache_utilities.GuildRecord),
             }
         )
-        assert cache_impl.get_voice_state(snowflakes.Snowflake(1235123), snowflakes.Snowflake(43124)) is None
+
+        result = cache_impl.get_voice_state(StubModel(1235123), StubModel(43124))
+
+        assert result is None
 
     def test_get_voice_state_for_unknown_voice_state_cache(self, cache_impl):
         cache_impl._guild_entries = collections.FreezableDict(
@@ -1944,11 +2229,17 @@ class TestCacheImpl:
                 snowflakes.Snowflake(73245): mock.Mock(cache_utilities.GuildRecord),
             }
         )
-        assert cache_impl.get_voice_state(snowflakes.Snowflake(1235123), snowflakes.Snowflake(43124)) is None
+
+        result = cache_impl.get_voice_state(StubModel(1235123), StubModel(43124))
+
+        assert result is None
 
     def test_get_voice_state_for_unknown_record(self, cache_impl):
         cache_impl._guild_entries = {snowflakes.Snowflake(73245): mock.Mock(cache_utilities.GuildRecord)}
-        assert cache_impl.get_voice_state(snowflakes.Snowflake(1235123), snowflakes.Snowflake(43124)) is None
+
+        result = cache_impl.get_voice_state(StubModel(1235123), StubModel(43124))
+
+        assert result is None
 
     @pytest.mark.skip(reason="TODO")
     def test_get_voice_state_view(self, cache_impl):
@@ -1983,7 +2274,8 @@ class TestCacheImpl:
         cache_impl._set_member = mock.Mock(return_value=mock_reffed_member)
         cache_impl._increment_ref_count = mock.Mock()
 
-        assert cache_impl.set_voice_state(voice_state) is None
+        cache_impl.set_voice_state(voice_state)
+
         cache_impl._increment_ref_count.assert_called_with(mock_reffed_member)
         cache_impl._set_member.assert_called_once_with(mock_member)
         voice_state_data = cache_impl._guild_entries[43123123].voice_states[4531231]
@@ -2005,7 +2297,9 @@ class TestCacheImpl:
         cache_impl.get_voice_state = mock.Mock(side_effect=[mock_old_voice_state, mock_new_voice_state])
         cache_impl.set_voice_state = mock.Mock()
 
-        assert cache_impl.update_voice_state(voice_state) == (mock_old_voice_state, mock_new_voice_state)
+        result = cache_impl.update_voice_state(voice_state)
+
+        assert result == (mock_old_voice_state, mock_new_voice_state)
         cache_impl.set_voice_state.assert_called_once_with(voice_state)
         cache_impl.get_voice_state.assert_has_calls(
             [
@@ -2066,6 +2360,7 @@ class TestCacheImpl:
         )
 
         result = cache_impl._build_message(cache_utilities.RefCell(message_data))
+
         assert result.id == 32123123
         assert result.channel_id == 3123123123
         assert result.guild_id == 5555555
@@ -2152,6 +2447,7 @@ class TestCacheImpl:
         )
 
         result = cache_impl._build_message(cache_utilities.RefCell(message_data))
+
         assert result.app is cache_impl._app
         assert result.member is None
         assert result.content is None
@@ -2185,7 +2481,9 @@ class TestCacheImpl:
         cache_impl._build_message = mock.Mock(return_value=mock_message)
         cache_impl._message_entries[snowflakes.Snowflake(32332123)] = mock_message_data
 
-        assert cache_impl.get_message(snowflakes.Snowflake(32332123)) is mock_message
+        result = cache_impl.get_message(StubModel(32332123))
+
+        assert result is mock_message
         cache_impl._build_message.assert_called_once_with(mock_message_data)
 
     def test_get_message_reference_only(self, cache_impl):
@@ -2194,13 +2492,17 @@ class TestCacheImpl:
         cache_impl._build_message = mock.Mock(return_value=mock_message)
         cache_impl._referenced_messages[snowflakes.Snowflake(32332123)] = mock_message_data
 
-        assert cache_impl.get_message(snowflakes.Snowflake(32332123)) is mock_message
+        result = cache_impl.get_message(StubModel(32332123))
+
+        assert result is mock_message
         cache_impl._build_message.assert_called_once_with(mock_message_data)
 
     def test_get_message_for_unknown_message(self, cache_impl):
         cache_impl._build_message = mock.Mock()
 
-        assert cache_impl.get_message(snowflakes.Snowflake(32332123)) is None
+        result = cache_impl.get_message(StubModel(32332123))
+
+        assert result is None
         cache_impl._build_message.assert_not_called()
 
     def test_get_messages_view(self, cache_impl):
@@ -2217,6 +2519,7 @@ class TestCacheImpl:
         cache_impl._referenced_messages = collections.FreezableDict({snowflakes.Snowflake(211111): mock_message_data_3})
 
         result = cache_impl.get_messages_view()
+
         assert result == {32123: mock_message_1, 451231: mock_message_2, 211111: mock_message_3}
         cache_impl._build_message.assert_has_calls(
             [mock.call(mock_message_data_1), mock.call(mock_message_data_2), mock.call(mock_message_data_3)]
@@ -2232,7 +2535,9 @@ class TestCacheImpl:
         cache_impl.get_message = mock.Mock(side_effect=(None, cached_message))
         cache_impl.set_message = mock.Mock()
 
-        assert cache_impl.update_message(message) == (None, cached_message)
+        result = cache_impl.update_message(message)
+
+        assert result == (None, cached_message)
         cache_impl.set_message.assert_called_once_with(message)
         cache_impl.get_message.assert_has_calls([mock.call(45312312), mock.call(45312312)])
 
@@ -2245,7 +2550,9 @@ class TestCacheImpl:
         cache_impl.get_message = mock.Mock(side_effect=(None, None))
         cache_impl.set_message = mock.Mock()
 
-        assert cache_impl.update_message(message) == (None, None)
+        result = cache_impl.update_message(message)
+
+        assert result == (None, None)
         cache_impl.set_message.assert_not_called()
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
### Summary
Allow models to be used in cache calls in place of IDs.
* Small format consistency changes to test_cache.py

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
