### PR TITLE
Remove partial implementation from GuildBuilder ABC

### DIFF
--- a/hikari/api/special_endpoints.py
+++ b/hikari/api/special_endpoints.py
@@ -28,8 +28,6 @@ __all__: typing.List[str] = ["TypingIndicator", "GuildBuilder"]
 import abc
 import typing
 
-import attr
-
 from hikari import undefined
 
 if typing.TYPE_CHECKING:
@@ -78,7 +76,6 @@ class TypingIndicator(abc.ABC):
         ...
 
 
-@attr.s(kw_only=True, slots=True, weakref_slot=False)
 class GuildBuilder(abc.ABC):
     """Result type of `hikari.api.rest.RESTClient.guild_builder`.
 
@@ -152,42 +149,7 @@ class GuildBuilder(abc.ABC):
     ```
     """
 
-    default_message_notifications: undefined.UndefinedOr[guilds.GuildMessageNotificationsLevel] = attr.ib(
-        default=undefined.UNDEFINED
-    )
-    """Default message notification level that can be overwritten.
-
-    If not overridden, this will use the Discord default level.
-    """
-
-    explicit_content_filter_level: undefined.UndefinedOr[guilds.GuildExplicitContentFilterLevel] = attr.ib(
-        default=undefined.UNDEFINED
-    )
-    """Explicit content filter level that can be overwritten.
-
-    If not overridden, this will use the Discord default level.
-    """
-
-    icon: undefined.UndefinedOr[files.Resourceish] = attr.ib(default=undefined.UNDEFINED)
-    """Guild icon to use that can be overwritten.
-
-    If not overridden, the guild will not have an icon.
-    """
-
-    region: undefined.UndefinedOr[voices.VoiceRegionish] = attr.ib(default=undefined.UNDEFINED)
-    """Guild voice channel region to use that can be overwritten.
-
-    If not overridden, the guild will use the default voice region for Discord.
-    """
-
-    verification_level: undefined.UndefinedOr[typing.Union[guilds.GuildVerificationLevel, int]] = attr.ib(
-        default=undefined.UNDEFINED
-    )
-    """Verification level required to join the guild that can be overwritten.
-
-    If not overridden, the guild will use the default verification level for
-    Discord.
-    """
+    __slots__: typing.Sequence[str] = ()
 
     @property
     @abc.abstractmethod
@@ -199,6 +161,97 @@ class GuildBuilder(abc.ABC):
         builtins.str
             The guild name.
         """
+
+    @property
+    @abc.abstractmethod
+    def default_message_notifications(self) -> undefined.UndefinedOr[guilds.GuildMessageNotificationsLevel]:
+        """Default message notification level that can be overwritten.
+
+        If not overridden, this will use the Discord default level.
+
+        Returns
+        -------
+        hikari.undefined.UndefinedOr[hikari.guilds.GuildMessageNotificationsLevel]
+            The default message notification level, if overwritten.
+        """  # noqa: D401 - Imperative mood
+
+    @default_message_notifications.setter
+    def default_message_notifications(
+        self, default_message_notifications: undefined.UndefinedOr[guilds.GuildMessageNotificationsLevel], /
+    ) -> None:
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def explicit_content_filter_level(self) -> undefined.UndefinedOr[guilds.GuildExplicitContentFilterLevel]:
+        """Explicit content filter level that can be overwritten.
+
+        If not overridden, this will use the Discord default level.
+
+        Returns
+        -------
+        hikari.undefined.UndefinedOr[hikari.guilds.GuildExplicitContentFilterLevel]
+            The explicit content filter level, if overwritten.
+        """
+
+    @explicit_content_filter_level.setter
+    def explicit_content_filter_level(
+        self, explicit_content_filter_level: undefined.UndefinedOr[guilds.GuildExplicitContentFilterLevel], /
+    ) -> None:
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def icon(self) -> undefined.UndefinedOr[files.Resourceish]:
+        """Guild icon to use that can be overwritten.
+
+        If not overridden, the guild will not have an icon.
+
+        Returns
+        -------
+        hikari.undefined.UndefinedOr[hikari.files.Resourceish]
+            The guild icon to use, if overwritten.
+        """
+
+    @icon.setter
+    def icon(self, icon: undefined.UndefinedOr[files.Resourceish], /) -> None:
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def region(self) -> undefined.UndefinedOr[voices.VoiceRegionish]:
+        """Guild voice channel region to use that can be overwritten.
+
+        If not overridden, the guild will use the default voice region for Discord.
+
+        Returns
+        -------
+        hikari.undefined.UndefinedOr[hikari.voices.VoiceRegionish]
+            The guild voice channel region to use, if overwritten.
+        """
+
+    @region.setter
+    def region(self, region: undefined.UndefinedOr[voices.VoiceRegionish], /) -> None:
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def verification_level(self) -> undefined.UndefinedOr[typing.Union[guilds.GuildVerificationLevel, int]]:
+        """Verification level required to join the guild that can be overwritten.
+
+        If not overridden, the guild will use the default verification level for
+
+        Returns
+        -------
+        hikari.undefined.UndefinedOr[typing.Union[hikari.guilds.GuildVerificationLevel, builtins.int]]
+            The verification level required to join the guild, if overwritten.
+        """
+
+    @verification_level.setter
+    def verification_level(
+        self, verification_level: undefined.UndefinedOr[typing.Union[guilds.GuildVerificationLevel, int]], /
+    ) -> None:
+        raise NotImplementedError
 
     @abc.abstractmethod
     async def create(self) -> guilds.RESTGuild:

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -58,6 +58,7 @@ if typing.TYPE_CHECKING:
     from hikari import messages
     from hikari import permissions as permissions_
     from hikari import users
+    from hikari import voices
     from hikari.api import entity_factory as entity_factory_
 
 
@@ -130,6 +131,7 @@ class TypingIndicator(special_endpoints.TypingIndicator):
                     await asyncio.gather(self, asyncio.wait_for(self._rest_close_event.wait(), timeout=9.0))
 
 
+# As a note, slotting allows us to override the settable properties while staying within the interface's spec.
 @attr_extensions.with_copy
 @attr.s(kw_only=True, slots=True, weakref_slot=False)
 class GuildBuilder(special_endpoints.GuildBuilder):
@@ -209,13 +211,26 @@ class GuildBuilder(special_endpoints.GuildBuilder):
     _entity_factory: entity_factory_.EntityFactory = attr.ib(metadata={attr_extensions.SKIP_DEEP_COPY: True})
     _executor: typing.Optional[concurrent.futures.Executor] = attr.ib(metadata={attr_extensions.SKIP_DEEP_COPY: True})
     _name: str = attr.ib()
-
-    # Optional args that we kept hidden.
-    _channels: typing.MutableSequence[data_binding.JSONObject] = attr.ib(factory=list, init=False)
-    _counter: int = attr.ib(default=0, init=False)
     _request_call: typing.Callable[
         ..., typing.Coroutine[None, None, typing.Union[None, data_binding.JSONObject, data_binding.JSONArray]]
     ] = attr.ib(metadata={attr_extensions.SKIP_DEEP_COPY: True})
+
+    # Optional arguments.
+    default_message_notifications: undefined.UndefinedOr[guilds.GuildMessageNotificationsLevel] = attr.ib(
+        default=undefined.UNDEFINED
+    )
+    explicit_content_filter_level: undefined.UndefinedOr[guilds.GuildExplicitContentFilterLevel] = attr.ib(
+        default=undefined.UNDEFINED
+    )
+    icon: undefined.UndefinedOr[files.Resourceish] = attr.ib(default=undefined.UNDEFINED)
+    region: undefined.UndefinedOr[voices.VoiceRegionish] = attr.ib(default=undefined.UNDEFINED)
+    verification_level: undefined.UndefinedOr[typing.Union[guilds.GuildVerificationLevel, int]] = attr.ib(
+        default=undefined.UNDEFINED
+    )
+
+    # Non-arguments
+    _channels: typing.MutableSequence[data_binding.JSONObject] = attr.ib(factory=list, init=False)
+    _counter: int = attr.ib(default=0, init=False)
     _roles: typing.MutableSequence[data_binding.JSONObject] = attr.ib(factory=list, init=False)
 
     @property


### PR DESCRIPTION
### Summary
Remove partial implementation from GuildBuilder ABC
* replace attrs instance variables with settable abstract proprties

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
