### PR TITLE
Fix MYPY typing of Embed.colour alias

### DIFF
--- a/hikari/embeds.py
+++ b/hikari/embeds.py
@@ -442,12 +442,32 @@ class Embed:
         """
         return self._color
 
+    # As a note, MYPY currently complains about setting embed.color to a Colourish value which isn't explicitly Color.
+    # see https://github.com/python/mypy/issues/3004
     @color.setter
     def color(self, value: typing.Optional[colors.Colorish]) -> None:
         self._color = colors.Color.of(value) if value is not None else None
 
     # Alias.
-    colour = color
+    @property
+    def colour(self) -> typing.Optional[colors.Color]:
+        """Return the colour of the embed. This is an alias of `Embed.color`.
+
+        This will be `builtins.None` if not set.
+
+        Returns
+        -------
+        typing.Optional[hikari.colors.Color]
+            The colour that is set.
+        """
+        return self._color
+
+    # Alias.
+    # As a note, MYPY currently complains about setting embed.color to a Colourish value which isn't explicitly Color.
+    # see https://github.com/python/mypy/issues/3004
+    @colour.setter
+    def colour(self, value: typing.Optional[colors.Colorish]) -> None:
+        self._color = colors.Color.of(value) if value is not None else None
 
     @property
     def timestamp(self) -> typing.Optional[datetime.datetime]:


### PR DESCRIPTION
* Mypy was incorrectly typing Embed.colour as a method (Callable[[], Optional[colors.Color]]) due to how it was aliased

### Summary
Fix MYPY typing of Embed.colour alias.
Mypy was incorrectly typing Embed.colour as a method (Callable[[], Optional[colors.Color]]) due to how it was aliased as shown in the following error:
```py
hikari\embeds.py:997:1: error: Cannot assign to a method  [assignment]
    Embed().colour = 42
    ^
hikari\embeds.py:997:18: error: Incompatible types in assignment (expression has type "int", variable has type "Callable[[], Optional[Color]]")  [assignment]
    Embed().colour = 42
                     ^
Found 2 errors in 1 file (checked 80 source files)
```

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
