### PR TITLE
Changes around mimetype handling

### DIFF
--- a/hikari/files.py
+++ b/hikari/files.py
@@ -1045,7 +1045,7 @@ class Bytes(Resource[IteratorReader]):
 
         if mimetype is None:
             # TODO: should I just default to application/octet-stream here?
-            mimetype = "text/plain"
+            mimetype = "text/plain;charset=UTF-8"
 
         self._filename = filename
         self.mimetype = mimetype

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -1056,7 +1056,8 @@ class RESTClientImpl(rest_api.RESTClient):
             try:
                 for i, attachment in enumerate(final_attachments):
                     stream = await stack.enter_async_context(attachment.stream(executor=self._executor))
-                    form.add_field(f"file{i}", stream, filename=stream.filename, content_type=_APPLICATION_OCTET_STREAM)
+                    mimetype = stream.mimetype or _APPLICATION_OCTET_STREAM
+                    form.add_field(f"file{i}", stream, filename=stream.filename, content_type=mimetype)
 
                 response = await self._request(route, form=form)
             finally:
@@ -1482,7 +1483,8 @@ class RESTClientImpl(rest_api.RESTClient):
             try:
                 for i, attachment in enumerate(final_attachments):
                     stream = await stack.enter_async_context(attachment.stream(executor=self._executor))
-                    form.add_field(f"file{i}", stream, filename=stream.filename, content_type=_APPLICATION_OCTET_STREAM)
+                    mimetype = stream.mimetype or _APPLICATION_OCTET_STREAM
+                    form.add_field(f"file{i}", stream, filename=stream.filename, content_type=mimetype)
 
                 response = await self._request(route, query=query, form=form, no_auth=True)
             finally:


### PR DESCRIPTION
### Summary
* Try to use stream mimetype if known before defaulting to application octet stream in message create
* Default to UTF-8 charset for mimetype in Bytes instead of implicit ascii default

As a note Discord currently ignores the mimetype sent for attachments but this future proofs against any changes to how they handle them.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
