### PR TITLE
Add get_guilds_view method to cache to match get_guild

### DIFF
--- a/hikari/api/cache.py
+++ b/hikari/api/cache.py
@@ -188,6 +188,16 @@ class Cache(abc.ABC):
         """
 
     @abc.abstractmethod
+    def get_guilds_view(self) -> CacheView[snowflakes.Snowflake, guilds.GatewayGuild]:
+        """Get a view of all the guild objects in the cache regardless if availability.
+
+        Returns
+        -------
+        CacheView[hikari.snowflakes.Snowflake, hikari.guilds.GatewayGuild]
+            A view of guild IDs to the guild objects found in the cache.
+        """
+
+    @abc.abstractmethod
     def get_available_guilds_view(self) -> CacheView[snowflakes.Snowflake, guilds.GatewayGuild]:
         """Get a view of the available guild objects in the cache.
 

--- a/hikari/impl/cache.py
+++ b/hikari/impl/cache.py
@@ -384,6 +384,11 @@ class CacheImpl(cache.MutableCache):
         }
         return cache_utility.CacheMappingView(results) if results else cache_utility.EmptyCacheView()
 
+    def get_guilds_view(self) -> cache.CacheView[snowflakes.Snowflake, guilds.GatewayGuild]:
+        return cache_utility.CacheMappingView(
+            {guild_id: record.guild for guild_id, record in self._guild_entries.items() if record.guild}
+        )
+
     def get_available_guilds_view(self) -> cache.CacheView[snowflakes.Snowflake, guilds.GatewayGuild]:
         if not self._is_cache_enabled_for(GUILDS):
             return cache_utility.EmptyCacheView()

--- a/tests/hikari/impl/test_cache.py
+++ b/tests/hikari/impl/test_cache.py
@@ -729,6 +729,27 @@ class TestCacheImpl:
 
         assert result is None
 
+    def test_get_guilds_view(self, cache_impl):
+        mock_guild_1 = mock.MagicMock(guilds.GatewayGuild)
+        mock_guild_2 = mock.MagicMock(guilds.GatewayGuild)
+        mock_guild_3 = mock.MagicMock(guilds.GatewayGuild)
+        cache_impl._guild_entries = collections.FreezableDict(
+            {
+                snowflakes.Snowflake(56132): cache_utilities.GuildRecord(guild=mock_guild_1, is_available=True),
+                snowflakes.Snowflake(56234): cache_utilities.GuildRecord(),
+                snowflakes.Snowflake(541123): cache_utilities.GuildRecord(guild=mock_guild_2, is_available=False),
+                snowflakes.Snowflake(65234): cache_utilities.GuildRecord(guild=mock_guild_3, is_available=False),
+            }
+        )
+
+        result = cache_impl.get_guilds_view()
+
+        assert result == {
+            snowflakes.Snowflake(56132): mock_guild_1,
+            snowflakes.Snowflake(541123): mock_guild_2,
+            snowflakes.Snowflake(65234): mock_guild_3,
+        }
+
     def test_get_available_guilds_view(self, cache_impl):
         mock_guild_1 = mock.MagicMock(guilds.GatewayGuild)
         mock_guild_2 = mock.MagicMock(guilds.GatewayGuild)


### PR DESCRIPTION
### Summary
Add get_guilds_view method to cache to match get_guild

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
