### PR TITLE
Convert Message.link property to Message.make_link function

### DIFF
--- a/hikari/messages.py
+++ b/hikari/messages.py
@@ -640,16 +640,26 @@ class PartialMessage(snowflakes.Unique):
 
         return channel.guild_id
 
-    @property
-    def link(self) -> str:
-        """Jump link to the message.
+    def make_link(self, guild: typing.Optional[snowflakes.SnowflakeishOr[guilds.PartialGuild]] = None) -> str:
+        """Generate a jump link to this message.
+
+        Other Parameters
+        ----------------
+        guild : typing.Union[hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]]
+            Object or ID of the guild this message is in. If not provided or then
+            this will return a DM message link.
+
+            !!! note
+                This parameter is necessary since `PartialMessage.guild_id`
+                isn't returned by the REST API regardless of whether the message
+                is in a DM or not.
 
         Returns
         -------
         builtins.str
             The jump link to the message.
         """
-        guild_id_str = "@me" if self.guild_id is None else str(self.guild_id)
+        guild_id_str = "@me" if guild is None else str(int(guild))
         return f"{urls.BASE_URL}/channels/{guild_id_str}/{self.channel_id}/{self.id}"
 
     async def fetch_channel(self) -> channels.PartialChannel:

--- a/hikari/messages.py
+++ b/hikari/messages.py
@@ -640,14 +640,14 @@ class PartialMessage(snowflakes.Unique):
 
         return channel.guild_id
 
-    def make_link(self, guild: typing.Optional[snowflakes.SnowflakeishOr[guilds.PartialGuild]] = None) -> str:
+    def make_link(self, guild: typing.Optional[snowflakes.SnowflakeishOr[guilds.PartialGuild]]) -> str:
         """Generate a jump link to this message.
 
         Other Parameters
         ----------------
         guild : typing.Union[hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]]
-            Object or ID of the guild this message is in. If not provided or then
-            this will return a DM message link.
+            Object or ID of the guild this message is in or `builtins.None`
+            to generate a DM message link.
 
             !!! note
                 This parameter is necessary since `PartialMessage.guild_id`

--- a/tests/hikari/test_messages.py
+++ b/tests/hikari/test_messages.py
@@ -133,7 +133,7 @@ class TestMessage:
         message.app = mock.Mock()
         message.id = 789
         message.channel_id = 456
-        assert message.make_link() == "https://discord.com/channels/@me/456/789"
+        assert message.make_link(None) == "https://discord.com/channels/@me/456/789"
 
     def test_guild_id_when_guild_is_not_none(self, message):
         message._guild_id = 123

--- a/tests/hikari/test_messages.py
+++ b/tests/hikari/test_messages.py
@@ -124,19 +124,16 @@ def message():
 
 
 class TestMessage:
-    def test_link_property_when_guild_is_not_none(self, message):
+    def test_make_link_when_guild_is_not_none(self, message):
         message.id = 789
         message.channel_id = 456
-        message._guild_id = 123
-        assert message.link == "https://discord.com/channels/123/456/789"
+        assert message.make_link(123) == "https://discord.com/channels/123/456/789"
 
-    def test_link_property_when_guild_is_none(self, message):
+    def test_make_link_when_guild_is_none(self, message):
         message.app = mock.Mock()
         message.id = 789
         message.channel_id = 456
-        message._guild_id = None
-        message.app.cache.get_guild_channel.return_value = None
-        assert message.link == "https://discord.com/channels/@me/456/789"
+        assert message.make_link() == "https://discord.com/channels/@me/456/789"
 
     def test_guild_id_when_guild_is_not_none(self, message):
         message._guild_id = 123


### PR DESCRIPTION
### Summary
Convert Message.link property to Message.make_link function

This change is necessary since the lib can't always work out whether a message is in a DM or guild and the old Message.link property would default to assuming it's DM which is incorrect behaviour. This would have primarily effected applications which are REST-only or cache-less/not caching channels.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
