### PR TITLE
Fix RESTApp.acquire return typing

### DIFF
--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -282,7 +282,7 @@ class RESTApp(traits.ExecutorAware):
         self,
         token: typing.Optional[str] = None,
         token_type: str = _BEARER_TOKEN_PREFIX,
-    ) -> rest_api.RESTClient:
+    ) -> RESTClientImpl:
         loop = asyncio.get_running_loop()
 
         if self._event_loop is None:


### PR DESCRIPTION
### Summary
Fix RESTApp.acquire return typing
this needs to be typed as returning RESTClientImpl rather than the generic RESTClient abc since the ABC doesn't include being an async context manager as a part of it's interface

Without this change errors like the following are returned by MYPY when using the RESTClient
```py
hikari\impl\rest.py: note: In function "foo":
hikari\impl\rest.py:2546:16: error: "RESTClient" has no attribute "__aenter__"  [attr-defined]
        async with RESTApp().acquire("OK") as client:
                   ^
hikari\impl\rest.py:2546:16: error: "RESTClient" has no attribute "__aexit__"  [attr-defined]
        async with RESTApp().acquire("OK") as client:
                   ^
hikari\impl\rest.py:2547:9: error: Returning Any from function declared to return "GatewayBot"  [no-any-return]
            return await client.fetch_gateway_bot()
            ^
```
for the following code
```py
async def foo() -> sessions.GatewayBot:
    async with RESTApp().acquire("OK") as client:
        return await client.fetch_gateway_bot()
```

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
