### PR TITLE
Add missing empty slots to event stream interface

### DIFF
--- a/hikari/event_stream.py
+++ b/hikari/event_stream.py
@@ -81,6 +81,8 @@ class Streamer(iterators.LazyIterator[EventT], abc.ABC):
     LazyIterator: `hikari.iterators.LazyIterator`
     """
 
+    __slots__: typing.Sequence[str] = ()
+
     @abc.abstractmethod
     async def close(self) -> None:
         """Mark this streamer as closed to stop it from queueing and receiving events.
@@ -120,7 +122,12 @@ class Streamer(iterators.LazyIterator[EventT], abc.ABC):
         cls = type(self)
         raise TypeError(f"{cls.__module__}.{cls.__qualname__} is async-only, did you mean 'async with'?") from None
 
-    def __exit__(self, exc_type: typing.Type[Exception], exc_val: Exception, exc_tb: types.TracebackType) -> None:
+    def __exit__(
+        self,
+        exc_type: typing.Optional[typing.Type[Exception]],
+        exc_val: typing.Optional[Exception],
+        exc_tb: typing.Optional[types.TracebackType],
+    ) -> None:
         return None
 
 
@@ -150,6 +157,7 @@ class EventStream(Streamer[EventT]):
     """
 
     __slots__ = (
+        "__weakref__",
         "_active",
         "_event_manager",
         "_event_type",

--- a/tests/hikari/test_event_stream.py
+++ b/tests/hikari/test_event_stream.py
@@ -134,9 +134,7 @@ class TestEventStream:
     @pytest.mark.asyncio
     @hikari_test_helpers.timeout()
     async def test___anext___when_stream_closed(self):
-        streamer = hikari_test_helpers.mock_class_namespace(event_stream.EventStream, _active=False)(
-            app=mock.Mock(), event_type=events.Event, timeout=float("inf")
-        )
+        streamer = event_stream.EventStream(mock.Mock(), event_type=events.Event, timeout=float("inf"))
 
         # flake8 gets annoyed if we use "with" here so here's a hacky alternative
         with pytest.raises(TypeError):
@@ -145,11 +143,9 @@ class TestEventStream:
     @pytest.mark.asyncio
     @hikari_test_helpers.timeout()
     async def test___anext___times_out(self):
-        streamer = hikari_test_helpers.mock_class_namespace(
-            event_stream.EventStream,
-            _active=True,
-            _queue=asyncio.Queue(),
-        )(app=mock.Mock(), event_type=events.Event, timeout=hikari_test_helpers.REASONABLE_QUICK_RESPONSE_TIME)
+        streamer = event_stream.EventStream(
+            mock.Mock(), event_type=events.Event, timeout=hikari_test_helpers.REASONABLE_QUICK_RESPONSE_TIME
+        )
 
         async with streamer:
             async for _ in streamer:
@@ -159,11 +155,9 @@ class TestEventStream:
     @hikari_test_helpers.timeout()
     async def test___anext___waits_for_next_event(self):
         mock_event = object()
-        streamer = hikari_test_helpers.mock_class_namespace(
-            event_stream.EventStream,
-            _active=True,
-            _queue=asyncio.Queue(),
-        )(app=mock.Mock(), event_type=events.Event, timeout=hikari_test_helpers.REASONABLE_QUICK_RESPONSE_TIME * 3)
+        streamer = event_stream.EventStream(
+            mock.Mock(), event_type=events.Event, timeout=hikari_test_helpers.REASONABLE_QUICK_RESPONSE_TIME * 3
+        )
 
         async def add_event():
             await asyncio.sleep(hikari_test_helpers.REASONABLE_SLEEP_TIME)
@@ -182,11 +176,9 @@ class TestEventStream:
     @hikari_test_helpers.timeout()
     async def test___anext__(self):
         mock_event = object()
-        streamer = hikari_test_helpers.mock_class_namespace(
-            event_stream.EventStream,
-            _active=True,
-            _queue=asyncio.Queue(),
-        )(app=mock.Mock(), event_type=events.Event, timeout=hikari_test_helpers.REASONABLE_QUICK_RESPONSE_TIME)
+        streamer = event_stream.EventStream(
+            app=mock.Mock(), event_type=events.Event, timeout=hikari_test_helpers.REASONABLE_QUICK_RESPONSE_TIME
+        )
         streamer._queue.put_nowait(mock_event)
 
         async with streamer:
@@ -253,9 +245,7 @@ class TestEventStream:
     @hikari_test_helpers.timeout()
     async def test_close_for_active_stream(self, mock_app):
         mock_registered_listener = object()
-        stream = hikari_test_helpers.mock_class_namespace(event_stream.EventStream)(
-            app=mock_app, event_type=events.Event, timeout=float("inf")
-        )
+        stream = event_stream.EventStream(mock_app, event_type=events.Event, timeout=float("inf"))
 
         await stream.open()
         stream._registered_listener = mock_registered_listener
@@ -269,9 +259,7 @@ class TestEventStream:
     async def test_close_for_active_stream_handles_value_error(self, mock_app):
         mock_registered_listener = object()
         mock_app.event_manager.unsubscribe.side_effect = ValueError
-        stream = hikari_test_helpers.mock_class_namespace(event_stream.EventStream)(
-            app=mock_app, event_type=events.Event, timeout=float("inf")
-        )
+        stream = event_stream.EventStream(mock_app, event_type=events.Event, timeout=float("inf"))
 
         await stream.open()
         stream._registered_listener = mock_registered_listener


### PR DESCRIPTION
### Summary
Add missing empty slots to event stream interface

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
