### PR TITLE
Allow a datetime to be passed for request_to_speak

### DIFF
--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -384,8 +384,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             * `datetime.datetime` to specify when they want to speak
 
             !!! note
-                If a datetime which is in the past is provided then Discord will
-                use the current time instead.
+                If a datetime from the past is passed then Discord will use the
+                current time instead.
 
         Raises
         ------

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -381,7 +381,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
             * `True` to indicate that the bot wants to speak.
             * `False` to remove any previously set request to speak.
-            * `datetime.datetime` to specify when they want to speak
+            * `datetime.datetime` to specify when they want their request to
+                speak timestamp to be set to.
 
             !!! note
                 If a datetime from the past is passed then Discord will use the

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -32,6 +32,8 @@ from hikari import traits
 from hikari import undefined
 
 if typing.TYPE_CHECKING:
+    import datetime
+
     from hikari import applications
     from hikari import audit_logs
     from hikari import channels as channels_
@@ -353,9 +355,13 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         channel: snowflakes.SnowflakeishOr[channels_.PartialChannel],
         *,
         suppress: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-        request_to_speak: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
+        request_to_speak: typing.Union[undefined.UndefinedType, bool, datetime.datetime] = undefined.UNDEFINED,
     ) -> None:
         """Edit the current user's voice state in a stage channel.
+
+        !!! note
+            The current user has to have already joined the target stage channel
+            before any calls can be made to this endpoint.
 
         Parameters
         ----------
@@ -370,10 +376,16 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If specificed, whether the user should be allowed to become a speaker
             in the target stage channel with `builtin.True` suppressing them from
             becoming one.
+        request_to_speak : typing.Union[hikari.undefined.UndefinedType, builtins.bool, datetime.datetime]
+            Whether to request to speak. This may be one of the following:
 
-        !!! note
-            The current user has to have already joined the target stage channel
-            before any calls can be made to this endpoint.
+            * `True` to indicate that the bot wants to speak.
+            * `False` to remove any previously set request to speak.
+            * `datetime.datetime` to specify when they want to speak
+
+            !!! note
+                If a datetime which is in the past is provided then Discord will
+                use the current time instead.
 
         Raises
         ------

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -863,16 +863,17 @@ class RESTClientImpl(rest_api.RESTClient):
         channel: snowflakes.SnowflakeishOr[channels_.PartialChannel],
         *,
         suppress: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-        request_to_speak: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
+        request_to_speak: typing.Union[undefined.UndefinedType, bool, datetime.datetime] = undefined.UNDEFINED,
     ) -> None:
         route = routes.PATCH_MY_GUILD_VOICE_STATE.compile(guild=guild)
         body = data_binding.JSONObjectBuilder()
         body.put_snowflake("channel_id", channel)
         body.put("suppress", suppress)
 
-        if request_to_speak:
-            # As a note, under current behaviour (as of writing) Discord seems to mostly ignore the value of the
-            # timestamp provided here and generate their own if it's provided as a valid iso8601 timestamp and not null.
+        if isinstance(request_to_speak, datetime.datetime):
+            body.put("request_to_speak_timestamp", request_to_speak.isoformat())
+
+        elif request_to_speak is True:
             body.put("request_to_speak_timestamp", time.utc_datetime().isoformat())
 
         elif request_to_speak is False:

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -1385,6 +1385,21 @@ class TestRESTClientImplAsync:
             expected_route, json={"channel_id": "999", "suppress": True, "request_to_speak_timestamp": None}
         )
 
+    async def test_edit_my_voice_state_when_providing_datetime_for_request_to_speak(self, rest_client):
+        rest_client._request = mock.AsyncMock()
+        expected_route = routes.PATCH_MY_GUILD_VOICE_STATE.compile(guild=5421)
+        mock_datetime = mock.Mock(spec=datetime.datetime, isoformat=mock.Mock(return_value="blamblamblam2"))
+
+        result = await rest_client.edit_my_voice_state(
+            StubModel(5421), StubModel(999), suppress=True, request_to_speak=mock_datetime
+        )
+
+        assert result is None
+        mock_datetime.isoformat.assert_called_once()
+        rest_client._request.assert_awaited_once_with(
+            expected_route, json={"channel_id": "999", "suppress": True, "request_to_speak_timestamp": "blamblamblam2"}
+        )
+
     async def test_edit_my_voice_state_without_optional_fields(self, rest_client):
         rest_client._request = mock.AsyncMock()
         expected_route = routes.PATCH_MY_GUILD_VOICE_STATE.compile(guild=5421)


### PR DESCRIPTION
### Summary
Allow a datetime to be passed for request_to_speak

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
