### PR TITLE
Fix mis-usage of PAYLOAD_ZLIB_STREAM where TRANSPORT_ZLIB_STREAM is being referred to

### DIFF
--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -342,7 +342,7 @@ class GatewayShardImpl(shard.GatewayShard):
     ----------------
     compression : typing.Optional[buitlins.str]
         Compression format to use for the shard. Only supported values are
-        `"payload_zlib_stream"` or `builtins.None` to disable it.
+        `"transport_zlib_stream"` or `builtins.None` to disable it.
     initial_activity : typing.Optional[hikari.presences.Activity]
         The initial activity to appear to have for this shard, or
         `builtins.None` if no activity should be set initially. This is the
@@ -418,7 +418,7 @@ class GatewayShardImpl(shard.GatewayShard):
     def __init__(
         self,
         *,
-        compression: typing.Optional[str] = shard.GatewayCompression.PAYLOAD_ZLIB_STREAM,
+        compression: typing.Optional[str] = shard.GatewayCompression.TRANSPORT_ZLIB_STREAM,
         initial_activity: typing.Optional[presences.Activity] = None,
         initial_idle_since: typing.Optional[datetime.datetime] = None,
         initial_is_afk: bool = False,
@@ -442,7 +442,7 @@ class GatewayShardImpl(shard.GatewayShard):
         query = {"v": _VERSION, "encoding": str(data_format)}
 
         if compression is not None:
-            if compression == shard.GatewayCompression.PAYLOAD_ZLIB_STREAM:
+            if compression == shard.GatewayCompression.TRANSPORT_ZLIB_STREAM:
                 query["compress"] = "zlib-stream"
             else:
                 raise NotImplementedError(f"Unsupported compression format {compression}")

--- a/tests/hikari/impl/test_shard.py
+++ b/tests/hikari/impl/test_shard.py
@@ -577,7 +577,7 @@ class TestGatewayShardImpl:
         ("compression", "expect"),
         [
             (None, f"v={shard._VERSION}&encoding=json"),
-            ("payload_zlib_stream", f"v={shard._VERSION}&encoding=json&compress=zlib-stream"),
+            ("transport_zlib_stream", f"v={shard._VERSION}&encoding=json&compress=zlib-stream"),
         ],
     )
     def test__init__sets_url_is_correct_json(self, compression, expect, http_settings, proxy_settings):


### PR DESCRIPTION
### Summary
Fix mis-usage of PAYLOAD_ZLIB_STREAM where TRANSPORT_ZLIB_STREAM is being referred to

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
