### PR TITLE
Add a token type property to the rest interface to allow for token introspection

### DIFF
--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -64,7 +64,7 @@ class TokenStrategy(abc.ABC):
     @property
     @abc.abstractmethod
     def token_type(self) -> typing.Union[applications.TokenType, str]:
-        """Type of token this token strategy returns.
+        """Type of token this strategy returns.
 
         Returns
         -------

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -61,9 +61,20 @@ class TokenStrategy(abc.ABC):
 
     __slots__: typing.Sequence[str] = ()
 
+    @property
+    @abc.abstractmethod
+    def token_type(self) -> typing.Union[applications.TokenType, str]:
+        """Type of token this token strategy returns.
+
+        Returns
+        -------
+        typing.Union[hikari.applications.TokenType, builtins.str]
+            The type of token this strategy returns.
+        """
+
     @abc.abstractmethod
     async def acquire(self, client: RESTClient) -> str:
-        """Acquire an authorization token (with the prefix).
+        """Acquire an authorization token (including the prefix).
 
         Returns
         -------
@@ -100,16 +111,16 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     @property
     @abc.abstractmethod
-    def token(self) -> typing.Union[str, TokenStrategy, None]:
-        """Token this client is using for most requests.
+    def token_type(self) -> typing.Union[str, applications.TokenType, None]:
+        """Type of token this client is using for most requests.
 
         Returns
         -------
-        typing.Union[builtins.str, TokenStrategy, builtins.None]
-            The token this client is using for most requests.
+        typing.Union[builtins.str, hikari.applications.TokenType, builtins.None]
+            The type of token this client is using for most requests.
 
-            If this is `builtins.None` then this client will only work for some
-            endpoints such as public and webhook ones.
+            If this is `builtins.None` then this client will likely only work
+            for some endpoints such as public and webhook ones.
         """
 
     @abc.abstractmethod

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -98,6 +98,20 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     __slots__: typing.Sequence[str] = ()
 
+    @property
+    @abc.abstractmethod
+    def token(self) -> typing.Union[str, TokenStrategy, None]:
+        """Token this client is using for most requests.
+
+        Returns
+        -------
+        typing.Union[builtins.str, TokenStrategy, builtins.None]
+            The token this client is using for most requests.
+
+            If this is `builtins.None` then this client will only work for some
+            endpoints such as public and webhook ones.
+        """
+
     @abc.abstractmethod
     async def close(self) -> None:
         """Close the client session."""

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -187,6 +187,10 @@ class ClientCredentialsStrategy(rest_api.TokenStrategy):
         """
         return self._scopes
 
+    @property
+    def token_type(self) -> typing.Union[applications.TokenType, str]:
+        return applications.TokenType.BEARER
+
     async def acquire(self, client: rest_api.RESTClient) -> str:
         if self._token and not self._is_expired:
             return self._token
@@ -336,6 +340,48 @@ class RESTApp(traits.ExecutorAware):
         token: typing.Union[str, rest_api.TokenStrategy, None] = None,
         token_type: typing.Union[str, applications.TokenType] = applications.TokenType.BEARER,
     ) -> RESTClientImpl:
+        """Acquire an instance of this REST client.
+
+        !!! note
+            The returned REST client should be started before it can be used,
+            either by calling `RESTClientImpl.start` or by using it as an
+            asynchronous context manager.
+
+        Examples
+        --------
+        ```py
+        rest_app = RESTApp()
+
+        # Using the returned client as a context manager to implicitly start
+        # and stop it.
+        async with rest_app.acquire("A token", "Bot") as client:
+            ...
+        ```
+
+        Parameters
+        ----------
+        token : typing.Union[builtins.str, builtins.None, hikari.api.rest.TokenStrategy]
+            The bot or bearer token. If no token is to be used,
+            this can be undefined.
+        token_type : typing.Union[builtins.str, hikari.applications.TokenType, builtins.None]
+            The type of token in use. This must be passed when a `builtins.str` is
+            passed for `token` but and can be `"Bot"` or `"Bearer"`.
+
+            This should be left as `builtins.None` when either
+            `hikari.api.rest.TokenStrategy` or `builtins.None` is passed for
+            `token`.
+
+        Returns
+        -------
+        RESTClientImpl
+            An instance of the REST client.
+
+        Raises
+        ------
+        ValueError
+            * If `token_type` is provided when a token strategy is passed for `token`.
+            * if `token_type` is left as `builtins.None` when a string is passed for `token`.
+        """
         # Since we essentially mimic a fake App instance, we need to make a circular provider.
         # We can achieve this using a lambda. This allows the entity factory to build models that
         # are also REST-aware
@@ -382,11 +428,21 @@ class RESTClientImpl(rest_api.RESTClient):
         The bot or bearer token. If no token is to be used,
         this can be undefined.
     token_type : typing.Union[builtins.str, hikari.applications.TokenType, builtins.None]
-        The type of token in use. If no token is used, this can be ignored and
-        left to the default value. This can be `"Bot"` or `"Bearer"`.
+        The type of token in use. This must be passed when a `builtins.str` is
+         passed for `token` but and can be `"Bot"` or `"Bearer"`.
+
+         This should be left as `builtins.None` when either
+         `hikari.api.rest.TokenStrategy` or `builtins.None` is passed for
+         `token`.
     rest_url : builtins.str
         The HTTP API base URL. This can contain format-string specifiers to
         interpolate information such as API version in use.
+
+    Raises
+    ------
+    ValueError
+        * If `token_type` is provided when a token strategy is passed for `token`
+        * if `token_type` is left as `builtins.None` when a string is passed for `token`.
     """
 
     __slots__: typing.Sequence[str] = (
@@ -402,6 +458,7 @@ class RESTClientImpl(rest_api.RESTClient):
         "_proxy_settings",
         "_rest_url",
         "_token",
+        "_token_type",
     )
 
     buckets: buckets_.RESTBucketManager
@@ -440,15 +497,21 @@ class RESTClientImpl(rest_api.RESTClient):
         self._http_settings = http_settings
         self._proxy_settings = proxy_settings
 
-        self._token: typing.Union[str, rest_api.TokenStrategy, None]
+        self._token: typing.Union[str, rest_api.TokenStrategy, None] = None
+        self._token_type: typing.Optional[str] = None
         if isinstance(token, str):
-            self._token = f"{token_type.title()} {token}" if token_type else token
+            if token_type is None:
+                raise ValueError("Token type required when a str is passed for `token`")
 
-        elif isinstance(token, rest_api.TokenStrategy) and token_type:
-            raise ValueError("Token type should be handled by the token strategy")
+            self._token = f"{token_type.title()} {token}"
+            self._token_type = applications.TokenType(token_type.title())
 
-        else:
+        elif isinstance(token, rest_api.TokenStrategy):
+            if token_type is not None:
+                raise ValueError("Token type should be handled by the token strategy")
+
             self._token = token
+            self._token_type = token.token_type
 
         self._rest_url = rest_url if rest_url is not None else urls.REST_API_URL
 
@@ -461,8 +524,8 @@ class RESTClientImpl(rest_api.RESTClient):
         return self._proxy_settings
 
     @property
-    def token(self) -> typing.Union[str, rest_api.TokenStrategy, None]:
-        return self._token
+    def token_type(self) -> typing.Union[str, applications.TokenType, None]:
+        return self._token_type
 
     @typing.final
     async def close(self) -> None:

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -377,7 +377,7 @@ class RESTApp(traits.ExecutorAware):
             this can be undefined.
         token_type : typing.Union[builtins.str, hikari.applications.TokenType, builtins.None]
             The type of token in use. This should only be passed when `builtins.str`
-            is passed for `token` but, can be `"Bot"` or `"Bearer"` and will be
+            is passed for `token`, can be `"Bot"` or `"Bearer"` and will be
             defaulted to `"Bearer"` in this situation.
 
             This should be left as `builtins.None` when either

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -391,7 +391,7 @@ class RESTApp(traits.ExecutorAware):
 
         Raises
         ------
-        ValueError
+        builtins.ValueError
             If `token_type` is provided when a token strategy is passed for `token`.
         """
         # Since we essentially mimic a fake App instance, we need to make a circular provider.

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -392,7 +392,7 @@ class RESTApp(traits.ExecutorAware):
         Raises
         ------
         ValueError
-            * If `token_type` is provided when a token strategy is passed for `token`.
+            If `token_type` is provided when a token strategy is passed for `token`.
         """
         # Since we essentially mimic a fake App instance, we need to make a circular provider.
         # We can achieve this using a lambda. This allows the entity factory to build models that

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -355,7 +355,7 @@ class RESTApp(traits.ExecutorAware):
         # Using the returned client as a context manager to implicitly start
         # and stop it.
         async with rest_app.acquire("A token", "Bot") as client:
-            ...
+            user = await client.fetch_my_user()
         ```
 
         Parameters
@@ -441,7 +441,7 @@ class RESTClientImpl(rest_api.RESTClient):
     Raises
     ------
     ValueError
-        * If `token_type` is provided when a token strategy is passed for `token`
+        * If `token_type` is provided when a token strategy is passed for `token`.
         * if `token_type` is left as `builtins.None` when a string is passed for `token`.
     """
 

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -460,6 +460,10 @@ class RESTClientImpl(rest_api.RESTClient):
     def proxy_settings(self) -> config.ProxySettings:
         return self._proxy_settings
 
+    @property
+    def token(self) -> typing.Union[str, rest_api.TokenStrategy, None]:
+        return self._token
+
     @typing.final
     async def close(self) -> None:
         """Close the HTTP client and any open HTTP connections."""

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -188,7 +188,7 @@ class ClientCredentialsStrategy(rest_api.TokenStrategy):
         return self._scopes
 
     @property
-    def token_type(self) -> typing.Union[applications.TokenType, str]:
+    def token_type(self) -> applications.TokenType:
         return applications.TokenType.BEARER
 
     async def acquire(self, client: rest_api.RESTClient) -> str:

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -455,7 +455,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
     Raises
     ------
-    ValueError
+    builtins.ValueError
         * If `token_type` is provided when a token strategy is passed for `token`.
         * if `token_type` is left as `builtins.None` when a string is passed for `token`.
     """

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -429,11 +429,11 @@ class RESTClientImpl(rest_api.RESTClient):
         this can be undefined.
     token_type : typing.Union[builtins.str, hikari.applications.TokenType, builtins.None]
         The type of token in use. This must be passed when a `builtins.str` is
-         passed for `token` but and can be `"Bot"` or `"Bearer"`.
+        passed for `token` but and can be `"Bot"` or `"Bearer"`.
 
-         This should be left as `builtins.None` when either
-         `hikari.api.rest.TokenStrategy` or `builtins.None` is passed for
-         `token`.
+        This should be left as `builtins.None` when either
+        `hikari.api.rest.TokenStrategy` or `builtins.None` is passed for
+        `token`.
     rest_url : builtins.str
         The HTTP API base URL. This can contain format-string specifiers to
         interpolate information such as API version in use.

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -378,7 +378,7 @@ class RESTApp(traits.ExecutorAware):
         token_type : typing.Union[builtins.str, hikari.applications.TokenType, builtins.None]
             The type of token in use. This should only be passed when `builtins.str`
             is passed for `token` but, can be `"Bot"` or `"Bearer"` and will be
-            default to `"Bearer"` in this situation.
+            defaulted to `"Bearer"` in this situation.
 
             This should be left as `builtins.None` when either
             `hikari.api.rest.TokenStrategy` or `builtins.None` is passed for

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -316,6 +316,7 @@ class TestRESTApp:
             rest_app.acquire(token="token")
 
         mock_client.assert_called_once_with(
+            cache=None,
             entity_factory=_entity_factory(),
             executor=rest_app._executor,
             http_settings=rest_app._http_settings,
@@ -441,6 +442,7 @@ class TestRESTClientImpl:
     def test__init__when_token_strategy_passed(self):
         mock_strategy = mock.Mock(rest_api.TokenStrategy)
         obj = rest.RESTClientImpl(
+            cache=None,
             http_settings=mock.Mock(),
             max_rate_limit=float("inf"),
             proxy_settings=mock.Mock(),
@@ -487,6 +489,7 @@ class TestRESTClientImpl:
     def test__init__when_token_provided_as_string_without_type(self):
         with pytest.raises(ValueError, match="Token type required when a str is passed for `token`"):
             rest.RESTClientImpl(
+                cache=None,
                 http_settings=mock.Mock(),
                 max_rate_limit=float("inf"),
                 proxy_settings=mock.Mock(),

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -487,6 +487,11 @@ class TestRESTClientImpl:
         rest_client._proxy_settings = mock_proxy_settings
         assert rest_client.proxy_settings is mock_proxy_settings
 
+    def test_token_property(self, rest_client):
+        mock_token = object()
+        rest_client._token = mock_token
+        assert rest_client.token is mock_token
+
     def test__acquire_client_session_when_None(self, rest_client):
         client_session_mock = object()
         rest_client._acquire_tcp_connector = mock.Mock()

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -303,6 +303,29 @@ class TestRESTApp:
             rest_url=rest_app._url,
         )
 
+    def test_acquire_defaults_to_bearer_for_a_string_token(self, rest_app):
+        mock_event_loop = object()
+        rest_app._event_loop = mock_event_loop
+
+        stack = contextlib.ExitStack()
+        _entity_factory = stack.enter_context(mock.patch.object(entity_factory, "EntityFactoryImpl"))
+        mock_client = stack.enter_context(mock.patch.object(rest, rest.RESTClientImpl.__qualname__))
+        stack.enter_context(mock.patch.object(asyncio, "get_running_loop", return_value=mock_event_loop))
+
+        with stack:
+            rest_app.acquire(token="token")
+
+        mock_client.assert_called_once_with(
+            entity_factory=_entity_factory(),
+            executor=rest_app._executor,
+            http_settings=rest_app._http_settings,
+            max_rate_limit=float("inf"),
+            proxy_settings=rest_app._proxy_settings,
+            token="token",
+            token_type=applications.TokenType.BEARER,
+            rest_url=rest_app._url,
+        )
+
 
 ##################
 # RESTClientImpl #


### PR DESCRIPTION
### Summary
Add a token type property to the rest interface to allow for token introspection

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
