### PR TITLE
Let OwnGuildIterator rely on the default limit

### DIFF
--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -551,7 +551,7 @@ class OwnGuildIterator(iterators.BufferedLazyIterator["applications.OwnGuild"]):
         query = data_binding.StringMapBuilder()
         query.put("before" if self._newest_first else "after", self._first_id)
         # We rely on Discord's default for the limit here since for this endpoint this has always scaled
-        # along side the maximum page size limit to match the maximum amount of guilds a user can be in. 
+        # along side the maximum page size limit to match the maximum amount of guilds a user can be in.
 
         chunk = await self._request_call(compiled_route=self._route, query=query)
         assert isinstance(chunk, list)

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -550,7 +550,8 @@ class OwnGuildIterator(iterators.BufferedLazyIterator["applications.OwnGuild"]):
     async def _next_chunk(self) -> typing.Optional[typing.Generator[applications.OwnGuild, typing.Any, None]]:
         query = data_binding.StringMapBuilder()
         query.put("before" if self._newest_first else "after", self._first_id)
-        query.put("limit", 100)
+        # We rely on Discord's default for the limit here since for this endpoint this has always scaled
+        # along side the maximum page size limit to match the maximum amount of guilds a user can be in. 
 
         chunk = await self._request_call(compiled_route=self._route, query=query)
         assert isinstance(chunk, list)


### PR DESCRIPTION
### Summary
Let OwnGuildIterator rely on the default limit
This means that it'll now return 200 guilds per request rather than 100.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
