### PR TITLE
Ensure Flags only handles int internally

### DIFF
--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -528,10 +528,12 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
 
     def deserialize_permission_overwrite(self, payload: data_binding.JSONObject) -> channel_models.PermissionOverwrite:
         return channel_models.PermissionOverwrite(
-            id=snowflakes.Snowflake(payload["id"]),
-            type=channel_models.PermissionOverwriteType(payload["type"]),
-            allow=permission_models.Permissions(int(payload["allow"])),
-            deny=permission_models.Permissions(int(payload["deny"])),
+            # PermissionOverwrite's init has converters set for these fields which will handle casting
+            id=payload["id"],
+            type=payload["type"],
+            # Permissions still have to be cast to int before they can be cast to Permission typing wise.
+            allow=int(payload["allow"]),
+            deny=int(payload["deny"]),
         )
 
     def serialize_permission_overwrite(self, overwrite: channel_models.PermissionOverwrite) -> data_binding.JSONObject:
@@ -1964,7 +1966,8 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
 
             activity = presence_models.RichActivity(
                 name=activity_payload["name"],
-                type=presence_models.ActivityType(activity_payload["type"]),
+                # RichActivity's generated init already declares a converter for the "type" field
+                type=activity_payload["type"],
                 url=activity_payload.get("url"),
                 created_at=time.unix_epoch_to_datetime(activity_payload["created_at"]),
                 timestamps=timestamps,

--- a/hikari/internal/enums.py
+++ b/hikari/internal/enums.py
@@ -322,6 +322,9 @@ def _name_resolver(members: typing.Dict[int, _Flag], value: int) -> typing.Gener
 
 class _FlagMeta(type):
     def __call__(cls, value: int = 0) -> typing.Any:
+        # We want to handle value invariantly to avoid issues brought in by different behaviours from sub-classed ints
+        # and floats. This also ensures that .__int__ only returns an invariant int.
+        value = int(value)
         try:
             return cls._value_to_member_map_[value]
         except KeyError:


### PR DESCRIPTION
### Summary
Ensure Flags only handles int internally
* Avoid redundant casts in the entity factory

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
