### PR TITLE
Fix rtc_region edge case

### DIFF
--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -747,7 +747,9 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             permission_overwrites=channel_fields.permission_overwrites,
             is_nsfw=channel_fields.is_nsfw,
             parent_id=channel_fields.parent_id,
-            region=payload["rtc_region"],
+            # There seems to be an edge case where rtc_region won't be included in gateway events (e.g. GUILD_CREATE)
+            # for a voice channel that just hasn't been touched since this was introduced (e.g. has been archived).
+            region=payload.get("rtc_region"),
             bitrate=int(payload["bitrate"]),
             user_limit=int(payload["user_limit"]),
             video_quality_mode=channel_models.VideoQualityMode(int(video_quality_mode)),

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -1186,7 +1186,6 @@ class TestEntityFactoryImpl:
                 "position": 2,
                 "bitrate": 64000,
                 "user_limit": 3,
-                "rtc_region": "europe",
                 "type": 6,
                 "guild_id": "123123",
             }
@@ -1194,6 +1193,7 @@ class TestEntityFactoryImpl:
         assert voice_channel.video_quality_mode is channel_models.VideoQualityMode.AUTO
         assert voice_channel.parent_id is None
         assert voice_channel.is_nsfw is None
+        assert voice_channel.region is None
 
     @pytest.fixture()
     def guild_stage_channel_payload(self, permission_overwrite_payload):


### PR DESCRIPTION
### Summary
There seems to be an edge case where rtc_region won't be included in gateway events (e.g. GUILD_CREATE)
for a voice channel that just hasn't been touched since this was introduced (e.g. has been archived) which we aren't handling.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
