### PR TITLE
Do not catch asyncio.CancelledError on canceled futures

### DIFF
--- a/hikari/impl/rate_limits.py
+++ b/hikari/impl/rate_limits.py
@@ -182,11 +182,7 @@ class ManualRateLimiter(BurstRateLimiter):
         else:
             future.set_result(None)
 
-        try:
-            await future
-        except asyncio.CancelledError:
-            # We are closing, so we can ignore these
-            pass
+        await future
 
     def throttle(self, retry_after: float) -> None:
         """Perform the throttling rate limiter logic.
@@ -320,11 +316,7 @@ class WindowedBurstRateLimiter(BurstRateLimiter):
             self.drip()
             future.set_result(None)
 
-        try:
-            await future
-        except asyncio.CancelledError:
-            # We are closing, so we can ignore these
-            pass
+        await future
 
     def get_time_until_reset(self, now: float) -> float:
         """Determine how long until the current rate limit is reset.


### PR DESCRIPTION
 - Doing this will cause all rate limits to be unlocked at the same time, which is not what we want

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Fixes a bug introduced by #558