### PR TITLE
Improve the UX around RESTClient.delete_messages

### DIFF
--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -1274,8 +1274,12 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     async def delete_messages(
         self,
         channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        messages: typing.Union[
+            snowflakes.SnowflakeishOr[messages_.PartialMessage],
+            snowflakes.SnowflakeishIterable[messages_.PartialMessage],
+        ],
         /,
-        *messages: snowflakes.SnowflakeishOr[messages_.PartialMessage],
+        *other_messages: snowflakes.SnowflakeishOr[messages_.PartialMessage],
     ) -> None:
         """Bulk-delete messages from the channel.
 
@@ -1284,9 +1288,14 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]
             The channel to bulk delete the messages in. This may be
             the object or the ID of an existing channel.
-        *messages : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
-            The messages to delete. This may be one or more
-            objects or IDs of existing messages.
+        messages : typing.Union[hikari.snowflakes.SnowflakeishOr[hikari.messages_.PartialMessage], hikari.snowflakes.SnowflakeishIterable[hikari.messages_.PartialMessage]]
+            Either the object/ID of an existing message to delete or an iterable
+            of the objects and/or IDs of existing messages to delete.
+
+        Other Parameters
+        ----------------
+        *other_messages : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+            The objects and/or IDs of other existing messages to delete.
 
         !!! note
             This API endpoint will only be able to delete 100 messages
@@ -1316,7 +1325,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             messages that were not removed. The
             `builtins.BaseException.__cause__` of the exception will be the
             original error that terminated this process.
-        """
+        """  # noqa: E501 - Line too long
 
     @abc.abstractmethod
     async def add_reaction(

--- a/hikari/snowflakes.py
+++ b/hikari/snowflakes.py
@@ -32,6 +32,7 @@ __all__: typing.List[str] = [
     "SearchableSnowflakeish",
     "SnowflakeishOr",
     "SearchableSnowflakeishOr",
+    "SnowflakeishIterable",
     "SnowflakeishSequence",
 ]
 
@@ -232,6 +233,10 @@ The valid types for this type hint are:
 - `Snowflake`
 - `datetime.datetime`
 """
+
+SnowflakeishIterable = typing.Iterable[SnowflakeishOr[T]]
+"""Type hint representing an iterable of unique object entities."""
+
 
 SnowflakeishSequence = typing.Sequence[SnowflakeishOr[T]]
 """Type hint representing a collection of unique object entities."""


### PR DESCRIPTION
### Summary
* Enforce that at least one message is passed in the interface by adding a required positional message argument before the other_messages variable length positional argument.
* Allow the first argument to either be SnowflakeishOr[PartialMessage] or an Iterable[SnowflakeishOr[PartialMessage]] to support directly passing an iterable as this could otherwise be a pretty common mistake.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
