### PR TITLE
Send a full heartbeat on a heartbeat request, not just an ACK

### DIFF
--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -744,7 +744,7 @@ class GatewayShardImpl(shard.GatewayShard):
             self._logger.log(ux.TRACE, "dispatching %s with seq %s", t, s)
             self._dispatch(t, s, d)
         elif op == _HEARTBEAT:
-            await self._send_heartbeat_ack()
+            await self._send_heartbeat()
             self._logger.log(ux.TRACE, "sent HEARTBEAT")
         elif op == _HEARTBEAT_ACK:
             now = time.monotonic()
@@ -944,9 +944,6 @@ class GatewayShardImpl(shard.GatewayShard):
     async def _send_heartbeat(self) -> None:
         await self._send_json({_OP: _HEARTBEAT, _D: self._seq})
         self._last_heartbeat_sent = time.monotonic()
-
-    async def _send_heartbeat_ack(self) -> None:
-        await self._send_json({_OP: _HEARTBEAT_ACK, _D: None})
 
     @staticmethod
     def _serialize_activity(activity: typing.Optional[presences.Activity]) -> data_binding.JSONish:

--- a/tests/hikari/impl/test_shard.py
+++ b/tests/hikari/impl/test_shard.py
@@ -1051,13 +1051,6 @@ class TestGatewayShardImpl:
         client._send_json.assert_awaited_once_with({"op": 1, "d": 10})
         assert client._last_heartbeat_sent == 200
 
-    async def test__send_heartbeat_ack(self, client):
-        client._send_json = mock.AsyncMock()
-
-        await client._send_heartbeat_ack()
-
-        client._send_json.assert_awaited_once_with({"op": 11, "d": None})
-
     def test__serialize_activity_when_activity_is_None(self, client):
         assert client._serialize_activity(None) is None
 


### PR DESCRIPTION
### Summary
According to the [API's docs](https://discord.com/developers/docs/topics/gateway#heartbeating) ` The gateway may request a heartbeat from you in some situations, and you should send a heartbeat back to the gateway as you normally would` with the bit "you should send a heartbeat back to the gateway as you normally would" infers that we should be responding with a full heartbeat which is inline with how [JDA](https://github.com/DV8FromTheWorld/JDA/blob/3a9fcd0ecc88f988ac81eb2c18527283a83f12d1/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java#L843) and [Detritus](https://github.com/detritusjs/client-socket/blob/4361739b1c824790e269db4f3abbde63fe5a5d24/src/gateway.ts#L492) handle received heartbeats and matches up with how `HEARTBEAT_ACK` is marked as Received only in the [API's docs](https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-opcodes)

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
