### PR TITLE
Improve request rate limiting

### DIFF
--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -102,9 +102,9 @@ class TypingIndicator(special_endpoints.TypingIndicator):
 
     async def __aexit__(
         self,
-        exception_type: typing.Type[BaseException],
-        exception: BaseException,
-        exception_traceback: types.TracebackType,
+        exc_type: typing.Optional[typing.Type[BaseException]],
+        exc_val: typing.Optional[BaseException],
+        exc_tb: typing.Optional[types.TracebackType],
     ) -> None:
         # This will always be true, but this keeps MyPy quiet.
         if self._task is not None:
@@ -115,7 +115,12 @@ class TypingIndicator(special_endpoints.TypingIndicator):
         cls = type(self)
         raise TypeError(f"{cls.__module__}.{cls.__qualname__} is async-only, did you mean 'async with'?") from None
 
-    def __exit__(self, exc_type: typing.Type[Exception], exc_val: Exception, exc_tb: types.TracebackType) -> None:
+    def __exit__(
+        self,
+        exc_type: typing.Optional[typing.Type[Exception]],
+        exc_val: typing.Optional[Exception],
+        exc_tb: typing.Optional[types.TracebackType],
+    ) -> None:
         return None
 
     async def _keep_typing(self) -> None:

--- a/hikari/internal/routes.py
+++ b/hikari/internal/routes.py
@@ -38,14 +38,12 @@ from hikari.internal import attr_extensions
 from hikari.internal import data_binding
 
 HASH_SEPARATOR: typing.Final[str] = ";"
-
+PARAM_REGEX: typing.Final[typing.Pattern[str]] = re.compile(r"{(\w+)}")
 MAJOR_PARAM_COMBOS: typing.Mapping[typing.FrozenSet[str], typing.Callable[[typing.Mapping[str, str]], str]] = {
     frozenset(("channel",)): lambda d: d["channel"],
     frozenset(("guild",)): lambda d: d["guild"],
     frozenset(("webhook", "token")): lambda d: d["webhook"] + ":" + d["token"],
 }
-
-PARAM_REGEX: typing.Final[typing.Pattern[str]] = re.compile(r"{(\w+)}")
 
 
 # This could be frozen, except attrs' docs advise against this for performance


### PR DESCRIPTION
- Move lock to per-bucket lock
- Don't acquire global_rate_limit when not using authentication

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
