### PR TITLE
Make voice and rest components multi-use

### DIFF
--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -85,10 +85,6 @@ class TokenStrategy(abc.ABC):
             prefix.
         """
 
-    @abc.abstractmethod
-    async def close(self) -> None:
-        """Close this access token handler."""
-
     def invalidate(self, token: typing.Optional[str]) -> None:
         """Invalidate the cached token in this handler.
 
@@ -110,6 +106,11 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     """Interface for functionality that a REST API implementation provides."""
 
     __slots__: typing.Sequence[str] = ()
+
+    @property
+    @abc.abstractmethod
+    def is_alive(self) -> bool:
+        """Whether this component is alive."""
 
     @property
     @abc.abstractmethod

--- a/hikari/api/voice.py
+++ b/hikari/api/voice.py
@@ -45,6 +45,11 @@ class VoiceComponent(abc.ABC):
 
     @property
     @abc.abstractmethod
+    def is_alive(self) -> bool:
+        """Whether this component is alive."""
+
+    @property
+    @abc.abstractmethod
     def connections(self) -> typing.Mapping[snowflakes.Snowflake, VoiceConnection]:
         """Return a mapping of guild-id to active voice connection."""
 

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -81,6 +81,9 @@ class GatewayBot(traits.GatewayBotAware):
     This is the class you will want to use to start, control, and build a bot
     with.
 
+    !!! warning
+        Bots built from this class are one-use and can only be started/run once.
+
     Parameters
     ----------
     token : builtins.str
@@ -225,6 +228,7 @@ class GatewayBot(traits.GatewayBotAware):
         "_rest",
         "_shards",
         "_token",
+        "_is_used",
         "_voice",
         "shards",
     )
@@ -258,6 +262,7 @@ class GatewayBot(traits.GatewayBotAware):
         self._intents = intents
         self._proxy_settings = proxy_settings if proxy_settings is not None else config.ProxySettings()
         self._token = token
+        self._is_used = False
 
         # Caching
         cache_settings = cache_settings if cache_settings is not None else config.CacheSettings()
@@ -745,6 +750,9 @@ class GatewayBot(traits.GatewayBotAware):
         if self._is_alive:
             raise errors.ComponentStateConflictError("bot is already running")
 
+        if self._is_used:
+            raise errors.ComponentStateConflictError("Cannot startup a bot multiple times")
+
         if shard_ids is not None and shard_count is None:
             raise TypeError("'shard_ids' must be passed with 'shard_count'")
 
@@ -785,6 +793,7 @@ class GatewayBot(traits.GatewayBotAware):
             raise errors.GatewayError("Attempted to start more sessions than were allowed in the given time-window")
 
         self._is_alive = True
+        self._is_used = True
         self._closing_event = asyncio.Event()
         _LOGGER.info(
             "you can start %s session%s before the next window which starts at %s; planning to start %s session%s... ",

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -760,6 +760,7 @@ class GatewayBot(traits.GatewayBotAware):
                 name="check for package updates",
             )
 
+        self._rest.start()
         requirements_task = asyncio.create_task(
             self._rest.fetch_gateway_bot_info(), name="fetch gateway sharding settings"
         )

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -228,7 +228,6 @@ class GatewayBot(traits.GatewayBotAware):
         "_rest",
         "_shards",
         "_token",
-        "_is_used",
         "_voice",
         "shards",
     )
@@ -262,7 +261,6 @@ class GatewayBot(traits.GatewayBotAware):
         self._intents = intents
         self._proxy_settings = proxy_settings if proxy_settings is not None else config.ProxySettings()
         self._token = token
-        self._is_used = False
 
         # Caching
         cache_settings = cache_settings if cache_settings is not None else config.CacheSettings()
@@ -750,9 +748,6 @@ class GatewayBot(traits.GatewayBotAware):
         if self._is_alive:
             raise errors.ComponentStateConflictError("bot is already running")
 
-        if self._is_used:
-            raise errors.ComponentStateConflictError("Cannot startup a bot multiple times")
-
         if shard_ids is not None and shard_count is None:
             raise TypeError("'shard_ids' must be passed with 'shard_count'")
 
@@ -793,7 +788,8 @@ class GatewayBot(traits.GatewayBotAware):
             raise errors.GatewayError("Attempted to start more sessions than were allowed in the given time-window")
 
         self._is_alive = True
-        self._is_used = True
+        # This needs to be started before shards.
+        self._voice.start()
         self._closing_event = asyncio.Event()
         _LOGGER.info(
             "you can start %s session%s before the next window which starts at %s; planning to start %s session%s... ",

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -81,9 +81,6 @@ class GatewayBot(traits.GatewayBotAware):
     This is the class you will want to use to start, control, and build a bot
     with.
 
-    !!! warning
-        Bots built from this class are one-use and can only be started/run once.
-
     Parameters
     ----------
     token : builtins.str

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -424,7 +424,7 @@ class RESTApp(traits.ExecutorAware):
 
 @attr.define()
 class _LiveAttributes:
-    """Fields which are only present within `RESTClientImpl` while it's "live".
+    """Fields which are only present within `RESTClientImpl` while it's "alive".
 
     !!! note
         This must be started within an active asyncio event loop.

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -424,6 +424,12 @@ class RESTApp(traits.ExecutorAware):
 
 @attr.define
 class _LiveAttributes:
+    """Fields which are only present within `RESTClientImpl` while it's "live".
+
+    !!! note
+        This must be started within an active asyncio event loop.
+    """
+
     buckets: buckets_.RESTBucketManager
     client_session: aiohttp.ClientSession
     closed_event: asyncio.Event

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -474,8 +474,8 @@ class _LiveAttributes:
         self.is_closing = True
         self.closed_event.set()
         self.buckets.close()
-        await self.client_session.close()
         self.global_rate_limit.close()
+        await self.client_session.close()
         await self.tcp_connector.close()
 
     def still_alive(self) -> _LiveAttributes:

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -470,9 +470,9 @@ class _LiveAttributes:
         )
 
     async def close(self) -> None:
+        self.closed_event.set()
         self.buckets.close()
         await self.client_session.close()
-        self.closed_event.set()
         self.global_rate_limit.close()
         await self.tcp_connector.close()
 

--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -529,7 +529,7 @@ class GatewayShardImpl(shard.GatewayShard):
 
     def _get_ws(self) -> _GatewayTransport:
         if not self._ws:
-            raise errors.ComponentStateConflictError("Shard shutting down")
+            raise errors.ComponentStateConflictError("Shard is shutting down")
 
         return self._ws
 

--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -527,6 +527,12 @@ class GatewayShardImpl(shard.GatewayShard):
             raise RuntimeError("user_id was not known, this is probably a bug")
         return self._user_id
 
+    def _get_ws(self) -> _GatewayTransport:
+        if not self._ws:
+            raise errors.ComponentStateConflictError("Shard shutting down")
+
+        return self._ws
+
     async def join(self) -> None:
         """Wait for this shard to close, if running."""
         await self._closed_event.wait()
@@ -540,7 +546,7 @@ class GatewayShardImpl(shard.GatewayShard):
     ) -> None:
         await self._total_rate_limit.acquire()
 
-        await self._ws.send_json(data=data, compress=compress, dumps=dumps)  # type: ignore[union-attr]
+        await self._get_ws().send_json(data=data, compress=compress, dumps=dumps)
 
     def _check_if_alive(self) -> None:
         if not self.is_alive:
@@ -732,7 +738,7 @@ class GatewayShardImpl(shard.GatewayShard):
         return False
 
     async def _poll_events(self) -> typing.Optional[bool]:
-        payload = await self._ws.receive_json(timeout=5)  # type: ignore[union-attr]
+        payload = await self._get_ws().receive_json(timeout=5)
 
         op = payload[_OP]  # opcode int
         d = payload[_D]  # data/payload. Usually a dict or a bool for INVALID_SESSION
@@ -880,7 +886,7 @@ class GatewayShardImpl(shard.GatewayShard):
                         "closing flag was set during handshake, disconnecting with GOING AWAY "
                         "(_run_once => do not reconnect)"
                     )
-                    await self._ws.send_close(  # type: ignore[union-attr]
+                    await self._get_ws().send_close(
                         code=errors.ShardCloseCode.GOING_AWAY, message=b"shard disconnecting"
                     )
                     return False
@@ -912,7 +918,7 @@ class GatewayShardImpl(shard.GatewayShard):
                     "shard has requested graceful termination, so will not attempt to reconnect "
                     "(_run_once => do not reconnect)"
                 )
-                await self._ws.send_close(  # type: ignore[union-attr]
+                await self._get_ws().send_close(
                     code=errors.ShardCloseCode.GOING_AWAY,
                     message=b"shard disconnecting",
                 )
@@ -1003,14 +1009,14 @@ class GatewayShardImpl(shard.GatewayShard):
 
     async def _wait_for_hello(self) -> asyncio.Task[bool]:
         # Expect HELLO.
-        payload = await self._ws.receive_json()  # type: ignore[union-attr]
+        payload = await self._get_ws().receive_json()
         if payload[_OP] != _HELLO:
             self._logger.debug(
                 "expected HELLO opcode, received %s which makes no sense, closing with PROTOCOL ERROR ",
                 "(_run_once => raise and do not reconnect)",
                 payload[_OP],
             )
-            await self._ws.send_close(  # type: ignore[union-attr]
+            await self._get_ws().send_close(
                 code=errors.ShardCloseCode.PROTOCOL_ERROR,
                 message=b"Expected HELLO op",
             )
@@ -1021,7 +1027,7 @@ class GatewayShardImpl(shard.GatewayShard):
                 "closing flag was set before we could handshake, disconnecting with GOING AWAY "
                 "(_run_once => do not reconnect)"
             )
-            await self._ws.send_close(  # type: ignore[union-attr]
+            await self._get_ws().send_close(
                 code=errors.ShardCloseCode.GOING_AWAY,
                 message=b"shard disconnecting",
             )

--- a/hikari/impl/voice.py
+++ b/hikari/impl/voice.py
@@ -85,11 +85,11 @@ class VoiceComponentImpl(voice.VoiceComponent):
     async def close(self) -> None:
         self._check_if_alive()
         self._is_alive = False
-        await self._disconnect()
         self._app.event_manager.unsubscribe(voice_events.VoiceEvent, self._on_voice_event)
+        await self._disconnect()
 
     def start(self) -> None:
-        """Start this voice component after it's been closed."""
+        """Start this voice component."""
         if self._is_alive:
             raise errors.ComponentStateConflictError("Cannot start a voice component which is already running")
 

--- a/hikari/impl/voice.py
+++ b/hikari/impl/voice.py
@@ -90,7 +90,12 @@ class VoiceComponentImpl(voice.VoiceComponent):
         self._app.event_manager.unsubscribe(voice_events.VoiceEvent, self._on_voice_event)
 
     def start(self) -> None:
-        """Start this voice component."""
+        """Start this voice component after it's been closed.
+
+        !!! note
+            For this implementation `VoiceComponentImplstart` is implicitly
+            called while initialising the class.
+        """
         self._is_alive = True
         self._app.event_manager.subscribe(voice_events.VoiceEvent, self._on_voice_event)
 

--- a/hikari/impl/voice.py
+++ b/hikari/impl/voice.py
@@ -64,7 +64,6 @@ class VoiceComponentImpl(voice.VoiceComponent):
         self._connections = {}
         self.connections = types.MappingProxyType(self._connections)
         self._is_alive = False
-        self.start()
 
     @property
     def is_alive(self) -> bool:
@@ -72,7 +71,7 @@ class VoiceComponentImpl(voice.VoiceComponent):
 
     def _check_if_alive(self) -> None:
         if not self._is_alive:
-            raise errors.ComponentStateConflictError("component cannot be used while it's not alive")
+            raise errors.ComponentStateConflictError("Component cannot be used while it's not alive")
 
     async def _disconnect(self) -> None:
         if self._connections:
@@ -90,12 +89,10 @@ class VoiceComponentImpl(voice.VoiceComponent):
         self._app.event_manager.unsubscribe(voice_events.VoiceEvent, self._on_voice_event)
 
     def start(self) -> None:
-        """Start this voice component after it's been closed.
+        """Start this voice component after it's been closed."""
+        if self._is_alive:
+            raise errors.ComponentStateConflictError("Cannot start a voice component which is already running")
 
-        !!! note
-            For this implementation `VoiceComponentImplstart` is implicitly
-            called while initialising the class.
-        """
         self._is_alive = True
         self._app.event_manager.subscribe(voice_events.VoiceEvent, self._on_voice_event)
 

--- a/tests/hikari/impl/test_bot.py
+++ b/tests/hikari/impl/test_bot.py
@@ -634,13 +634,6 @@ class TestGatewayBot:
         with pytest.raises(errors.ComponentStateConflictError):
             await bot.start()
 
-    @pytest.mark.asyncio
-    async def test_start_when_used(self, bot):
-        bot._is_used = True
-
-        with pytest.raises(errors.ComponentStateConflictError):
-            await bot.start()
-
     @pytest.mark.skip("TODO")
     def test_start(self, bot):
         ...

--- a/tests/hikari/impl/test_bot.py
+++ b/tests/hikari/impl/test_bot.py
@@ -462,7 +462,7 @@ class TestGatewayBot:
     def test_run_when_already_running(self, bot):
         bot._is_alive = True
 
-        with pytest.raises(RuntimeError, match=r"bot is already running"):
+        with pytest.raises(errors.ComponentStateConflictError):
             bot.run()
 
     def test_run_when_shard_ids_specified_without_shard_count(self, bot):
@@ -631,7 +631,14 @@ class TestGatewayBot:
     async def test_start_when_already_running(self, bot):
         bot._is_alive = True
 
-        with pytest.raises(RuntimeError, match=r"bot is already running"):
+        with pytest.raises(errors.ComponentStateConflictError):
+            await bot.start()
+
+    @pytest.mark.asyncio
+    async def test_start_when_used(self, bot):
+        bot._is_used = True
+
+        with pytest.raises(errors.ComponentStateConflictError):
             await bot.start()
 
     @pytest.mark.skip("TODO")

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -605,6 +605,12 @@ class TestRESTClientImpl:
         except AttributeError as exc:
             pytest.fail(exc)
 
+    @pytest.mark.parametrize(("attributes", "expected_result"), [(None, False), (object(), True)])
+    def test_is_alive_property(self, rest_client, attributes, expected_result):
+        rest_client._live_attributes = attributes
+
+        assert rest_client.is_alive is expected_result
+
     def test_http_settings_property(self, rest_client):
         mock_http_settings = object()
         rest_client._http_settings = mock_http_settings
@@ -620,6 +626,7 @@ class TestRESTClientImpl:
         rest_client._token_type = mock_type
         assert rest_client.token_type is mock_type
 
+    @pytest.mark.asyncio()
     async def test_close(self, rest_client):
         rest_client._live_attributes = mock_live_attributes = mock.AsyncMock()
 
@@ -638,6 +645,12 @@ class TestRESTClientImpl:
                 rest_client._max_rate_limit, rest_client.http_settings, rest_client.proxy_settings
             )
             assert rest_client._live_attributes is build.return_value
+
+    def test_start_when_active(self, rest_client):
+        rest_client._live_attributes = object()
+
+        with pytest.raises(errors.ComponentStateConflictError):
+            rest_client.start()
 
     def test__get_live_attributes_when_active(self, rest_client):
         mock_attributes = rest_client._live_attributes = object()

--- a/tests/hikari/impl/test_shard.py
+++ b/tests/hikari/impl/test_shard.py
@@ -801,7 +801,7 @@ class TestGatewayShardImpl:
     async def test_start_when_already_running(self, client):
         client._run_task = object()
 
-        with pytest.raises(RuntimeError, match="Cannot run more than one instance of one shard concurrently"):
+        with pytest.raises(errors.ComponentStateConflictError):
             await client.start()
 
     async def test_start_when_shard_closed_before_starting(self, client):

--- a/tests/hikari/impl/test_shard.py
+++ b/tests/hikari/impl/test_shard.py
@@ -710,6 +710,17 @@ class TestGatewayShardImpl:
         client._user_id = 123
         assert await client.get_user_id() == 123
 
+    def test__get_ws_when_active(self, client):
+        mock_ws = client._ws = object()
+
+        assert client._get_ws() is mock_ws
+
+    def test__get_ws_when_inactive(self, client):
+        client._ws = None
+
+        with pytest.raises(errors.ComponentStateConflictError):
+            client._get_ws()
+
     async def test_join(self, client):
         client._closed_event = mock.Mock(wait=mock.AsyncMock())
 

--- a/tests/hikari/impl/test_voice.py
+++ b/tests/hikari/impl/test_voice.py
@@ -53,6 +53,13 @@ class TestVoiceComponentImpl:
         with pytest.raises(errors.ComponentStateConflictError):
             voice_client._check_if_alive()
 
+    def test__check_if_alive_when_closing(self, voice_client):
+        voice_client._is_alive = True
+        voice_client._is_closing = True
+
+        with pytest.raises(errors.ComponentStateConflictError):
+            voice_client._check_if_alive()
+
     @pytest.mark.asyncio()
     async def test_disconnect(self, voice_client):
         mock_connection = mock.AsyncMock()
@@ -74,6 +81,7 @@ class TestVoiceComponentImpl:
         )
         voice_client._disconnect.assert_awaited_once_with()
         assert voice_client._is_alive is False
+        assert voice_client._is_closing is False
 
     def test_start(self, voice_client, mock_app):
         voice_client._is_alive = False

--- a/tests/hikari/impl/test_voice.py
+++ b/tests/hikari/impl/test_voice.py
@@ -1,0 +1,300 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Nekokatt
+# Copyright (c) 2021 davfsa
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import mock
+import pytest
+
+from hikari import errors
+from hikari.events import voice_events
+from hikari.impl import voice
+from tests.hikari import hikari_test_helpers
+
+
+class TestVoiceComponentImpl:
+    @pytest.fixture()
+    def mock_app(self):
+        return mock.Mock()
+
+    @pytest.fixture()
+    def voice_client(self, mock_app):
+        client = hikari_test_helpers.mock_class_namespace(voice.VoiceComponentImpl, slots_=False)(mock_app)
+        client._is_alive = True
+        return client
+
+    def test_is_alive_property(self, voice_client):
+        voice_client.is_alive is voice_client._is_alive
+
+    def test__check_if_alive_when_alive(self, voice_client):
+        voice_client._is_alive = True
+        voice_client._check_if_alive()
+
+    def test__check_if_alive_when_not_alive(self, voice_client):
+        voice_client._is_alive = False
+
+        with pytest.raises(errors.ComponentStateConflictError):
+            voice_client._check_if_alive()
+
+    @pytest.mark.asyncio()
+    async def test_disconnect(self, voice_client):
+        mock_connection = mock.AsyncMock()
+        mock_connection_2 = mock.AsyncMock()
+        voice_client._connections = {123: mock_connection, 5324: mock_connection_2}
+
+        await voice_client.disconnect()
+
+        mock_connection.disconnect.assert_awaited_once_with()
+        mock_connection_2.disconnect.assert_awaited_once_with()
+
+    @pytest.mark.asyncio()
+    async def test_close(self, voice_client, mock_app):
+        voice_client._disconnect = mock.AsyncMock()
+        await voice_client.close()
+
+        mock_app.event_manager.unsubscribe.assert_called_once_with(
+            voice_events.VoiceEvent, voice_client._on_voice_event
+        )
+        voice_client._disconnect.assert_awaited_once_with()
+        assert voice_client._is_alive is False
+
+    def test_start(self, voice_client, mock_app):
+        voice_client._is_alive = False
+
+        voice_client.start()
+
+        mock_app.event_manager.subscribe.assert_called_once_with(voice_events.VoiceEvent, voice_client._on_voice_event)
+        assert voice_client._is_alive is True
+
+    @pytest.mark.asyncio()
+    async def test_start_when_already_alive(self, voice_client, mock_app):
+        voice_client._is_alive = True
+
+        with pytest.raises(errors.ComponentStateConflictError):
+            await voice_client.start()
+
+    @pytest.mark.asyncio()
+    async def test_connect_to(self, voice_client, mock_app):
+        voice_client._init_state_update_predicate = mock.Mock()
+        voice_client._init_server_update_predicate = mock.Mock()
+        mock_other_connection = object()
+        voice_client._connections = {555: mock_other_connection}
+        mock_shard = mock.AsyncMock(is_alive=True)
+        mock_app.event_manager.wait_for = mock.AsyncMock()
+        mock_app.shard_count = 42
+        mock_app.shards = {0: mock_shard}
+        mock_connection_type = mock.AsyncMock()
+
+        result = await voice_client.connect_to(123, 4532, mock_connection_type, deaf=False, mute=True)
+
+        mock_app.event_manager.wait_for.assert_has_awaits(
+            [
+                mock.call(
+                    voice_events.VoiceStateUpdateEvent,
+                    timeout=None,
+                    predicate=voice_client._init_state_update_predicate.return_value,
+                ),
+                mock.call(
+                    voice_events.VoiceServerUpdateEvent,
+                    timeout=None,
+                    predicate=voice_client._init_server_update_predicate.return_value,
+                ),
+            ]
+        )
+        mock_app.rest.fetch_my_user.assert_not_called()
+        mock_app.cache.get_me.assert_called_once_with()
+        voice_client._init_state_update_predicate.assert_called_once_with(123, mock_app.cache.get_me.return_value.id)
+        voice_client._init_server_update_predicate.assert_called_once_with(123)
+        mock_shard.update_voice_state.assert_awaited_once_with(
+            123,
+            4532,
+            self_deaf=False,
+            self_mute=True,
+        )
+        assert voice_client._connections == {
+            123: mock_connection_type.initialize.return_value,
+            555: mock_other_connection,
+        }
+        assert result is mock_connection_type.initialize.return_value
+
+    @pytest.mark.asyncio()
+    async def test_connect_to_falls_back_to_rest_to_get_own_user(self, voice_client, mock_app):
+        voice_client._init_state_update_predicate = mock.Mock()
+        voice_client._init_server_update_predicate = mock.Mock()
+        mock_shard = mock.AsyncMock(is_alive=True)
+        mock_app.event_manager.wait_for = mock.AsyncMock()
+        mock_app.shard_count = 42
+        mock_app.shards = {0: mock_shard}
+        mock_app.cache.get_me.return_value = None
+        mock_app.rest = mock.AsyncMock()
+        mock_connection_type = mock.AsyncMock()
+
+        await voice_client.connect_to(123, 4532, mock_connection_type, deaf=False, mute=True)
+
+        mock_app.event_manager.wait_for.assert_has_awaits(
+            [
+                mock.call(
+                    voice_events.VoiceStateUpdateEvent,
+                    timeout=None,
+                    predicate=voice_client._init_state_update_predicate.return_value,
+                ),
+                mock.call(
+                    voice_events.VoiceServerUpdateEvent,
+                    timeout=None,
+                    predicate=voice_client._init_server_update_predicate.return_value,
+                ),
+            ]
+        )
+        mock_app.cache.get_me.assert_called_once_with()
+        mock_app.rest.fetch_my_user.assert_awaited_once_with()
+        voice_client._init_state_update_predicate.assert_called_once_with(
+            123, mock_app.rest.fetch_my_user.return_value.id
+        )
+
+    @pytest.mark.asyncio()
+    async def test_connect_to_when_connection_already_present(self, voice_client, mock_app):
+        mock_app.shard_count = 42
+        voice_client._connections = {123: object()}
+
+        with pytest.raises(
+            errors.VoiceError,
+            match="The bot is already in a voice channel for this guild. Close the other connection first, or "
+            "request that the application moves to the new voice channel instead.",
+        ):
+            await voice_client.connect_to(123, 4532, object())
+
+    @pytest.mark.asyncio()
+    async def test_connect_to_for_unknown_shard(self, voice_client, mock_app):
+        mock_app.shard_count = 42
+        mock_app.shards = {}
+
+        with pytest.raises(
+            errors.VoiceError, match="Cannot connect to shard 0, it is not present in this application."
+        ):
+            await voice_client.connect_to(123, 4532, object())
+
+    @pytest.mark.asyncio()
+    async def test_connect_to_for_dead_shard(self, voice_client, mock_app):
+        mock_shard = mock.Mock(is_alive=False)
+        mock_app.shard_count = 42
+        mock_app.shards = {0: mock_shard}
+
+        with pytest.raises(errors.VoiceError, match="Cannot connect to shard 0, the shard is not online."):
+            await voice_client.connect_to(123, 4532, object())
+
+    @pytest.mark.asyncio()
+    async def test_connect_to_handles_failed_connection_initialise(self, voice_client, mock_app):
+        voice_client._init_state_update_predicate = mock.Mock()
+        voice_client._init_server_update_predicate = mock.Mock()
+        mock_shard = mock.AsyncMock(is_alive=True)
+        mock_app.event_manager.wait_for = mock.AsyncMock()
+        mock_app.shard_count = 42
+        mock_app.shards = {0: mock_shard}
+
+        class StubError(Exception):
+            ...
+
+        mock_connection_type = mock.AsyncMock()
+        mock_connection_type.initialize.side_effect = StubError
+
+        with pytest.raises(StubError):
+            await voice_client.connect_to(123, 4532, mock_connection_type, deaf=False, mute=True)
+
+        mock_app.event_manager.wait_for.assert_has_awaits(
+            [
+                mock.call(
+                    voice_events.VoiceStateUpdateEvent,
+                    timeout=None,
+                    predicate=voice_client._init_state_update_predicate.return_value,
+                ),
+                mock.call(
+                    voice_events.VoiceServerUpdateEvent,
+                    timeout=None,
+                    predicate=voice_client._init_server_update_predicate.return_value,
+                ),
+            ]
+        )
+        mock_app.cache.get_me.assert_called_once_with()
+        voice_client._init_state_update_predicate.assert_called_once_with(123, mock_app.cache.get_me.return_value.id)
+        voice_client._init_server_update_predicate.assert_called_once_with(123)
+        mock_shard.update_voice_state.assert_has_awaits(
+            [mock.call(123, 4532, self_deaf=False, self_mute=True), mock.call(123, None)], any_order=False
+        )
+
+    @pytest.mark.asyncio()
+    async def test__on_connection_close(self, voice_client, mock_app):
+        mock_other_connection = object()
+        mock_shard = mock.AsyncMock()
+        mock_app.shards = {69: mock_shard}
+        voice_client._connections = {65234123: mock_other_connection, 123123: object()}
+
+        await voice_client._on_connection_close(mock.Mock(guild_id=123123, shard_id=69))
+
+        mock_shard.update_voice_state.assert_awaited_once_with(guild=123123, channel=None)
+        assert voice_client._connections == {65234123: mock_other_connection}
+
+    def test__init_state_update_predicate_matches(self, voice_client):
+        predicate = voice_client._init_state_update_predicate(42069, 696969)
+        mock_voice_state = mock.Mock(state=mock.Mock(guild_id=42069, user_id=696969))
+
+        assert predicate(mock_voice_state) is True
+
+    def test__init_state_update_predicate_ignores(self, voice_client):
+        predicate = voice_client._init_state_update_predicate(999, 420)
+        mock_voice_state = mock.Mock(state=mock.Mock(guild_id=6969, user_id=3333))
+
+        assert predicate(mock_voice_state) is False
+
+    def test__init_server_update_predicate_matches(self, voice_client):
+        predicate = voice_client._init_server_update_predicate(696969)
+        mock_voice_state = mock.Mock(guild_id=696969)
+
+        assert predicate(mock_voice_state) is True
+
+    def test__init_server_update_predicate_ignores(self, voice_client):
+        predicate = voice_client._init_server_update_predicate(321231)
+        mock_voice_state = mock.Mock(guild_id=123123123)
+
+        assert predicate(mock_voice_state) is False
+
+    @pytest.mark.asyncio()
+    async def test__on_connection_close_ignores_unknown_voice_state(self, voice_client):
+        connections = {123132: object(), 65234234: object()}
+        voice_client._connections = connections.copy()
+
+        await voice_client._on_connection_close(mock.Mock(guild_id=-1))
+
+        assert voice_client._connections == connections
+
+    @pytest.mark.asyncio()
+    async def test__on_voice_event(self, voice_client):
+        mock_connection = mock.AsyncMock()
+        voice_client._connections = {6633: mock_connection}
+        mock_event = mock.Mock(guild_id=6633)
+
+        await voice_client._on_voice_event(mock_event)
+
+        mock_connection.notify.assert_awaited_once_with(mock_event)
+
+    @pytest.mark.asyncio()
+    async def test__on_voice_event_for_untracked_guild(self, voice_client):
+        mock_event = mock.Mock(guild_id=44444)
+
+        await voice_client._on_voice_event(mock_event)


### PR DESCRIPTION
### Summary
* This adds an is_alive property to Voice component along with ComponentStateConflictError cases in the main implementation to avoid erronous behaviour from connections being added after it stops tracking voice events.
* ~~This also explicitly raises ComponentStateConflictError in BotApp if it's already been used instead of letting the rest client raise it on fetch_gateway_bot and documents the fact that BotApp is one use~~

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
