### PR TITLE
Fix edit_permission_overwrites route using wrong method

### DIFF
--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -918,7 +918,7 @@ class RESTClientImpl(rest_api.RESTClient):
                     "Cannot determine the type of the target to update. Try specifying 'target_type' manually."
                 )
 
-        route = routes.PATCH_CHANNEL_PERMISSIONS.compile(channel=channel, overwrite=target)
+        route = routes.PUT_CHANNEL_PERMISSIONS.compile(channel=channel, overwrite=target)
         body = data_binding.JSONObjectBuilder()
         body.put("type", target_type)
         body.put("allow", allow)

--- a/hikari/internal/routes.py
+++ b/hikari/internal/routes.py
@@ -315,7 +315,7 @@ POST_CHANNEL_MESSAGES: typing.Final[Route] = Route(POST, "/channels/{channel}/me
 
 POST_DELETE_CHANNEL_MESSAGES_BULK: typing.Final[Route] = Route(POST, "/channels/{channel}/messages/bulk-delete")
 
-PATCH_CHANNEL_PERMISSIONS: typing.Final[Route] = Route(PATCH, "/channels/{channel}/permissions/{overwrite}")
+PUT_CHANNEL_PERMISSIONS: typing.Final[Route] = Route(PUT, "/channels/{channel}/permissions/{overwrite}")
 DELETE_CHANNEL_PERMISSIONS: typing.Final[Route] = Route(DELETE, "/channels/{channel}/permissions/{overwrite}")
 
 GET_CHANNEL_PINS: typing.Final[Route] = Route(GET, "/channels/{channel}/pins")

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -1414,7 +1414,7 @@ class TestRESTClientImplAsync:
 
     async def test_edit_permission_overwrites(self, rest_client):
         target = StubModel(456)
-        expected_route = routes.PATCH_CHANNEL_PERMISSIONS.compile(channel=123, overwrite=456)
+        expected_route = routes.PUT_CHANNEL_PERMISSIONS.compile(channel=123, overwrite=456)
         rest_client._request = mock.AsyncMock()
         expected_json = {"type": 1, "allow": 4, "deny": 1}
 
@@ -1469,7 +1469,7 @@ class TestRESTClientImplAsync:
         ],
     )
     async def test_edit_permission_overwrites_when_target_undefined(self, rest_client, target, expected_type):
-        expected_route = routes.PATCH_CHANNEL_PERMISSIONS.compile(channel=123, overwrite=456)
+        expected_route = routes.PUT_CHANNEL_PERMISSIONS.compile(channel=123, overwrite=456)
         rest_client._request = mock.AsyncMock()
         expected_json = {"type": expected_type}
 


### PR DESCRIPTION
### Summary
https://discord.com/developers/docs/resources/channel#edit-channel-permissions

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
