### PR TITLE
Rewrite `protocol.Protocol` to a typing extension

### DIFF
--- a/hikari/internal/attr_extensions.py
+++ b/hikari/internal/attr_extensions.py
@@ -20,7 +20,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-"""Utility for extending and optimising the usage of attr models."""
+"""Utility for extending and optimising the usage of `attr` models."""
 from __future__ import annotations
 
 __all__: typing.List[str] = [

--- a/hikari/internal/enums.py
+++ b/hikari/internal/enums.py
@@ -116,7 +116,6 @@ class _EnumMeta(type):
     def __iter__(cls) -> typing.Iterator[typing.Any]:
         yield from cls._name_to_member_map_.values()
 
-    @staticmethod
     def __new__(
         mcs: typing.Type[_T],
         name: str,

--- a/hikari/internal/enums.pyi
+++ b/hikari/internal/enums.pyi
@@ -30,6 +30,8 @@
 # ship my own MyPy plugin for this, so just make MyPy think that the types
 # we are using are just aliases from the enum types in the standard library.
 
+__all__ = ["Enum", "Flag"]
+
 import enum as __enum
 from typing import Iterator as __Iterator
 from typing import Sequence as __Sequence
@@ -69,5 +71,3 @@ class Flag(__enum.IntFlag):
     __rsub__ = __sub__ = difference
     __rxor__ = __xor__ = symmetric_difference
     __invert__ = invert
-
-__all__ = ["Enum", "Flag"]

--- a/hikari/internal/fast_protocol.pyi
+++ b/hikari/internal/fast_protocol.pyi
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# cython: language_level=3
 # Copyright (c) 2020 Nekokatt
 # Copyright (c) 2021 davfsa
 #
@@ -20,9 +19,12 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-"""Typehints for `hikari.internal.protocol`."""
-from typing import Protocol as __Protocol
 
-class Protocol(__Protocol): ...
+__all__ = ["FastProtocolChecking"]
 
-__all__ = ["Protocol"]
+import typing as __typing
+
+# This exist purely due to having to do a lot of hacky stuff to make it work with MyPy.
+# As far as MyPy is concerned, this is just another runtime protocol.
+@__typing.runtime_checkable
+class FastProtocolChecking(__typing.Protocol): ...

--- a/hikari/traits.py
+++ b/hikari/traits.py
@@ -41,7 +41,7 @@ import typing
 
 from hikari import presences
 from hikari import undefined
-from hikari.internal import protocol
+from hikari.internal import fast_protocol
 
 if typing.TYPE_CHECKING:
     import datetime
@@ -59,7 +59,8 @@ if typing.TYPE_CHECKING:
     from hikari.api import voice as voice_
 
 
-class NetworkSettingsAware(protocol.Protocol):
+@typing.runtime_checkable
+class NetworkSettingsAware(fast_protocol.FastProtocolChecking, typing.Protocol):
     """Structural supertype for any component aware of network settings."""
 
     __slots__: typing.Sequence[str] = ()
@@ -87,7 +88,8 @@ class NetworkSettingsAware(protocol.Protocol):
         raise NotImplementedError
 
 
-class EventManagerAware(protocol.Protocol):
+@typing.runtime_checkable
+class EventManagerAware(fast_protocol.FastProtocolChecking, typing.Protocol):
     """Structural supertype for a event manager-aware object.
 
     event manager-aware components are able to manage event listeners and waiters.
@@ -107,7 +109,8 @@ class EventManagerAware(protocol.Protocol):
         raise NotImplementedError
 
 
-class EntityFactoryAware(protocol.Protocol):
+@typing.runtime_checkable
+class EntityFactoryAware(fast_protocol.FastProtocolChecking, typing.Protocol):
     """Structural supertype for an entity factory-aware object.
 
     These components will be able to construct library entities.
@@ -127,7 +130,8 @@ class EntityFactoryAware(protocol.Protocol):
         raise NotImplementedError
 
 
-class ExecutorAware(protocol.Protocol):
+@typing.runtime_checkable
+class ExecutorAware(fast_protocol.FastProtocolChecking, typing.Protocol):
     """Structural supertype for an executor-aware object.
 
     These components will contain an `executor` attribute that may return
@@ -153,7 +157,8 @@ class ExecutorAware(protocol.Protocol):
         raise NotImplementedError
 
 
-class EventFactoryAware(protocol.Protocol):
+@typing.runtime_checkable
+class EventFactoryAware(fast_protocol.FastProtocolChecking, typing.Protocol):
     """Structural supertype for an event factory-aware object.
 
     These components are able to construct library events.
@@ -173,7 +178,8 @@ class EventFactoryAware(protocol.Protocol):
         raise NotImplementedError
 
 
-class IntentsAware(protocol.Protocol):
+@typing.runtime_checkable
+class IntentsAware(fast_protocol.FastProtocolChecking, typing.Protocol):
     """A component that is aware of the application intents."""
 
     __slots__: typing.Sequence[str] = ()
@@ -190,7 +196,10 @@ class IntentsAware(protocol.Protocol):
         raise NotImplementedError
 
 
-class RESTAware(EntityFactoryAware, NetworkSettingsAware, ExecutorAware, protocol.Protocol):
+@typing.runtime_checkable
+class RESTAware(
+    EntityFactoryAware, NetworkSettingsAware, ExecutorAware, fast_protocol.FastProtocolChecking, typing.Protocol
+):
     """Structural supertype for a REST-aware object.
 
     These are able to perform REST API calls.
@@ -210,7 +219,8 @@ class RESTAware(EntityFactoryAware, NetworkSettingsAware, ExecutorAware, protoco
         raise NotImplementedError
 
 
-class VoiceAware(protocol.Protocol):
+@typing.runtime_checkable
+class VoiceAware(fast_protocol.FastProtocolChecking, typing.Protocol):
     """Structural supertype for a voice-aware object.
 
     This is an object that provides a `voice` property to allow the creation
@@ -231,7 +241,15 @@ class VoiceAware(protocol.Protocol):
         raise NotImplementedError
 
 
-class ShardAware(IntentsAware, NetworkSettingsAware, ExecutorAware, VoiceAware, protocol.Protocol):
+@typing.runtime_checkable
+class ShardAware(
+    IntentsAware,
+    NetworkSettingsAware,
+    ExecutorAware,
+    VoiceAware,
+    fast_protocol.FastProtocolChecking,
+    typing.Protocol,
+):
     """Structural supertype for a shard-aware object.
 
     These will expose a mapping of shards, the intents in use
@@ -361,7 +379,8 @@ class ShardAware(IntentsAware, NetworkSettingsAware, ExecutorAware, VoiceAware, 
         raise NotImplementedError
 
 
-class CacheAware(protocol.Protocol):
+@typing.runtime_checkable
+class CacheAware(fast_protocol.FastProtocolChecking, typing.Protocol):
     """Structural supertype for a cache-aware object.
 
     Any cache-aware objects are able to access the Discord application cache.
@@ -381,7 +400,16 @@ class CacheAware(protocol.Protocol):
         raise NotImplementedError
 
 
-class BotAware(RESTAware, ShardAware, EventFactoryAware, EventManagerAware, CacheAware, protocol.Protocol):
+@typing.runtime_checkable
+class BotAware(
+    RESTAware,
+    ShardAware,
+    EventFactoryAware,
+    EventManagerAware,
+    CacheAware,
+    fast_protocol.FastProtocolChecking,
+    typing.Protocol,
+):
     """Structural supertype for a component that is aware of all internals."""
 
     __slots__: typing.Sequence[str] = ()

--- a/scripts/protocol_benchmark.py
+++ b/scripts/protocol_benchmark.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import timeit
 import typing
 
-from hikari.internal import protocol
+from hikari.internal import fast_protocol
 
 
 @typing.runtime_checkable
@@ -60,7 +60,7 @@ class BasicPyProtocol(typing.Protocol):
         raise NotImplementedError
 
 
-class BasicHikariProtocol(protocol.Protocol):
+class BasicHikariProtocol(fast_protocol.FastProtocolChecking, typing.Protocol):
     def test(self, arg1: str, arg2: bool) -> typing.List[int]:
         raise NotImplementedError
 

--- a/tests/hikari/internal/test_typing_extensions.py
+++ b/tests/hikari/internal/test_typing_extensions.py
@@ -19,114 +19,104 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-import abc
 import contextlib
+import typing
 
 import mock
 import pytest
 
-from hikari.internal import protocol as protocol_impl
+from hikari.internal import fast_protocol
 
 
 class TestCheckIfIgnored:
     def test_when_startswith_abc(self):
         mock_string = mock.Mock(startswith=mock.Mock(return_value=True))
 
-        assert protocol_impl._check_if_ignored(mock_string) is True
+        assert fast_protocol._check_if_ignored(mock_string) is True
 
         mock_string.startswith.assert_called_once_with("_abc_")
 
     def test_when_in_IGNORED_ATTRS(self):
         with mock.patch.object(
-            protocol_impl, "IGNORED_ATTRS", new=mock.Mock(__contains__=mock.Mock(return_value=True))
+            fast_protocol, "_IGNORED_ATTRS", new=mock.Mock(__contains__=mock.Mock(return_value=True))
         ) as mock_list:
-            assert protocol_impl._check_if_ignored("testing") is True
+            assert fast_protocol._check_if_ignored("testing") is True
 
             mock_list.__contains__.assert_called_once_with("testing")
 
     def test_when_not_ignored(self):
         mock_string = mock.Mock(startswith=mock.Mock(return_value=False))
         with mock.patch.object(
-            protocol_impl, "IGNORED_ATTRS", new=mock.Mock(__contains__=mock.Mock(return_value=False))
+            fast_protocol, "_IGNORED_ATTRS", new=mock.Mock(__contains__=mock.Mock(return_value=False))
         ) as mock_list:
-            assert protocol_impl._check_if_ignored(mock_string) is False
+            assert fast_protocol._check_if_ignored(mock_string) is False
 
             mock_list.__contains__.assert_called_once_with(mock_string)
 
 
-class TestNoInit:
-    @pytest.fixture()
-    def mock_class(self):
-        class MockClass:
-            _is_protocol = NotImplemented
-
-        return MockClass
-
-    def test_no_init_when_protocol(self, mock_class):
-        mock_class._is_protocol = True
-        with pytest.raises(TypeError, match=r"Protocols cannot be instantiated"):
-            protocol_impl._no_init(mock_class())
-
-    def test_no_init_when_not_protocol(self, mock_class):
-        mock_class._is_protocol = False
-        protocol_impl._no_init(mock_class())
-
-
-class TestFastProtocol:
-    def test_new_when_first_protocol_not_Protocol(self):
+class TestFastProtocolChecking:
+    def test_new_when_first_protocol_not_FastProtocolChecking(self):
         stack = contextlib.ExitStack()
-        stack.enter_context(pytest.raises(TypeError, match=r"First instance of _FastProtocol must be Protocol"))
-        stack.enter_context(mock.patch.object(protocol_impl, "_Protocol", new=NotImplemented))
+        stack.enter_context(
+            pytest.raises(TypeError, match=r"First instance of _FastProtocolChecking must be FastProtocolChecking")
+        )
+        stack.enter_context(mock.patch.object(fast_protocol, "_Protocol", new=NotImplemented))
 
         with stack:
 
-            class NotProtocol(metaclass=protocol_impl._FastProtocol):
+            class NotProtocol(metaclass=fast_protocol._FastProtocolChecking):
                 ...
 
-    def test_new_when_first_protocol_is_Protocol(self):
-        with mock.patch.object(protocol_impl, "_Protocol", new=NotImplemented):
+    def test_new_when_first_protocol_is_FastProtocolChecking(self):
+        with mock.patch.object(fast_protocol, "_Protocol", new=NotImplemented):
 
-            class Protocol(metaclass=protocol_impl._FastProtocol):
+            class FastProtocolChecking(metaclass=fast_protocol._FastProtocolChecking):
                 ...
 
-            assert protocol_impl._Protocol is Protocol
+            assert fast_protocol._Protocol is FastProtocolChecking
 
-        assert Protocol._is_protocol is True
-        assert Protocol._attributes_ == ()
-        assert Protocol.__init__ is protocol_impl._no_init
+        assert FastProtocolChecking._attributes_ == ()
 
-    def test_new_when_bases_not_protocols(self):
-        with pytest.raises(TypeError, match=r"Protocols can only inherit from other protocols, got <class 'object'>"):
+    def test_new_when_bases_not_fastprotocols(self):
+        with pytest.raises(
+            TypeError,
+            match=r"FastProtocolChecking can only inherit from other fast checking protocols, got <class 'object'>",
+        ):
 
-            class MyProtocol(object, protocol_impl.Protocol):
+            class MyProtocol(object, fast_protocol.FastProtocolChecking, typing.Protocol):
                 ...
 
-    def test_new_when_protocol_is_not_a_base(self):
-        class MyProtocol(protocol_impl.Protocol):
-            ...
+    def test_new_when_fastprotocolchecking_in_bases_but_not_protocol(self):
+        with pytest.raises(
+            TypeError,
+            match=r"FastProtocolChecking can only be used with protocols",
+        ):
 
-        class ApiProtocol(MyProtocol):
-            ...
-
-        assert ApiProtocol._is_protocol is False
-        assert hasattr(ApiProtocol, "_attributes__") is False
-        assert ApiProtocol.__init__ is protocol_impl._no_init
+            class MyProtocol(fast_protocol.FastProtocolChecking):
+                ...
 
     def test_new(self):
-        class MyProtocol(protocol_impl.Protocol):
+        class MyProtocol(fast_protocol.FastProtocolChecking, typing.Protocol):
             def test1():
                 ...
 
-        class OtherProtocol(MyProtocol, protocol_impl.Protocol):
+        class OtherProtocol(MyProtocol, fast_protocol.FastProtocolChecking, typing.Protocol):
             def test2():
                 ...
 
-        assert OtherProtocol._is_protocol is True
-        assert OtherProtocol.__init__ is protocol_impl._no_init
         assert sorted(OtherProtocol._attributes_) == ["test1", "test2"]
 
+    def test_init_subclass_does_not_overwrite_subclasshoook(self):
+        def subclass_hook():
+            ...
+
+        class MyProtocol(fast_protocol.FastProtocolChecking, typing.Protocol):
+            __subclasshook__ = subclass_hook
+
+        assert MyProtocol.__subclasshook__ is subclass_hook
+
     def test_isinstance_when_not_protocol(self):
-        class MyProtocol(protocol_impl.Protocol):
+        class MyProtocol(fast_protocol.FastProtocolChecking, typing.Protocol):
             ...
 
         class Class:
@@ -135,13 +125,13 @@ class TestFastProtocol:
         MyProtocol._is_protocol = False
         class_instance = Class()
 
-        with mock.patch.object(abc.ABCMeta, "__instancecheck__", return_value=True) as instance_check:
+        with mock.patch.object(type(typing.Protocol), "__instancecheck__", return_value=True) as instance_check:
             assert isinstance(class_instance, MyProtocol) is True
 
             instance_check.assert_called_once_with(class_instance)
 
     def test_isinstance_fastfail(self):
-        class MyProtocol(protocol_impl.Protocol):
+        class MyProtocol(fast_protocol.FastProtocolChecking, typing.Protocol):
             def test():
                 ...
 
@@ -151,7 +141,7 @@ class TestFastProtocol:
         assert isinstance(Class(), MyProtocol) is False
 
     def test_isinstance(self):
-        class MyProtocol(protocol_impl.Protocol):
+        class MyProtocol(fast_protocol.FastProtocolChecking, typing.Protocol):
             def test():
                 ...
 
@@ -162,19 +152,19 @@ class TestFastProtocol:
         assert isinstance(Class(), MyProtocol) is True
 
     def test_issubclass_when_not_protocol(self):
-        class MyProtocol(protocol_impl.Protocol):
+        class MyProtocol(fast_protocol.FastProtocolChecking, typing.Protocol):
             ...
 
         class Class:
             ...
 
-        with mock.patch.object(abc.ABCMeta, "__subclasscheck__", return_value=True) as instance_check:
+        with mock.patch.object(type(typing.Protocol), "__subclasscheck__", return_value=True) as subclass_check:
             assert issubclass(Class, MyProtocol) is True
 
-            instance_check.assert_called_once_with(Class)
+            subclass_check.assert_called_once_with(Class)
 
     def test_issubclass_fastfail(self):
-        class MyProtocol(protocol_impl.Protocol):
+        class MyProtocol(fast_protocol.FastProtocolChecking, typing.Protocol):
             def test():
                 ...
 
@@ -184,7 +174,7 @@ class TestFastProtocol:
         assert issubclass(Class, MyProtocol) is False
 
     def test_issubclass(self):
-        class MyProtocol(protocol_impl.Protocol):
+        class MyProtocol(fast_protocol.FastProtocolChecking, typing.Protocol):
             def test():
                 ...
 


### PR DESCRIPTION
### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Fixes #467 
