### PR TITLE
ComponentNotRunningError error refactors

### DIFF
--- a/hikari/errors.py
+++ b/hikari/errors.py
@@ -39,7 +39,6 @@ __all__: typing.List[str] = [
     "RESTErrorCode",
     "HTTPError",
     "HTTPResponseError",
-    "HTTPClientClosedError",
     "ClientHTTPResponseError",
     "InternalServerError",
     "ShardCloseCode",
@@ -223,18 +222,6 @@ class HTTPError(HikariError):
     """Base exception raised if an HTTP error occurs while making a request."""
 
     message: str = attr.field()
-    """The error message."""
-
-
-@attr.define(auto_exc=True, repr=False, weakref_slot=False)
-class HTTPClientClosedError(HTTPError):
-    """Exception raised if an `aiohttp.ClientSession` was closed.
-
-    This fires when using a closed `aiohttp.ClientSession` to make a
-    request.
-    """
-
-    message: str = attr.field(default="The client session has been closed, no HTTP requests can occur.", init=False)
     """The error message."""
 
 

--- a/hikari/errors.py
+++ b/hikari/errors.py
@@ -28,7 +28,7 @@ __all__: typing.List[str] = [
     "HikariError",
     "HikariWarning",
     "HikariInterrupt",
-    "ComponentNotRunningError",
+    "ComponentStateConflictError",
     "UnrecognisedEntityError",
     "NotFoundError",
     "RateLimitedError",
@@ -104,8 +104,12 @@ class HikariInterrupt(KeyboardInterrupt, HikariError):
 
 
 @attr.define(auto_exc=True, repr=False, weakref_slot=False)
-class ComponentNotRunningError(HikariError):
-    """An exception thrown if trying to interact with a component that is not running."""
+class ComponentStateConflictError(HikariError):
+    """Exception thrown when an action cannot be executed in the component's current state.
+
+    Dependent on context this will be thrown for components which are already
+    running or haven't been started yet.
+    """
 
     reason: str = attr.field()
     """A string to explain the issue."""

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -355,7 +355,7 @@ class BotApp(traits.BotAware):
 
     def _check_if_alive(self) -> None:
         if not self._is_alive:
-            raise errors.ComponentNotRunningError("bot is not running so it cannot be interacted with")
+            raise errors.ComponentStateConflictError("bot is not running so it cannot be interacted with")
 
     async def close(self, force: bool = True) -> None:
         """Kill the application by shutting all components down."""
@@ -565,13 +565,13 @@ class BotApp(traits.BotAware):
 
         Raises
         ------
-        builtins.RuntimeError
+        hikari.errors.ComponentStateConflictError
             If bot is already running.
         builtins.TypeError
             If `shard_ids` is passed without `shard_count`.
         """
         if self._is_alive:
-            raise RuntimeError("bot is already running")
+            raise errors.ComponentStateConflictError("bot is already running")
 
         if shard_ids is not None and shard_count is None:
             raise TypeError("'shard_ids' must be passed with 'shard_count'")
@@ -733,13 +733,13 @@ class BotApp(traits.BotAware):
 
         Raises
         ------
-        builtins.RuntimeError
+        hikari.errors.ComponentStateConflictError
             If bot is already running.
         builtins.TypeError
             If `shard_ids` is passed without `shard_count`.
         """
         if self._is_alive:
-            raise RuntimeError("bot is already running")
+            raise errors.ComponentStateConflictError("bot is already running")
 
         if shard_ids is not None and shard_count is None:
             raise TypeError("'shard_ids' must be passed with 'shard_count'")

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -504,7 +504,7 @@ class RESTClientImpl(rest_api.RESTClient):
             _LOGGER.log(ux.TRACE, "acquired new tcp connector")
 
         elif self._tcp_connector.closed:
-            raise errors.HTTPClientClosedError
+            raise errors.ComponentStateConflictError("The client session has been closed, no HTTP requests can occur.")
 
         return self._tcp_connector
 
@@ -524,7 +524,7 @@ class RESTClientImpl(rest_api.RESTClient):
             _LOGGER.log(ux.TRACE, "acquired new aiohttp client session")
 
         elif self._client_session.closed:
-            raise errors.HTTPClientClosedError
+            raise errors.ComponentStateConflictError("The client session has been closed, no HTTP requests can occur.")
 
         return self._client_session
 

--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -542,7 +542,7 @@ class GatewayShardImpl(shard.GatewayShard):
 
     def _check_if_alive(self) -> None:
         if not self.is_alive:
-            raise errors.ComponentNotRunningError(
+            raise errors.ComponentStateConflictError(
                 f"shard {self._shard_id} is not running so it cannot be interacted with"
             )
 
@@ -589,7 +589,7 @@ class GatewayShardImpl(shard.GatewayShard):
 
     async def start(self) -> None:
         if self._run_task is not None:
-            raise RuntimeError("Cannot run more than one instance of one shard concurrently")
+            raise errors.ComponentStateConflictError("Cannot run more than one instance of one shard concurrently")
 
         run_task = asyncio.create_task(self._run(), name=f"run shard {self._shard_id}")
         self._run_task = run_task

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -136,7 +136,7 @@ class TypingIndicator(special_endpoints.TypingIndicator):
                 except asyncio.TimeoutError:
                     pass
 
-        except (asyncio.CancelledError, errors.HTTPClientClosedError):
+        except (asyncio.CancelledError, errors.ComponentStateConflictError):
             pass
 
 

--- a/hikari/traits.py
+++ b/hikari/traits.py
@@ -501,7 +501,7 @@ class BotAware(
         """Check whether the bot is running or not.
 
         This is useful as some functions might raise
-        `hikari.errors.ComponentNotRunningError` if this is
+        `hikari.errors.ComponentStateConflictError` if this is
         `builtins.False`.
 
         Returns

--- a/tests/hikari/impl/test_bot.py
+++ b/tests/hikari/impl/test_bot.py
@@ -268,7 +268,7 @@ class TestBotApp:
     def test_check_if_alive_when_False(self, bot):
         bot._is_alive = False
 
-        with pytest.raises(errors.ComponentNotRunningError):
+        with pytest.raises(errors.ComponentStateConflictError):
             bot._check_if_alive()
 
     def test_check_if_alive(self, bot):

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -507,7 +507,7 @@ class TestRESTClientImpl:
         client_session_mock = mock.Mock(closed=True)
         rest_client._client_session = client_session_mock
 
-        with pytest.raises(errors.HTTPClientClosedError):
+        with pytest.raises(errors.ComponentStateConflictError):
             assert rest_client._acquire_client_session() is client_session_mock
 
     def test__acquire_tcp_connector_when_None(self, rest_client):
@@ -539,7 +539,7 @@ class TestRESTClientImpl:
         tcp_connector_mock = mock.Mock(closed=True)
         rest_client._tcp_connector = tcp_connector_mock
 
-        with pytest.raises(errors.HTTPClientClosedError):
+        with pytest.raises(errors.ComponentStateConflictError):
             assert rest_client._acquire_tcp_connector() is tcp_connector_mock
 
     @pytest.mark.parametrize(

--- a/tests/hikari/impl/test_shard.py
+++ b/tests/hikari/impl/test_shard.py
@@ -644,7 +644,7 @@ class TestGatewayShardImpl:
 
     def test_shard__check_if_alive_when_not_alive(self, client):
         with mock.patch.object(shard.GatewayShardImpl, "is_alive", new=False):
-            with pytest.raises(errors.ComponentNotRunningError):
+            with pytest.raises(errors.ComponentStateConflictError):
                 client._check_if_alive()
 
     def test_shard__check_if_alive_when_alive(self, client):

--- a/tests/hikari/test_errors.py
+++ b/tests/hikari/test_errors.py
@@ -34,10 +34,10 @@ class TestShardCloseCode:
         assert errors.ShardCloseCode(code).is_standard is expected
 
 
-class TestComponentNotRunningError:
+class TestComponentStateConflictError:
     @pytest.fixture()
     def error(self):
-        return errors.ComponentNotRunningError("some reason")
+        return errors.ComponentStateConflictError("some reason")
 
     def test_str(self, error):
         assert str(error) == "some reason"


### PR DESCRIPTION
### Summary
* Rename ComponentNotRunningError to ComponentStateConflictError 
* Plus replace some usages of RuntimeError for functions which cannot be called while a component is still alive with ComponentStateConflictError
* Replace HTTPClientClosedError with ComponentStateConflictError

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
