### PR TITLE
Set repository version to latest and update on new release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,10 @@ jobs:
         run: |
           pip install wheel
 
-          pip install -e .
+          pip install .
           pip uninstall -y hikari
 
-          pip install -e .[speedups]
+          pip install .[speedups]
           pip uninstall -y hikari
 
       - name: Run tests
@@ -168,7 +168,6 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       GITHUB_TAG: ${{ github.event.release.tag_name }}
       GITHUB_REPO_SLUG: ${{ github.repository }}
-      GITHUB_BUILD_NUMBER: ${{ github.run_number }}
       DEPLOY_WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
       TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/pipelines/twemoji.nox.py
+++ b/pipelines/twemoji.nox.py
@@ -27,5 +27,5 @@ from pipelines import nox
 @nox.inherit_environment_vars
 def twemoji_test(session: nox.Session):
     """Brute-force test all possible Twemoji mappings for Discord unicode emojis."""
-    session.install("-U", "-e", ".", "requests")
+    session.install("-U", ".", "requests")
     session.run("python", "scripts/test_twemoji_mapping.py")

--- a/scripts/deploy-pages.sh
+++ b/scripts/deploy-pages.sh
@@ -26,12 +26,7 @@ cd public || exit 1
 git init
 git config user.name "davfsa"
 git config user.email "29100934+davfsa@users.noreply.github.com"
-
-if [ -z ${CI+x} ]; then
-    git remote add origin git@github.com:hikari-py/hikari
-else
-    git remote add origin https://davfsa:${GITHUB_TOKEN}@github.com/${GITHUB_REPO_SLUG}
-fi
+git remote add origin https://davfsa:${GITHUB_TOKEN}@github.com/${GITHUB_REPO_SLUG}
 
 git checkout -B gh-pages
 git add -Av .

--- a/scripts/deploy_webhook.sh
+++ b/scripts/deploy_webhook.sh
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2020 Nekokatt
 # Copyright (c) 2021 davfsa
 #
@@ -19,34 +18,23 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-import os
 
-import requests
+# We first format the payload and then replace ' with " to make it valid JSON
+PAYLOAD=$(echo "{
+        'username': 'Github Actions',
+        'embeds': [
+            {
+                'title': '${GITHUB_TAG} has been deployed to PyPI',
+                'color': 6697881,
+                'description': 'Install it now by executing: \`\`\`pip install hikari==${GITHUB_TAG}\`\`\`',
+                'footer': {
+                    'text': 'SHA: ${GITHUB_SHA}'
+                }
+            }
+        ]
+    }" | tr "'" '"')
 
-if os.getenv("CI"):
-    webhook_url = os.environ["DEPLOY_WEBHOOK_URL"]
-    tag = os.environ["GITHUB_TAG"]
-    build_no = os.environ["GITHUB_BUILD_NUMBER"]
-    commit_sha = os.environ["GITHUB_SHA"]
-
-    payload = dict(
-        username="Github Actions",
-        embeds=[
-            dict(
-                title=f"{tag} has been deployed to PyPI",
-                color=0x663399,
-                description="Install it now!",
-                footer=dict(text=f"#{build_no} | {commit_sha}"),
-            )
-        ],
-    )
-
-    with requests.post(webhook_url, json=payload) as resp:
-        print("POST", payload)
-        print(resp.status_code, resp.reason)
-        try:
-            print(resp.json())
-        except:
-            print(resp.content)
-else:
-    print("Skipping webhook, not on CI.")
+curl --request POST \
+  --url ${DEPLOY_WEBHOOK_URL} \
+  --header 'Content-Type: application/json' \
+  --data "${PAYLOAD}"

--- a/scripts/increase_version_number.py
+++ b/scripts/increase_version_number.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# cython: language_level=3
 # Copyright (c) 2020 Nekokatt
 # Copyright (c) 2021 davfsa
 #
@@ -20,21 +19,23 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-"""Package metadata."""
+"""A little helpful script to increment the package version after every release."""
+import os
+import sys
 
-# DO NOT ADD TYPE HINTS TO THESE FIELDS. THESE ARE AUTOMATICALLY UPDATED
-# FROM THE CI SCRIPT AND DOING THIS MAY LEAD TO THE DEPLOY PROCESS FAILING.
+sys.path.append(os.getcwd())
 
-__author__ = "Nekokatt"
-__maintainer__ = "davfsa"
-__ci__ = "https://github.com/hikari-py/hikari/actions"
-__copyright__ = "© 2021 davfsa"
-__coverage__ = "https://codeclimate.com/github/hikari-py/hikari"
-__discord_invite__ = "https://discord.gg/Jx4cNGG"
-__docs__ = "https://hikari-py.github.io/hikari/hikari"
-__email__ = "davfsa@gmail.com"
-__issue_tracker__ = "https://github.com/hikari-py/hikari/issues"
-__license__ = "MIT"
-__url__ = "https://github.com/hikari-py/hikari"
-__version__ = "2.0.0.dev101"
-__git_sha1__ = "HEAD"
+from hikari.internal import ux
+
+version = ux.HikariVersion(sys.argv[1])
+
+if version.prerelease is not None:
+    # Increase the pre-release number if there
+    prerelease_str, prerelease_num = version.prerelease
+    version.prerelease = (prerelease_str, prerelease_num + 1)
+
+else:
+    # Or add it if missing
+    version.prerelease = (".dev", 0)
+
+print(version)


### PR DESCRIPTION
### Summary
Installing hikari from the repository does not work anymore as of [PEP 517](https://www.python.org/dev/peps/pep-0517/). Due to this we have relied on editable mode (`-e`) to bypass that. With [PEP 660](https://www.python.org/dev/peps/pep-0660/), right around the corner, this will break, so we need a better alternative.

This PR will fix that by setting a new default version that will update with every release.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.