### PR TITLE
Move away from hiding cache calls behind properties

### DIFF
--- a/examples/image_resources/image_resources.py
+++ b/examples/image_resources/image_resources.py
@@ -64,15 +64,15 @@ async def inspect_image(event: hikari.GuildMessageCreateEvent, what: str) -> Non
 
     # Show the guild icon:
     elif what.casefold() in ("guild", "server", "here", "this"):
-        if event.guild is None:
+        guild = event.get_guild()
+        if guild is None:
             await event.message.respond("Guild is missing from the cache :(")
             return
 
-        icon = event.guild.icon_url
-        if icon is None:
+        if guild.icon_url is None:
             await event.message.respond("This guild doesn't have an icon")
         else:
-            await event.message.respond("Guild icon", attachment=icon)
+            await event.message.respond("Guild icon", attachment=guild.icon_url)
 
     # Show the image for the given emoji if there is some content present:
     elif what:

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -224,8 +224,7 @@ class ChannelFollow:
         assert isinstance(webhook, webhooks.ChannelFollowerWebhook)
         return webhook
 
-    @property
-    def channel(self) -> typing.Union[GuildNewsChannel, GuildTextChannel, None]:
+    def get_channel(self) -> typing.Union[GuildNewsChannel, GuildTextChannel, None]:
         """Get the channel being followed from the cache.
 
         !!! warning

--- a/hikari/errors.py
+++ b/hikari/errors.py
@@ -169,9 +169,7 @@ class ShardCloseCode(int, enums.Enum):
     @property
     def is_standard(self) -> bool:
         """Return `builtins.True` if this is a standard code."""
-        # Appears to be some MyPy bug where == is expected to
-        # return anything.
-        return bool((self.value // 1000) == 1)
+        return (self.value // 1000) == 1
 
 
 @attr.define(auto_exc=True, repr=False, weakref_slot=False)

--- a/hikari/events/channel_events.py
+++ b/hikari/events/channel_events.py
@@ -141,8 +141,7 @@ class GuildChannelEvent(ChannelEvent, abc.ABC):
             The ID of the guild that relates to this event.
         """
 
-    @property
-    def guild(self) -> typing.Optional[guilds.GatewayGuild]:
+    def get_guild(self) -> typing.Optional[guilds.GatewayGuild]:
         """Get the cached guild that this event relates to, if known.
 
         If not, return `builtins.None`.
@@ -190,8 +189,7 @@ class GuildChannelEvent(ChannelEvent, abc.ABC):
         """
         return await self.app.rest.fetch_guild(self.guild_id)
 
-    @property
-    def channel(self) -> typing.Optional[channels.GuildChannel]:
+    def get_channel(self) -> typing.Optional[channels.GuildChannel]:
         """Get the cached channel that this event relates to, if known.
 
         If not, return `builtins.None`.
@@ -301,6 +299,11 @@ class ChannelCreateEvent(ChannelEvent, abc.ABC):
     __slots__: typing.Sequence[str] = ()
 
     @property
+    def app(self) -> traits.RESTAware:
+        # <<inherited docstring from Event>>.
+        return self.channel.app
+
+    @property
     @abc.abstractmethod
     def channel(self) -> channels.PartialChannel:
         """Channel this event represents.
@@ -322,9 +325,6 @@ class ChannelCreateEvent(ChannelEvent, abc.ABC):
 @attr.define(kw_only=True, weakref_slot=False)
 class GuildChannelCreateEvent(GuildChannelEvent, ChannelCreateEvent):
     """Event fired when a guild channel is created."""
-
-    app: traits.RESTAware = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
-    # <<inherited docstring from Event>>.
 
     shard: gateway_shard.GatewayShard = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>.
@@ -351,6 +351,11 @@ class ChannelUpdateEvent(ChannelEvent, abc.ABC):
     __slots__: typing.Sequence[str] = ()
 
     @property
+    def app(self) -> traits.RESTAware:
+        # <<inherited docstring from Event>>.
+        return self.channel.app
+
+    @property
     @abc.abstractmethod
     def channel(self) -> channels.PartialChannel:
         """Channel this event represents.
@@ -372,9 +377,6 @@ class ChannelUpdateEvent(ChannelEvent, abc.ABC):
 @attr.define(kw_only=True, weakref_slot=False)
 class GuildChannelUpdateEvent(GuildChannelEvent, ChannelUpdateEvent):
     """Event fired when a guild channel is edited."""
-
-    app: traits.RESTAware = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
-    # <<inherited docstring from Event>>.
 
     shard: gateway_shard.GatewayShard = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>.
@@ -407,6 +409,11 @@ class ChannelDeleteEvent(ChannelEvent, abc.ABC):
     __slots__: typing.Sequence[str] = ()
 
     @property
+    def app(self) -> traits.RESTAware:
+        # <<inherited docstring from Event>>.
+        return self.channel.app
+
+    @property
     @abc.abstractmethod
     def channel(self) -> channels.PartialChannel:
         """Channel this event represents.
@@ -433,9 +440,6 @@ class ChannelDeleteEvent(ChannelEvent, abc.ABC):
 @attr.define(kw_only=True, weakref_slot=False)
 class GuildChannelDeleteEvent(GuildChannelEvent, ChannelDeleteEvent):
     """Event fired when a guild channel is deleted."""
-
-    app: traits.RESTAware = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
-    # <<inherited docstring from Event>>.
 
     shard: gateway_shard.GatewayShard = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>.
@@ -523,11 +527,9 @@ class GuildPinsUpdateEvent(PinsUpdateEvent, GuildChannelEvent):
     # <<inherited docstring from GuildChannelEvent>>.
 
     last_pin_timestamp: typing.Optional[datetime.datetime] = attr.field(repr=True)
-
     # <<inherited docstring from ChannelPinsUpdateEvent>>.
 
-    @property
-    def channel(self) -> typing.Optional[channels.TextableGuildChannel]:
+    def get_channel(self) -> typing.Optional[channels.TextableGuildChannel]:
         """Get the cached channel that this event relates to, if known.
 
         If not, return `builtins.None`.
@@ -538,10 +540,7 @@ class GuildPinsUpdateEvent(PinsUpdateEvent, GuildChannelEvent):
             The cached channel this event relates to. If not known, this
             will return `builtins.None` instead.
         """
-        if not isinstance(self.app, traits.CacheAware):
-            return None
-
-        channel = self.app.cache.get_guild_channel(self.channel_id)
+        channel = super().get_channel()
         assert channel is None or isinstance(channel, channels.TextableGuildChannel)
         return channel
 
@@ -687,9 +686,6 @@ class InviteEvent(GuildChannelEvent, abc.ABC):
 class InviteCreateEvent(InviteEvent):
     """Event fired when an invite is created in a channel."""
 
-    app: traits.RESTAware = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
-    # <<inherited docstring from Event>>.
-
     shard: gateway_shard.GatewayShard = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>.
 
@@ -703,6 +699,11 @@ class InviteCreateEvent(InviteEvent):
     """
 
     @property
+    def app(self) -> traits.RESTAware:
+        # <<inherited docstring from Event>>.
+        return self.invite.app
+
+    @property
     def channel_id(self) -> snowflakes.Snowflake:
         # <<inherited docstring from ChannelEvent>>.
         return self.invite.channel_id
@@ -710,7 +711,7 @@ class InviteCreateEvent(InviteEvent):
     @property
     def guild_id(self) -> snowflakes.Snowflake:
         # <<inherited docstring from GuildChannelEvent>>.
-        # This will always be non-None for guild channel invites.
+        # This will always not be None for guild channel invites.
         assert self.invite.guild_id is not None
         return self.invite.guild_id
 

--- a/hikari/events/channel_events.py
+++ b/hikari/events/channel_events.py
@@ -711,7 +711,7 @@ class InviteCreateEvent(InviteEvent):
     @property
     def guild_id(self) -> snowflakes.Snowflake:
         # <<inherited docstring from GuildChannelEvent>>.
-        # This will always not be None for guild channel invites.
+        # This will never be None for guild channel invites.
         assert self.invite.guild_id is not None
         return self.invite.guild_id
 

--- a/hikari/events/guild_events.py
+++ b/hikari/events/guild_events.py
@@ -83,22 +83,6 @@ class GuildEvent(shard_events.ShardEvent, abc.ABC):
             The ID of the guild that relates to this event.
         """
 
-    @property
-    def guild(self) -> typing.Optional[guilds.GatewayGuild]:
-        """Get the cached guild that this event relates to, if known.
-
-        If not known, this will return `builtins.None` instead.
-
-        Returns
-        -------
-        typing.Optional[hikari.guilds.GatewayGuild]
-            The guild this event relates to, or `builtins.None` if not known.
-        """
-        if not isinstance(self.app, traits.CacheAware):
-            return None
-
-        return self.app.cache.get_available_guild(self.guild_id) or self.app.cache.get_unavailable_guild(self.guild_id)
-
     async def fetch_guild(self) -> guilds.RESTGuild:
         """Perform an API call to get the guild that this event relates to.
 
@@ -118,6 +102,21 @@ class GuildEvent(shard_events.ShardEvent, abc.ABC):
             The preview of the guild this event occurred in.
         """
         return await self.app.rest.fetch_guild_preview(self.guild_id)
+
+    def get_guild(self) -> typing.Optional[guilds.GatewayGuild]:
+        """Get the cached guild that this event relates to, if known.
+
+        If not known, this will return `builtins.None` instead.
+
+        Returns
+        -------
+        typing.Optional[hikari.guilds.GatewayGuild]
+            The guild this event relates to, or `builtins.None` if not known.
+        """
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
+        return self.app.cache.get_available_guild(self.guild_id) or self.app.cache.get_unavailable_guild(self.guild_id)
 
 
 @base_events.requires_intents(intents.Intents.GUILDS)
@@ -146,9 +145,6 @@ class GuildAvailableEvent(GuildVisibilityEvent):
         the other `GuildUpdateEvent` and `GuildUnavailableEvent` guild visibility
         event models.
     """
-
-    app: traits.RESTAware = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
-    # <<inherited docstring from Event>>.
 
     shard: gateway_shard.GatewayShard = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>.
@@ -231,9 +227,18 @@ class GuildAvailableEvent(GuildVisibilityEvent):
     """
 
     @property
+    def app(self) -> traits.RESTAware:
+        # <<inherited docstring from Event>>.
+        return self.guild.app
+
+    @property
     def guild_id(self) -> snowflakes.Snowflake:
         # <<inherited docstring from GuildEvent>>.
         return self.guild.id
+
+    def get_guild(self) -> typing.Optional[guilds.GatewayGuild]:
+        # <<Inherited docstring from GuildEvent>>
+        return super().get_guild() or self.guild
 
 
 @attr_extensions.with_copy
@@ -282,9 +287,6 @@ class GuildUnavailableEvent(GuildVisibilityEvent):
 class GuildUpdateEvent(GuildEvent):
     """Event fired when an existing guild is updated."""
 
-    app: traits.RESTAware = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
-    # <<inherited docstring from Event>>.
-
     shard: gateway_shard.GatewayShard = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>.
 
@@ -322,9 +324,18 @@ class GuildUpdateEvent(GuildEvent):
     """
 
     @property
+    def app(self) -> traits.RESTAware:
+        # <<inherited docstring from Event>>.
+        return self.guild.app
+
+    @property
     def guild_id(self) -> snowflakes.Snowflake:
         # <<inherited docstring from GuildEvent>>.
         return self.guild.id
+
+    def get_guild(self) -> typing.Optional[guilds.GatewayGuild]:
+        # <<Inherited docstring from GuildEvent>>
+        return super().get_guild() or self.guild
 
 
 @base_events.requires_intents(intents.Intents.GUILD_BANS)
@@ -332,6 +343,11 @@ class BanEvent(GuildEvent, abc.ABC):
     """Event base for any guild ban or unban."""
 
     __slots__: typing.Sequence[str] = ()
+
+    @property
+    def app(self) -> traits.RESTAware:
+        # <<inherited docstring from Event>>.
+        return self.user.app
 
     @property
     @abc.abstractmethod
@@ -360,9 +376,6 @@ class BanEvent(GuildEvent, abc.ABC):
 @base_events.requires_intents(intents.Intents.GUILD_BANS)
 class BanCreateEvent(BanEvent):
     """Event that is fired when a user is banned from a guild."""
-
-    app: traits.RESTAware = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
-    # <<inherited docstring from Event>>.
 
     shard: gateway_shard.GatewayShard = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>.
@@ -403,9 +416,6 @@ class BanCreateEvent(BanEvent):
 @base_events.requires_intents(intents.Intents.GUILD_BANS)
 class BanDeleteEvent(BanEvent):
     """Event that is fired when a user is unbanned from a guild."""
-
-    app: traits.RESTAware = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
-    # <<inherited docstring from Event>>.
 
     shard: gateway_shard.GatewayShard = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>.
@@ -606,9 +616,6 @@ class PresenceUpdateEvent(shard_events.ShardEvent):
     shards that saw the presence update.
     """
 
-    app: traits.RESTAware = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
-    # <<inherited docstring from Event>>.
-
     shard: gateway_shard.GatewayShard = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>.
 
@@ -642,6 +649,11 @@ class PresenceUpdateEvent(shard_events.ShardEvent):
     typing.Optional[hikari.users.PartialUser]
         The partial user containing the updated fields.
     """
+
+    @property
+    def app(self) -> traits.RESTAware:
+        # <<inherited docstring from Event>>.
+        return self.presence.app
 
     @property
     def user_id(self) -> snowflakes.Snowflake:

--- a/hikari/events/guild_events.py
+++ b/hikari/events/guild_events.py
@@ -236,10 +236,6 @@ class GuildAvailableEvent(GuildVisibilityEvent):
         # <<inherited docstring from GuildEvent>>.
         return self.guild.id
 
-    def get_guild(self) -> typing.Optional[guilds.GatewayGuild]:
-        # <<Inherited docstring from GuildEvent>>
-        return super().get_guild() or self.guild
-
 
 @attr_extensions.with_copy
 @attr.define(kw_only=True, weakref_slot=False)
@@ -332,10 +328,6 @@ class GuildUpdateEvent(GuildEvent):
     def guild_id(self) -> snowflakes.Snowflake:
         # <<inherited docstring from GuildEvent>>.
         return self.guild.id
-
-    def get_guild(self) -> typing.Optional[guilds.GatewayGuild]:
-        # <<Inherited docstring from GuildEvent>>
-        return super().get_guild() or self.guild
 
 
 @base_events.requires_intents(intents.Intents.GUILD_BANS)

--- a/hikari/events/guild_events.py
+++ b/hikari/events/guild_events.py
@@ -48,6 +48,7 @@ import typing
 import attr
 
 from hikari import intents
+from hikari import traits
 from hikari.events import base_events
 from hikari.events import shard_events
 from hikari.internal import attr_extensions
@@ -58,7 +59,6 @@ if typing.TYPE_CHECKING:
     from hikari import guilds
     from hikari import presences as presences_
     from hikari import snowflakes
-    from hikari import traits
     from hikari import users
     from hikari import voices
     from hikari.api import shard as gateway_shard

--- a/hikari/events/member_events.py
+++ b/hikari/events/member_events.py
@@ -55,6 +55,11 @@ class MemberEvent(shard_events.ShardEvent, abc.ABC):
     __slots__: typing.Sequence[str] = ()
 
     @property
+    def app(self) -> traits.RESTAware:
+        # <<inherited docstring from Event>>.
+        return self.user.app
+
+    @property
     @abc.abstractmethod
     def guild_id(self) -> snowflakes.Snowflake:
         """ID of the guild that this event relates to.
@@ -87,8 +92,7 @@ class MemberEvent(shard_events.ShardEvent, abc.ABC):
         """
         return self.user.id
 
-    @property
-    def guild(self) -> typing.Optional[guilds.GatewayGuild]:
+    def get_guild(self) -> typing.Optional[guilds.GatewayGuild]:
         """Get the cached view of the guild this member event occurred in.
 
         If the guild itself is not cached, this will return `builtins.None`.
@@ -110,9 +114,6 @@ class MemberEvent(shard_events.ShardEvent, abc.ABC):
 @base_events.requires_intents(intents.Intents.GUILD_MEMBERS)
 class MemberCreateEvent(MemberEvent):
     """Event that is fired when a member joins a guild."""
-
-    app: traits.RESTAware = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
-    # <<inherited docstring from Event>>.
 
     shard: gateway_shard.GatewayShard = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>.
@@ -145,9 +146,6 @@ class MemberUpdateEvent(MemberEvent):
 
     This may occur if roles are amended, or if the nickname is changed.
     """
-
-    app: traits.RESTAware = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
-    # <<inherited docstring from Event>>.
 
     shard: gateway_shard.GatewayShard = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>.
@@ -183,9 +181,6 @@ class MemberUpdateEvent(MemberEvent):
 @base_events.requires_intents(intents.Intents.GUILD_MEMBERS)
 class MemberDeleteEvent(MemberEvent):
     """Event fired when a member is kicked from or leaves a guild."""
-
-    app: traits.RESTAware = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
-    # <<inherited docstring from Event>>.
 
     shard: gateway_shard.GatewayShard = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>.

--- a/hikari/events/message_events.py
+++ b/hikari/events/message_events.py
@@ -486,7 +486,7 @@ class GuildMessageUpdateEvent(MessageUpdateEvent):
     shard: shard_.GatewayShard = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>
 
-    @property  # TODO: why this is so implicit? remove?
+    @property  # TODO: this doesn't match up with the new standard for get_x cache getter method naming
     def author(self) -> typing.Optional[users.User]:
         """User that sent the message.
 

--- a/hikari/events/reaction_events.py
+++ b/hikari/events/reaction_events.py
@@ -208,9 +208,6 @@ class ReactionDeleteEmojiEvent(ReactionEvent, abc.ABC):
 class GuildReactionAddEvent(GuildReactionEvent, ReactionAddEvent):
     """Event fired when a reaction is added to a guild message."""
 
-    app: traits.RESTAware = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
-    # <<inherited docstring from Event>>.
-
     shard: gateway_shard.GatewayShard = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>.
 
@@ -230,8 +227,12 @@ class GuildReactionAddEvent(GuildReactionEvent, ReactionAddEvent):
     # <<inherited docstring from ReactionEvent>>.
 
     emoji: emojis.Emoji = attr.field()
-
     # <<inherited docstring from ReactionAddEvent>>.
+
+    @property
+    def app(self) -> traits.RESTAware:
+        # <<inherited docstring from Event>>.
+        return self.member.app
 
     @property
     def guild_id(self) -> snowflakes.Snowflake:

--- a/hikari/events/role_events.py
+++ b/hikari/events/role_events.py
@@ -82,9 +82,6 @@ class RoleEvent(shard_events.ShardEvent, abc.ABC):
 class RoleCreateEvent(RoleEvent):
     """Event fired when a role is created."""
 
-    app: traits.RESTAware = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
-    # <<inherited docstring from Event>>.
-
     shard: gateway_shard.GatewayShard = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>.
 
@@ -96,6 +93,11 @@ class RoleCreateEvent(RoleEvent):
     hikari.guilds.Role
         The created role.
     """
+
+    @property
+    def app(self) -> traits.RESTAware:
+        # <<inherited docstring from Event>>.
+        return self.role.app
 
     @property
     def guild_id(self) -> snowflakes.Snowflake:
@@ -114,9 +116,6 @@ class RoleCreateEvent(RoleEvent):
 class RoleUpdateEvent(RoleEvent):
     """Event fired when a role is updated."""
 
-    app: traits.RESTAware = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
-    # <<inherited docstring from Event>>.
-
     shard: gateway_shard.GatewayShard = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>.
 
@@ -134,6 +133,11 @@ class RoleUpdateEvent(RoleEvent):
     hikari.guilds.Role
         The created role.
     """
+
+    @property
+    def app(self) -> traits.RESTAware:
+        # <<inherited docstring from Event>>.
+        return self.role.app
 
     @property
     def guild_id(self) -> snowflakes.Snowflake:

--- a/hikari/events/shard_events.py
+++ b/hikari/events/shard_events.py
@@ -132,9 +132,6 @@ class ShardDisconnectedEvent(ShardStateEvent):
 class ShardReadyEvent(ShardStateEvent):
     """Event fired when a shard declares it is ready."""
 
-    app: traits.RESTAware = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
-    # <<inherited docstring from Event>>.
-
     shard: gateway_shard.GatewayShard = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
     # <<docstring inherited from ShardEvent>>.
 
@@ -194,6 +191,11 @@ class ShardReadyEvent(ShardStateEvent):
     hikari.applications.ApplicationFlags
         The current application's flags.
     """
+
+    @property
+    def app(self) -> traits.RESTAware:
+        # <<inherited docstring from Event>>.
+        return self.my_user.app
 
 
 @attr_extensions.with_copy

--- a/hikari/events/typing_events.py
+++ b/hikari/events/typing_events.py
@@ -99,7 +99,7 @@ class TypingEvent(shard_events.ShardEvent, abc.ABC):
             The channel.
         """
         channel = await self.app.rest.fetch_channel(self.channel_id)
-        assert isinstance(channel, channels.TextChannel)
+        assert isinstance(channel, channels.TextableChannel)
         return channel
 
     def get_user(self) -> typing.Optional[users.User]:
@@ -257,7 +257,7 @@ class GuildTypingEvent(TypingEvent):
 
         channel = self.app.cache.get_guild_channel(self.channel_id)
         assert channel is None or isinstance(
-            channel, channesl.TextableGuildChannel
+            channel, channels.TextableGuildChannel
         ), f"expected TextableGuildChannel from cache, got {channel}"
         return channel
 

--- a/hikari/events/typing_events.py
+++ b/hikari/events/typing_events.py
@@ -90,18 +90,6 @@ class TypingEvent(shard_events.ShardEvent, abc.ABC):
             UTC timestamp of when the user started typing.
         """
 
-    @property
-    @abc.abstractmethod
-    def user(self) -> typing.Optional[users.User]:
-        """Get the cached user that is typing, if known.
-
-        Returns
-        -------
-        typing.Optional[hikari.users.User]
-            The user, if known.
-        """
-
-    @abc.abstractmethod
     async def fetch_channel(self) -> channels.TextableChannel:
         """Perform an API call to fetch an up-to-date image of this channel.
 
@@ -110,8 +98,23 @@ class TypingEvent(shard_events.ShardEvent, abc.ABC):
         hikari.channels.TextableChannel
             The channel.
         """
+        channel = await self.app.rest.fetch_channel(self.channel_id)
+        assert isinstance(channel, channels.TextChannel)
+        return channel
 
-    @abc.abstractmethod
+    def get_user(self) -> typing.Optional[users.User]:
+        """Get the cached user that is typing, if known.
+
+        Returns
+        -------
+        typing.Optional[hikari.users.User]
+            The user, if known.
+        """
+        if isinstance(self.app, traits.CacheAware):
+            return self.app.cache.get_user(self.user_id)
+
+        return None
+
     async def fetch_user(self) -> users.User:
         """Perform an API call to fetch an up-to-date image of this user.
 
@@ -119,7 +122,28 @@ class TypingEvent(shard_events.ShardEvent, abc.ABC):
         -------
         hikari.users.User
             The user.
+
+        Raises
+        ------
+        hikari.errors.UnauthorizedError
+            If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.NotFoundError
+            If the user is not found.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
+        hikari.errors.RateLimitedError
+            Usually, Hikari will handle and retry on hitting
+            rate-limits automatically. This includes most bucket-specific
+            rate-limits and global rate-limits. In some rare edge cases,
+            however, Discord implements other undocumented rules for
+            rate-limiting, such as limits per attribute. These cannot be
+            detected or handled normally by Hikari due to their undocumented
+            nature, and will trigger this exception if they occur.
+        hikari.errors.InternalServerError
+            If an internal error occurs on Discord while handling the request.
         """
+        return await self.app.rest.fetch_user(self.user_id)
 
     def trigger_typing(self) -> special_endpoints.TypingIndicator:
         """Return a typing indicator for this channel that can be awaited.
@@ -139,9 +163,6 @@ class TypingEvent(shard_events.ShardEvent, abc.ABC):
 class GuildTypingEvent(TypingEvent):
     """Event fired when a user starts typing in a guild channel."""
 
-    app: traits.RESTAware = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
-    # <<inherited docstring from Event>>.
-
     shard: gateway_shard.GatewayShard = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>.
 
@@ -160,56 +181,24 @@ class GuildTypingEvent(TypingEvent):
         The ID of the guild that relates to this event.
     """
 
-    user: guilds.Member = attr.field(repr=False)
-    """Member object of the user who triggered this typing event.
-
-    Unlike on `PrivateTypingEvent` instances, Discord will always send
-    this field in any payload.
+    member: guilds.Member = attr.field(repr=False)
+    """Object of the member who triggered this typing event.
 
     Returns
     -------
     hikari.guilds.Member
-        Member of the user who triggered this typing event.
+        Object of the member who triggered this typing event.
     """
 
     @property
-    def channel(self) -> typing.Optional[channels.TextableGuildChannel]:
-        """Get the cached channel object this typing event occurred in.
-
-        Returns
-        -------
-        typing.Optional[hikari.channels.TextableGuildChannel]
-            The channel.
-        """
-        if not isinstance(self.app, traits.CacheAware):
-            return None
-
-        channel = self.app.cache.get_guild_channel(self.channel_id)
-        assert channel is None or isinstance(
-            channel, channels.TextableGuildChannel
-        ), f"expected TextableGuildChannel from cache, got {channel}"
-        return channel
-
-    @property
-    def guild(self) -> typing.Optional[guilds.GatewayGuild]:
-        """Get the cached object of the guild this typing event occurred in.
-
-        If the guild is not found then this will return `builtins.None`.
-
-        Returns
-        -------
-        typing.Optional[hikari.guilds.GatewayGuild]
-            The object of the gateway guild if found else `builtins.None`.
-        """
-        if not isinstance(self.app, traits.CacheAware):
-            return None
-
-        return self.app.cache.get_available_guild(self.guild_id) or self.app.cache.get_unavailable_guild(self.guild_id)
+    def app(self) -> traits.RESTAware:
+        # <<inherited docstring from Event>>.
+        return self.member.app
 
     @property
     def user_id(self) -> snowflakes.Snowflake:
         # <<inherited docstring from TypingEvent>>.
-        return self.user.id
+        return self.member.id
 
     async def fetch_channel(self) -> typing.Union[channels.TextableGuildChannel]:
         """Perform an API call to fetch an up-to-date image of this channel.
@@ -219,7 +208,7 @@ class GuildTypingEvent(TypingEvent):
         typing.Union[hikari.channels.TextableGuildChannel]
             The channel.
         """
-        channel = await self.app.rest.fetch_channel(self.channel_id)
+        channel = await super().fetch_channel()
         assert isinstance(
             channel, channels.TextableGuildChannel
         ), f"expected TextableGuildChannel from API, got {channel}"
@@ -245,8 +234,8 @@ class GuildTypingEvent(TypingEvent):
         """
         return await self.app.rest.fetch_guild_preview(self.guild_id)
 
-    async def fetch_user(self) -> guilds.Member:
-        """Perform an API call to fetch an up-to-date image of this member.
+    async def fetch_member(self) -> guilds.Member:
+        """Perform an API call to fetch an up-to-date image of this event's member.
 
         Returns
         -------
@@ -254,6 +243,42 @@ class GuildTypingEvent(TypingEvent):
             The member.
         """
         return await self.app.rest.fetch_member(self.guild_id, self.user_id)
+
+    def get_channel(self) -> typing.Optional[channels.TextableGuildChannel]:
+        """Get the cached channel object this typing event occurred in.
+
+        Returns
+        -------
+        typing.Optional[hikari.channels.TextableGuildChannel]
+            The channel.
+        """
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
+        channel = self.app.cache.get_guild_channel(self.channel_id)
+        assert channel is None or isinstance(
+            channel, channesl.TextableGuildChannel
+        ), f"expected TextableGuildChannel from cache, got {channel}"
+        return channel
+
+    def get_guild(self) -> typing.Optional[guilds.GatewayGuild]:
+        """Get the cached object of the guild this typing event occurred in.
+
+        If the guild is not found then this will return `builtins.None`.
+
+        Returns
+        -------
+        typing.Optional[hikari.guilds.GatewayGuild]
+            The object of the gateway guild if found else `builtins.None`.
+        """
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
+        return self.app.cache.get_available_guild(self.guild_id) or self.app.cache.get_unavailable_guild(self.guild_id)
+
+    def get_user(self) -> typing.Optional[users.User]:
+        # <<inherited docstring from TypingEvent>>.
+        return super().get_user() or self.member.user
 
 
 @base_events.requires_intents(intents.Intents.DM_MESSAGES)
@@ -276,14 +301,6 @@ class DMTypingEvent(TypingEvent):
 
     timestamp: datetime.datetime = attr.field(repr=False)
     # <<inherited docstring from TypingEvent>>.
-
-    @property
-    def user(self) -> typing.Optional[users.User]:
-        # <<inherited docstring from TypingEvent>>.
-        if not isinstance(self.app, traits.CacheAware):
-            return None
-
-        return self.app.cache.get_user(self.user_id)
 
     async def fetch_channel(self) -> channels.DMChannel:
         """Perform an API call to fetch an up-to-date image of this channel.
@@ -318,36 +335,6 @@ class DMTypingEvent(TypingEvent):
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
         """
-        channel = await self.app.rest.fetch_channel(self.channel_id)
+        channel = await super().fetch_channel()
         assert isinstance(channel, channels.DMChannel), f"expected DMChannel from API, got {channel}"
         return channel
-
-    async def fetch_user(self) -> users.User:
-        """Perform an API call to fetch an up-to-date image of the user.
-
-        Returns
-        -------
-        hikari.users.User
-            The user.
-
-        Raises
-        ------
-        hikari.errors.UnauthorizedError
-            If you are unauthorized to make the request (invalid/missing token).
-        hikari.errors.NotFoundError
-            If the user is not found.
-        hikari.errors.RateLimitTooLongError
-            Raised in the event that a rate limit occurs that is
-            longer than `max_rate_limit` when making a request.
-        hikari.errors.RateLimitedError
-            Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes most bucket-specific
-            rate-limits and global rate-limits. In some rare edge cases,
-            however, Discord implements other undocumented rules for
-            rate-limiting, such as limits per attribute. These cannot be
-            detected or handled normally by Hikari due to their undocumented
-            nature, and will trigger this exception if they occur.
-        hikari.errors.InternalServerError
-            If an internal error occurs on Discord while handling the request.
-        """
-        return await self.app.rest.fetch_user(self.user_id)

--- a/hikari/events/typing_events.py
+++ b/hikari/events/typing_events.py
@@ -276,10 +276,6 @@ class GuildTypingEvent(TypingEvent):
 
         return self.app.cache.get_available_guild(self.guild_id) or self.app.cache.get_unavailable_guild(self.guild_id)
 
-    def get_user(self) -> typing.Optional[users.User]:
-        # <<inherited docstring from TypingEvent>>.
-        return super().get_user() or self.member.user
-
 
 @base_events.requires_intents(intents.Intents.DM_MESSAGES)
 @attr_extensions.with_copy

--- a/hikari/events/user_events.py
+++ b/hikari/events/user_events.py
@@ -43,9 +43,6 @@ if typing.TYPE_CHECKING:
 class OwnUserUpdateEvent(shard_events.ShardEvent):
     """Event fired when the account user is updated."""
 
-    app: traits.RESTAware = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
-    # <<inherited docstring from Event>>.
-
     shard: gateway_shard.GatewayShard = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>.
 
@@ -63,3 +60,8 @@ class OwnUserUpdateEvent(shard_events.ShardEvent):
     hikari.users.OwnUser
         This application user.
     """
+
+    @property
+    def app(self) -> traits.RESTAware:
+        # <<inherited docstring from Event>>.
+        return self.user.app

--- a/hikari/events/voice_events.py
+++ b/hikari/events/voice_events.py
@@ -76,9 +76,6 @@ class VoiceStateUpdateEvent(VoiceEvent):
     to connect to the voice gateway to stream audio or video content.
     """
 
-    app: traits.RESTAware = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
-    # <<inherited docstring from Event>>.
-
     shard: gateway_shard.GatewayShard = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring>>.
 
@@ -96,6 +93,11 @@ class VoiceStateUpdateEvent(VoiceEvent):
     hikari.voices.VoiceState
         The voice state that was updated.
     """
+
+    @property
+    def app(self) -> traits.RESTAware:
+        # <<inherited docstring from Event>>.
+        return self.state.app
 
     @property
     def guild_id(self) -> snowflakes.Snowflake:

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -489,10 +489,11 @@ class Member(users.User):
         typing.Sequence[hikari.guilds.Role]
             The roles the users has.
         """
-        if not isinstance(self.user.app, traits.CacheAware):
-            return []
+        roles: typing.List[Role] = []
 
-        roles = []
+        if not isinstance(self.user.app, traits.CacheAware):
+            return roles
+
         for role_id in self.role_ids:
             if role := self.user.app.cache.get_role(role_id):
                 roles.append(role)

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -462,7 +462,7 @@ class Member(users.User):
         """
         return f"<@!{self.id}>" if self.nickname is not None else self.user.mention
 
-    @property
+    @property  # TODO: fix this
     def presence(self) -> typing.Optional[presences_.MemberPresence]:
         """Get the cached presence for this member, if known.
 
@@ -2458,7 +2458,7 @@ class Guild(PartialGuild, abc.ABC):
         return self.app.cache.get_voice_states_view_for_guild(self.id)
 
     @property
-    @abc.abstractmethod
+    @abc.abstractmethod  # TODO: fix this
     def emojis(self) -> typing.Mapping[snowflakes.Snowflake, emojis_.KnownCustomEmoji]:
         """Return the emojis in this guild.
 

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -331,10 +331,6 @@ class GatewayBot(traits.GatewayBotAware):
         return self._intents
 
     @property
-    def me(self) -> typing.Optional[users_.OwnUser]:
-        return self._cache.get_me()
-
-    @property
     def proxy_settings(self) -> config.ProxySettings:
         return self._proxy_settings
 
@@ -357,6 +353,9 @@ class GatewayBot(traits.GatewayBotAware):
     def _check_if_alive(self) -> None:
         if not self._is_alive:
             raise errors.ComponentStateConflictError("bot is not running so it cannot be interacted with")
+
+    def get_me(self) -> typing.Optional[users_.OwnUser]:
+        return self._cache.get_me()
 
     async def close(self) -> None:
         """Kill the application by shutting all components down."""

--- a/hikari/impl/event_factory.py
+++ b/hikari/impl/event_factory.py
@@ -410,9 +410,7 @@ class EventFactoryImpl(event_factory.EventFactory):
     ) -> member_events.MemberDeleteEvent:
         guild_id = snowflakes.Snowflake(payload["guild_id"])
         user = self._app.entity_factory.deserialize_user(payload["user"])
-        return member_events.MemberDeleteEvent(
-            shard=shard, guild_id=guild_id, user=user, old_member=old_member
-        )
+        return member_events.MemberDeleteEvent(shard=shard, guild_id=guild_id, user=user, old_member=old_member)
 
     ###############
     # ROLE EVENTS #

--- a/hikari/impl/event_factory.py
+++ b/hikari/impl/event_factory.py
@@ -80,7 +80,7 @@ class EventFactoryImpl(event_factory.EventFactory):
     ) -> channel_events.ChannelCreateEvent:
         channel = self._app.entity_factory.deserialize_channel(payload)
         if isinstance(channel, channel_models.GuildChannel):
-            return channel_events.GuildChannelCreateEvent(app=self._app, shard=shard, channel=channel)
+            return channel_events.GuildChannelCreateEvent(shard=shard, channel=channel)
         if isinstance(channel, channel_models.PrivateChannel):
             raise NotImplementedError("DM channel create events are undocumented behaviour")
         raise TypeError(f"Expected GuildChannel or PrivateChannel but received {type(channel).__name__}")
@@ -94,9 +94,7 @@ class EventFactoryImpl(event_factory.EventFactory):
     ) -> channel_events.ChannelUpdateEvent:
         channel = self._app.entity_factory.deserialize_channel(payload)
         if isinstance(channel, channel_models.GuildChannel):
-            return channel_events.GuildChannelUpdateEvent(
-                app=self._app, shard=shard, channel=channel, old_channel=old_channel
-            )
+            return channel_events.GuildChannelUpdateEvent(shard=shard, channel=channel, old_channel=old_channel)
         if isinstance(channel, channel_models.PrivateChannel):
             raise NotImplementedError("DM channel update events are undocumented behaviour")
         raise TypeError(f"Expected GuildChannel or PrivateChannel but received {type(channel).__name__}")
@@ -106,7 +104,7 @@ class EventFactoryImpl(event_factory.EventFactory):
     ) -> channel_events.ChannelDeleteEvent:
         channel = self._app.entity_factory.deserialize_channel(payload)
         if isinstance(channel, channel_models.GuildChannel):
-            return channel_events.GuildChannelDeleteEvent(app=self._app, shard=shard, channel=channel)
+            return channel_events.GuildChannelDeleteEvent(shard=shard, channel=channel)
         if isinstance(channel, channel_models.PrivateChannel):
             raise NotImplementedError("DM channel delete events are undocumented behaviour")
         raise TypeError(f"Expected GuildChannel or PrivateChannel but received {type(channel).__name__}")
@@ -151,7 +149,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> channel_events.InviteCreateEvent:
         invite = self._app.entity_factory.deserialize_invite_with_metadata(payload)
-        return channel_events.InviteCreateEvent(app=self._app, shard=shard, invite=invite)
+        return channel_events.InviteCreateEvent(shard=shard, invite=invite)
 
     def deserialize_invite_delete_event(
         self,
@@ -184,12 +182,11 @@ class EventFactoryImpl(event_factory.EventFactory):
             guild_id = snowflakes.Snowflake(payload["guild_id"])
             member = self._app.entity_factory.deserialize_member(payload["member"], guild_id=guild_id)
             return typing_events.GuildTypingEvent(
-                app=self._app,
                 shard=shard,
                 channel_id=channel_id,
                 guild_id=guild_id,
                 timestamp=timestamp,
-                user=member,
+                member=member,
             )
 
         user_id = snowflakes.Snowflake(payload["user_id"])
@@ -210,7 +207,6 @@ class EventFactoryImpl(event_factory.EventFactory):
         assert guild_information.presences is not None
         assert guild_information.voice_states is not None
         return guild_events.GuildAvailableEvent(
-            app=self._app,
             shard=shard,
             guild=guild_information.guild,
             emojis=guild_information.emojis,
@@ -230,7 +226,6 @@ class EventFactoryImpl(event_factory.EventFactory):
     ) -> guild_events.GuildUpdateEvent:
         guild_information = self._app.entity_factory.deserialize_gateway_guild(payload)
         return guild_events.GuildUpdateEvent(
-            app=self._app,
             shard=shard,
             guild=guild_information.guild,
             emojis=guild_information.emojis,
@@ -254,7 +249,6 @@ class EventFactoryImpl(event_factory.EventFactory):
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> guild_events.BanCreateEvent:
         return guild_events.BanCreateEvent(
-            app=self._app,
             shard=shard,
             guild_id=snowflakes.Snowflake(payload["guild_id"]),
             user=self._app.entity_factory.deserialize_user(payload["user"]),
@@ -264,7 +258,6 @@ class EventFactoryImpl(event_factory.EventFactory):
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> guild_events.BanDeleteEvent:
         return guild_events.BanDeleteEvent(
-            app=self._app,
             shard=shard,
             guild_id=snowflakes.Snowflake(payload["guild_id"]),
             user=self._app.entity_factory.deserialize_user(payload["user"]),
@@ -345,9 +338,7 @@ class EventFactoryImpl(event_factory.EventFactory):
                 is_system=user_payload.get("system", undefined.UNDEFINED),
                 flags=flags,
             )
-        return guild_events.PresenceUpdateEvent(
-            app=self._app, shard=shard, presence=presence, user=user, old_presence=old_presence
-        )
+        return guild_events.PresenceUpdateEvent(shard=shard, presence=presence, user=user, old_presence=old_presence)
 
     ######################
     # INTERACTION EVENTS #
@@ -398,7 +389,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> member_events.MemberCreateEvent:
         member = self._app.entity_factory.deserialize_member(payload)
-        return member_events.MemberCreateEvent(app=self._app, shard=shard, member=member)
+        return member_events.MemberCreateEvent(shard=shard, member=member)
 
     def deserialize_guild_member_update_event(
         self,
@@ -408,7 +399,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         old_member: typing.Optional[guild_models.Member],
     ) -> member_events.MemberUpdateEvent:
         member = self._app.entity_factory.deserialize_member(payload)
-        return member_events.MemberUpdateEvent(app=self._app, shard=shard, member=member, old_member=old_member)
+        return member_events.MemberUpdateEvent(shard=shard, member=member, old_member=old_member)
 
     def deserialize_guild_member_remove_event(
         self,
@@ -420,7 +411,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         guild_id = snowflakes.Snowflake(payload["guild_id"])
         user = self._app.entity_factory.deserialize_user(payload["user"])
         return member_events.MemberDeleteEvent(
-            app=self._app, shard=shard, guild_id=guild_id, user=user, old_member=old_member
+            shard=shard, guild_id=guild_id, user=user, old_member=old_member
         )
 
     ###############
@@ -434,7 +425,7 @@ class EventFactoryImpl(event_factory.EventFactory):
             payload["role"],
             guild_id=snowflakes.Snowflake(payload["guild_id"]),
         )
-        return role_events.RoleCreateEvent(app=self._app, shard=shard, role=role)
+        return role_events.RoleCreateEvent(shard=shard, role=role)
 
     def deserialize_guild_role_update_event(
         self,
@@ -447,7 +438,7 @@ class EventFactoryImpl(event_factory.EventFactory):
             payload["role"],
             guild_id=snowflakes.Snowflake(payload["guild_id"]),
         )
-        return role_events.RoleUpdateEvent(app=self._app, shard=shard, role=role, old_role=old_role)
+        return role_events.RoleUpdateEvent(shard=shard, role=role, old_role=old_role)
 
     def deserialize_guild_role_delete_event(
         self,
@@ -490,9 +481,9 @@ class EventFactoryImpl(event_factory.EventFactory):
         message = self._app.entity_factory.deserialize_message(payload)
 
         if message.guild_id is None:
-            return message_events.DMMessageCreateEvent(app=self._app, shard=shard, message=message)
+            return message_events.DMMessageCreateEvent(shard=shard, message=message)
 
-        return message_events.GuildMessageCreateEvent(app=self._app, shard=shard, message=message)
+        return message_events.GuildMessageCreateEvent(shard=shard, message=message)
 
     def deserialize_message_update_event(  # noqa: CFQ001
         self,
@@ -504,13 +495,9 @@ class EventFactoryImpl(event_factory.EventFactory):
         message = self._app.entity_factory.deserialize_partial_message(payload)
 
         if message.guild_id is None:
-            return message_events.DMMessageUpdateEvent(
-                app=self._app, shard=shard, message=message, old_message=old_message
-            )
+            return message_events.DMMessageUpdateEvent(shard=shard, message=message, old_message=old_message)
 
-        return message_events.GuildMessageUpdateEvent(
-            app=self._app, shard=shard, message=message, old_message=old_message
-        )
+        return message_events.GuildMessageUpdateEvent(shard=shard, message=message, old_message=old_message)
 
     def deserialize_message_delete_event(
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
@@ -572,7 +559,6 @@ class EventFactoryImpl(event_factory.EventFactory):
             guild_id = snowflakes.Snowflake(payload["guild_id"])
             member = self._app.entity_factory.deserialize_member(payload["member"], guild_id=guild_id)
             return reaction_events.GuildReactionAddEvent(
-                app=self._app,
                 shard=shard,
                 member=member,
                 channel_id=channel_id,
@@ -684,7 +670,6 @@ class EventFactoryImpl(event_factory.EventFactory):
         session_id = payload["session_id"]
 
         return shard_events.ShardReadyEvent(
-            app=self._app,
             shard=shard,
             actual_gateway_version=gateway_version,
             session_id=session_id,
@@ -750,7 +735,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         old_user: typing.Optional[user_models.OwnUser],
     ) -> user_events.OwnUserUpdateEvent:
         return user_events.OwnUserUpdateEvent(
-            app=self._app, shard=shard, user=self._app.entity_factory.deserialize_my_user(payload), old_user=old_user
+            shard=shard, user=self._app.entity_factory.deserialize_my_user(payload), old_user=old_user
         )
 
     ################
@@ -765,7 +750,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         old_state: typing.Optional[voices_models.VoiceState],
     ) -> voice_events.VoiceStateUpdateEvent:
         state = self._app.entity_factory.deserialize_voice_state(payload)
-        return voice_events.VoiceStateUpdateEvent(app=self._app, shard=shard, state=state, old_state=old_state)
+        return voice_events.VoiceStateUpdateEvent(shard=shard, state=state, old_state=old_state)
 
     def deserialize_voice_server_update_event(
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject

--- a/hikari/messages.py
+++ b/hikari/messages.py
@@ -317,7 +317,6 @@ class Mentions:
     everyone: undefined.UndefinedOr[bool] = attr.field()
     """Whether the message notifies using `@everyone` or `@here`."""
 
-    # TODO: can we just type this as returning AbstractSet instead of casting to list?
     @property
     def channels_ids(self) -> undefined.UndefinedOr[typing.Sequence[snowflakes.Snowflake]]:
         if self.channels is undefined.UNDEFINED:
@@ -325,7 +324,6 @@ class Mentions:
 
         return list(self.channels.keys())
 
-    # TODO: can we just type this as returning AbstractSet instead of casting to list?
     @property
     def user_ids(self) -> undefined.UndefinedOr[typing.Sequence[snowflakes.Snowflake]]:
         if self.users is undefined.UNDEFINED:
@@ -662,7 +660,7 @@ class PartialMessage(snowflakes.Unique):
         This will only be provided for interaction messages.
     """
 
-    @property
+    @property  # TODO: this breaks from the new convention for cache methods
     def guild_id(self) -> typing.Optional[snowflakes.Snowflake]:
         """ID of the guild that the message was sent in.
 
@@ -702,6 +700,7 @@ class PartialMessage(snowflakes.Unique):
         builtins.str
             The jump link to the message.
         """
+        # TODO: this doesn't seem like a safe assumption for rest only applications
         guild_id_str = "@me" if guild is None else str(int(guild))
         return f"{urls.BASE_URL}/channels/{guild_id_str}/{self.channel_id}/{self.id}"
 

--- a/hikari/messages.py
+++ b/hikari/messages.py
@@ -660,7 +660,7 @@ class PartialMessage(snowflakes.Unique):
         This will only be provided for interaction messages.
     """
 
-    @property  # TODO: this breaks from the new convention for cache methods
+    @property  # TODO: update this while refactoring message structure
     def guild_id(self) -> typing.Optional[snowflakes.Snowflake]:
         """ID of the guild that the message was sent in.
 

--- a/hikari/messages.py
+++ b/hikari/messages.py
@@ -317,6 +317,7 @@ class Mentions:
     everyone: undefined.UndefinedOr[bool] = attr.field()
     """Whether the message notifies using `@everyone` or `@here`."""
 
+    # TODO: can we just type this as returning AbstractSet instead of casting to list?
     @property
     def channels_ids(self) -> undefined.UndefinedOr[typing.Sequence[snowflakes.Snowflake]]:
         if self.channels is undefined.UNDEFINED:
@@ -324,6 +325,7 @@ class Mentions:
 
         return list(self.channels.keys())
 
+    # TODO: can we just type this as returning AbstractSet instead of casting to list?
     @property
     def user_ids(self) -> undefined.UndefinedOr[typing.Sequence[snowflakes.Snowflake]]:
         if self.users is undefined.UNDEFINED:
@@ -331,8 +333,7 @@ class Mentions:
 
         return list(self.users.keys())
 
-    @property
-    def members(self) -> undefined.UndefinedOr[typing.Mapping[snowflakes.Snowflake, guilds.Member]]:
+    def get_members(self) -> undefined.UndefinedOr[typing.Mapping[snowflakes.Snowflake, guilds.Member]]:
         """Discover any cached members notified by this message.
 
         If this message was sent in a DM, this will always be empty.
@@ -366,8 +367,7 @@ class Mentions:
 
         return {}
 
-    @property
-    def roles(self) -> typing.Mapping[snowflakes.Snowflake, guilds.Role]:
+    def get_roles(self) -> undefined.UndefinedOr[typing.Mapping[snowflakes.Snowflake, guilds.Role]]:
         """Attempt to look up the roles that are notified by this message.
 
         If this message was sent in a DM, this will always be empty.
@@ -389,10 +389,13 @@ class Mentions:
             in `notifies_role_ids` may not be present here. This is a limitation
             of Discord, again.
         """
+        if self.role_ids is undefined.UNDEFINED:
+            return undefined.UNDEFINED
+
         if isinstance(self._message.app, traits.CacheAware) and self._message.guild_id is not None:
             app = self._message.app
             return self._map_cache_maybe_discover(
-                self.roles,
+                self.role_ids,
                 app.cache.get_role,
             )
 

--- a/hikari/snowflakes.py
+++ b/hikari/snowflakes.py
@@ -89,16 +89,22 @@ class Snowflake(int):
     @classmethod
     def min(cls) -> Snowflake:
         """Minimum value for a snowflakes."""
-        if not hasattr(cls, "___MIN___"):
+        try:
+            return cls.___MIN___
+
+        except AttributeError:
             cls.___MIN___ = Snowflake(0)
-        return cls.___MIN___
+            return cls.___MIN___
 
     @classmethod
     def max(cls) -> Snowflake:
         """Maximum value for a snowflakes."""
-        if not hasattr(cls, "___MAX___"):
+        try:
+            return cls.___MAX___
+
+        except AttributeError:
             cls.___MAX___ = Snowflake((1 << 63) - 1)
-        return cls.___MAX___
+            return cls.___MAX___
 
     @classmethod
     def from_data(cls, timestamp: datetime.datetime, worker_id: int, process_id: int, increment: int) -> Snowflake:

--- a/hikari/traits.py
+++ b/hikari/traits.py
@@ -296,22 +296,6 @@ class ShardAware(
         raise NotImplementedError
 
     @property
-    def me(self) -> typing.Optional[users_.OwnUser]:
-        """Return the bot user, if known.
-
-        This should be available as soon as the bot has fired the
-        `hikari.events.lifetime_events.StartingEvent`.
-
-        Until then, this may or may not be `builtins.None`.
-
-        Returns
-        -------
-        typing.Optional[hikari.users.OwnUser]
-            The bot user, if known, otherwise `builtins.None`.
-        """
-        raise NotImplementedError
-
-    @property
     def shards(self) -> typing.Mapping[int, gateway_shard.GatewayShard]:
         """Return a mapping of shards in this application instance.
 
@@ -338,6 +322,21 @@ class ShardAware(
         -------
         builtins.int
             The number of shards in the total application.
+        """
+        raise NotImplementedError
+
+    def get_me(self) -> typing.Optional[users_.OwnUser]:
+        """Return the bot user, if known.
+
+        This should be available as soon as the bot has fired the
+        `hikari.events.lifetime_events.StartingEvent`.
+
+        Until then, this may or may not be `builtins.None`.
+
+        Returns
+        -------
+        typing.Optional[hikari.users.OwnUser]
+            The bot user, if known, otherwise `builtins.None`.
         """
         raise NotImplementedError
 

--- a/tests/hikari/events/test_channel_events.py
+++ b/tests/hikari/events/test_channel_events.py
@@ -39,20 +39,25 @@ class TestGuildChannelEvent:
         )
         return cls()
 
-    def test_guild_when_available(self, event):
-        result = event.guild
+    def test_get_guild_when_available(self, event):
+        result = event.get_guild()
 
         assert result is event.app.cache.get_available_guild.return_value
         event.app.cache.get_available_guild.assert_called_once_with(929292929)
         event.app.cache.get_unavailable_guild.assert_not_called()
 
-    def test_guild_when_unavailable(self, event):
+    def test_get_guild_when_unavailable(self, event):
         event.app.cache.get_available_guild.return_value = None
-        result = event.guild
+        result = event.get_guild()
 
         assert result is event.app.cache.get_unavailable_guild.return_value
         event.app.cache.get_available_guild.assert_called_once_with(929292929)
         event.app.cache.get_unavailable_guild.assert_called_once_with(929292929)
+
+    def test_get_guild_without_cache(self):
+        event = hikari_test_helpers.mock_class_namespace(channel_events.GuildChannelEvent, app=None)()
+
+        assert event.get_guild() is None
 
     @pytest.mark.asyncio()
     async def test_fetch_guild(self, event):
@@ -62,11 +67,16 @@ class TestGuildChannelEvent:
         assert result is event.app.rest.fetch_guild.return_value
         event.app.rest.fetch_guild.assert_awaited_once_with(929292929)
 
-    def test_channel(self, event):
-        result = event.channel
+    def test_get_channel(self, event):
+        result = event.get_channel()
 
         assert result is event.app.cache.get_guild_channel.return_value
         event.app.cache.get_guild_channel.assert_called_once_with(432432432)
+
+    def test_get_channel_without_cache(self):
+        event = hikari_test_helpers.mock_class_namespace(channel_events.GuildChannelEvent, app=None)()
+
+        assert event.get_channel() is None
 
     @pytest.mark.asyncio()
     async def test_fetch_channel(self, event):
@@ -83,6 +93,9 @@ class TestChannelCreateEvent:
         cls = hikari_test_helpers.mock_class_namespace(channel_events.ChannelCreateEvent)
         return cls()
 
+    def test_app_property(self, event):
+        assert event.channel.app is event.channel.app
+
     def test_channel_id_property(self, event):
         event.channel.id = 123
         assert event.channel_id == 123
@@ -91,7 +104,7 @@ class TestChannelCreateEvent:
 class TestGuildChannelCreateEvent:
     @pytest.fixture()
     def event(self):
-        return channel_events.GuildChannelCreateEvent(app=None, channel=mock.Mock(), shard=None)
+        return channel_events.GuildChannelCreateEvent(channel=mock.Mock(), shard=None)
 
     def test_guild_id_property(self, event):
         event.channel.guild_id = 123
@@ -103,6 +116,9 @@ class TestChannelUpdateEvent:
     def event(self):
         return hikari_test_helpers.mock_class_namespace(channel_events.ChannelUpdateEvent)()
 
+    def test_app_property(self, event):
+        assert event.app is event.channel.app
+
     def test_channel_id_property(self, event):
         event.channel.id = 123
         assert event.channel_id == 123
@@ -111,9 +127,7 @@ class TestChannelUpdateEvent:
 class TestGuildChannelUpdateEvent:
     @pytest.fixture()
     def event(self):
-        return channel_events.GuildChannelUpdateEvent(
-            app=None, channel=mock.Mock(), old_channel=mock.Mock(), shard=None
-        )
+        return channel_events.GuildChannelUpdateEvent(channel=mock.Mock(), old_channel=mock.Mock(), shard=None)
 
     def test_guild_id_property(self, event):
         event.channel.guild_id = 123
@@ -129,6 +143,9 @@ class TestChannelDeleteEvent:
     def event(self):
         return hikari_test_helpers.mock_class_namespace(channel_events.ChannelDeleteEvent)()
 
+    def test_app_property(self, event):
+        assert event.app is event.channel.app
+
     def test_channel_id_property(self, event):
         event.channel.id = 123
         assert event.channel_id == 123
@@ -137,7 +154,7 @@ class TestChannelDeleteEvent:
 class TestGuildChannelDeleteEvent:
     @pytest.fixture()
     def event(self):
-        return channel_events.GuildChannelDeleteEvent(app=None, channel=mock.Mock(), shard=None)
+        return channel_events.GuildChannelDeleteEvent(channel=mock.Mock(), shard=None)
 
     def test_guild_id_property(self, event):
         event.channel.guild_id = 123
@@ -164,7 +181,10 @@ class TestInviteEvent:
 class TestInviteCreateEvent:
     @pytest.fixture()
     def event(self):
-        return channel_events.InviteCreateEvent(app=None, shard=None, invite=mock.Mock)
+        return channel_events.InviteCreateEvent(shard=None, invite=mock.Mock())
+
+    def test_app_property(self, event):
+        assert event.app is event.invite.app
 
     async def test_channel_id_property(self, event):
         event.invite.channel_id = 123

--- a/tests/hikari/events/test_channel_events.py
+++ b/tests/hikari/events/test_channel_events.py
@@ -94,7 +94,7 @@ class TestChannelCreateEvent:
         return cls()
 
     def test_app_property(self, event):
-        assert event.channel.app is event.channel.app
+        assert event.app is event.channel.app
 
     def test_channel_id_property(self, event):
         event.channel.id = 123
@@ -159,6 +159,23 @@ class TestGuildChannelDeleteEvent:
     def test_guild_id_property(self, event):
         event.channel.guild_id = 123
         assert event.guild_id == 123
+
+
+class TestGuildPinsUpdateEvent:
+    @pytest.fixture()
+    def event(self):
+        return channel_events.GuildPinsUpdateEvent(
+            app=mock.Mock(), shard=None, channel_id=12343, guild_id=None, last_pin_timestamp=None
+        )
+
+    @pytest.mark.parametrize("result", [mock.Mock(spec=channels.GuildTextChannel), None])
+    def test_get_channel(self, event, result):
+        event.app.cache.get_guild_channel.return_value = result
+
+        result = event.get_channel()
+
+        assert result is event.app.cache.get_guild_channel.return_value
+        event.app.cache.get_guild_channel.assert_called_once_with(event.channel_id)
 
 
 @pytest.mark.asyncio()

--- a/tests/hikari/events/test_guild_events.py
+++ b/tests/hikari/events/test_guild_events.py
@@ -53,6 +53,11 @@ class TestGuildEvent:
         event.app.cache.get_unavailable_guild.assert_called_once_with(534123123)
         event.app.cache.get_available_guild.assert_called_once_with(534123123)
 
+    def test_get_guild_cacheless(self, event):
+        event = hikari_test_helpers.mock_class_namespace(guild_events.GuildEvent, app=object())()
+
+        assert event.get_guild() is None
+
     @pytest.mark.asyncio()
     async def test_fetch_guild(self, event):
         event.app.rest.fetch_guild = mock.AsyncMock()
@@ -127,6 +132,17 @@ class TestGuildUpdateEvent:
     def test_old_guild_id_property(self, event):
         event.old_guild.id = 123
         assert event.old_guild.id == 123
+
+    def test_get_guild_when_super_returns(self, event):
+        with mock.patch.object(guild_events.GuildEvent, "get_guild") as patched_super:
+            assert event.get_guild() is patched_super.return_value
+
+    def test_get_guild_when_super_returns_none(self, event):
+        with mock.patch.object(guild_events.GuildEvent, "get_guild", return_value=None) as patched_super:
+            result = event.get_guild()
+
+            assert result is event.guild
+            patched_super.assert_called_once_with()
 
 
 class TestBanEvent:

--- a/tests/hikari/events/test_guild_events.py
+++ b/tests/hikari/events/test_guild_events.py
@@ -96,20 +96,6 @@ class TestGuildAvailableEvent:
         event.guild.id = 123
         assert event.guild_id == 123
 
-    def test_get_guild_when_super_returns_a_guild(self, event):
-        with mock.patch.object(guild_events.GuildEvent, "get_guild") as patched_super:
-            result = event.get_guild()
-
-            assert result is patched_super.return_value
-            patched_super.assert_called_once()
-
-    def test_get_guild_when_super_returns_none(self, event):
-        with mock.patch.object(guild_events.GuildEvent, "get_guild", return_value=None) as patched_super:
-            result = event.get_guild()
-
-            assert result is event.guild
-            patched_super.assert_called_once()
-
 
 class TestGuildUpdateEvent:
     @pytest.fixture()
@@ -132,17 +118,6 @@ class TestGuildUpdateEvent:
     def test_old_guild_id_property(self, event):
         event.old_guild.id = 123
         assert event.old_guild.id == 123
-
-    def test_get_guild_when_super_returns(self, event):
-        with mock.patch.object(guild_events.GuildEvent, "get_guild") as patched_super:
-            assert event.get_guild() is patched_super.return_value
-
-    def test_get_guild_when_super_returns_none(self, event):
-        with mock.patch.object(guild_events.GuildEvent, "get_guild", return_value=None) as patched_super:
-            result = event.get_guild()
-
-            assert result is event.guild
-            patched_super.assert_called_once_with()
 
 
 class TestBanEvent:

--- a/tests/hikari/events/test_guild_events.py
+++ b/tests/hikari/events/test_guild_events.py
@@ -30,7 +30,7 @@ from hikari.events import guild_events
 from tests.hikari import hikari_test_helpers
 
 
-class GuildEvent:
+class TestGuildEvent:
     @pytest.fixture()
     def event(self):
         cls = hikari_test_helpers.mock_class_namespace(
@@ -38,16 +38,16 @@ class GuildEvent:
         )
         return cls()
 
-    def test_guild_when_available(self, event):
-        result = event.guild
+    def test_get_guild_when_available(self, event):
+        result = event.get_guild()
 
         assert result is event.app.cache.get_available_guild.return_value
         event.app.cache.get_available_guild.assert_called_once_with(534123123)
         event.app.cache.get_unavailable_guild.assert_not_called()
 
-    def test_guild_when_unavailable(self, event):
+    def test_get_guild_when_unavailable(self, event):
         event.app.cache.get_available_guild.return_value = None
-        result = event.guild
+        result = event.get_guild()
 
         assert result is event.app.cache.get_unavailable_guild.return_value
         event.app.cache.get_unavailable_guild.assert_called_once_with(534123123)
@@ -90,6 +90,20 @@ class TestGuildAvailableEvent:
     def test_guild_id_property(self, event):
         event.guild.id = 123
         assert event.guild_id == 123
+
+    def test_get_guild_when_super_returns_a_guild(self, event):
+        with mock.patch.object(guild_events.GuildEvent, "get_guild") as patched_super:
+            result = event.get_guild()
+
+            assert result is patched_super.return_value
+            patched_super.assert_called_once()
+
+    def test_get_guild_when_super_returns_none(self, event):
+        with mock.patch.object(guild_events.GuildEvent, "get_guild", return_value=None) as patched_super:
+            result = event.get_guild()
+
+            assert result is event.guild
+            patched_super.assert_called_once()
 
 
 class TestGuildUpdateEvent:

--- a/tests/hikari/events/test_guild_events.py
+++ b/tests/hikari/events/test_guild_events.py
@@ -74,7 +74,6 @@ class TestGuildAvailableEvent:
     @pytest.fixture()
     def event(self):
         return guild_events.GuildAvailableEvent(
-            app=None,
             shard=object(),
             guild=mock.Mock(guilds.Guild),
             emojis={},
@@ -85,6 +84,9 @@ class TestGuildAvailableEvent:
             voice_states={},
         )
 
+    def test_app_property(self, event):
+        assert event.app is event.guild.app
+
     def test_guild_id_property(self, event):
         event.guild.id = 123
         assert event.guild_id == 123
@@ -94,13 +96,15 @@ class TestGuildUpdateEvent:
     @pytest.fixture()
     def event(self):
         return guild_events.GuildUpdateEvent(
-            app=None,
             shard=object(),
             guild=mock.Mock(guilds.Guild),
             old_guild=mock.Mock(guilds.Guild),
             emojis={},
             roles={},
         )
+
+    def test_app_property(self, event):
+        assert event.app is event.guild.app
 
     def test_guild_id_property(self, event):
         event.guild.id = 123
@@ -111,16 +115,27 @@ class TestGuildUpdateEvent:
         assert event.old_guild.id == 123
 
 
+class TestBanEvent:
+    @pytest.fixture()
+    def event(self):
+        return hikari_test_helpers.mock_class_namespace(guild_events.BanEvent)()
+
+    def test_app_property(self, event):
+        assert event.app is event.user.app
+
+
 class TestPresenceUpdateEvent:
     @pytest.fixture()
     def event(self):
         return guild_events.PresenceUpdateEvent(
-            app=None,
             shard=object(),
             presence=mock.Mock(presences.MemberPresence),
             old_presence=mock.Mock(presences.MemberPresence),
             user=mock.Mock(),
         )
+
+    def test_app_property(self, event):
+        assert event.app is event.presence.app
 
     def test_user_id_property(self, event):
         event.presence.user_id = 123

--- a/tests/hikari/events/test_member_events.py
+++ b/tests/hikari/events/test_member_events.py
@@ -40,16 +40,22 @@ class TestMemberEvent:
         )
         return cls()
 
+    def test_app_property(self, event):
+        assert event.app is event.user.app
+
     def test_user_id_property(self, event):
         event.user_id == 456
 
-    def test_guild_when_no_cache_trait(self, event):
-        event.app = object()
+    def test_guild_when_no_cache_trait(self):
+        event = hikari_test_helpers.mock_class_namespace(
+            member_events.MemberEvent,
+            app=None,
+        )()
 
-        assert event.guild is None
+        assert event.get_guild() is None
 
-    def test_guild_when_available(self, event):
-        result = event.guild
+    def test_get_guild_when_available(self, event):
+        result = event.get_guild()
 
         assert result is event.app.cache.get_available_guild.return_value
         event.app.cache.get_available_guild.assert_called_once_with(123)
@@ -57,7 +63,7 @@ class TestMemberEvent:
 
     def test_guild_when_unavailable(self, event):
         event.app.cache.get_available_guild.return_value = None
-        result = event.guild
+        result = event.get_guild()
 
         assert result is event.app.cache.get_unavailable_guild.return_value
         event.app.cache.get_unavailable_guild.assert_called_once_with(123)
@@ -67,7 +73,7 @@ class TestMemberEvent:
 class TestMemberCreateEvent:
     @pytest.fixture()
     def event(self):
-        return member_events.MemberCreateEvent(app=None, shard=None, member=mock.Mock())
+        return member_events.MemberCreateEvent(shard=None, member=mock.Mock())
 
     def test_guild_property(self, event):
         event.member.guild_id = 123
@@ -82,9 +88,7 @@ class TestMemberCreateEvent:
 class TestMemberUpdateEvent:
     @pytest.fixture()
     def event(self):
-        return member_events.MemberUpdateEvent(
-            app=None, shard=None, member=mock.Mock(), old_member=mock.Mock(guilds.Member)
-        )
+        return member_events.MemberUpdateEvent(shard=None, member=mock.Mock(), old_member=mock.Mock(guilds.Member))
 
     def test_guild_property(self, event):
         event.member.guild_id = 123

--- a/tests/hikari/events/test_message_events.py
+++ b/tests/hikari/events/test_message_events.py
@@ -218,6 +218,19 @@ class TestGuildMessageCreateEvent:
     def test_member_property(self, event):
         assert event.member is event.message.member
 
+    def test_get_member_when_cacheless(self, event):
+        event.message.app = None
+
+        result = event.get_member()
+
+        assert result is None
+
+    def test_get_member(self, event):
+        result = event.get_member()
+
+        assert result is event.app.cache.get_member.return_value
+        event.app.cache.get_member.assert_called_once_with(event.guild_id, event.author_id)
+
 
 class TestGuildMessageUpdateEvent:
     @pytest.fixture()
@@ -238,41 +251,6 @@ class TestGuildMessageUpdateEvent:
     def test_member_property(self, event):
         assert event.member is event.message.member
 
-    def test_member_property_when_member_defined(self, event):
-        event.message.member = mock.Mock()
-        event.message.author = undefined.UNDEFINED
-
-        assert event.member is event.message.member
-
-    def test_member_property_when_member_none_but_cached(self, event):
-        event.message.member = None
-        event.message.author = mock.Mock(id=1234321)
-        event.message.guild_id = snowflakes.Snowflake(696969)
-        real_member = mock.Mock()
-        event.app.cache.get_member = mock.Mock(return_value=real_member)
-
-        assert event.member is real_member
-
-        event.app.cache.get_member.assert_called_once_with(696969, 1234321)
-
-    def test_member_property_when_member_none_and_author_none(self, event):
-        event.message.author = None
-        event.message.member = None
-
-        assert event.member is None
-
-        event.app.cache.get_member.assert_not_called()
-
-    def test_member_property_when_member_none_and_uncached(self, event):
-        event.message.member = None
-        event.message.author = mock.Mock(id=1234321)
-        event.message.guild_id = snowflakes.Snowflake(696969)
-        event.app.cache.get_member = mock.Mock(return_value=None)
-
-        assert event.member is None
-
-        event.app.cache.get_member.assert_called_once_with(696969, 1234321)
-
     def test_guild_id_property(self, event):
         assert event.guild_id == snowflakes.Snowflake(54123123123)
 
@@ -290,6 +268,19 @@ class TestGuildMessageUpdateEvent:
         result = event.get_channel()
         assert result is event.app.cache.get_guild_channel.return_value
         event.app.cache.get_guild_channel.assert_called_once_with(800001066)
+
+    def test_get_member_when_cacheless(self, event):
+        event.message.app = None
+
+        result = event.get_member()
+
+        assert result is None
+
+    def test_get_member(self, event):
+        result = event.get_member()
+
+        assert result is event.app.cache.get_member.return_value
+        event.app.cache.get_member.assert_called_once_with(event.guild_id, event.author_id)
 
     def test_get_guild_when_no_cache_trait(self):
         event = hikari_test_helpers.mock_class_namespace(

--- a/tests/hikari/events/test_message_events.py
+++ b/tests/hikari/events/test_message_events.py
@@ -37,7 +37,6 @@ class TestMessageCreateEvent:
     def event(self):
         cls = hikari_test_helpers.mock_class_namespace(
             message_events.MessageCreateEvent,
-            app=object(),
             message=mock.Mock(
                 spec_set=messages.Message,
                 author=mock.Mock(
@@ -48,6 +47,9 @@ class TestMessageCreateEvent:
         )
 
         return cls()
+
+    def test_app_property(self, event):
+        assert event.app is event.message.app
 
     def test_author_property(self, event):
         assert event.author is event.message.author
@@ -97,7 +99,6 @@ class TestMessageUpdateEvent:
     def event(self):
         cls = hikari_test_helpers.mock_class_namespace(
             message_events.MessageUpdateEvent,
-            app=object(),
             message=mock.Mock(
                 spec_set=messages.Message,
                 author=mock.Mock(
@@ -108,6 +109,9 @@ class TestMessageUpdateEvent:
         )
 
         return cls()
+
+    def test_app_property(self, event):
+        assert event.app is event.message.app
 
     @pytest.mark.parametrize("author", [mock.Mock(spec_set=users.User), undefined.UNDEFINED])
     def test_author_property(self, event, author):
@@ -169,7 +173,6 @@ class TestGuildMessageCreateEvent:
     @pytest.fixture()
     def event(self):
         return message_events.GuildMessageCreateEvent(
-            app=mock.Mock(),
             message=mock.Mock(
                 spec_set=messages.Message,
                 guild_id=snowflakes.Snowflake(342123123),
@@ -181,26 +184,30 @@ class TestGuildMessageCreateEvent:
     def test_guild_id_property(self, event):
         assert event.guild_id == snowflakes.Snowflake(342123123)
 
-    def test_channel_property_when_no_cache_trait(self, event):
-        event.app = object()
+    def test_get_channel_when_no_cache_trait(self):
+        event = hikari_test_helpers.mock_class_namespace(
+            message_events.GuildMessageCreateEvent, app=None, init_=False
+        )()
 
-        assert event.channel is None
+        assert event.get_channel() is None
 
     @pytest.mark.parametrize("guild_channel_impl", [channels.GuildTextChannel, channels.GuildNewsChannel])
-    def test_channel_property(self, event, guild_channel_impl):
+    def test_get_channel(self, event, guild_channel_impl):
         event.app.cache.get_guild_channel = mock.Mock(return_value=mock.Mock(spec_set=guild_channel_impl))
 
-        result = event.channel
+        result = event.get_channel()
         assert result is event.app.cache.get_guild_channel.return_value
         event.app.cache.get_guild_channel.assert_called_once_with(9121234)
 
-    def test_guild_property_when_no_cache_trait(self, event):
-        event.app = object()
+    def test_get_guild_when_no_cache_trait(self):
+        event = hikari_test_helpers.mock_class_namespace(
+            message_events.GuildMessageCreateEvent, app=None, init_=False
+        )()
 
-        assert event.guild is None
+        assert event.get_guild() is None
 
-    def test_guild_property(self, event):
-        result = event.guild
+    def test_get_guild(self, event):
+        result = event.get_guild()
 
         assert result is event.app.cache.get_guild.return_value
         event.app.cache.get_guild.assert_called_once_with(342123123)
@@ -216,7 +223,6 @@ class TestGuildMessageUpdateEvent:
     @pytest.fixture()
     def event(self):
         return message_events.GuildMessageUpdateEvent(
-            app=mock.Mock(),
             message=mock.Mock(
                 spec_set=messages.Message,
                 guild_id=snowflakes.Snowflake(54123123123),
@@ -270,26 +276,30 @@ class TestGuildMessageUpdateEvent:
     def test_guild_id_property(self, event):
         assert event.guild_id == snowflakes.Snowflake(54123123123)
 
-    def test_channel_property_when_no_cache_trait(self, event):
-        event.app = object()
+    def test_get_channel_when_no_cache_trait(self):
+        event = hikari_test_helpers.mock_class_namespace(
+            message_events.GuildMessageUpdateEvent, app=None, init_=False
+        )()
 
-        assert event.channel is None
+        assert event.get_channel() is None
 
     @pytest.mark.parametrize("guild_channel_impl", [channels.GuildTextChannel, channels.GuildNewsChannel])
-    def test_channel_property(self, event, guild_channel_impl):
+    def test_get_channel(self, event, guild_channel_impl):
         event.app.cache.get_guild_channel = mock.Mock(return_value=mock.Mock(spec_set=guild_channel_impl))
 
-        result = event.channel
+        result = event.get_channel()
         assert result is event.app.cache.get_guild_channel.return_value
         event.app.cache.get_guild_channel.assert_called_once_with(800001066)
 
-    def test_guild_property_when_no_cache_trait(self, event):
-        event.app = object()
+    def test_get_guild_when_no_cache_trait(self):
+        event = hikari_test_helpers.mock_class_namespace(
+            message_events.GuildMessageUpdateEvent, app=None, init_=False
+        )()
 
-        assert event.guild is None
+        assert event.get_guild() is None
 
-    def test_guild_property(self, event):
-        result = event.guild
+    def test_get_guild(self, event):
+        result = event.get_guild()
 
         assert result is event.app.cache.get_guild.return_value
         event.app.cache.get_guild.assert_called_once_with(54123123123)
@@ -302,7 +312,6 @@ class TestDMMessageUpdateEvent:
     @pytest.fixture()
     def event(self):
         return message_events.DMMessageUpdateEvent(
-            app=mock.Mock(),
             message=mock.Mock(
                 spec_set=messages.Message, author=mock.Mock(spec_set=users.User, id=snowflakes.Snowflake(8000010662))
             ),
@@ -337,26 +346,26 @@ class TestGuildMessageDeleteEvent:
             is_bulk=True,
         )
 
-    def test_channel_property_when_no_cache_trait(self, event):
+    def test_get_channel_when_no_cache_trait(self, event):
         event.app = object()
 
-        assert event.channel is None
+        assert event.get_channel() is None
 
     @pytest.mark.parametrize("guild_channel_impl", [channels.GuildTextChannel, channels.GuildNewsChannel])
-    def test_channel_property(self, event, guild_channel_impl):
+    def test_get_channel(self, event, guild_channel_impl):
         event.app.cache.get_guild_channel = mock.Mock(return_value=mock.Mock(spec_set=guild_channel_impl))
-        result = event.channel
+        result = event.get_channel()
 
         assert result is event.app.cache.get_guild_channel.return_value
         event.app.cache.get_guild_channel.assert_called_once_with(54213123123)
 
-    def test_guild_property_when_no_cache_trait(self, event):
+    def test_get_guild_when_no_cache_trait(self, event):
         event.app = object()
 
-        assert event.guild is None
+        assert event.get_guild() is None
 
-    def test_guild_property(self, event):
-        result = event.guild
+    def test_get_guild_property(self, event):
+        result = event.get_guild()
 
         assert result is event.app.cache.get_guild.return_value
         event.app.cache.get_guild.assert_called_once_with(542342354564)

--- a/tests/hikari/events/test_reaction_events.py
+++ b/tests/hikari/events/test_reaction_events.py
@@ -31,8 +31,11 @@ class TestGuildReactionAddEvent:
     @pytest.fixture()
     def event(self):
         return reaction_events.GuildReactionAddEvent(
-            app=None, shard=object(), member=mock.MagicMock(guilds.Member), channel_id=123, message_id=456, emoji="👌"
+            shard=object(), member=mock.MagicMock(guilds.Member), channel_id=123, message_id=456, emoji="👌"
         )
+
+    def test_app_property(self, event):
+        assert event.app is event.member.app
 
     def test_guild_id_property(self, event):
         event.member.guild_id = 123

--- a/tests/hikari/events/test_role_events.py
+++ b/tests/hikari/events/test_role_events.py
@@ -30,7 +30,10 @@ from hikari.events import role_events
 class TestRoleCreateEvent:
     @pytest.fixture()
     def event(self):
-        return role_events.RoleCreateEvent(app=None, shard=object(), role=mock.Mock(guilds.Role))
+        return role_events.RoleCreateEvent(shard=object(), role=mock.Mock(guilds.Role))
+
+    def test_app_property(self, event):
+        assert event.app is event.role.app
 
     def test_guild_id_property(self, event):
         event.role.guild_id = 123
@@ -44,9 +47,10 @@ class TestRoleCreateEvent:
 class TestRoleUpdateEvent:
     @pytest.fixture()
     def event(self):
-        return role_events.RoleUpdateEvent(
-            app=None, shard=object(), role=mock.Mock(guilds.Role), old_role=mock.Mock(guilds.Role)
-        )
+        return role_events.RoleUpdateEvent(shard=object(), role=mock.Mock(guilds.Role), old_role=mock.Mock(guilds.Role))
+
+    def test_app_property(self, event):
+        assert event.app is event.role.app
 
     def test_guild_id_property(self, event):
         event.role.guild_id = 123

--- a/tests/hikari/events/test_shard_events.py
+++ b/tests/hikari/events/test_shard_events.py
@@ -26,6 +26,23 @@ from hikari import snowflakes
 from hikari.events import shard_events
 
 
+class TestShardReadyEvent:
+    @pytest.fixture()
+    def event(self):
+        return shard_events.ShardReadyEvent(
+            my_user=mock.Mock(),
+            shard=None,
+            actual_gateway_version=1,
+            session_id="ok",
+            application_id=1,
+            application_flags=1,
+            unavailable_guilds=[],
+        )
+
+    def test_app_property(self, event):
+        assert event.app is event.my_user.app
+
+
 class TestMemberChunkEvent:
     @pytest.fixture()
     def event(self):

--- a/tests/hikari/events/test_typing_events.py
+++ b/tests/hikari/events/test_typing_events.py
@@ -107,20 +107,6 @@ class TestGuildTypingEvent:
         event.app.cache.get_unavailable_guild.assert_called_once_with(789)
         event.app.cache.get_available_guild.assert_called_once_with(789)
 
-    def test_get_user_when_super_returns_user(self, event):
-        with mock.patch.object(typing_events.TypingEvent, "get_user") as patched_super:
-            result = event.get_user()
-
-            assert result is patched_super.return_value
-            patched_super.assert_called_once()
-
-    def test_get_user_when_super_returns_none(self, event):
-        with mock.patch.object(typing_events.TypingEvent, "get_user", return_value=None) as patched_super:
-            result = event.get_user()
-
-            assert result is event.member.user
-            patched_super.assert_called_once()
-
     def test_user_id(self, event):
         assert event.user_id == event.member.id
         assert event.user_id == 456

--- a/tests/hikari/events/test_typing_events.py
+++ b/tests/hikari/events/test_typing_events.py
@@ -60,46 +60,48 @@ class TestGuildTypingEvent:
             channel_id=123,
             timestamp=object(),
             shard=object(),
-            app=mock.Mock(rest=mock.AsyncMock()),
             guild_id=789,
-            user=mock.Mock(id=456),
+            member=mock.Mock(id=456, app=mock.Mock(rest=mock.AsyncMock())),
         )
 
-    def test_channel_when_no_cache(self, event):
-        event.app = object()
+    def test_app_property(self, event):
+        assert event.app is event.member.app
 
-        assert event.channel is None
+    def test_get_channel_when_no_cache(self):
+        event = hikari_test_helpers.mock_class_namespace(typing_events.GuildTypingEvent, app=None, init_=False)()
+
+        assert event.get_channel() is None
 
     @pytest.mark.parametrize("guild_channel_impl", [channels.GuildNewsChannel, channels.GuildTextChannel])
-    def test_channel(self, event, guild_channel_impl):
+    def test_get_channel(self, event, guild_channel_impl):
         event.app.cache.get_guild_channel = mock.Mock(return_value=mock.Mock(spec_set=guild_channel_impl))
-        result = event.channel
+        result = event.get_channel()
 
         assert result is event.app.cache.get_guild_channel.return_value
         event.app.cache.get_guild_channel.assert_called_once_with(123)
 
-    async def test_guild_when_no_cache(self, event):
-        event.app = object()
+    async def test_get_guild_when_no_cache(self):
+        event = hikari_test_helpers.mock_class_namespace(typing_events.GuildTypingEvent, app=None, init_=False)()
 
-        assert event.guild is None
+        assert event.get_guild() is None
 
-    def test_guild_when_available(self, event):
-        result = event.guild
+    def test_get_guild_when_available(self, event):
+        result = event.get_guild()
 
         assert result is event.app.cache.get_available_guild.return_value
         event.app.cache.get_available_guild.assert_called_once_with(789)
         event.app.cache.get_unavailable_guild.assert_not_called()
 
-    def test_guild_when_unavailable(self, event):
+    def test_get_guild_when_unavailable(self, event):
         event.app.cache.get_available_guild.return_value = None
-        result = event.guild
+        result = event.get_guild()
 
         assert result is event.app.cache.get_unavailable_guild.return_value
         event.app.cache.get_unavailable_guild.assert_called_once_with(789)
         event.app.cache.get_available_guild.assert_called_once_with(789)
 
     def test_user_id(self, event):
-        assert event.user_id == event.user.id
+        assert event.user_id == event.member.id
         assert event.user_id == 456
 
     @pytest.mark.parametrize("guild_channel_impl", [channels.GuildNewsChannel, channels.GuildTextChannel])
@@ -119,8 +121,8 @@ class TestGuildTypingEvent:
 
         event.app.rest.fetch_guild_preview.assert_awaited_once_with(789)
 
-    async def test_fetch_user(self, event):
-        await event.fetch_user()
+    async def test_fetch_member(self, event):
+        await event.fetch_member()
 
         event.app.rest.fetch_member.assert_awaited_once_with(789, 456)
 
@@ -139,15 +141,15 @@ class TestDMTypingEvent:
             user_id=456,
         )
 
-    async def test_user_when_no_cache(self, event):
-        event.app = object()
+    async def test_get_user_when_no_cache(self):
+        event = hikari_test_helpers.mock_class_namespace(typing_events.DMTypingEvent, app=None, init_=False)()
 
-        assert event.user is None
+        assert event.get_user() is None
 
-    def test_user(self, event):
+    def test_get_user(self, event):
         event.app.cache.get_user = mock.Mock(return_value=mock.Mock(spec_set=users.User))
 
-        assert event.user is event.app.cache.get_user.return_value
+        assert event.get_user() is event.app.cache.get_user.return_value
 
     async def test_fetch_channel(self, event):
         event.app.rest.fetch_channel = mock.AsyncMock(return_value=mock.Mock(spec_set=channels.DMChannel))

--- a/tests/hikari/events/test_user_events.py
+++ b/tests/hikari/events/test_user_events.py
@@ -23,39 +23,13 @@
 import mock
 import pytest
 
-from hikari import voices
-from hikari.events import voice_events
+from hikari.events import user_events
 
 
-class TestVoiceStateUpdateEvent:
+class TestOwnUserUpdateEvent:
     @pytest.fixture()
     def event(self):
-        return voice_events.VoiceStateUpdateEvent(
-            shard=object(), state=mock.Mock(voices.VoiceState), old_state=mock.Mock(voices.VoiceState)
-        )
+        return user_events.OwnUserUpdateEvent(shard=None, old_user=None, user=mock.Mock())
 
     def test_app_property(self, event):
-        assert event.app is event.state.app
-
-    def test_guild_id_property(self, event):
-        event.state.guild_id = 123
-        assert event.guild_id == 123
-
-    def test_old_voice_state(self, event):
-        event.old_state.guild_id = 123
-        assert event.old_state.guild_id == 123
-
-
-class TestVoiceServerUpdateEvent:
-    @pytest.fixture()
-    def event(self):
-        return voice_events.VoiceServerUpdateEvent(
-            app=None, shard=object(), guild_id=123, token="token", raw_endpoint="voice.discord.com:123"
-        )
-
-    def test_endpoint_property(self, event):
-        assert event.endpoint == "wss://voice.discord.com:123"
-
-    def test_endpoint_property_when_raw_endpoint_is_None(self, event):
-        event.raw_endpoint = None
-        assert event.endpoint is None
+        assert event.app is event.user.app

--- a/tests/hikari/impl/test_bot.py
+++ b/tests/hikari/impl/test_bot.py
@@ -239,8 +239,8 @@ class TestGatewayBot:
     def test_intents(self, bot, intents):
         assert bot.intents is intents
 
-    def test_me(self, bot, cache):
-        assert bot.me is cache.get_me.return_value
+    def test_get_me(self, bot, cache):
+        assert bot.get_me() is cache.get_me.return_value
 
     def test_proxy_settings(self, bot, proxy_settings):
         assert bot.proxy_settings is proxy_settings

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -3431,7 +3431,7 @@ class TestEntityFactoryImpl:
         assert partial_message.app is mock_app
         assert partial_message.id == 123
         assert partial_message.channel_id == 456
-        assert partial_message._guild_id == 678
+        assert partial_message.guild_id == 678
         assert partial_message.author == entity_factory_impl.deserialize_user(user_payload)
         assert partial_message.member == entity_factory_impl.deserialize_member(
             member_payload, user=partial_message.author, guild_id=snowflakes.Snowflake(678)
@@ -3537,7 +3537,7 @@ class TestEntityFactoryImpl:
 
         assert partial_message.content is None
         assert partial_message.edited_timestamp is None
-        assert partial_message._guild_id is not None
+        assert partial_message.guild_id is not None
         assert partial_message.member is None
         assert partial_message.application.primary_sku_id is None
         assert partial_message.application.icon_hash is None
@@ -3552,7 +3552,7 @@ class TestEntityFactoryImpl:
         assert partial_message.app is mock_app
         assert partial_message.id == 123
         assert partial_message.channel_id == 456
-        assert partial_message._guild_id is None
+        assert partial_message.guild_id is None
         assert partial_message.author is None
         assert partial_message.member is None
         assert partial_message.content is undefined.UNDEFINED
@@ -3605,7 +3605,7 @@ class TestEntityFactoryImpl:
         assert message.app is mock_app
         assert message.id == 123
         assert message.channel_id == 456
-        assert message._guild_id == 678
+        assert message.guild_id == 678
         assert message.author == entity_factory_impl.deserialize_user(user_payload)
         assert message.member == entity_factory_impl.deserialize_member(
             member_payload, user=message.author, guild_id=snowflakes.Snowflake(678)
@@ -3719,7 +3719,7 @@ class TestEntityFactoryImpl:
         message = entity_factory_impl.deserialize_message(message_payload)
         assert message.app is mock_app
         assert message.content is None
-        assert message._guild_id is None
+        assert message.guild_id is None
         assert message.member is None
         assert message.edited_timestamp is None
         assert message.mentions.everyone is True

--- a/tests/hikari/impl/test_event_factory.py
+++ b/tests/hikari/impl/test_event_factory.py
@@ -62,13 +62,12 @@ class TestEventFactoryImpl:
 
     def test_deserialize_channel_create_event_for_guild_channel(self, event_factory, mock_app, mock_shard):
         mock_app.entity_factory.deserialize_channel.return_value = mock.Mock(spec=channel_models.GuildChannel)
-        mock_payload = object()
+        mock_payload = mock.Mock(app=mock_app)
 
         event = event_factory.deserialize_channel_create_event(mock_shard, mock_payload)
 
         mock_app.entity_factory.deserialize_channel.assert_called_once_with(mock_payload)
         assert isinstance(event, channel_events.GuildChannelCreateEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.channel is mock_app.entity_factory.deserialize_channel.return_value
 
@@ -91,7 +90,6 @@ class TestEventFactoryImpl:
 
         mock_app.entity_factory.deserialize_channel.assert_called_once_with(mock_payload)
         assert isinstance(event, channel_events.GuildChannelUpdateEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.channel is mock_app.entity_factory.deserialize_channel.return_value
         assert event.old_channel is mock_old_channel
@@ -108,13 +106,12 @@ class TestEventFactoryImpl:
 
     def test_deserialize_channel_delete_event_with_guild_channel(self, event_factory, mock_app, mock_shard):
         mock_app.entity_factory.deserialize_channel.return_value = mock.Mock(spec=channel_models.GuildChannel)
-        mock_payload = object()
+        mock_payload = mock.Mock(app=mock_app)
 
         event = event_factory.deserialize_channel_delete_event(mock_shard, mock_payload)
 
         mock_app.entity_factory.deserialize_channel.assert_called_once_with(mock_payload)
         assert isinstance(event, channel_events.GuildChannelDeleteEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.channel is mock_app.entity_factory.deserialize_channel.return_value
 
@@ -175,13 +172,12 @@ class TestEventFactoryImpl:
         assert event.guild_id == 123123
 
     def test_deserialize_invite_create_event(self, event_factory, mock_app, mock_shard):
-        mock_payload = object()
+        mock_payload = mock.Mock(app=mock_app)
 
         event = event_factory.deserialize_invite_create_event(mock_shard, mock_payload)
 
         mock_app.entity_factory.deserialize_invite_with_metadata.assert_called_once_with(mock_payload)
         assert isinstance(event, channel_events.InviteCreateEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.invite is mock_app.entity_factory.deserialize_invite_with_metadata.return_value
 
@@ -211,17 +207,17 @@ class TestEventFactoryImpl:
             "timestamp": 7634521233,
             "member": mock_member_payload,
         }
+        mock_app.entity_factory.deserialize_member.return_value = mock.Mock(app=mock_app)
 
         event = event_factory.deserialize_typing_start_event(mock_shard, mock_payload)
 
         mock_app.entity_factory.deserialize_member.assert_called_once_with(mock_member_payload, guild_id=123321)
         assert isinstance(event, typing_events.GuildTypingEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.channel_id == 48585858
         assert event.guild_id == 123321
         assert event.timestamp == datetime.datetime(2211, 12, 6, 12, 20, 33, tzinfo=datetime.timezone.utc)
-        assert event.user == mock_app.entity_factory.deserialize_member.return_value
+        assert event.member == mock_app.entity_factory.deserialize_member.return_value
 
     def test_deserialize_typing_start_event_for_dm(self, event_factory, mock_app, mock_shard):
         mock_payload = {"channel_id": "534123", "timestamp": 7634521212, "user_id": "9494994"}
@@ -240,13 +236,12 @@ class TestEventFactoryImpl:
     ################
 
     def test_deserialize_guild_create_event(self, event_factory, mock_app, mock_shard):
-        mock_payload = object()
+        mock_payload = mock.Mock(app=mock_app)
 
         event = event_factory.deserialize_guild_create_event(mock_shard, mock_payload)
 
         mock_app.entity_factory.deserialize_gateway_guild.assert_called_once_with(mock_payload)
         assert isinstance(event, guild_events.GuildAvailableEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.guild is mock_app.entity_factory.deserialize_gateway_guild.return_value.guild
         assert event.emojis is mock_app.entity_factory.deserialize_gateway_guild.return_value.emojis
@@ -257,14 +252,13 @@ class TestEventFactoryImpl:
         assert event.voice_states is mock_app.entity_factory.deserialize_gateway_guild.return_value.voice_states
 
     def test_deserialize_guild_update_event(self, event_factory, mock_app, mock_shard):
-        mock_payload = object()
+        mock_payload = mock.Mock(app=mock_app)
         mock_old_guild = object()
 
         event = event_factory.deserialize_guild_update_event(mock_shard, mock_payload, old_guild=mock_old_guild)
 
         mock_app.entity_factory.deserialize_gateway_guild.assert_called_once_with(mock_payload)
         assert isinstance(event, guild_events.GuildUpdateEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.guild is mock_app.entity_factory.deserialize_gateway_guild.return_value.guild
         assert event.emojis is mock_app.entity_factory.deserialize_gateway_guild.return_value.emojis
@@ -292,27 +286,25 @@ class TestEventFactoryImpl:
         assert event.guild_id == 6541233
 
     def test_deserialize_guild_ban_add_event(self, event_factory, mock_app, mock_shard):
-        mock_user_payload = object()
+        mock_user_payload = mock.Mock(app=mock_app)
         mock_payload = {"guild_id": "4212312", "user": mock_user_payload}
 
         event = event_factory.deserialize_guild_ban_add_event(mock_shard, mock_payload)
 
         mock_app.entity_factory.deserialize_user.assert_called_once_with(mock_user_payload)
         assert isinstance(event, guild_events.BanCreateEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.guild_id == 4212312
         assert event.user is mock_app.entity_factory.deserialize_user.return_value
 
     def test_deserialize_guild_ban_remove_event(self, event_factory, mock_app, mock_shard):
-        mock_user_payload = object()
+        mock_user_payload = mock.Mock(app=mock_app)
         mock_payload = {"guild_id": "9292929", "user": mock_user_payload}
 
         event = event_factory.deserialize_guild_ban_remove_event(mock_shard, mock_payload)
 
         mock_app.entity_factory.deserialize_user.assert_called_once_with(mock_user_payload)
         assert isinstance(event, guild_events.BanDeleteEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.guild_id == 9292929
         assert event.user is mock_app.entity_factory.deserialize_user.return_value
@@ -380,6 +372,7 @@ class TestEventFactoryImpl:
     def test_deserialize_presence_update_event_with_only_user_id(self, event_factory, mock_app, mock_shard):
         mock_payload = {"user": {"id": "1231312"}}
         mock_old_presence = object()
+        mock_app.entity_factory.deserialize_member_presence.return_value = mock.Mock(app=mock_app)
 
         event = event_factory.deserialize_presence_update_event(
             mock_shard, mock_payload, old_presence=mock_old_presence
@@ -387,7 +380,6 @@ class TestEventFactoryImpl:
 
         mock_app.entity_factory.deserialize_member_presence.assert_called_once_with(mock_payload)
         assert isinstance(event, guild_events.PresenceUpdateEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.old_presence is mock_old_presence
         assert event.user is None
@@ -405,7 +397,7 @@ class TestEventFactoryImpl:
                 "discriminator": "1231",
             }
         }
-        mock_old_presence = object()
+        mock_old_presence = mock.Mock(app=mock_app)
 
         event = event_factory.deserialize_presence_update_event(
             mock_shard, mock_payload, old_presence=mock_old_presence
@@ -413,7 +405,6 @@ class TestEventFactoryImpl:
 
         mock_app.entity_factory.deserialize_member_presence.assert_called_once_with(mock_payload)
         assert isinstance(event, guild_events.PresenceUpdateEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.old_presence is mock_old_presence
 
@@ -431,6 +422,7 @@ class TestEventFactoryImpl:
     def test_deserialize_presence_update_event_with_partial_user_object(self, event_factory, mock_app, mock_shard):
         mock_payload = {"user": {"id": "1231312", "e": "OK"}}
         mock_old_presence = object()
+        mock_app.entity_factory.deserialize_member_presence.return_value = mock.Mock(app=mock_app)
 
         event = event_factory.deserialize_presence_update_event(
             mock_shard, mock_payload, old_presence=mock_old_presence
@@ -438,7 +430,6 @@ class TestEventFactoryImpl:
 
         mock_app.entity_factory.deserialize_member_presence.assert_called_once_with(mock_payload)
         assert isinstance(event, guild_events.PresenceUpdateEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.old_presence is mock_old_presence
 
@@ -502,18 +493,17 @@ class TestEventFactoryImpl:
     #################
 
     def test_deserialize_guild_member_add_event(self, event_factory, mock_app, mock_shard):
-        mock_payload = object()
+        mock_payload = mock.Mock(app=mock_app)
 
         event = event_factory.deserialize_guild_member_add_event(mock_shard, mock_payload)
 
         mock_app.entity_factory.deserialize_member.assert_called_once_with(mock_payload)
         assert isinstance(event, member_events.MemberCreateEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.member is mock_app.entity_factory.deserialize_member.return_value
 
     def test_deserialize_guild_member_update_event(self, event_factory, mock_app, mock_shard):
-        mock_payload = object()
+        mock_payload = mock.Mock(app=mock_app)
         mock_old_member = object()
 
         event = event_factory.deserialize_guild_member_update_event(
@@ -522,13 +512,12 @@ class TestEventFactoryImpl:
 
         mock_app.entity_factory.deserialize_member.assert_called_once_with(mock_payload)
         assert isinstance(event, member_events.MemberUpdateEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.member is mock_app.entity_factory.deserialize_member.return_value
         assert event.old_member is mock_old_member
 
     def test_deserialize_guild_member_remove_event(self, event_factory, mock_app, mock_shard):
-        mock_user_payload = object()
+        mock_user_payload = mock.Mock(app=mock_app)
         mock_old_member = object()
         mock_payload = {"guild_id": "43123", "user": mock_user_payload}
 
@@ -538,7 +527,6 @@ class TestEventFactoryImpl:
 
         mock_app.entity_factory.deserialize_user.assert_called_once_with(mock_user_payload)
         assert isinstance(event, member_events.MemberDeleteEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.guild_id == 43123
         assert event.user is mock_app.entity_factory.deserialize_user.return_value
@@ -549,19 +537,18 @@ class TestEventFactoryImpl:
     ###############
 
     def test_deserialize_guild_role_create_event(self, event_factory, mock_app, mock_shard):
-        mock_role_payload = object()
+        mock_role_payload = mock.Mock(app=mock_app)
         mock_payload = {"role": mock_role_payload, "guild_id": "45123"}
 
         event = event_factory.deserialize_guild_role_create_event(mock_shard, mock_payload)
 
         mock_app.entity_factory.deserialize_role.assert_called_once_with(mock_role_payload, guild_id=45123)
         assert isinstance(event, role_events.RoleCreateEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.role is mock_app.entity_factory.deserialize_role.return_value
 
     def test_deserialize_guild_role_update_event(self, event_factory, mock_app, mock_shard):
-        mock_role_payload = object()
+        mock_role_payload = mock.Mock(app=mock_app)
         mock_old_role = object()
         mock_payload = {"role": mock_role_payload, "guild_id": "45123"}
 
@@ -569,7 +556,6 @@ class TestEventFactoryImpl:
 
         mock_app.entity_factory.deserialize_role.assert_called_once_with(mock_role_payload, guild_id=45123)
         assert isinstance(event, role_events.RoleUpdateEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.role is mock_app.entity_factory.deserialize_role.return_value
         assert event.old_role is mock_old_role
@@ -620,49 +606,45 @@ class TestEventFactoryImpl:
     ##################
 
     def test_deserialize_message_create_event_in_guild(self, event_factory, mock_app, mock_shard):
-        mock_payload = object()
+        mock_payload = mock.Mock(app=mock_app)
         mock_app.entity_factory.deserialize_message.return_value = mock.Mock(guild_id=123321)
 
         event = event_factory.deserialize_message_create_event(mock_shard, mock_payload)
 
         assert isinstance(event, message_events.GuildMessageCreateEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.message is mock_app.entity_factory.deserialize_message.return_value
 
     def test_deserialize_message_create_event_in_dm(self, event_factory, mock_app, mock_shard):
-        mock_payload = object()
+        mock_payload = mock.Mock(app=mock_app)
         mock_app.entity_factory.deserialize_message.return_value = mock.Mock(guild_id=None)
 
         event = event_factory.deserialize_message_create_event(mock_shard, mock_payload)
 
         assert isinstance(event, message_events.DMMessageCreateEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.message is mock_app.entity_factory.deserialize_message.return_value
 
     def test_deserialize_message_update_event_in_guild(self, event_factory, mock_app, mock_shard):
-        mock_payload = object()
+        mock_payload = mock.Mock(app=mock_app)
         mock_old_message = object()
-        mock_app.entity_factory.deserialize_partial_message.return_value = mock.Mock(guild_id=123321)
+        mock_app.entity_factory.deserialize_partial_message.return_value = mock.Mock(guild_id=123321, app=mock_app)
 
         event = event_factory.deserialize_message_update_event(mock_shard, mock_payload, old_message=mock_old_message)
 
         assert isinstance(event, message_events.GuildMessageUpdateEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.message is mock_app.entity_factory.deserialize_partial_message.return_value
         assert event.old_message is mock_old_message
 
     def test_deserialize_message_update_event_in_dm(self, event_factory, mock_app, mock_shard):
-        mock_payload = object()
+        mock_payload = mock.Mock(app=mock_app)
         mock_old_message = object()
         mock_app.entity_factory.deserialize_partial_message.return_value = mock.Mock(guild_id=None)
 
         event = event_factory.deserialize_message_update_event(mock_shard, mock_payload, old_message=mock_old_message)
 
         assert isinstance(event, message_events.DMMessageUpdateEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.message is mock_app.entity_factory.deserialize_partial_message.return_value
         assert event.old_message is mock_old_message
@@ -722,7 +704,7 @@ class TestEventFactoryImpl:
     ###################
 
     def test_deserialize_message_reaction_add_event_in_guild(self, event_factory, mock_shard, mock_app):
-        mock_member_payload = object()
+        mock_member_payload = mock.Mock(app=mock_app)
         mock_emoji_payload = object()
         mock_payload = {
             "member": mock_member_payload,
@@ -737,7 +719,6 @@ class TestEventFactoryImpl:
         mock_app.entity_factory.deserialize_emoji.assert_called_once_with(mock_emoji_payload)
         mock_app.entity_factory.deserialize_member.assert_called_once_with(mock_member_payload, guild_id=43949494)
         assert isinstance(event, reaction_events.GuildReactionAddEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.channel_id == 34123
         assert event.message_id == 43123123
@@ -881,12 +862,12 @@ class TestEventFactoryImpl:
             "session_id": "kjsdjiodsaiosad",
             "application": {"id": "4123212", "flags": "4949494"},
         }
+        mock_app.entity_factory.deserialize_my_user.return_value = mock.Mock(app=mock_app)
 
         event = event_factory.deserialize_ready_event(mock_shard, mock_payload)
 
         mock_app.entity_factory.deserialize_my_user.assert_called_once_with(mock_user_payload)
         assert isinstance(event, shard_events.ShardReadyEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.actual_gateway_version == 69
         assert event.my_user is mock_app.entity_factory.deserialize_my_user.return_value
@@ -966,14 +947,14 @@ class TestEventFactoryImpl:
     ###############
 
     def test_deserialize_own_user_update_event(self, event_factory, mock_app, mock_shard):
-        mock_payload = object()
+        mock_payload = mock.Mock(app=mock_app)
         mock_old_user = object()
+        mock_app.entity_factory.deserialize_my_user.return_value = mock.Mock(app=mock_app)
 
         event = event_factory.deserialize_own_user_update_event(mock_shard, mock_payload, old_user=mock_old_user)
 
         mock_app.entity_factory.deserialize_my_user.assert_called_once_with(mock_payload)
         assert isinstance(event, user_events.OwnUserUpdateEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.user is mock_app.entity_factory.deserialize_my_user.return_value
         assert event.old_user is mock_old_user
@@ -985,6 +966,7 @@ class TestEventFactoryImpl:
     def test_deserialize_voice_state_update_event(self, event_factory, mock_app, mock_shard):
         mock_payload = object()
         mock_old_voice_state = object()
+        mock_app.entity_factory.deserialize_voice_state.return_value = mock.Mock(app=mock_app)
 
         event = event_factory.deserialize_voice_state_update_event(
             mock_shard, mock_payload, old_state=mock_old_voice_state
@@ -992,7 +974,6 @@ class TestEventFactoryImpl:
 
         mock_app.entity_factory.deserialize_voice_state.assert_called_once_with(mock_payload)
         assert isinstance(event, voice_events.VoiceStateUpdateEvent)
-        assert event.app is mock_app
         assert event.shard is mock_shard
         assert event.state is mock_app.entity_factory.deserialize_voice_state.return_value
         assert event.old_state is mock_old_voice_state

--- a/tests/hikari/test_channels.py
+++ b/tests/hikari/test_channels.py
@@ -65,24 +65,24 @@ class TestChannelFollow:
         assert result is mock_app.rest.fetch_webhook.return_value
         mock_app.rest.fetch_webhook.assert_awaited_once_with(54123123)
 
-    def test_channel(self, mock_app):
+    def test_get_channel(self, mock_app):
         mock_channel = mock.Mock(spec=channels.GuildNewsChannel)
         mock_app.cache.get_guild_channel = mock.Mock(return_value=mock_channel)
         follow = channels.ChannelFollow(
             webhook_id=snowflakes.Snowflake(993883), app=mock_app, channel_id=snowflakes.Snowflake(696969)
         )
 
-        result = follow.channel
+        result = follow.get_channel()
 
         assert result is mock_channel
         mock_app.cache.get_guild_channel.assert_called_once_with(696969)
 
-    def test_channel_when_no_cache_trait(self):
+    def test_get_channel_when_no_cache_trait(self):
         follow = channels.ChannelFollow(
             webhook_id=snowflakes.Snowflake(993883), app=object(), channel_id=snowflakes.Snowflake(696969)
         )
 
-        assert follow.channel is None
+        assert follow.get_channel() is None
 
 
 class TestPermissionOverwrite:

--- a/tests/hikari/test_guilds.py
+++ b/tests/hikari/test_guilds.py
@@ -764,37 +764,69 @@ class TestGuild:
             system_channel_flags=guilds.GuildSystemChannelFlag.SUPPRESS_PREMIUM_SUBSCRIPTION,
         )
 
-    def test_channels(self, model):
-        assert model.channels is model.app.cache.get_guild_channels_view_for_guild.return_value
+    def test_get_channels(self, model):
+        assert model.get_channels() is model.app.cache.get_guild_channels_view_for_guild.return_value
         model.app.cache.get_guild_channels_view_for_guild.assert_called_once_with(123)
 
-    def test_channels_when_no_cache_trait(self, model):
+    def test_get_channels_when_no_cache_trait(self, model):
         model.app = object()
-        assert model.channels == {}
+        assert model.get_channels() == {}
 
-    def test_members(self, model):
-        assert model.members is model.app.cache.get_members_view_for_guild.return_value
+    def test_get_members(self, model):
+        assert model.get_members() is model.app.cache.get_members_view_for_guild.return_value
         model.app.cache.get_members_view_for_guild.assert_called_once_with(123)
 
-    def test_members_when_no_cache_trait(self, model):
+    def test_get_members_when_no_cache_trait(self, model):
         model.app = object()
-        assert model.members == {}
+        assert model.get_members() == {}
 
-    def test_presences(self, model):
-        assert model.presences is model.app.cache.get_presences_view_for_guild.return_value
+    def test_get_presences(self, model):
+        assert model.get_presences() is model.app.cache.get_presences_view_for_guild.return_value
         model.app.cache.get_presences_view_for_guild.assert_called_once_with(123)
 
-    def test_presences_when_no_cache_trait(self, model):
+    def test_get_presences_when_no_cache_trait(self, model):
         model.app = object()
-        assert model.presences == {}
+        assert model.get_presences() == {}
 
-    def test_voice_states(self, model):
-        assert model.voice_states is model.app.cache.get_voice_states_view_for_guild.return_value
+    def test_get_voice_states(self, model):
+        assert model.get_voice_states() is model.app.cache.get_voice_states_view_for_guild.return_value
         model.app.cache.get_voice_states_view_for_guild.assert_called_once_with(123)
 
-    def test_voice_states_when_no_cache_trait(self, model):
+    def test_get_voice_states_when_no_cache_trait(self, model):
         model.app = object()
-        assert model.voice_states == {}
+        assert model.get_voice_states() == {}
+
+    def test_get_emojis(self, model):
+        assert model.get_emojis() is model.app.cache.get_emojis_view_for_guild.return_value
+        model.app.cache.get_emojis_view_for_guild.assert_called_once_with(123)
+
+    def test_emojis_when_no_cache_trait(self, model):
+        model.app = object()
+        assert model.get_emojis() == {}
+
+    def test_roles(self, model):
+        assert model.get_roles() is model.app.cache.get_roles_view_for_guild.return_value
+        model.app.cache.get_roles_view_for_guild.assert_called_once_with(123)
+
+    def test_get_roles_when_no_cache_trait(self, model):
+        model.app = object()
+        assert model.get_roles() == {}
+
+    def test_get_emoji(self, model):
+        assert model.get_emoji(456) is model.app.cache.get_emoji.return_value
+        model.app.cache.get_emoji.assert_called_once_with(456)
+
+    def test_get_emoji_when_no_cache_trait(self, model):
+        model.app = object()
+        assert model.get_emoji(456) is None
+
+    def test_get_role(self, model):
+        assert model.get_role(456) is model.app.cache.get_role.return_value
+        model.app.cache.get_role.assert_called_once_with(456)
+
+    def test_get_role_when_no_cache_trait(self, model):
+        model.app = object()
+        assert model.get_role(456) is None
 
     def test_splash_url(self, model):
         splash = object()
@@ -986,16 +1018,21 @@ class TestGuild:
         assert model.get_my_member() is None
 
     def test_get_my_member_when_no_me(self, model):
-        model.app.me = None
+        model.app.get_me = mock.Mock(return_value=None)
+
         assert model.get_my_member() is None
 
+        model.app.get_me.assert_called_once_with()
+
     def test_get_my_member(self, model):
-        model.app.me = mock.Mock(id=123)
+        model.app.get_me = mock.Mock()
+        model.app.get_me.return_value.id = 123
 
         with mock.patch.object(guilds.Guild, "get_member") as get_member:
             assert model.get_my_member() is get_member.return_value
 
         get_member.assert_called_once_with(123)
+        model.app.get_me.assert_called_once_with()
 
 
 class TestRestGuild:
@@ -1038,104 +1075,3 @@ class TestRestGuild:
             max_members=100,
             nsfw_level=guilds.GuildNSFWLevel.AGE_RESTRICTED,
         )
-
-    def test_get_emoji(self, model):
-        emoji = object()
-        model._emojis = {snowflakes.Snowflake(123): emoji}
-
-        assert model.get_emoji(123) is emoji
-
-    def test_get_role(self, model):
-        role = object()
-        model._roles = {snowflakes.Snowflake(123): role}
-
-        assert model.get_role(123) is role
-
-
-class TestGatewayGuild:
-    @pytest.fixture()
-    def model(self, mock_app):
-        return guilds.GatewayGuild(
-            app=mock_app,
-            id=snowflakes.Snowflake(123),
-            splash_hash="splash_hash",
-            discovery_splash_hash="discovery_splash_hash",
-            banner_hash="banner_hash",
-            icon_hash="icon_hash",
-            features=[guilds.GuildFeature.ANIMATED_ICON],
-            name="some guild",
-            application_id=snowflakes.Snowflake(9876),
-            afk_channel_id=snowflakes.Snowflake(1234),
-            afk_timeout=datetime.timedelta(seconds=60),
-            default_message_notifications=guilds.GuildMessageNotificationsLevel.ONLY_MENTIONS,
-            description=None,
-            explicit_content_filter=guilds.GuildExplicitContentFilterLevel.ALL_MEMBERS,
-            is_widget_enabled=False,
-            max_video_channel_users=10,
-            mfa_level=guilds.GuildMFALevel.NONE,
-            owner_id=snowflakes.Snowflake(1111),
-            preferred_locale="en-GB",
-            premium_subscription_count=12,
-            premium_tier=guilds.GuildPremiumTier.TIER_3,
-            public_updates_channel_id=None,
-            rules_channel_id=None,
-            system_channel_id=None,
-            vanity_url_code="yeet",
-            verification_level=guilds.GuildVerificationLevel.VERY_HIGH,
-            widget_channel_id=None,
-            system_channel_flags=guilds.GuildSystemChannelFlag.SUPPRESS_PREMIUM_SUBSCRIPTION,
-            is_large=True,
-            joined_at=None,
-            member_count=1,
-            nsfw_level=guilds.GuildNSFWLevel.AGE_RESTRICTED,
-        )
-
-    @pytest.fixture()
-    def channels(self):
-        return {
-            4321: mock.Mock(channels_.GuildTextChannel),
-            3321: mock.Mock(channels_.GuildNewsChannel),
-            2321: mock.Mock(channels_.GuildStoreChannel),
-            5321: mock.Mock(channels_.GuildVoiceChannel),
-            6321: mock.Mock(channels_.GuildStageChannel),
-        }
-
-    def test_channels(self, model):
-        assert model.channels is model.app.cache.get_guild_channels_view_for_guild.return_value
-        model.app.cache.get_guild_channels_view_for_guild.assert_called_once_with(123)
-
-    def test_channels_when_no_cache_trait(self, model):
-        model.app = object()
-        assert model.channels == {}
-
-    def test_emojis(self, model):
-        assert model.emojis is model.app.cache.get_emojis_view_for_guild.return_value
-        model.app.cache.get_emojis_view_for_guild.assert_called_once_with(123)
-
-    def test_emojis_when_no_cache_trait(self, model):
-        model.app = object()
-        assert model.emojis == {}
-
-    def test_roles(self, model):
-        assert model.roles is model.app.cache.get_roles_view_for_guild.return_value
-        model.app.cache.get_roles_view_for_guild.assert_called_once_with(123)
-
-    def test_roles_when_no_cache_trait(self, model):
-        model.app = object()
-        assert model.roles == {}
-
-    def test_get_emoji(self, model):
-        assert model.get_emoji(456) is model.app.cache.get_emoji.return_value
-        model.app.cache.get_emoji.assert_called_once_with(456)
-
-    def test_get_emoji_when_no_cache_trait(self, model):
-        model.app = object()
-        assert model.get_emoji(456) is None
-
-    def test_get_role(self, model):
-        assert model.get_role(456) is model.app.cache.get_role.return_value
-        model.app.cache.get_role.assert_called_once_with(456)
-
-    def test_get_role_when_no_cache_trait(self, model):
-        model.app = object()
-        assert model.get_role(456) is None


### PR DESCRIPTION
### Summary
Move away from hiding cache calls behind properties
* This mainly applies to events (plus Guild, Member and Message)
* Add in "app" properties to applicable event objects to replace the app attrs field
* rename some cache getting properties to `get_{original_name}`

Since previously we've already had the standard of having cache calls behing get_x methods with the idea that a property/instance variable should remain relatively constant while the results of get methods has no guarantee of being constant, this is being used in this PR. The idea here is to make it more explicit when a cache call is being made vs when a field being present is dependent on API cases within the scope of the object that's currently being operated on to help keep semantics simple and explicit. This also helps avoid issues where a seemingly simple property may be making multiple non-lazy cache calls to build a dict where multiple accesses to the property would lead to extra unnecessary work being done.

This also has a fix for an internal bug which likely stemmed from this approach of hiding cache calls behind properties

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
