### PR TITLE
Remove preview_asset_hash as Discord no longer send it

### DIFF
--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -1594,7 +1594,6 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             description=payload["description"],
             tags=[tag.strip() for tag in payload["tags"].split(",")] if "tags" in payload else [],
             asset_hash=payload["asset"],
-            preview_asset_hash=payload["preview_asset"],
             format_type=message_models.StickerFormatType(payload["format_type"]),
         )
 

--- a/hikari/messages.py
+++ b/hikari/messages.py
@@ -274,13 +274,6 @@ class Sticker(snowflakes.Unique):
         The CDN endpoint for this hash is currently undocumented.
     """
 
-    preview_asset_hash: typing.Optional[str] = attr.ib(eq=False, hash=False, repr=False)
-    """The hash of this sticker's preview asset.
-
-    !!! note
-        The CDN endpoint for this hash is currently undocumented.
-    """
-
     format_type: typing.Union[StickerFormatType, int] = attr.ib(eq=False, hash=False, repr=True)
     """The format of this sticker's asset."""
 

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -2746,7 +2746,6 @@ class TestEntityFactoryImpl:
                     "description": "very descript",
                     "pack_id": "749043879713701898",
                     "asset": "2be10a547ceb0116998f5bb878d5bc1c",
-                    "preview_asset": "078c91d6cb1a29820343149f2e2212cd",
                     "format_type": 3,
                     "tags": "curious, huh, what, confused, wut, 🤔, 😕, 🧐",
                 }
@@ -2848,7 +2847,6 @@ class TestEntityFactoryImpl:
         assert sticker.description == "very descript"
         assert sticker.pack_id == 749043879713701898
         assert sticker.asset_hash == "2be10a547ceb0116998f5bb878d5bc1c"
-        assert sticker.preview_asset_hash == "078c91d6cb1a29820343149f2e2212cd"
         assert sticker.format_type is message_models.StickerFormatType.LOTTIE
         assert sticker.tags == ["curious", "huh", "what", "confused", "wut", "🤔", "😕", "🧐"]
         assert isinstance(sticker, message_models.Sticker)
@@ -3005,7 +3003,6 @@ class TestEntityFactoryImpl:
         assert sticker.description == "very descript"
         assert sticker.pack_id == 749043879713701898
         assert sticker.asset_hash == "2be10a547ceb0116998f5bb878d5bc1c"
-        assert sticker.preview_asset_hash == "078c91d6cb1a29820343149f2e2212cd"
         assert sticker.format_type is message_models.StickerFormatType.LOTTIE
         assert sticker.tags == ["curious", "huh", "what", "confused", "wut", "🤔", "😕", "🧐"]
         assert isinstance(sticker, message_models.Sticker)


### PR DESCRIPTION
### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Closes #540 