### PR TITLE
Even more tests and fixes

### DIFF
--- a/hikari/api/event_manager.py
+++ b/hikari/api/event_manager.py
@@ -237,6 +237,7 @@ class EventManager(abc.ABC):
     def get_listeners(
         self,
         event_type: typing.Type[EventT_co],
+        /,
         *,
         polymorphic: bool = True,
     ) -> typing.Collection[CallbackT[EventT_co]]:

--- a/hikari/event_stream.py
+++ b/hikari/event_stream.py
@@ -41,7 +41,7 @@ if typing.TYPE_CHECKING:
     from hikari.events import base_events  # noqa F401 - Unused (False positive)
 
 EventT = typing.TypeVar("EventT", bound="base_events.Event")
-_LOGGER: typing.Final[logging.Logger] = logging.getLogger("hikari")
+_LOGGER: typing.Final[logging.Logger] = logging.getLogger("hikari.event_stream")
 
 
 class Streamer(iterators.LazyIterator[EventT], abc.ABC):

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -69,7 +69,7 @@ if typing.TYPE_CHECKING:
     from hikari.api import shard as gateway_shard
     from hikari.api import voice as voice_
 
-_LOGGER: typing.Final[logging.Logger] = logging.getLogger("hikari")
+_LOGGER: typing.Final[logging.Logger] = logging.getLogger("hikari.bot")
 
 
 class BotApp(traits.BotAware):
@@ -410,7 +410,7 @@ class BotApp(traits.BotAware):
         return self._event_manager.dispatch(event)
 
     def get_listeners(
-        self, event_type: typing.Type[event_manager_.EventT_co], *, polymorphic: bool = True
+        self, event_type: typing.Type[event_manager_.EventT_co], /, *, polymorphic: bool = True
     ) -> typing.Collection[event_manager_.CallbackT[event_manager_.EventT_co]]:
         return self._event_manager.get_listeners(event_type, polymorphic=polymorphic)
 
@@ -565,6 +565,8 @@ class BotApp(traits.BotAware):
         ------
         builtins.RuntimeError
             If bot is already running.
+        builtins.TypeError
+            If `shard_ids` is passed without `shard_count`.
         """
         if self._is_alive:
             raise RuntimeError("bot is already running")
@@ -670,7 +672,7 @@ class BotApp(traits.BotAware):
                 if close_loop:
                     self._destroy_loop(loop)
 
-                _LOGGER.info("application has successfully terminated")
+                _LOGGER.info("successfully terminated")
 
                 if propagate_interrupts and interrupt is not None:
                     raise interrupt
@@ -728,7 +730,7 @@ class BotApp(traits.BotAware):
             Defaults to `hikari.presences.Status.ONLINE`.
         """
         if shard_ids is not None and shard_count is None:
-            raise TypeError("Must pass shard_count if specifying shard_ids manually")
+            raise TypeError("'shard_ids' must be passed with 'shard_count'")
 
         self._validate_activity(activity)
 
@@ -836,7 +838,7 @@ class BotApp(traits.BotAware):
 
         await self._event_manager.dispatch(self._event_factory.deserialize_started_event())
 
-        _LOGGER.info("application started successfully in approx %.2f seconds", time.monotonic() - start_time)
+        _LOGGER.info("started successfully in approx %.2f seconds", time.monotonic() - start_time)
 
     def stream(
         self,
@@ -931,7 +933,7 @@ class BotApp(traits.BotAware):
         end = time.monotonic()
 
         if new_shard.is_alive:
-            _LOGGER.debug("Shard %s started successfully in %.1fms", shard_id, (end - start) * 1_000)
+            _LOGGER.debug("shard %s started successfully in %.1fms", shard_id, (end - start) * 1_000)
             return new_shard
 
         raise errors.GatewayError(f"shard {shard_id} shut down immediately when starting")

--- a/hikari/impl/event_manager_base.py
+++ b/hikari/impl/event_manager_base.py
@@ -44,7 +44,7 @@ from hikari.internal import reflect
 if typing.TYPE_CHECKING:
     from hikari.api import shard as gateway_shard
 
-_LOGGER: typing.Final[logging.Logger] = logging.getLogger("hikari")
+_LOGGER: typing.Final[logging.Logger] = logging.getLogger("hikari.event_manager")
 
 if typing.TYPE_CHECKING:
     ConsumerT = typing.Callable[
@@ -143,6 +143,7 @@ class EventManagerBase(event_manager.EventManager):
     def get_listeners(
         self,
         event_type: typing.Type[event_manager.EventT_co],
+        /,
         *,
         polymorphic: bool = True,
     ) -> typing.Collection[event_manager.CallbackT[event_manager.EventT_co]]:

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -1662,6 +1662,13 @@ class TestRESTClientImplAsync:
         with pytest.raises(ValueError, match="You may only specify one of 'embed' or 'embeds', not both"):
             await rest_client.execute_webhook(StubModel(123), "token", embed=object(), embeds=object())
 
+    async def test_delete_webhook_message(self, rest_client):
+        expected_route = routes.DELETE_WEBHOOK_MESSAGE.compile(webhook=123, token="token", message=456)
+        rest_client._request = mock.AsyncMock()
+
+        await rest_client.delete_webhook_message(StubModel(123), "token", StubModel(456))
+        rest_client._request.assert_awaited_once_with(expected_route, no_auth=True)
+
     async def test_fetch_gateway_url(self, rest_client):
         expected_route = routes.GET_GATEWAY.compile()
         rest_client._request = mock.AsyncMock(return_value={"url": "wss://some.url"})
@@ -2817,76 +2824,6 @@ class TestRESTClientImplAsync:
         rest_client._request.assert_awaited_once_with(expected_route)
         rest_client._entity_factory.deserialize_vanity_url.assert_called_once_with({"id": "789"})
 
-    async def test_create_template_without_description(self, rest_client):
-        expected_routes = routes.POST_GUILD_TEMPLATES.compile(guild=1235432)
-        rest_client._request = mock.AsyncMock(return_value={"code": "94949sdfkds"})
-
-        result = await rest_client.create_template(StubModel(1235432), "OKOKOK")
-        assert result is rest_client._entity_factory.deserialize_template.return_value
-        rest_client._request.assert_awaited_once_with(expected_routes, json={"name": "OKOKOK"})
-        rest_client._entity_factory.deserialize_template.assert_called_once_with({"code": "94949sdfkds"})
-
-    async def test_create_template_with_description(self, rest_client):
-        expected_route = routes.POST_GUILD_TEMPLATES.compile(guild=4123123)
-        rest_client._request = mock.AsyncMock(return_value={"code": "76345345"})
-
-        result = await rest_client.create_template(StubModel(4123123), "33", description="43123123")
-        assert result is rest_client._entity_factory.deserialize_template.return_value
-        rest_client._request.assert_awaited_once_with(expected_route, json={"name": "33", "description": "43123123"})
-        rest_client._entity_factory.deserialize_template.assert_called_once_with({"code": "76345345"})
-
-    async def test_create_guild_from_template_without_icon(self, rest_client):
-        expected_route = routes.POST_TEMPLATE.compile(template="odkkdkdkd")
-        rest_client._request = mock.AsyncMock(return_value={"id": "543123123"})
-
-        result = await rest_client.create_guild_from_template("odkkdkdkd", "ok a name")
-        assert result is rest_client._entity_factory.deserialize_rest_guild.return_value
-        rest_client._request.assert_awaited_once_with(expected_route, json={"name": "ok a name"})
-        rest_client._entity_factory.deserialize_rest_guild.assert_called_once_with({"id": "543123123"})
-
-    async def test_create_guild_from_template_with_icon(self, rest_client, file_resource):
-        expected_route = routes.POST_TEMPLATE.compile(template="odkkdkdkd")
-        rest_client._request = mock.AsyncMock(return_value={"id": "543123123"})
-        icon_resource = file_resource("icon data")
-
-        with mock.patch.object(files, "ensure_resource", return_value=icon_resource):
-            result = await rest_client.create_guild_from_template("odkkdkdkd", "ok a name", icon="icon.png")
-
-        assert result is rest_client._entity_factory.deserialize_rest_guild.return_value
-        rest_client._request.assert_awaited_once_with(expected_route, json={"name": "ok a name", "icon": "icon data"})
-        rest_client._entity_factory.deserialize_rest_guild.assert_called_once_with({"id": "543123123"})
-
-    async def delete_template(self, rest_client):
-        expected_route = routes.DELETE_GUILD_TEMPLATE(guild=34123123, template="945949494394")
-        rest_client._request = mock.AsyncMock(return_value={"code": "oeoekfgkdkf"})
-
-        result = await rest_client.delete_template(StubModel(3123123), "eoiesri9er99")
-        assert result is rest_client._entity_factory.deserialize_template.return_value
-        rest_client._request.assert_awaited_once_with(expected_route)
-        rest_client._entity_factory.deserialize_template.assert_called_once_with({"code": "oeoekfgkdkf"})
-
-    async def test_edit_template_without_optionals(self, rest_client):
-        expected_route = routes.PATCH_GUILD_TEMPLATE.compile(guild=3412312, template="oeodsosda")
-        rest_client._request = mock.AsyncMock(return_value={"code": "9493293ikiwopop"})
-
-        result = await rest_client.edit_template(StubModel(3412312), "oeodsosda")
-        assert result is rest_client._entity_factory.deserialize_template.return_value
-        rest_client._request.assert_awaited_once_with(expected_route, json={})
-        rest_client._entity_factory.deserialize_template.assert_called_once_with({"code": "9493293ikiwopop"})
-
-    async def test_edit_template_with_optionals(self, rest_client):
-        expected_route = routes.PATCH_GUILD_TEMPLATE.compile(guild=34123122, template="oeodsosda2")
-        rest_client._request = mock.AsyncMock(return_value={"code": "9493293ikiwopop"})
-
-        result = await rest_client.edit_template(
-            StubModel(34123122), "oeodsosda2", name="new name", description="i'm lazy"
-        )
-        assert result is rest_client._entity_factory.deserialize_template.return_value
-        rest_client._request.assert_awaited_once_with(
-            expected_route, json={"name": "new name", "description": "i'm lazy"}
-        )
-        rest_client._entity_factory.deserialize_template.assert_called_once_with({"code": "9493293ikiwopop"})
-
     async def test_fetch_template(self, rest_client):
         expected_route = routes.GET_TEMPLATE.compile(template="kodfskoijsfikoiok")
         rest_client._request = mock.AsyncMock(return_value={"code": "KSDAOKSDKIO"})
@@ -2913,3 +2850,73 @@ class TestRESTClientImplAsync:
         assert result is rest_client._entity_factory.deserialize_template.return_value
         rest_client._request.assert_awaited_once_with(expected_route)
         rest_client._entity_factory.deserialize_template.assert_called_once_with({"code": "ldsaosdokskdoa"})
+
+    async def test_create_guild_from_template_without_icon(self, rest_client):
+        expected_route = routes.POST_TEMPLATE.compile(template="odkkdkdkd")
+        rest_client._request = mock.AsyncMock(return_value={"id": "543123123"})
+
+        result = await rest_client.create_guild_from_template("odkkdkdkd", "ok a name")
+        assert result is rest_client._entity_factory.deserialize_rest_guild.return_value
+        rest_client._request.assert_awaited_once_with(expected_route, json={"name": "ok a name"})
+        rest_client._entity_factory.deserialize_rest_guild.assert_called_once_with({"id": "543123123"})
+
+    async def test_create_guild_from_template_with_icon(self, rest_client, file_resource):
+        expected_route = routes.POST_TEMPLATE.compile(template="odkkdkdkd")
+        rest_client._request = mock.AsyncMock(return_value={"id": "543123123"})
+        icon_resource = file_resource("icon data")
+
+        with mock.patch.object(files, "ensure_resource", return_value=icon_resource):
+            result = await rest_client.create_guild_from_template("odkkdkdkd", "ok a name", icon="icon.png")
+
+        assert result is rest_client._entity_factory.deserialize_rest_guild.return_value
+        rest_client._request.assert_awaited_once_with(expected_route, json={"name": "ok a name", "icon": "icon data"})
+        rest_client._entity_factory.deserialize_rest_guild.assert_called_once_with({"id": "543123123"})
+
+    async def test_create_template_without_description(self, rest_client):
+        expected_routes = routes.POST_GUILD_TEMPLATES.compile(guild=1235432)
+        rest_client._request = mock.AsyncMock(return_value={"code": "94949sdfkds"})
+
+        result = await rest_client.create_template(StubModel(1235432), "OKOKOK")
+        assert result is rest_client._entity_factory.deserialize_template.return_value
+        rest_client._request.assert_awaited_once_with(expected_routes, json={"name": "OKOKOK"})
+        rest_client._entity_factory.deserialize_template.assert_called_once_with({"code": "94949sdfkds"})
+
+    async def test_create_template_with_description(self, rest_client):
+        expected_route = routes.POST_GUILD_TEMPLATES.compile(guild=4123123)
+        rest_client._request = mock.AsyncMock(return_value={"code": "76345345"})
+
+        result = await rest_client.create_template(StubModel(4123123), "33", description="43123123")
+        assert result is rest_client._entity_factory.deserialize_template.return_value
+        rest_client._request.assert_awaited_once_with(expected_route, json={"name": "33", "description": "43123123"})
+        rest_client._entity_factory.deserialize_template.assert_called_once_with({"code": "76345345"})
+
+    async def test_edit_template_without_optionals(self, rest_client):
+        expected_route = routes.PATCH_GUILD_TEMPLATE.compile(guild=3412312, template="oeodsosda")
+        rest_client._request = mock.AsyncMock(return_value={"code": "9493293ikiwopop"})
+
+        result = await rest_client.edit_template(StubModel(3412312), "oeodsosda")
+        assert result is rest_client._entity_factory.deserialize_template.return_value
+        rest_client._request.assert_awaited_once_with(expected_route, json={})
+        rest_client._entity_factory.deserialize_template.assert_called_once_with({"code": "9493293ikiwopop"})
+
+    async def test_edit_template_with_optionals(self, rest_client):
+        expected_route = routes.PATCH_GUILD_TEMPLATE.compile(guild=34123122, template="oeodsosda2")
+        rest_client._request = mock.AsyncMock(return_value={"code": "9493293ikiwopop"})
+
+        result = await rest_client.edit_template(
+            StubModel(34123122), "oeodsosda2", name="new name", description="i'm lazy"
+        )
+        assert result is rest_client._entity_factory.deserialize_template.return_value
+        rest_client._request.assert_awaited_once_with(
+            expected_route, json={"name": "new name", "description": "i'm lazy"}
+        )
+        rest_client._entity_factory.deserialize_template.assert_called_once_with({"code": "9493293ikiwopop"})
+
+    async def test_delete_template(self, rest_client):
+        expected_route = routes.DELETE_GUILD_TEMPLATE.compile(guild=3123123, template="eoiesri9er99")
+        rest_client._request = mock.AsyncMock(return_value={"code": "oeoekfgkdkf"})
+
+        result = await rest_client.delete_template(StubModel(3123123), "eoiesri9er99")
+        assert result is rest_client._entity_factory.deserialize_template.return_value
+        rest_client._request.assert_awaited_once_with(expected_route)
+        rest_client._entity_factory.deserialize_template.assert_called_once_with({"code": "oeoekfgkdkf"})

--- a/tests/hikari/test_audit_logs.py
+++ b/tests/hikari/test_audit_logs.py
@@ -25,14 +25,36 @@ from hikari import audit_logs
 from hikari import snowflakes
 
 
-def test_AuditLogChangeKey_str_operator():
-    change_key = audit_logs.AuditLogChangeKey("owner_id")
-    assert str(change_key) == "OWNER_ID"
+class TestUnrecognisedAuditLogEntryInfo:
+    def test_eq_when_not_same_class(self):
+        audit_log = audit_logs.UnrecognisedAuditLogEntryInfo(app=None, payload={})
+        # Unfortunately there is no other way to do this
+        returned = audit_logs.UnrecognisedAuditLogEntryInfo.__eq__(audit_log, object())
+        assert returned is NotImplemented
 
+    @pytest.mark.parametrize(
+        ("payload1", "payload2", "expected"),
+        [
+            ({"test": "test2"}, {"test": "test3"}, False),
+            ({}, {"test": "test2"}, False),
+            ({"test": "test2"}, {"test": "test2"}, True),
+        ],
+    )
+    def test_eq(self, payload1, payload2, expected):
+        audit_log = audit_logs.UnrecognisedAuditLogEntryInfo(app=None, payload=payload1)
+        other = audit_logs.UnrecognisedAuditLogEntryInfo(app=None, payload=payload2)
 
-def test_AuditLogEventType_str_operator():
-    event_type = audit_logs.AuditLogEventType(80)
-    assert str(event_type) == "INTEGRATION_CREATE"
+        assert (audit_log == other) is expected
+
+    def test_str(self):
+        audit_log = audit_logs.UnrecognisedAuditLogEntryInfo(app=None, payload={"test": "test2", "test3": 98})
+
+        assert str(audit_log) == "UnrecognisedAuditLogEntryInfo(test='test2', test3=98)"
+
+    def test_repr(self):
+        audit_log = audit_logs.UnrecognisedAuditLogEntryInfo(app=None, payload={"test": "test2", "test3": 98})
+
+        assert repr(audit_log) == "UnrecognisedAuditLogEntryInfo(test='test2', test3=98)"
 
 
 class TestAuditLog:

--- a/tests/hikari/test_event_stream.py
+++ b/tests/hikari/test_event_stream.py
@@ -221,16 +221,14 @@ class TestEventStream:
         streamer._event_type = events.Event
         streamer._active = True
 
-        with mock.patch.object(asyncio, "ensure_future", side_effect=RuntimeError):
-            with unittest.TestCase().assertLogs("hikari", level=logging.WARNING) as logging_watcher:
+        with mock.patch.object(asyncio, "ensure_future", side_effect=RuntimeError) as ensure_future:
+            with unittest.TestCase().assertLogs("hikari.event_stream", level=logging.WARNING) as logging_watcher:
                 del streamer
 
-                assert logging_watcher.output == [
-                    "WARNING:hikari:active 'Event' streamer fell out of scope before being closed"
-                ]
-
-            asyncio.ensure_future.assert_called_once_with(mock_coroutine)
-
+        assert logging_watcher.output == [
+            "WARNING:hikari.event_stream:active 'Event' streamer fell out of scope before being closed"
+        ]
+        ensure_future.assert_called_once_with(mock_coroutine)
         close_method.assert_called_once_with()
 
     def test___del___for_inactive_stream(self):


### PR DESCRIPTION
- Add app, eq, str and repr to UnrecognisedAuditLogEntryInfo
- Fix edit_webhook_message and delete_webhook_message to not use auth
- Make get_listeners(..., polymorphic=...) kwarg only
- Fix loggers used by components

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
