### PR TITLE
Upgrade pip before running safety

### DIFF
--- a/pipelines/safety.nox.py
+++ b/pipelines/safety.nox.py
@@ -27,5 +27,7 @@ from pipelines import nox
 @nox.session(reuse_venv=True)
 def safety(session: nox.Session) -> None:
     """Perform dependency scanning."""
+    # Temporary addition to avoid safety erroring due to https://github.com/pypa/pip/pull/9827
+    session.install("--upgrade", "pip")
     session.install("-r", "requirements.txt", "-r", "dev-requirements.txt")
     session.run("safety", "check", "--full-report")


### PR DESCRIPTION
### Summary
This avoids safety erroring due to https://github.com/pypa/pip/pull/9827 by ensuring an up to date pip version is installed.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
