### PR TITLE
Enums consistency changes/fixes

### DIFF
--- a/tests/hikari/internal/test_enums.py
+++ b/tests/hikari/internal/test_enums.py
@@ -263,6 +263,34 @@ class TestEnum:
         assert repr(Enum) == "<enum Enum>"
         assert repr(Enum.foo) == "<Enum.foo: 9>"
 
+    def test_can_overwrite_method(self):
+        class TestEnum1(str, enums.Enum):
+            FOO = "foo"
+
+            def __str__(self) -> str:
+                return "Ok"
+
+        assert str(TestEnum1.FOO) == "Ok"
+
+    @pytest.mark.parametrize(("type_", "value"), [(int, 42), (str, "ok"), (bytes, b"no"), (float, 4.56), (complex, 3j)])
+    def test_inherits_type_dunder_method_behaviour(self, type_, value):
+        class TestEnum(type_, enums.Enum):
+            BAR = value
+
+        result = type_(TestEnum.BAR)
+
+        assert type(result) is type_
+        assert result == value
+
+    def test_allows_overriding_methods(self):
+        class TestEnum(int, enums.Enum):
+            BAR = 2222
+
+            def __int__(self):
+                return 53
+
+        assert int(TestEnum.BAR) == 53
+
 
 class TestIntFlag:
     @mock.patch.object(enums, "_Flag", new=NotImplemented)
@@ -1224,3 +1252,16 @@ class TestIntFlag:
 
         assert repr(TestFlag) == "<enum TestFlag>"
         assert repr(TestFlag.FOO) == "<TestFlag.FOO: 1>"
+
+    def test_allows_overriding_methods(self):
+        class TestFlag(enums.Flag):
+            FOO = 0x1
+            BAR = 0x2
+            BAZ = 0x4
+            BORK = 0x8
+            QUX = 0x10
+
+            def __int__(self):
+                return 855555
+
+        assert int(TestFlag.FOO | TestFlag.BAR) == 855555

--- a/tests/hikari/test_applications.py
+++ b/tests/hikari/test_applications.py
@@ -29,24 +29,6 @@ from hikari.internal import routes
 from tests.hikari import hikari_test_helpers
 
 
-class TestOAuth2Scope:
-    def test_str_operator(self):
-        scope = applications.OAuth2Scope("activities.read")
-        assert str(scope) == "ACTIVITIES_READ"
-
-
-class TestConnectionVisibility:
-    def test_str_operator(self):
-        connection_visibility = applications.ConnectionVisibility(1)
-        assert str(connection_visibility) == "EVERYONE"
-
-
-class TestTeamMembershipState:
-    def test_str_operator(self):
-        state = applications.TeamMembershipState(2)
-        assert str(state) == "ACCEPTED"
-
-
 class TestTeamMember:
     @pytest.fixture()
     def model(self):

--- a/tests/hikari/test_channels.py
+++ b/tests/hikari/test_channels.py
@@ -37,12 +37,6 @@ def mock_app():
     return mock.Mock()
 
 
-class TestChannelType:
-    def test_str_operator(self):
-        channel_type = channels.ChannelType(1)
-        assert str(channel_type) == "DM"
-
-
 class TestChannelFollow:
     @pytest.mark.asyncio
     async def test_fetch_channel(self, mock_app):
@@ -91,11 +85,6 @@ class TestChannelFollow:
 
 
 class TestPermissionOverwrite:
-    @pytest.mark.parametrize(("type", "expect_name"), [(0, "ROLE"), (1, "MEMBER")])
-    def test_str_operator(self, type, expect_name):
-        overwrite_type = channels.PermissionOverwriteType(type)
-        assert str(overwrite_type) == expect_name
-
     def test_unset(self):
         overwrite = channels.PermissionOverwrite(
             type=channels.PermissionOverwriteType.MEMBER, id=snowflakes.Snowflake(1234321)

--- a/tests/hikari/test_guilds.py
+++ b/tests/hikari/test_guilds.py
@@ -40,48 +40,6 @@ def mock_app():
     return mock.Mock(spec_set=bot.BotApp)
 
 
-class TestGuildExplicitContentFilterLevel:
-    def test_str_operator(self):
-        level = guilds.GuildExplicitContentFilterLevel(1)
-        assert str(level) == "MEMBERS_WITHOUT_ROLES"
-
-
-class TestGuildFeature:
-    def test_str_operator(self):
-        feature = guilds.GuildFeature("ANIMATED_ICON")
-        assert str(feature) == "ANIMATED_ICON"
-
-
-class TestGuildNotificationsLevel:
-    def test_str_operator(self):
-        level = guilds.GuildMessageNotificationsLevel(1)
-        assert str(level) == "ONLY_MENTIONS"
-
-
-class TestGuildMFALevel:
-    def test_str_operator(self):
-        level = guilds.GuildMFALevel(1)
-        assert str(level) == "ELEVATED"
-
-
-class TestGuildPremiumTier:
-    def test_str_operator(self):
-        level = guilds.GuildPremiumTier(1)
-        assert str(level) == "TIER_1"
-
-
-class TestGuildSystemChannelFlag:
-    def test_str_operator(self):
-        flag = guilds.GuildSystemChannelFlag(1 << 0)
-        assert str(flag) == "SUPPRESS_USER_JOIN"
-
-
-class TestGuildVerificationLevel:
-    def test_str_operator(self):
-        level = guilds.GuildVerificationLevel(0)
-        assert str(level) == "NONE"
-
-
 class TestPartialRole:
     @pytest.fixture()
     def model(self, mock_app):

--- a/tests/hikari/test_intents.py
+++ b/tests/hikari/test_intents.py
@@ -23,16 +23,6 @@
 from hikari import intents
 
 
-def test_Intent_str_operator():
-    intent = intents.Intents.GUILD_MESSAGES
-    assert str(intent) == "GUILD_MESSAGES"
-
-
-def test_Intent_str_operator_when_value_is_zero():
-    intent = intents.Intents(0)
-    assert str(intent) == "NONE"
-
-
 def test_Intent_is_privileged():
     intent = intents.Intents.GUILD_MESSAGES
     intent2 = intents.Intents.GUILD_MEMBERS

--- a/tests/hikari/test_invites.py
+++ b/tests/hikari/test_invites.py
@@ -24,11 +24,6 @@ import mock
 from hikari import invites
 
 
-def test_TargetUserType_str_operator():
-    invite_type = invites.TargetUserType(1)
-    assert str(invite_type) == "STREAM"
-
-
 def test_VanityURL_str_operator():
     mock_url = mock.Mock(invites.VanityURL, code="hikari")
     assert invites.VanityURL.__str__(mock_url) == "https://discord.gg/hikari"

--- a/tests/hikari/test_messages.py
+++ b/tests/hikari/test_messages.py
@@ -33,24 +33,6 @@ from hikari import users
 from hikari.internal import routes
 
 
-class TestMessageType:
-    def test_str_operator(self):
-        message_type = messages.MessageType(10)
-        assert str(message_type) == "USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_2"
-
-
-class TestMessageFlag:
-    def test_str_operator(self):
-        flag = messages.MessageFlag(0)
-        assert str(flag) == "NONE"
-
-
-class TestMessageActivityType:
-    def test_str_operator(self):
-        activity_type = messages.MessageActivityType(5)
-        assert str(activity_type) == "JOIN_REQUEST"
-
-
 class TestAttachment:
     def test_str_operator(self):
         attachment = messages.Attachment(

--- a/tests/hikari/test_presences.py
+++ b/tests/hikari/test_presences.py
@@ -23,21 +23,6 @@
 from hikari import presences
 
 
-def test_ActivityType_str_operator():
-    activity_type = presences.ActivityType(4)
-    assert str(activity_type) == "CUSTOM"
-
-
-def test_ActivityFlag_str_operator():
-    flag = presences.ActivityFlag(1 << 4)
-    assert str(flag) == "SYNC"
-
-
 def test_Activity_str_operator():
     activity = presences.Activity(name="something", type=presences.ActivityType(1))
     assert str(activity) == "something"
-
-
-def test_Status_str_operator():
-    status = presences.Status("idle")
-    assert str(status) == "IDLE"

--- a/tests/hikari/test_users.py
+++ b/tests/hikari/test_users.py
@@ -30,18 +30,6 @@ from hikari.internal import routes
 from tests.hikari import hikari_test_helpers
 
 
-class TestUserFlag:
-    def test_str_operator(self):
-        flag = users.UserFlag(1 << 17)
-        assert str(flag) == "EARLY_VERIFIED_DEVELOPER"
-
-
-class TestPremiumType:
-    def test_str_operator(self):
-        premium_type = users.PremiumType(1)
-        assert str(premium_type) == "NITRO_CLASSIC"
-
-
 class TestPartialUser:
     @pytest.fixture()
     def obj(self):

--- a/tests/hikari/test_webhooks.py
+++ b/tests/hikari/test_webhooks.py
@@ -25,11 +25,6 @@ import pytest
 from hikari import webhooks
 
 
-def test_WebhookType_str_operator():
-    webhook_type = webhooks.WebhookType(1)
-    assert str(webhook_type) == "INCOMING"
-
-
 class TestWebhook:
     @pytest.fixture()
     def webhook(self):


### PR DESCRIPTION
### Summary
* Fixup enums.Enum and enums.IntFlag to allow methods to be overwritten
* Add in a special case to let string enums return their value when cast to string rather than name
* Remove unnecessary/out-dated str operator tests that targeted enums which now inherit the behaviour

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
