### PR TITLE
Start filtering events before unmarshalling

### DIFF
--- a/hikari/api/cache.py
+++ b/hikari/api/cache.py
@@ -92,13 +92,7 @@ class Cache(abc.ABC):
     @property
     @abc.abstractmethod
     def settings(self) -> config.CacheSettings:
-        """Get the configured settings for this cache.
-
-        Returns
-        -------
-        hikari.config.CacheSettings
-            The configured settings for this cache.
-        """
+        """Get the configured settings for this cache."""
 
     @abc.abstractmethod
     def get_dm_channel_id(

--- a/hikari/api/cache.py
+++ b/hikari/api/cache.py
@@ -32,6 +32,7 @@ from hikari import iterators
 
 if typing.TYPE_CHECKING:
     from hikari import channels
+    from hikari import config
     from hikari import emojis
     from hikari import guilds
     from hikari import invites
@@ -87,6 +88,17 @@ class Cache(abc.ABC):
     """
 
     __slots__: typing.Sequence[str] = ()
+
+    @property
+    @abc.abstractmethod
+    def settings(self) -> config.CacheSettings:
+        """Get the configured settings for this cache.
+
+        Returns
+        -------
+        hikari.config.CacheSettings
+            The configured settings for this cache.
+        """
 
     @abc.abstractmethod
     def get_dm_channel_id(

--- a/hikari/api/entity_factory.py
+++ b/hikari/api/entity_factory.py
@@ -63,7 +63,10 @@ class GatewayGuildDefinition(abc.ABC):
         when the relevant resource isn't available in the inner payload.
     """
 
+    __slots__: typing.Sequence[str] = ()
+
     @property
+    @abc.abstractmethod
     def id(self) -> snowflakes.Snowflake:
         """ID of the guild the definition is for."""
 

--- a/hikari/api/entity_factory.py
+++ b/hikari/api/entity_factory.py
@@ -63,21 +63,17 @@ if typing.TYPE_CHECKING:
 class GatewayGuildDefinition:
     """A structure for handling entities within guild create and update events."""
 
-    guild: guild_models.GatewayGuild = attr.field()
+    id: snowflakes.Snowflake = attr.field()
+    """ID of the guild the definition is for."""
+
+    guild: typing.Optional[guild_models.GatewayGuild] = attr.field()
     """Object of the guild the definition is for."""
 
     channels: typing.Optional[typing.Mapping[snowflakes.Snowflake, channel_models.GuildChannel]] = attr.field()
-    """Mapping of channel IDs to the channels that belong to the guild.
-
-    Will be `builtins.None` when returned by guild update gateway events rather
-    than create.
-    """
+    """Mapping of channel IDs to the channels that belong to the guild."""
 
     members: typing.Optional[typing.Mapping[snowflakes.Snowflake, guild_models.Member]] = attr.field()
     """Mapping of user IDs to the members that belong to the guild.
-
-    Will be `builtins.None` when returned by guild update gateway events rather
-    than create.
 
     !!! note
         This may be a partial mapping of members in the guild.
@@ -85,9 +81,6 @@ class GatewayGuildDefinition:
 
     presences: typing.Optional[typing.Mapping[snowflakes.Snowflake, presence_models.MemberPresence]] = attr.field()
     """Mapping of user IDs to the presences that are active in the guild.
-
-    Will be `builtins.None` when returned by guild update gateway events rather
-    than create.
 
     !!! note
         This may be a partial mapping of presences active in the guild.
@@ -100,11 +93,7 @@ class GatewayGuildDefinition:
     """Mapping of emoji IDs to the emojis that belong to the guild."""
 
     voice_states: typing.Optional[typing.Mapping[snowflakes.Snowflake, voice_models.VoiceState]] = attr.field()
-    """Mapping of user IDs to the voice states that are active in the guild.
-
-    !!! note
-        This may be a partial mapping of voice states active in the guild.
-    """
+    """Mapping of user IDs to the voice states that are active in the guild."""
 
 
 class EntityFactory(abc.ABC):
@@ -935,6 +924,7 @@ class EntityFactory(abc.ABC):
         self,
         payload: data_binding.JSONObject,
         *,
+        include_guild: bool = True,
         include_channels: bool = False,
         include_emojis: bool = True,
         include_members: bool = False,

--- a/hikari/api/entity_factory.py
+++ b/hikari/api/entity_factory.py
@@ -93,10 +93,10 @@ class GatewayGuildDefinition:
         This may be a partial mapping of presences active in the guild.
     """
 
-    roles: typing.Mapping[snowflakes.Snowflake, guild_models.Role] = attr.field()
+    roles: typing.Optional[typing.Mapping[snowflakes.Snowflake, guild_models.Role]] = attr.field()
     """Mapping of role IDs to the roles that belong to the guild."""
 
-    emojis: typing.Mapping[snowflakes.Snowflake, emoji_models.KnownCustomEmoji] = attr.field()
+    emojis: typing.Optional[typing.Mapping[snowflakes.Snowflake, emoji_models.KnownCustomEmoji]] = attr.field()
     """Mapping of emoji IDs to the emojis that belong to the guild."""
 
     voice_states: typing.Optional[typing.Mapping[snowflakes.Snowflake, voice_models.VoiceState]] = attr.field()
@@ -931,7 +931,17 @@ class EntityFactory(abc.ABC):
         """
 
     @abc.abstractmethod
-    def deserialize_gateway_guild(self, payload: data_binding.JSONObject) -> GatewayGuildDefinition:
+    def deserialize_gateway_guild(
+        self,
+        payload: data_binding.JSONObject,
+        *,
+        include_channels: bool = False,
+        include_emojis: bool = True,
+        include_members: bool = False,
+        include_presences: bool = False,
+        include_roles: bool = True,
+        include_voice_states: bool = False,
+    ) -> GatewayGuildDefinition:
         """Parse a raw payload from Discord into a guild object.
 
         Parameters

--- a/hikari/api/entity_factory.py
+++ b/hikari/api/entity_factory.py
@@ -54,94 +54,54 @@ if typing.TYPE_CHECKING:
     from hikari.interactions import component_interactions
     from hikari.internal import data_binding
 
-    GatewayGuildDefinitionT = typing.TypeVar("GatewayGuildDefinitionT", bound="GatewayGuildDefinition")
-
 
 class GatewayGuildDefinition(abc.ABC):
-    """A builder object for handling entities within guild create and update events.
-
-    !!! note
-        By default the only field that's parsed here is `id` with other attributes
-        only being filled if their relevant "parse_resource" method has been
-        called.
+    """Structure for handling entities within guild create and update events.
 
     !!! warning
-        If a parse_resource method is called for a resource which isn't present
-        in the provided payload then a `KeyError` will be raised.
+        The methods on this class may raise `builtins.LookupError` if called
+        when the relevant resource isn't available in the inner payload.
     """
 
-    id: snowflakes.Snowflake
-    """ID of the guild the definition is for."""
-
-    guild: typing.Optional[guild_models.GatewayGuild]
-    """Object of the guild the definition is for."""
-
-    channels: typing.Optional[typing.Mapping[snowflakes.Snowflake, channel_models.GuildChannel]]
-    """Mapping of channel IDs to the channels that belong to the guild."""
-
-    members: typing.Optional[typing.Mapping[snowflakes.Snowflake, guild_models.Member]]
-    """Mapping of user IDs to the members that belong to the guild.
-
-    !!! note
-        This may be a partial mapping of members in the guild.
-    """
-
-    presences: typing.Optional[typing.Mapping[snowflakes.Snowflake, presence_models.MemberPresence]]
-    """Mapping of user IDs to the presences that are active in the guild.
-
-    !!! note
-        This may be a partial mapping of presences active in the guild.
-    """
-
-    roles: typing.Optional[typing.Mapping[snowflakes.Snowflake, guild_models.Role]]
-    """Mapping of role IDs to the roles that belong to the guild."""
-
-    emojis: typing.Optional[typing.Mapping[snowflakes.Snowflake, emoji_models.KnownCustomEmoji]]
-    """Mapping of emoji IDs to the emojis that belong to the guild."""
-
-    voice_states: typing.Optional[typing.Mapping[snowflakes.Snowflake, voice_models.VoiceState]]
-    """Mapping of user IDs to the voice states that are active in the guild."""
-
-    def parse_all(self: GatewayGuildDefinitionT) -> GatewayGuildDefinitionT:
-        """Short hand for calling all the "parse" builder methods."""
-        return (
-            self.parse_guild()
-            .parse_channels()
-            .parse_emojis()
-            .parse_guild()
-            .parse_members()
-            .parse_presences()
-            .parse_roles()
-            .parse_voice_states()
-        )
+    @property
+    def id(self) -> snowflakes.Snowflake:
+        """ID of the guild the definition is for."""
 
     @abc.abstractmethod
-    def parse_channels(self: GatewayGuildDefinitionT) -> GatewayGuildDefinitionT:
-        """Builder method called to parse the channels in this definition."""
+    def channels(self) -> typing.Mapping[snowflakes.Snowflake, channel_models.GuildChannel]:
+        """Get a mapping of channel IDs to the channels that belong to the guild."""
 
     @abc.abstractmethod
-    def parse_emojis(self: GatewayGuildDefinitionT) -> GatewayGuildDefinitionT:
-        """Builder method called to parse the emojis in this definition."""
+    def emojis(self) -> typing.Mapping[snowflakes.Snowflake, emoji_models.KnownCustomEmoji]:
+        """Get a mapping of emoji IDs to the emojis that belong to the guild."""
 
     @abc.abstractmethod
-    def parse_guild(self: GatewayGuildDefinitionT) -> GatewayGuildDefinitionT:
-        """Builder method called to parse the guild in this definition."""
+    def guild(self) -> guild_models.GatewayGuild:
+        """Get the object of the guild this definition is for."""
 
     @abc.abstractmethod
-    def parse_members(self: GatewayGuildDefinitionT) -> GatewayGuildDefinitionT:
-        """Builder method called to parse the members in this definition."""
+    def members(self) -> typing.Mapping[snowflakes.Snowflake, guild_models.Member]:
+        """Get a mapping of user IDs to the members that belong to the guild.
+
+        !!! note
+            This may be a partial mapping of members in the guild.
+        """
 
     @abc.abstractmethod
-    def parse_presences(self: GatewayGuildDefinitionT) -> GatewayGuildDefinitionT:
-        """Builder method called to parse the channels in this definition."""
+    def presences(self) -> typing.Mapping[snowflakes.Snowflake, presence_models.MemberPresence]:
+        """Get a mapping of user IDs to the presences that are active in the guild.
+
+        !!! note
+            This may be a partial mapping of presences active in the guild.
+        """
 
     @abc.abstractmethod
-    def parse_roles(self: GatewayGuildDefinitionT) -> GatewayGuildDefinitionT:
-        """Builder method called to parse the presences in this definition."""
+    def roles(self) -> typing.Mapping[snowflakes.Snowflake, guild_models.Role]:
+        """Get a mapping of role IDs to the roles that belong to the guild."""
 
     @abc.abstractmethod
-    def parse_voice_states(self: GatewayGuildDefinitionT) -> GatewayGuildDefinitionT:
-        """Builder method called to parse the voice states in this definition."""
+    def voice_states(self) -> typing.Mapping[snowflakes.Snowflake, voice_models.VoiceState]:
+        """Get a mapping of user IDs to the voice states that are active in the guild."""
 
 
 class EntityFactory(abc.ABC):

--- a/hikari/config.py
+++ b/hikari/config.py
@@ -420,6 +420,9 @@ class CacheComponents(enums.Flag):
     MESSAGES = 1 << 8
     """Enables the messages cache."""
 
+    ME = 1 << 9
+    """Enables the me cache."""
+
     DM_CHANNEL_IDS = 1 << 10
     """Enables the DM channel IDs cache."""
 
@@ -433,6 +436,7 @@ class CacheComponents(enums.Flag):
         | PRESENCES
         | VOICE_STATES
         | MESSAGES
+        | ME
         | DM_CHANNEL_IDS
     )
     """Fully enables the cache."""

--- a/hikari/config.py
+++ b/hikari/config.py
@@ -447,13 +447,13 @@ class CacheComponents(enums.Flag):
 class CacheSettings:
     """Settings to control the cache."""
 
-    components: CacheComponents = attr.field(default=CacheComponents.ALL)
+    components: CacheComponents = attr.field(converter=CacheComponents, default=CacheComponents.ALL)
     """The cache components to use.
 
     Defaults to `CacheComponents.ALL`.
     """
 
-    max_messages: int = attr.field(default=300)
+    max_messages: int = attr.field(converter=int, default=300)
     """The maximum number of messages to store in the cache at once.
 
     This will have no effect if the messages cache is not enabled.

--- a/hikari/events/base_events.py
+++ b/hikari/events/base_events.py
@@ -61,7 +61,7 @@ class Event(abc.ABC):
 
     def __init_subclass__(cls) -> None:
         super().__init_subclass__()
-        # hasattr doesn't work with protected variables in this case so we use a try except.
+        # hasattr doesn't work with private variables in this case so we use a try except.
         # We need to set Event's __dispatches when the first subclass is made as Event itself cannot
         # be included in a tuple literal on itself due to not existing yet.
         try:

--- a/hikari/events/base_events.py
+++ b/hikari/events/base_events.py
@@ -62,8 +62,8 @@ class Event(abc.ABC):
     def __init_subclass__(cls) -> None:
         super().__init_subclass__()
         # hasattr doesn't work with protected variables in this case so we use a try except.
-        # we need to set Event's __dispatches when the first subclass is made as Event itself cannot
-        # be included in a set literal on itself due to not existing yet.
+        # We need to set Event's __dispatches when the first subclass is made as Event itself cannot
+        # be included in a tuple literal on itself due to not existing yet.
         try:
             Event.__dispatches
         except AttributeError:

--- a/hikari/events/base_events.py
+++ b/hikari/events/base_events.py
@@ -70,7 +70,8 @@ class Event(abc.ABC):
             Event.__dispatches = (Event,)
 
         mro = cls.mro()
-        cls.__dispatches = tuple(mro[: mro.index(Event) + 1])
+        # Non-event classes should be ignored.
+        cls.__dispatches = tuple(cls for cls in mro if issubclass(cls, Event))
 
     @property
     @abc.abstractmethod
@@ -85,7 +86,7 @@ class Event(abc.ABC):
 
     @classmethod
     def dispatches(cls) -> typing.Sequence[typing.Type[Event]]:
-        """Sequence of the event classes this class is dispatched as."""
+        """Sequence of the event classes this event is dispatched as."""
         return cls.__dispatches
 
 

--- a/hikari/events/base_events.py
+++ b/hikari/events/base_events.py
@@ -62,7 +62,7 @@ class Event(abc.ABC):
     def __init_subclass__(cls) -> None:
         super().__init_subclass__()
         # hasattr doesn't work with private variables in this case so we use a try except.
-        # We need to set Event's __dispatches when the first subclass is made as Event itself cannot
+        # We need to set Event's __dispatches when the first subclass is made as Event cannot
         # be included in a tuple literal on itself due to not existing yet.
         try:
             Event.__dispatches

--- a/hikari/events/base_events.py
+++ b/hikari/events/base_events.py
@@ -70,6 +70,7 @@ class Event(abc.ABC):
             Event.__dispatches = (Event,)
 
         mro = cls.mro()
+        # We don't have to explicitly include Event here as issubclass(Event, Event) returns True.
         # Non-event classes should be ignored.
         cls.__dispatches = tuple(cls for cls in mro if issubclass(cls, Event))
 

--- a/hikari/events/base_events.py
+++ b/hikari/events/base_events.py
@@ -70,7 +70,6 @@ class Event(abc.ABC):
             Event.__dispatches = (Event,)
 
         mro = cls.mro()
-
         cls.__dispatches = tuple(mro[: mro.index(Event) + 1])
 
     @property

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -274,7 +274,9 @@ class GatewayBot(traits.GatewayBotAware):
         self._event_factory = event_factory_impl.EventFactoryImpl(self)
 
         # Event handling
-        self._event_manager = event_manager_impl.EventManagerImpl(self._event_factory, self._intents, cache=self._cache)
+        self._event_manager = event_manager_impl.EventManagerImpl(
+            self._entity_factory, self._event_factory, self._intents, cache=self._cache
+        )
 
         # Voice subsystem
         self._voice = voice_impl.VoiceComponentImpl(self)

--- a/hikari/impl/cache.py
+++ b/hikari/impl/cache.py
@@ -770,7 +770,8 @@ class CacheImpl(cache.MutableCache):
         return copy.copy(self._me)
 
     def set_me(self, user: users.OwnUser, /) -> None:
-        self._me = copy.copy(user)
+        if self._is_cache_enabled_for(config.CacheComponents.ME):
+            self._me = copy.copy(user)
 
     def update_me(
         self, user: users.OwnUser, /

--- a/hikari/impl/cache.py
+++ b/hikari/impl/cache.py
@@ -771,15 +771,18 @@ class CacheImpl(cache.MutableCache):
 
     def set_me(self, user: users.OwnUser, /) -> None:
         if self._is_cache_enabled_for(config.CacheComponents.ME):
+            _LOGGER.debug("setting my user to %s", user)
             self._me = copy.copy(user)
 
     def update_me(
         self, user: users.OwnUser, /
     ) -> typing.Tuple[typing.Optional[users.OwnUser], typing.Optional[users.OwnUser]]:
-        _LOGGER.debug("setting my user to %s", user)
+        if not self._is_cache_enabled_for(config.CacheComponents.ME):
+            return None, None
+
         cached_user = self.get_me()
         self.set_me(user)
-        return cached_user, self._me
+        return cached_user, self.get_me()
 
     def _build_member(
         self,

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -1458,8 +1458,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         include_roles: bool = True,
         include_voice_states: bool = False,
     ) -> entity_factory.GatewayGuildDefinition:
-        guild_id = snowflakes.Snowflake(payload["id"])
-        guild: typing.Optional[guild_models.GatewayGuild] = None
+        guild: typing.Optional[guild_models.GatewayGuild]
         if include_guild:
             guild_fields = self._set_guild_attributes(payload)
             is_large = payload.get("large")
@@ -1470,7 +1469,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
 
             guild = guild_models.GatewayGuild(
                 app=self._app,
-                id=guild_id,
+                id=guild_fields.id,
                 name=guild_fields.name,
                 icon_hash=guild_fields.icon_hash,
                 features=guild_fields.features,
@@ -1502,6 +1501,11 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
                 joined_at=joined_at,
                 member_count=member_count,
             )
+            guild_id = guild.id
+
+        else:
+            guild = None
+            guild_id = snowflakes.Snowflake(payload["id"])
 
         members: typing.Optional[typing.Dict[snowflakes.Snowflake, guild_models.Member]] = None
         if include_members:

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -300,7 +300,7 @@ class _GatewayGuildDefinition(entity_factory.GatewayGuildDefinition):
         return self._presences
 
     def roles(self) -> typing.Mapping[snowflakes.Snowflake, guild_models.Role]:
-        if not self._roles:
+        if self._roles is None:
             self._roles = {
                 snowflakes.Snowflake(role["id"]): self._entity_factory.deserialize_role(role, guild_id=self.id)
                 for role in self._payload["roles"]
@@ -1596,7 +1596,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         )
 
     def deserialize_gateway_guild(self, payload: data_binding.JSONObject) -> entity_factory.GatewayGuildDefinition:
-        guild_id = snowflakes.Snowflake(payload["guild_id"])
+        guild_id = snowflakes.Snowflake(payload["id"])
         return _GatewayGuildDefinition(id=guild_id, payload=payload, entity_factory=self)
 
     #################

--- a/hikari/impl/event_factory.py
+++ b/hikari/impl/event_factory.py
@@ -193,10 +193,20 @@ class EventFactoryImpl(event_factory.EventFactory):
     def deserialize_guild_available_event(
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> guild_events.GuildAvailableEvent:
-        guild_information = self._app.entity_factory.deserialize_gateway_guild(payload)
+        guild_information = self._app.entity_factory.deserialize_gateway_guild(
+            payload,
+            include_channels=True,
+            include_members=True,
+            include_presences=True,
+            include_voice_states=True,
+            include_emojis=True,
+            include_roles=True,
+        )
         assert guild_information.channels is not None
+        assert guild_information.emojis is not None
         assert guild_information.members is not None
         assert guild_information.presences is not None
+        assert guild_information.roles is not None
         assert guild_information.voice_states is not None
         return guild_events.GuildAvailableEvent(
             shard=shard,
@@ -235,7 +245,11 @@ class EventFactoryImpl(event_factory.EventFactory):
         *,
         old_guild: typing.Optional[guild_models.GatewayGuild],
     ) -> guild_events.GuildUpdateEvent:
-        guild_information = self._app.entity_factory.deserialize_gateway_guild(payload)
+        guild_information = self._app.entity_factory.deserialize_gateway_guild(
+            payload, include_emojis=True, include_roles=True
+        )
+        assert guild_information.emojis is not None
+        assert guild_information.roles is not None
         return guild_events.GuildUpdateEvent(
             shard=shard,
             guild=guild_information.guild,

--- a/hikari/impl/event_factory.py
+++ b/hikari/impl/event_factory.py
@@ -215,13 +215,13 @@ class EventFactoryImpl(event_factory.EventFactory):
         assert guild_information.voice_states is not None
         return guild_events.GuildJoinEvent(
             shard=shard,
-            guild=guild_information.guild,
-            emojis=guild_information.emojis,
-            roles=guild_information.roles,
-            channels=guild_information.channels,
-            members=guild_information.members,
-            presences=guild_information.presences,
-            voice_states=guild_information.voice_states,
+            guild=guild_information.guild(),
+            emojis=guild_information.emojis(),
+            roles=guild_information.roles(),
+            channels=guild_information.channels(),
+            members=guild_information.members(),
+            presences=guild_information.presences(),
+            voice_states=guild_information.voice_states(),
         )
 
     def deserialize_guild_update_event(

--- a/hikari/impl/event_factory.py
+++ b/hikari/impl/event_factory.py
@@ -193,23 +193,16 @@ class EventFactoryImpl(event_factory.EventFactory):
     def deserialize_guild_available_event(
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> guild_events.GuildAvailableEvent:
-        guild_information = self._app.entity_factory.deserialize_gateway_guild(payload).parse_all()
-        assert guild_information.guild is not None
-        assert guild_information.channels is not None
-        assert guild_information.emojis is not None
-        assert guild_information.members is not None
-        assert guild_information.presences is not None
-        assert guild_information.roles is not None
-        assert guild_information.voice_states is not None
+        guild_information = self._app.entity_factory.deserialize_gateway_guild(payload)
         return guild_events.GuildAvailableEvent(
             shard=shard,
-            guild=guild_information.guild,
-            emojis=guild_information.emojis,
-            roles=guild_information.roles,
-            channels=guild_information.channels,
-            members=guild_information.members,
-            presences=guild_information.presences,
-            voice_states=guild_information.voice_states,
+            guild=guild_information.guild(),
+            emojis=guild_information.emojis(),
+            roles=guild_information.roles(),
+            channels=guild_information.channels(),
+            members=guild_information.members(),
+            presences=guild_information.presences(),
+            voice_states=guild_information.voice_states(),
         )
 
     def deserialize_guild_join_event(
@@ -238,17 +231,12 @@ class EventFactoryImpl(event_factory.EventFactory):
         *,
         old_guild: typing.Optional[guild_models.GatewayGuild],
     ) -> guild_events.GuildUpdateEvent:
-        guild_information = (
-            self._app.entity_factory.deserialize_gateway_guild(payload).parse_guild().parse_emojis().parse_roles()
-        )
-        assert guild_information.guild is not None
-        assert guild_information.emojis is not None
-        assert guild_information.roles is not None
+        guild_information = self._app.entity_factory.deserialize_gateway_guild(payload)
         return guild_events.GuildUpdateEvent(
             shard=shard,
-            guild=guild_information.guild,
-            emojis=guild_information.emojis,
-            roles=guild_information.roles,
+            guild=guild_information.guild(),
+            emojis=guild_information.emojis(),
+            roles=guild_information.roles(),
             old_guild=old_guild,
         )
 

--- a/hikari/impl/event_factory.py
+++ b/hikari/impl/event_factory.py
@@ -195,6 +195,7 @@ class EventFactoryImpl(event_factory.EventFactory):
     ) -> guild_events.GuildAvailableEvent:
         guild_information = self._app.entity_factory.deserialize_gateway_guild(
             payload,
+            include_guild=True,
             include_channels=True,
             include_members=True,
             include_presences=True,
@@ -202,6 +203,7 @@ class EventFactoryImpl(event_factory.EventFactory):
             include_emojis=True,
             include_roles=True,
         )
+        assert guild_information.guild is not None
         assert guild_information.channels is not None
         assert guild_information.emojis is not None
         assert guild_information.members is not None
@@ -246,8 +248,9 @@ class EventFactoryImpl(event_factory.EventFactory):
         old_guild: typing.Optional[guild_models.GatewayGuild],
     ) -> guild_events.GuildUpdateEvent:
         guild_information = self._app.entity_factory.deserialize_gateway_guild(
-            payload, include_emojis=True, include_roles=True
+            payload, include_guild=True, include_emojis=True, include_roles=True
         )
+        assert guild_information.guild is not None
         assert guild_information.emojis is not None
         assert guild_information.roles is not None
         return guild_events.GuildUpdateEvent(

--- a/hikari/impl/event_factory.py
+++ b/hikari/impl/event_factory.py
@@ -193,16 +193,7 @@ class EventFactoryImpl(event_factory.EventFactory):
     def deserialize_guild_available_event(
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> guild_events.GuildAvailableEvent:
-        guild_information = self._app.entity_factory.deserialize_gateway_guild(
-            payload,
-            include_guild=True,
-            include_channels=True,
-            include_members=True,
-            include_presences=True,
-            include_voice_states=True,
-            include_emojis=True,
-            include_roles=True,
-        )
+        guild_information = self._app.entity_factory.deserialize_gateway_guild(payload).parse_all()
         assert guild_information.guild is not None
         assert guild_information.channels is not None
         assert guild_information.emojis is not None
@@ -247,8 +238,8 @@ class EventFactoryImpl(event_factory.EventFactory):
         *,
         old_guild: typing.Optional[guild_models.GatewayGuild],
     ) -> guild_events.GuildUpdateEvent:
-        guild_information = self._app.entity_factory.deserialize_gateway_guild(
-            payload, include_guild=True, include_emojis=True, include_roles=True
+        guild_information = (
+            self._app.entity_factory.deserialize_gateway_guild(payload).parse_guild().parse_emojis().parse_roles()
         )
         assert guild_information.guild is not None
         assert guild_information.emojis is not None

--- a/hikari/impl/event_manager.py
+++ b/hikari/impl/event_manager.py
@@ -97,7 +97,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         self._cache = cache
         super().__init__(event_factory=event_factory, intents=intents)
 
-    @event_manager_base.as_listener(shard_events.ShardReadyEvent, config.CacheComponents.ME)
+    @event_manager_base.filtered(shard_events.ShardReadyEvent, config.CacheComponents.ME)
     async def on_ready(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#ready for more info."""
         # TODO: cache unavailable guilds on startup, I didn't bother for the time being.
@@ -108,12 +108,12 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
         await self.dispatch(event)
 
-    @event_manager_base.as_listener(shard_events.ShardResumedEvent)
+    @event_manager_base.filtered(shard_events.ShardResumedEvent)
     async def on_resumed(self, shard: gateway_shard.GatewayShard, _: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#resumed for more info."""
         await self.dispatch(self._event_factory.deserialize_resumed_event(shard))
 
-    @event_manager_base.as_listener(channel_events.GuildChannelCreateEvent, config.CacheComponents.GUILD_CHANNELS)
+    @event_manager_base.filtered(channel_events.GuildChannelCreateEvent, config.CacheComponents.GUILD_CHANNELS)
     async def on_channel_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#channel-create for more info."""
         event = self._event_factory.deserialize_guild_channel_create_event(shard, payload)
@@ -123,7 +123,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
         await self.dispatch(event)
 
-    @event_manager_base.as_listener(channel_events.GuildChannelUpdateEvent, config.CacheComponents.GUILD_CHANNELS)
+    @event_manager_base.filtered(channel_events.GuildChannelUpdateEvent, config.CacheComponents.GUILD_CHANNELS)
     async def on_channel_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#channel-update for more info."""
         old = self._cache.get_guild_channel(snowflakes.Snowflake(payload["id"])) if self._cache else None
@@ -134,7 +134,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
         await self.dispatch(event)
 
-    @event_manager_base.as_listener(channel_events.GuildChannelDeleteEvent, config.CacheComponents.GUILD_CHANNELS)
+    @event_manager_base.filtered(channel_events.GuildChannelDeleteEvent, config.CacheComponents.GUILD_CHANNELS)
     async def on_channel_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#channel-delete for more info."""
         event = self._event_factory.deserialize_guild_channel_delete_event(shard, payload)
@@ -144,27 +144,17 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
         await self.dispatch(event)
 
-    @event_manager_base.as_listener((channel_events.GuildPinsUpdateEvent, channel_events.DMPinsUpdateEvent))
+    @event_manager_base.filtered((channel_events.GuildPinsUpdateEvent, channel_events.DMPinsUpdateEvent))
     async def on_channel_pins_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#channel-pins-update for more info."""
         # TODO: we need a method for this specifically
         await self.dispatch(self._event_factory.deserialize_channel_pins_update_event(shard, payload))
 
-    @event_manager_base.as_listener(
-        guild_events.GuildAvailableEvent,
-        config.CacheComponents.GUILDS
-        | config.CacheComponents.GUILD_CHANNELS
-        | config.CacheComponents.EMOJIS
-        | config.CacheComponents.ROLES
-        | config.CacheComponents.PRESENCES
-        | config.CacheComponents.VOICE_STATES
-        | config.CacheComponents.MEMBERS,
-    )
+    # on_guild_create prefers internal granularity over filtering with event_manager_base.filtered
     async def on_guild_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#guild-create for more info."""
-        event: typing.Union[guild_events.GuildAvailableEvent, guild_events.GuildJoinEvent, None] = None
-
         if not self._enabled_for(guild_events.GuildAvailableEvent):
+            event: typing.Union[guild_events.GuildAvailableEvent, guild_events.GuildJoinEvent, None] = None
             guild_definition = self._app.entity_factory.deserialize_gateway_guild(
                 payload,
                 include_channels=self._cache_enabled_for_any(config.CacheComponents.GUILD_CHANNELS),
@@ -255,14 +245,11 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         if event:
             await self.dispatch(event)
 
-    @event_manager_base.as_listener(
-        guild_events.GuildUpdateEvent,
-        config.CacheComponents.GUILDS | config.CacheComponents.ROLES | config.CacheComponents.EMOJIS,
-    )
+    # on_guild_update prefers internal granularity over filtering with event_manager_base.filtered
     async def on_guild_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#guild-update for more info."""
-        event: typing.Optional[guild_events.GuildUpdateEvent] = None
         if not self._enabled_for(guild_events.GuildUpdateEvent):
+            event: typing.Optional[guild_events.GuildUpdateEvent] = None
             guild_definition = self._app.entity_factory.deserialize_gateway_guild(
                 payload,
                 include_emojis=self._cache_enabled_for_any(config.CacheComponents.EMOJIS),
@@ -295,7 +282,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         if event:
             await self.dispatch(event)
 
-    @event_manager_base.as_listener(
+    @event_manager_base.filtered(
         (guild_events.GuildLeaveEvent, guild_events.GuildUnavailableEvent),
         config.CacheComponents.GUILDS
         | config.CacheComponents.GUILD_CHANNELS
@@ -332,17 +319,17 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
         await self.dispatch(event)
 
-    @event_manager_base.as_listener(guild_events.BanCreateEvent)
+    @event_manager_base.filtered(guild_events.BanCreateEvent)
     async def on_guild_ban_add(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#guild-ban-add for more info."""
         await self.dispatch(self._event_factory.deserialize_guild_ban_add_event(shard, payload))
 
-    @event_manager_base.as_listener(guild_events.BanDeleteEvent)
+    @event_manager_base.filtered(guild_events.BanDeleteEvent)
     async def on_guild_ban_remove(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#guild-ban-remove for more info."""
         await self.dispatch(self._event_factory.deserialize_guild_ban_remove_event(shard, payload))
 
-    @event_manager_base.as_listener(guild_events.EmojisUpdateEvent, config.CacheComponents.EMOJIS)
+    @event_manager_base.filtered(guild_events.EmojisUpdateEvent, config.CacheComponents.EMOJIS)
     async def on_guild_emojis_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#guild-emojis-update for more info."""
         guild_id = snowflakes.Snowflake(payload["guild_id"])
@@ -356,29 +343,29 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
         await self.dispatch(event)
 
-    @event_manager_base.as_listener(())
+    @event_manager_base.filtered(())
     async def on_guild_integrations_update(self, _: gateway_shard.GatewayShard, __: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#guild-integrations-update for more info."""
         # This is only here to stop this being logged or dispatched as an "unknown event".
         # This event is made redundant by INTEGRATION_CREATE/DELETE/UPDATE and is thus not parsed or dispatched.
         return None
 
-    @event_manager_base.as_listener(guild_events.IntegrationCreateEvent)
+    @event_manager_base.filtered(guild_events.IntegrationCreateEvent)
     async def on_integration_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         event = self._event_factory.deserialize_integration_create_event(shard, payload)
         await self.dispatch(event)
 
-    @event_manager_base.as_listener(guild_events.IntegrationDeleteEvent)
+    @event_manager_base.filtered(guild_events.IntegrationDeleteEvent)
     async def on_integration_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         event = self._event_factory.deserialize_integration_delete_event(shard, payload)
         await self.dispatch(event)
 
-    @event_manager_base.as_listener(guild_events.IntegrationUpdateEvent)
+    @event_manager_base.filtered(guild_events.IntegrationUpdateEvent)
     async def on_integration_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         event = self._event_factory.deserialize_integration_update_event(shard, payload)
         await self.dispatch(event)
 
-    @event_manager_base.as_listener(member_events.MemberCreateEvent, config.CacheComponents.MEMBERS)
+    @event_manager_base.filtered(member_events.MemberCreateEvent, config.CacheComponents.MEMBERS)
     async def on_guild_member_add(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#guild-member-add for more info."""
         event = self._event_factory.deserialize_guild_member_add_event(shard, payload)
@@ -388,7 +375,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
         await self.dispatch(event)
 
-    @event_manager_base.as_listener(member_events.MemberDeleteEvent, config.CacheComponents.MEMBERS)
+    @event_manager_base.filtered(member_events.MemberDeleteEvent, config.CacheComponents.MEMBERS)
     async def on_guild_member_remove(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#guild-member-remove for more info."""
         old: typing.Optional[guilds.Member] = None
@@ -400,7 +387,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         event = self._event_factory.deserialize_guild_member_remove_event(shard, payload, old_member=old)
         await self.dispatch(event)
 
-    @event_manager_base.as_listener(member_events.MemberUpdateEvent, config.CacheComponents.MEMBERS)
+    @event_manager_base.filtered(member_events.MemberUpdateEvent, config.CacheComponents.MEMBERS)
     async def on_guild_member_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#guild-member-update for more info."""
         old: typing.Optional[guilds.Member] = None
@@ -416,7 +403,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
         await self.dispatch(event)
 
-    @event_manager_base.as_listener(shard_events.MemberChunkEvent, config.CacheComponents.MEMBERS)
+    @event_manager_base.filtered(shard_events.MemberChunkEvent, config.CacheComponents.MEMBERS)
     async def on_guild_members_chunk(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#guild-members-chunk for more info."""
         event = self._event_factory.deserialize_guild_member_chunk_event(shard, payload)
@@ -430,7 +417,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
         await self.dispatch(event)
 
-    @event_manager_base.as_listener(role_events.RoleCreateEvent, config.CacheComponents.ROLES)
+    @event_manager_base.filtered(role_events.RoleCreateEvent, config.CacheComponents.ROLES)
     async def on_guild_role_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#guild-role-create for more info."""
         event = self._event_factory.deserialize_guild_role_create_event(shard, payload)
@@ -440,7 +427,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
         await self.dispatch(event)
 
-    @event_manager_base.as_listener(role_events.RoleUpdateEvent, config.CacheComponents.ROLES)
+    @event_manager_base.filtered(role_events.RoleUpdateEvent, config.CacheComponents.ROLES)
     async def on_guild_role_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#guild-role-update for more info."""
         old = self._cache.get_role(snowflakes.Snowflake(payload["role"]["id"])) if self._cache else None
@@ -451,7 +438,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
         await self.dispatch(event)
 
-    @event_manager_base.as_listener(role_events.RoleDeleteEvent, config.CacheComponents.ROLES)
+    @event_manager_base.filtered(role_events.RoleDeleteEvent, config.CacheComponents.ROLES)
     async def on_guild_role_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#guild-role-delete for more info."""
         old: typing.Optional[guilds.Role] = None
@@ -462,7 +449,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
         await self.dispatch(event)
 
-    @event_manager_base.as_listener(channel_events.InviteCreateEvent, config.CacheComponents.INVITES)
+    @event_manager_base.filtered(channel_events.InviteCreateEvent, config.CacheComponents.INVITES)
     async def on_invite_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#invite-create for more info."""
         event = self._event_factory.deserialize_invite_create_event(shard, payload)
@@ -472,7 +459,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
         await self.dispatch(event)
 
-    @event_manager_base.as_listener(channel_events.InviteDeleteEvent, config.CacheComponents.INVITES)
+    @event_manager_base.filtered(channel_events.InviteDeleteEvent, config.CacheComponents.INVITES)
     async def on_invite_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#invite-delete for more info."""
         old: typing.Optional[invites.InviteWithMetadata] = None
@@ -483,7 +470,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
         await self.dispatch(event)
 
-    @event_manager_base.as_listener(
+    @event_manager_base.filtered(
         (message_events.GuildMessageCreateEvent, message_events.DMMessageCreateEvent), config.CacheComponents.MESSAGES
     )
     async def on_message_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
@@ -495,7 +482,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
         await self.dispatch(event)
 
-    @event_manager_base.as_listener(
+    @event_manager_base.filtered(
         (message_events.GuildMessageUpdateEvent, message_events.DMMessageUpdateEvent), config.CacheComponents.MESSAGES
     )
     async def on_message_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
@@ -508,7 +495,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
         await self.dispatch(event)
 
-    @event_manager_base.as_listener(
+    @event_manager_base.filtered(
         (message_events.GuildMessageDeleteEvent, message_events.DMMessageDeleteEvent), config.CacheComponents.MESSAGES
     )
     async def on_message_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
@@ -520,7 +507,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
         await self.dispatch(event)
 
-    @event_manager_base.as_listener(
+    @event_manager_base.filtered(
         (message_events.GuildMessageDeleteEvent, message_events.DMMessageDeleteEvent), config.CacheComponents.MESSAGES
     )
     async def on_message_delete_bulk(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
@@ -533,7 +520,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
         await self.dispatch(event)
 
-    @event_manager_base.as_listener((reaction_events.GuildReactionAddEvent, reaction_events.DMReactionAddEvent))
+    @event_manager_base.filtered((reaction_events.GuildReactionAddEvent, reaction_events.DMReactionAddEvent))
     async def on_message_reaction_add(
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> None:
@@ -542,14 +529,14 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
     # TODO: this is unlikely but reaction cache?
 
-    @event_manager_base.as_listener((reaction_events.GuildReactionDeleteEvent, reaction_events.DMReactionDeleteEvent))
+    @event_manager_base.filtered((reaction_events.GuildReactionDeleteEvent, reaction_events.DMReactionDeleteEvent))
     async def on_message_reaction_remove(
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> None:
         """See https://discord.com/developers/docs/topics/gateway#message-reaction-remove for more info."""
         await self.dispatch(self._event_factory.deserialize_message_reaction_remove_event(shard, payload))
 
-    @event_manager_base.as_listener(
+    @event_manager_base.filtered(
         (reaction_events.GuildReactionDeleteAllEvent, reaction_events.DMReactionDeleteAllEvent)
     )
     async def on_message_reaction_remove_all(
@@ -558,7 +545,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         """See https://discord.com/developers/docs/topics/gateway#message-reaction-remove-all for more info."""
         await self.dispatch(self._event_factory.deserialize_message_reaction_remove_all_event(shard, payload))
 
-    @event_manager_base.as_listener(
+    @event_manager_base.filtered(
         (reaction_events.GuildReactionDeleteEmojiEvent, reaction_events.DMReactionDeleteEmojiEvent)
     )
     async def on_message_reaction_remove_emoji(
@@ -567,7 +554,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         """See https://discord.com/developers/docs/topics/gateway#message-reaction-remove-emoji for more info."""
         await self.dispatch(self._event_factory.deserialize_message_reaction_remove_emoji_event(shard, payload))
 
-    @event_manager_base.as_listener(guild_events.PresenceUpdateEvent, config.CacheComponents.PRESENCES)
+    @event_manager_base.filtered(guild_events.PresenceUpdateEvent, config.CacheComponents.PRESENCES)
     async def on_presence_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#presence-update for more info."""
         old: typing.Optional[presences_.MemberPresence] = None
@@ -586,12 +573,12 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         # TODO: update user here when partial_user is set self._cache.update_user(event.partial_user)
         await self.dispatch(event)
 
-    @event_manager_base.as_listener((typing_events.GuildTypingEvent, typing_events.DMTypingEvent))
+    @event_manager_base.filtered((typing_events.GuildTypingEvent, typing_events.DMTypingEvent))
     async def on_typing_start(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#typing-start for more info."""
         await self.dispatch(self._event_factory.deserialize_typing_start_event(shard, payload))
 
-    @event_manager_base.as_listener(user_events.OwnUserUpdateEvent, config.CacheComponents.ME)
+    @event_manager_base.filtered(user_events.OwnUserUpdateEvent, config.CacheComponents.ME)
     async def on_user_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#user-update for more info."""
         old = self._cache.get_me() if self._cache else None
@@ -602,7 +589,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
         await self.dispatch(event)
 
-    @event_manager_base.as_listener(voice_events.VoiceStateUpdateEvent, config.CacheComponents.VOICE_STATES)
+    @event_manager_base.filtered(voice_events.VoiceStateUpdateEvent, config.CacheComponents.VOICE_STATES)
     async def on_voice_state_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#voice-state-update for more info."""
         old: typing.Optional[voices.VoiceState] = None
@@ -620,12 +607,12 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
         await self.dispatch(event)
 
-    @event_manager_base.as_listener(voice_events.VoiceServerUpdateEvent)
+    @event_manager_base.filtered(voice_events.VoiceServerUpdateEvent)
     async def on_voice_server_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#voice-server-update for more info."""
         await self.dispatch(self._event_factory.deserialize_voice_server_update_event(shard, payload))
 
-    @event_manager_base.as_listener(channel_events.WebhookUpdateEvent)
+    @event_manager_base.filtered(channel_events.WebhookUpdateEvent)
     async def on_webhooks_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#webhooks-update for more info."""
         await self.dispatch(self._event_factory.deserialize_webhook_update_event(shard, payload))

--- a/hikari/impl/event_manager.py
+++ b/hikari/impl/event_manager.py
@@ -52,7 +52,6 @@ from hikari.internal import time
 from hikari.internal import ux
 
 if typing.TYPE_CHECKING:
-    from hikari import emojis as emojis_
     from hikari import guilds
     from hikari import invites
     from hikari import voices
@@ -166,38 +165,16 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         if not enabled_for_event and self._cache:
             _LOGGER.log(ux.TRACE, "Skipping on_guild_create dispatch due to lack of any registered listeners")
             event: typing.Optional[guild_events.GuildAvailableEvent] = None
-            event: typing.Union[guild_events.GuildAvailableEvent, guild_events.GuildJoinEvent, None] = None
-            guild_definition = self._app.entity_factory.deserialize_gateway_guild(payload)
+            gd = self._app.entity_factory.deserialize_gateway_guild(payload)
 
-            if self._cache_enabled_for(config.CacheComponents.GUILD_CHANNELS):
-                guild_definition.parse_channels()
-
-            if self._cache_enabled_for(config.CacheComponents.EMOJIS):
-                guild_definition.parse_emojis()
-
-            if self._cache_enabled_for(config.CacheComponents.GUILDS):
-                guild_definition.parse_guild()
-
-            if self._cache_enabled_for(config.CacheComponents.MEMBERS):
-                guild_definition.parse_members()
-
-            if self._cache_enabled_for(config.CacheComponents.PRESENCES):
-                guild_definition.parse_presences()
-
-            if self._cache_enabled_for(config.CacheComponents.ROLES):
-                guild_definition.parse_roles()
-
-            if self._cache_enabled_for(config.CacheComponents.VOICE_STATES):
-                guild_definition.parse_voice_states()
-
-            channels = guild_definition.channels
-            emojis = guild_definition.emojis
-            guild = guild_definition.guild
-            guild_id = guild_definition.id
-            members = guild_definition.members
-            presences = guild_definition.presences
-            roles = guild_definition.roles
-            voice_states = guild_definition.voice_states
+            channels = gd.channels() if self._cache_enabled_for(config.CacheComponents.GUILD_CHANNELS) else None
+            emojis = gd.emojis() if self._cache_enabled_for(config.CacheComponents.EMOJIS) else None
+            guild = gd.guild() if self._cache_enabled_for(config.CacheComponents.GUILDS) else None
+            guild_id = gd.id
+            members = gd.members() if self._cache_enabled_for(config.CacheComponents.MEMBERS) else None
+            presences = gd.presences() if self._cache_enabled_for(config.CacheComponents.PRESENCES) else None
+            roles = gd.roles() if self._cache_enabled_for(config.CacheComponents.ROLES) else None
+            voice_states = gd.voice_states() if self._cache_enabled_for(config.CacheComponents.VOICE_STATES) else None
 
         elif enabled_for_event:
             if "unavailable" in payload:
@@ -215,6 +192,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
             voice_states = event.voice_states
 
         else:
+            event = None
             channels = None
             emojis = None
             members = None
@@ -287,21 +265,11 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         if not enabled_for_event and self._cache:
             _LOGGER.log(ux.TRACE, "Skipping on_guild_update raw dispatch due to lack of any registered listeners")
             event: typing.Optional[guild_events.GuildUpdateEvent] = None
-            guild_definition = self._app.entity_factory.deserialize_gateway_guild(payload)
-
-            if self._cache_enabled_for(config.CacheComponents.GUILDS):
-                guild_definition.parse_guild()
-
-            if self._cache_enabled_for(config.CacheComponents.EMOJIS):
-                guild_definition.parse_emojis()
-
-            if self._cache_enabled_for(config.CacheComponents.ROLES):
-                guild_definition.parse_roles()
-
-            guild = guild_definition.guild
-            guild_id = guild_definition.id
-            emojis = guild_definition.emojis
-            roles = guild_definition.roles
+            gd = self._app.entity_factory.deserialize_gateway_guild(payload)
+            emojis = gd.emojis() if self._cache_enabled_for(config.CacheComponents.GUILDS) else None
+            guild = gd.guild() if self._cache_enabled_for(config.CacheComponents.GUILDS) else None
+            guild_id = gd.id
+            roles = gd.roles() if self._cache_enabled_for(config.CacheComponents.ROLES) else None
 
         elif enabled_for_event:
             guild_id = snowflakes.Snowflake(payload["guild_id"])

--- a/hikari/impl/event_manager.py
+++ b/hikari/impl/event_manager.py
@@ -195,6 +195,8 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
             event = None
             channels = None
             emojis = None
+            guild = None
+            guild_id = snowflakes.Snowflake(payload["id"])
             members = None
             presences = None
             roles = None
@@ -272,7 +274,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
             roles = gd.roles() if self._cache_enabled_for(config.CacheComponents.ROLES) else None
 
         elif enabled_for_event:
-            guild_id = snowflakes.Snowflake(payload["guild_id"])
+            guild_id = snowflakes.Snowflake(payload["id"])
             old = self._cache.get_guild(guild_id) if self._cache else None
             event = self._event_factory.deserialize_guild_update_event(shard, payload, old_guild=old)
             emojis = event.emojis
@@ -315,7 +317,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
     async def on_guild_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#guild-delete for more info."""
         event: typing.Union[guild_events.GuildUnavailableEvent, guild_events.GuildLeaveEvent]
-        if payload.get("unavailable", False):
+        if payload.get("unavailable"):
             event = self._event_factory.deserialize_guild_unavailable_event(shard, payload)
 
             if self._cache:

--- a/hikari/impl/event_manager.py
+++ b/hikari/impl/event_manager.py
@@ -28,6 +28,7 @@ __all__: typing.List[str] = ["EventManagerImpl"]
 
 import asyncio
 import base64
+import logging
 import random
 import typing
 
@@ -48,6 +49,7 @@ from hikari.events import user_events
 from hikari.events import voice_events
 from hikari.impl import event_manager_base
 from hikari.internal import time
+from hikari.internal import ux
 
 if typing.TYPE_CHECKING:
     from hikari import guilds
@@ -57,6 +59,9 @@ if typing.TYPE_CHECKING:
     from hikari.api import event_factory as event_factory_
     from hikari.api import shard as gateway_shard
     from hikari.internal import data_binding
+
+
+_LOGGER: typing.Final[logging.Logger] = logging.getLogger("hikari.event_manager")
 
 
 def _fixed_size_nonce() -> str:
@@ -157,6 +162,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
     async def on_guild_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#guild-create for more info."""
         if not self._enabled_for_event(guild_events.GuildAvailableEvent):
+            _LOGGER.log(ux.TRACE, "Skipping on_guild_create dispatch due to lack of any registered listeners")
             event: typing.Union[guild_events.GuildAvailableEvent, guild_events.GuildJoinEvent, None] = None
             guild_definition = self._app.entity_factory.deserialize_gateway_guild(
                 payload,
@@ -253,6 +259,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
     async def on_guild_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#guild-update for more info."""
         if not self._enabled_for_event(guild_events.GuildUpdateEvent):
+            _LOGGER.log(ux.TRACE, "Skipping on_guild_update dispatch due to lack of any registered listeners")
             event: typing.Optional[guild_events.GuildUpdateEvent] = None
             guild_definition = self._app.entity_factory.deserialize_gateway_guild(
                 payload,

--- a/hikari/impl/event_manager.py
+++ b/hikari/impl/event_manager.py
@@ -103,7 +103,8 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
     ) -> None:
         self._cache = cache
         self._entity_factory = entity_factory
-        super().__init__(event_factory=event_factory, intents=intents, cache_settings=cache.settings if cache else None)
+        components = cache.settings.components if cache else config.CacheComponents.NONE
+        super().__init__(event_factory=event_factory, intents=intents, cache_components=components)
 
     def _cache_enabled_for(self, components: config.CacheComponents, /) -> bool:
         return self._cache is not None and (self._cache.settings.components & components) == components

--- a/hikari/impl/event_manager.py
+++ b/hikari/impl/event_manager.py
@@ -236,8 +236,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         # When intents are enabled discord will only send other member objects on the guild create
         # payload if presence intents are also declared, so if this isn't the case then we also want
         # to chunk small guilds.
-        guild_is_large = payload.get("large")
-        if recv_chunks and members_declared and (guild_is_large or not presences_declared):
+        if recv_chunks and members_declared and (payload.get("large") or not presences_declared):
             # We create a task here instead of awaiting the result to avoid any rate-limits from delaying dispatch.
             nonce = f"{shard.id}.{_fixed_size_nonce()}"
 

--- a/hikari/impl/event_manager.py
+++ b/hikari/impl/event_manager.py
@@ -74,7 +74,7 @@ def _fixed_size_nonce() -> str:
 
 async def _request_guild_members(
     shard: gateway_shard.GatewayShard,
-    guild: guilds.PartialGuild,
+    guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
     *,
     include_presences: bool,
     nonce: str,

--- a/hikari/impl/event_manager.py
+++ b/hikari/impl/event_manager.py
@@ -168,7 +168,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         enabled_for_event = self._enabled_for_event(guild_events.GuildAvailableEvent)
         if not enabled_for_event and self._cache:
             _LOGGER.log(ux.TRACE, "Skipping on_guild_create dispatch due to lack of any registered listeners")
-            event: typing.Optional[guild_events.GuildAvailableEvent] = None
+            event: typing.Union[guild_events.GuildAvailableEvent, guild_events.GuildJoinEvent, None] = None
             gd = self._entity_factory.deserialize_gateway_guild(payload)
 
             channels = gd.channels() if self._cache_enabled_for(config.CacheComponents.GUILD_CHANNELS) else None

--- a/hikari/impl/event_manager.py
+++ b/hikari/impl/event_manager.py
@@ -37,6 +37,7 @@ from hikari import errors
 from hikari import intents as intents_
 from hikari import presences as presences_
 from hikari import snowflakes
+from hikari.events import  interaction_events
 from hikari.events import channel_events
 from hikari.events import guild_events
 from hikari.events import member_events

--- a/hikari/impl/event_manager.py
+++ b/hikari/impl/event_manager.py
@@ -37,7 +37,6 @@ from hikari import errors
 from hikari import intents as intents_
 from hikari import presences as presences_
 from hikari import snowflakes
-from hikari.events import  interaction_events
 from hikari.events import channel_events
 from hikari.events import guild_events
 from hikari.events import member_events

--- a/hikari/impl/event_manager_base.py
+++ b/hikari/impl/event_manager_base.py
@@ -283,7 +283,6 @@ class _Consumer:
 
 def _get_mro(event_type: typing.Type[base_events.Event]) -> typing.List[typing.Type[base_events.Event]]:
     mro = event_type.mro()
-    result = mro[: mro.index(base_events.Event) + 1]
     return typing.cast("typing.List[typing.Type[base_events.Event]]", mro[: mro.index(base_events.Event) + 1])
 
 

--- a/hikari/impl/event_manager_base.py
+++ b/hikari/impl/event_manager_base.py
@@ -54,16 +54,14 @@ if typing.TYPE_CHECKING:
     ConsumerT = typing.Callable[
         [gateway_shard.GatewayShard, data_binding.JSONObject], typing.Coroutine[typing.Any, typing.Any, None]
     ]
-    ListenerMapT = typing.MutableMapping[
+    ListenerMapT = typing.Dict[
         typing.Type[event_manager_.EventT_co],
-        typing.MutableSequence[event_manager_.CallbackT[event_manager_.EventT_co]],
+        typing.List[event_manager_.CallbackT[event_manager_.EventT_co]],
     ]
     WaiterT = typing.Tuple[
         event_manager_.PredicateT[event_manager_.EventT_co], asyncio.Future[event_manager_.EventT_co]
     ]
-    WaiterMapT = typing.MutableMapping[
-        typing.Type[event_manager_.EventT_co], typing.MutableSet[WaiterT[event_manager_.EventT_co]]
-    ]
+    WaiterMapT = typing.Dict[typing.Type[event_manager_.EventT_co], typing.Set[WaiterT[event_manager_.EventT_co]]]
 
 
 def _generate_weak_listener(
@@ -237,6 +235,14 @@ def _assert_is_listener(parameters: typing.Iterator[inspect.Parameter], /) -> No
         raise TypeError("Only the first argument for a listener can be required, the event argument.")
 
 
+def _get_mro(cls: typing.Type[base_events.Event]) -> typing.List[typing.Type[base_events.Event]]:
+    # We only need to iterate through the MRO until we hit Event, as
+    # anything after that is random garbage we don't care about, as they do
+    # not describe event types. This improves efficiency as well.
+    mro = cls.mro()
+    return mro[: mro.index(base_events.Event) + 1]
+
+
 class EventManagerBase(event_manager_.EventManager):
     """Provides functionality to consume and dispatch events.
 
@@ -244,13 +250,14 @@ class EventManagerBase(event_manager_.EventManager):
     is the raw event name being dispatched in lower-case.
     """
 
-    __slots__: typing.Sequence[str] = ("_event_factory", "_intents", "_listeners", "_consumers", "_waiters")
+    __slots__: typing.Sequence[str] = ("_event_factory", "_intents", "_listeners", "_listeners_non_poly", "_consumers", "_waiters")
 
     def __init__(self, event_factory: event_factory_.EventFactory, intents: intents_.Intents) -> None:
         self._consumers: typing.Dict[str, ConsumerT] = {}
         self._event_factory = event_factory
         self._intents = intents
         self._listeners: ListenerMapT[base_events.Event] = {}
+        self._listeners_non_poly: ListenerMapT[base_events.Event] = {}
         self._waiters: WaiterMapT[base_events.Event] = {}
 
         for name, member in inspect.getmembers(self):
@@ -282,9 +289,6 @@ class EventManagerBase(event_manager_.EventManager):
         # warning is triggered.
         self._check_intents(event_type, _nested)
 
-        if event_type not in self._listeners:
-            self._listeners[event_type] = []
-
         _LOGGER.debug(
             "subscribing callback 'async def %s%s' to event-type %s.%s",
             getattr(callback, "__name__", "<anon>"),
@@ -293,7 +297,16 @@ class EventManagerBase(event_manager_.EventManager):
             event_type.__qualname__,
         )
 
-        self._listeners[event_type].append(callback)  # type: ignore[arg-type]
+        try:
+            self._listeners_non_poly[event_type].append(callback)  # type: ignore[arg-type]
+        except KeyError:
+            self._listeners_non_poly[event_type] = [callback]  # type: ignore[list-item]
+
+        for cls in _get_mro(event_type):
+            try:
+                self._listeners[cls].append(callback)  # type: ignore[arg-type]
+            except KeyError:
+                self._listeners[cls] = [callback]  # type: ignore[list-item]
 
     def _check_intents(self, event_type: typing.Type[event_manager_.EventT_co], nested: int) -> None:
         # Collection of combined bitfield combinations of intents that
@@ -322,24 +335,23 @@ class EventManagerBase(event_manager_.EventManager):
         polymorphic: bool = True,
     ) -> typing.Collection[event_manager_.CallbackT[event_manager_.EventT_co]]:
         if polymorphic:
-            listeners: typing.List[event_manager_.CallbackT[event_manager_.EventT_co]] = []
-            for subscribed_event_type, subscribed_listeners in self._listeners.items():
-                if issubclass(subscribed_event_type, event_type):
-                    listeners += subscribed_listeners
-            return listeners
-        else:
             items = self._listeners.get(event_type)
             if items is not None:
-                return items[:]
+                return items.copy()
 
-            return []
+        else:
+            items = self._listeners_non_poly.get(event_type)
+            if items is not None:
+                return items.copy()
+
+        return []
 
     def unsubscribe(
         self,
         event_type: typing.Type[event_manager_.EventT_co],
         callback: event_manager_.CallbackT[event_manager_.EventT_co],
     ) -> None:
-        if event_type in self._listeners:
+        if event_type in self._listeners and (listeners := self._listeners_non_poly.get(event_type)):
             _LOGGER.debug(
                 "unsubscribing callback %s%s from event-type %s.%s",
                 getattr(callback, "__name__", "<anon>"),
@@ -347,9 +359,17 @@ class EventManagerBase(event_manager_.EventManager):
                 event_type.__module__,
                 event_type.__qualname__,
             )
-            self._listeners[event_type].remove(callback)  # type: ignore[arg-type]
-            if not self._listeners[event_type]:
-                del self._listeners[event_type]
+
+            listeners.remove(callback)  # type: ignore[arg-type]
+            if not listeners:
+                del self._listeners_non_poly[event_type]
+
+            for cls in _get_mro(event_type):
+                if listeners := self._listeners.get(cls):
+                    listeners.remove(callback)  # type: ignore[arg-type]
+
+                    if not listeners:
+                        del self._listeners[cls]
 
     def listen(
         self,
@@ -387,35 +407,28 @@ class EventManagerBase(event_manager_.EventManager):
         if not isinstance(event, base_events.Event):
             raise TypeError(f"Events must be subclasses of {base_events.Event.__name__}, not {type(event).__name__}")
 
-        # We only need to iterate through the MRO until we hit Event, as
-        # anything after that is random garbage we don't care about, as they do
-        # not describe event types. This improves efficiency as well.
-        mro = type(event).mro()
-
+        event_type = type(event)
         tasks: typing.List[typing.Coroutine[None, typing.Any, None]] = []
 
-        for cls in mro[: mro.index(base_events.Event) + 1]:
-            if cls in self._listeners:
-                for callback in self._listeners[cls]:
-                    tasks.append(self._invoke_callback(callback, event))
+        if listeners := self._listeners.get(event_type):
+            for callback in listeners:
+                tasks.append(self._invoke_callback(callback, event))
 
-            if cls not in self._waiters:
-                continue
-
-            waiter_set = self._waiters[cls]
+        if waiter_set := self._waiters.get(event_type):
             for waiter in tuple(waiter_set):
                 predicate, future = waiter
                 if not future.done():
                     try:
                         result = predicate(event)
-                        if not result:
-                            continue
                     except Exception as ex:
                         future.set_exception(ex)
                     else:
-                        future.set_result(event)
+                        if result:
+                            future.set_result(event)
 
-                waiter_set.remove(waiter)
+                # The future was probably cancelled meaning we need to remove it here.
+                else:
+                    waiter_set.remove(waiter)
 
         return asyncio.gather(*tasks) if tasks else aio.completed_future()
 
@@ -443,20 +456,24 @@ class EventManagerBase(event_manager_.EventManager):
         self._check_intents(event_type, 1)
 
         future: asyncio.Future[event_manager_.EventT_co] = asyncio.get_running_loop().create_future()
-
-        try:
-            waiter_set = self._waiters[event_type]
-        except KeyError:
-            waiter_set = set()
-            self._waiters[event_type] = waiter_set
-
         pair = (predicate, future)
+        mro = _get_mro(event_type)
 
-        waiter_set.add(pair)  # type: ignore[arg-type]
+        for cls in mro:
+            try:
+                self._waiters[cls].add(pair)  # type: ignore[arg-type]
+            except KeyError:
+                self._waiters[cls] = {pair}  # type: ignore[arg-type]
+
         try:
             return await asyncio.wait_for(future, timeout=timeout)
-        except asyncio.TimeoutError:
-            waiter_set.remove(pair)  # type: ignore[arg-type]
+        finally:
+            for cls in mro:
+                try:
+                    self._waiters[cls].remove(pair)  # type: ignore[arg-type]
+                except KeyError:
+                    pass
+
             raise
 
     @staticmethod

--- a/hikari/impl/event_manager_base.py
+++ b/hikari/impl/event_manager_base.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["as_listener", "EventManagerBase", "EventStream"]
+__all__: typing.List[str] = ["filtered", "EventManagerBase", "EventStream"]
 
 import asyncio
 import inspect
@@ -253,7 +253,7 @@ _CACHE_RESOURCE_ATTRIBUTE = "__CACHE_RESOURCE__"
 _EVENT_TYPES_ATTRIBUTE = "__EVENT_TYPES__"
 
 
-def as_listener(
+def filtered(
     event_types: typing.Union[typing.Type[base_events.Event], typing.Sequence[typing.Type[base_events.Event]]],
     cache_resource: config.CacheComponents = config.CacheComponents.NONE,
     /,

--- a/hikari/impl/event_manager_base.py
+++ b/hikari/impl/event_manager_base.py
@@ -332,7 +332,7 @@ class EventManagerBase(event_manager_.EventManager):
         event_factory: event_factory_.EventFactory,
         intents: intents_.Intents,
         *,
-        cache_settings: typing.Optional[config.CacheSettings] = None,
+        cache_components: config.CacheComponents = config.CacheComponents.NONE,
     ) -> None:
         self._consumers: typing.Dict[str, _Consumer] = {}
         self._dispatches_for_cache: typing.Dict[_Consumer, bool] = {}
@@ -346,11 +346,13 @@ class EventManagerBase(event_manager_.EventManager):
             if name.startswith("on_"):
                 event_name = name[3:]
                 if isinstance(member, _FilteredMethodT):
-                    caching = bool(cache_settings and (member.__cache_components__ & cache_settings.components))
+                    caching = (member.__cache_components__ & cache_components) != 0
                     self._consumers[event_name] = _Consumer(member, member.__event_types__, caching)
 
                 else:
-                    self._consumers[event_name] = _Consumer(member, undefined.UNDEFINED, bool(cache_settings))
+                    self._consumers[event_name] = _Consumer(
+                        member, undefined.UNDEFINED, cache_components != cache_components.NONE
+                    )
 
     def _clear_enabled_cache(self) -> None:
         self._enabled_consumers_cache = {}

--- a/hikari/impl/event_manager_base.py
+++ b/hikari/impl/event_manager_base.py
@@ -308,6 +308,17 @@ class EventManagerBase(event_manager_.EventManager):
             )
             self._consumers[name[3:]] = _Consumer(member, cache_resource, event_types)
 
+        base_events.Event.on_new_subclass(self._on_new_event_cls)
+
+    def _on_new_event_cls(self, event_type: typing.Type[base_events.Event], /) -> None:
+        parent_cls = event_type.mro()[1]
+        if issubclass(parent_cls, base_events.Event):
+            if listeners := self._listeners.get(parent_cls):
+                self._listeners[event_type] = listeners.copy()
+
+            if waiters := self._waiters.get(parent_cls):
+                self._waiters[event_type] = waiters.copy()
+
     def _enabled_for(self, event_type: typing.Type[base_events.Event], /) -> bool:
         return event_type in self._listeners or event_type in self._waiters
 

--- a/hikari/impl/event_manager_base.py
+++ b/hikari/impl/event_manager_base.py
@@ -319,7 +319,6 @@ class EventManagerBase(event_manager_.EventManager):
 
     __slots__: typing.Sequence[str] = (
         "_consumers",
-        "_dispatches_for_cache",
         "_enabled_consumers_cache",
         "_event_factory",
         "_intents",
@@ -335,7 +334,6 @@ class EventManagerBase(event_manager_.EventManager):
         cache_components: config.CacheComponents = config.CacheComponents.NONE,
     ) -> None:
         self._consumers: typing.Dict[str, _Consumer] = {}
-        self._dispatches_for_cache: typing.Dict[_Consumer, bool] = {}
         self._enabled_consumers_cache: typing.Dict[_Consumer, bool] = {}
         self._event_factory = event_factory
         self._intents = intents

--- a/hikari/impl/event_manager_base.py
+++ b/hikari/impl/event_manager_base.py
@@ -351,6 +351,8 @@ class EventManagerBase(event_manager_.EventManager):
         if consumer.event_types is undefined.UNDEFINED:
             return True
 
+        # If event_types is not UNDEFINED then cache_components shouldn't ever be undefined.
+        assert consumer.cache_components is not undefined.UNDEFINED
         if (cached_value := self._enabled_consumers_cache.get(consumer)) is True:
             return True
 
@@ -364,11 +366,9 @@ class EventManagerBase(event_manager_.EventManager):
 
             self._enabled_consumers_cache[consumer] = False
 
-        # If cache_components is UNDEFINED then we have to fall back to assuming that the consumer might alter state.
         # If cache_components is NONE then it doesn't make any altering state calls.
         return (
-            consumer.cache_components is undefined.UNDEFINED
-            or consumer.cache_components != config.CacheComponents.NONE
+            consumer.cache_components != config.CacheComponents.NONE
             and (consumer.cache_components & self._app.cache.settings.components) != 0
         )
 

--- a/hikari/impl/event_manager_base.py
+++ b/hikari/impl/event_manager_base.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["EventManagerBase", "EventStream"]
+__all__: typing.List[str] = ["as_listener", "EventManagerBase", "EventStream"]
 
 import asyncio
 import inspect
@@ -32,6 +32,8 @@ import logging
 import typing
 import warnings
 import weakref
+
+import attr
 
 from hikari import errors
 from hikari import iterators
@@ -43,6 +45,7 @@ from hikari.internal import reflect
 if typing.TYPE_CHECKING:
     import types
 
+    from hikari import config
     from hikari import intents as intents_
     from hikari.api import event_factory as event_factory_
     from hikari.api import shard as gateway_shard
@@ -63,6 +66,15 @@ if typing.TYPE_CHECKING:
     ]
     WaiterMapT = typing.Dict[typing.Type[event_manager_.EventT_co], typing.Set[WaiterT[event_manager_.EventT_co]]]
 
+    EventManagerBaseT = typing.TypeVar("EventManagerBaseT", bound="EventManagerBase")
+    UnboundMethodT = typing.Callable[
+        [EventManagerBaseT, gateway_shard.GatewayShard, data_binding.JSONObject],
+        typing.Coroutine[typing.Any, typing.Any, None],
+    ]
+    MethodT = typing.Callable[
+        [gateway_shard.GatewayShard, data_binding.JSONObject],
+        typing.Coroutine[typing.Any, typing.Any, None],
+    ]
 
 def _generate_weak_listener(
     reference: weakref.WeakMethod,
@@ -243,6 +255,29 @@ def _get_mro(cls: typing.Type[base_events.Event]) -> typing.List[typing.Type[bas
     return mro[: mro.index(base_events.Event) + 1]
 
 
+def as_listener(
+    event_types: typing.Union[typing.Type[base_events.Event], typing.Sequence[typing.Type[base_events.Event]]],
+    cache_resource: typing.Optional[config.CacheComponents] = None,
+    /,
+) -> typing.Callable[[UnboundMethodT[EventManagerBaseT]], UnboundMethodT[EventManagerBaseT]]:
+    """Add metadata to a listener method to indicate when it should be unmarshalled and dispatched."""
+    event_types = event_types if isinstance(event_types, typing.Sequence) else (event_types,)
+
+    def decorator(method: UnboundMethodT[EventManagerBaseT], /) -> UnboundMethodT[EventManagerBaseT]:
+        method.__CACHE_RESOURCE__ = cache_resource  # type: ignore[attr-defined]
+        method.__EVENT_TYPES__ = event_types  # type: ignore[attr-defined]
+        return method
+
+    return decorator
+
+
+@attr.define()
+class _Consumer:
+    callback: ConsumerT
+    cache_resource: typing.Optional[config.CacheComponents]
+    event_types: typing.Optional[typing.Sequence[typing.Type[base_events.Event]]]
+
+
 class EventManagerBase(event_manager_.EventManager):
     """Provides functionality to consume and dispatch events.
 
@@ -253,7 +288,7 @@ class EventManagerBase(event_manager_.EventManager):
     __slots__: typing.Sequence[str] = ("_event_factory", "_intents", "_listeners", "_listeners_non_poly", "_consumers", "_waiters")
 
     def __init__(self, event_factory: event_factory_.EventFactory, intents: intents_.Intents) -> None:
-        self._consumers: typing.Dict[str, ConsumerT] = {}
+        self._consumers: typing.Dict[str, _Consumer] = {}
         self._event_factory = event_factory
         self._intents = intents
         self._listeners: ListenerMapT[base_events.Event] = {}
@@ -261,16 +296,39 @@ class EventManagerBase(event_manager_.EventManager):
         self._waiters: WaiterMapT[base_events.Event] = {}
 
         for name, member in inspect.getmembers(self):
-            if name.startswith("on_"):
-                self._consumers[name[3:]] = member
+            if not name.startswith("on_"):
+                continue
+
+            member = typing.cast("MethodT", member)
+            cache_resource = getattr(member, "__CACHE_RESOURCE__", None)
+            event_types = getattr(member, "__EVENT_TYPES__", None)
+
+            cache_resource = typing.cast("typing.Optional[config.CacheComponents]", cache_resource)
+            event_types = typing.cast("typing.Optional[typing.Sequence[typing.Type[base_events.Event]]]", event_types)
+            self._consumers[name[3:]] = _Consumer(member, cache_resource, event_types)
+
+    def _enabled_for(self, event_type: typing.Type[base_events.Event], /) -> bool:
+        return event_type in self._listeners or event_type in self._waiters
 
     def consume_raw_event(
         self, event_name: str, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> None:
         payload_event = self._event_factory.deserialize_shard_payload_event(shard, payload, name=event_name)
         self.dispatch(payload_event)
-        callback = self._consumers[event_name.casefold()]
-        asyncio.create_task(self._handle_dispatch(callback, shard, payload), name=f"dispatch {event_name}")
+        consumer = self._consumers[event_name.casefold()]
+
+        if consumer.cache_resource is not None and self._app.cache.settings.components & consumer.cache_resource:
+            return
+
+        if consumer.event_types is not None:
+            for event_type in consumer.event_types:
+                if self._enabled_for(event_type):
+                    break
+
+            else:
+                return
+
+        asyncio.create_task(self._handle_dispatch(consumer.callback, shard, payload), name=f"dispatch {event_name}")
 
     def subscribe(
         self,

--- a/tests/hikari/impl/test_bot.py
+++ b/tests/hikari/impl/test_bot.py
@@ -159,7 +159,9 @@ class TestGatewayBot:
         assert bot._cache is cache.return_value
         cache.assert_called_once_with(bot, cache_settings)
         assert bot._event_manager is event_manager.return_value
-        event_manager.assert_called_once_with(event_factory.return_value, intents, cache=cache.return_value)
+        event_manager.assert_called_once_with(
+            entity_factory.return_value, event_factory.return_value, intents, cache=cache.return_value
+        )
         assert bot._entity_factory is entity_factory.return_value
         entity_factory.assert_called_once_with(bot)
         assert bot._event_factory is event_factory.return_value

--- a/tests/hikari/impl/test_cache.py
+++ b/tests/hikari/impl/test_cache.py
@@ -1471,6 +1471,13 @@ class TestCacheImpl:
         assert cache_impl._me == mock_own_user
         assert cache_impl._me is not mock_own_user
 
+    def test_set_me_when_not_enabled(self, cache_impl):
+        cache_impl._settings.components = 0
+
+        cache_impl.set_me(object())
+
+        assert cache_impl._me is None
+
     def test_update_me_for_cached_me(self, cache_impl):
         mock_cached_own_user = mock.MagicMock(users.OwnUser)
         mock_own_user = mock.MagicMock(users.OwnUser)
@@ -1488,6 +1495,17 @@ class TestCacheImpl:
 
         assert result == (None, mock_own_user)
         assert cache_impl._me == mock_own_user
+
+    def test_update_me_for_when_not_enabled(self, cache_impl):
+        cache_impl._settings.components = 0
+        cache_impl.get_me = mock.Mock()
+        cache_impl.set_me = mock.Mock()
+
+        result = cache_impl.update_me(object())
+
+        assert result == (None, None)
+        cache_impl.get_me.assert_not_called()
+        cache_impl.set_me.assert_not_called()
 
     def test__build_member(self, cache_impl):
         mock_user = mock.MagicMock(users.User)

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -2488,7 +2488,7 @@ class TestEntityFactoryImpl:
             "nsfw_level": 0,
         }
 
-    def test_deserialize_gateway_guild(
+    def test_deserialize_gateway_guild_with_all_resources_enabled(
         self,
         entity_factory_impl,
         mock_app,
@@ -2502,7 +2502,17 @@ class TestEntityFactoryImpl:
         guild_role_payload,
         voice_state_payload,
     ):
-        guild_definition = entity_factory_impl.deserialize_gateway_guild(deserialize_gateway_guild_payload)
+        guild_definition = entity_factory_impl.deserialize_gateway_guild(
+            deserialize_gateway_guild_payload,
+            include_guild=True,
+            include_channels=True,
+            include_emojis=True,
+            include_members=True,
+            include_presences=True,
+            include_roles=True,
+            include_voice_states=True,
+        )
+        assert guild_definition.id == 265828729970753537
         guild = guild_definition.guild
         assert guild.app is mock_app
         assert guild.id == 265828729970753537
@@ -2584,6 +2594,27 @@ class TestEntityFactoryImpl:
             )
         }
 
+    def test_deserialize_gateway_guild_with_no_resources_enabled(self, entity_factory_impl):
+        guild_definition = entity_factory_impl.deserialize_gateway_guild(
+            {"id": "123123"},
+            include_guild=False,
+            include_channels=False,
+            include_emojis=False,
+            include_members=False,
+            include_presences=False,
+            include_roles=False,
+            include_voice_states=False,
+        )
+
+        assert guild_definition.id == 123123
+        assert guild_definition.guild is None
+        assert guild_definition.channels is None
+        assert guild_definition.emojis is None
+        assert guild_definition.members is None
+        assert guild_definition.presences is None
+        assert guild_definition.roles is None
+        assert guild_definition.voice_states is None
+
     def test_deserialize_gateway_guild_with_unset_fields(self, entity_factory_impl):
         guild_definition = entity_factory_impl.deserialize_gateway_guild(
             {
@@ -2613,7 +2644,8 @@ class TestEntityFactoryImpl:
                 "vanity_url_code": "loool",
                 "verification_level": 4,
                 "nsfw_level": 0,
-            }
+            },
+            include_guild=True,
         )
         guild = guild_definition.guild
         assert guild.joined_at is None
@@ -2623,10 +2655,6 @@ class TestEntityFactoryImpl:
         assert guild.premium_subscription_count is None
         assert guild.widget_channel_id is None
         assert guild.is_widget_enabled is None
-        assert guild_definition.channels is None
-        assert guild_definition.members is None
-        assert guild_definition.presences is None
-        assert guild_definition.voice_states is None
 
     def test_deserialize_gateway_guild_with_null_fields(self, entity_factory_impl):
         guild_definition = entity_factory_impl.deserialize_gateway_guild(
@@ -2674,7 +2702,8 @@ class TestEntityFactoryImpl:
                 "widget_channel_id": None,
                 "widget_enabled": True,
                 "nsfw_level": 0,
-            }
+            },
+            include_guild=True,
         )
         guild = guild_definition.guild
         assert guild.icon_hash is None
@@ -2695,7 +2724,9 @@ class TestEntityFactoryImpl:
         self, entity_factory_impl, deserialize_gateway_guild_payload
     ):
         deserialize_gateway_guild_payload["channels"] = [{"id": 123, "type": 1000}]
-        guild_definition = entity_factory_impl.deserialize_gateway_guild(deserialize_gateway_guild_payload)
+        guild_definition = entity_factory_impl.deserialize_gateway_guild(
+            deserialize_gateway_guild_payload, include_channels=True
+        )
 
         assert guild_definition.channels == {}
 

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -47,9 +47,201 @@ from hikari import users as user_models
 from hikari import voices as voice_models
 from hikari import webhooks as webhook_models
 from hikari.impl import entity_factory
+from hikari.interactions import command_interactions
 from hikari.interactions import base_interactions
 from hikari.interactions import command_interactions
 from hikari.interactions import component_interactions
+from tests.hikari import hikari_test_helpers
+
+
+@pytest.fixture()
+def mock_app() -> traits.RESTAware:
+    return mock.MagicMock(traits.RESTAware)
+
+
+@pytest.fixture()
+def permission_overwrite_payload():
+    return {"id": "4242", "type": 1, "allow": 65, "deny": 49152, "allow_new": "65", "deny_new": "49152"}
+
+
+@pytest.fixture()
+def guild_text_channel_payload(permission_overwrite_payload):
+    return {
+        "id": "123",
+        "guild_id": "567",
+        "name": "general",
+        "type": 0,
+        "position": 6,
+        "permission_overwrites": [permission_overwrite_payload],
+        "rate_limit_per_user": 2,
+        "nsfw": True,
+        "topic": "¯\\_(ツ)_/¯",
+        "last_message_id": "123456",
+        "last_pin_timestamp": "2020-05-27T15:58:51.545252+00:00",
+        "parent_id": "987",
+    }
+
+
+@pytest.fixture()
+def guild_voice_channel_payload(permission_overwrite_payload):
+    return {
+        "id": "555",
+        "guild_id": "789",
+        "name": "Secret Developer Discussions",
+        "type": 2,
+        "nsfw": True,
+        "position": 4,
+        "permission_overwrites": [permission_overwrite_payload],
+        "bitrate": 64000,
+        "user_limit": 3,
+        "rtc_region": "europe",
+        "parent_id": "456",
+        "video_quality_mode": 1,
+    }
+
+
+@pytest.fixture()
+def guild_news_channel_payload(permission_overwrite_payload):
+    return {
+        "id": "7777",
+        "guild_id": "123",
+        "name": "Important Announcements",
+        "type": 5,
+        "position": 0,
+        "permission_overwrites": [permission_overwrite_payload],
+        "nsfw": True,
+        "topic": "Super Important Announcements",
+        "last_message_id": "456",
+        "parent_id": "654",
+        "last_pin_timestamp": "2020-05-27T15:58:51.545252+00:00",
+    }
+
+
+@pytest.fixture()
+def user_payload(self):
+    return {
+        "id": "115590097100865541",
+        "username": "nyaa",
+        "avatar": "b3b24c6d7cbcdec129d5d537067061a8",
+        "banner": "a_221313e1e2edsncsncsmcndsc",
+        "accent_color": 231321,
+        "discriminator": "6127",
+        "bot": True,
+        "system": True,
+        "public_flags": int(user_models.UserFlag.EARLY_VERIFIED_DEVELOPER),
+    }
+
+
+@pytest.fixture()
+def custom_emoji_payload():
+    return {"id": "691225175349395456", "name": "test", "animated": True}
+
+
+@pytest.fixture()
+def known_custom_emoji_payload(user_payload):
+    return {
+        "id": "12345",
+        "name": "testing",
+        "animated": False,
+        "available": True,
+        "roles": ["123", "456"],
+        "user": user_payload,
+        "require_colons": True,
+        "managed": False,
+    }
+
+
+@pytest.fixture()
+def member_payload(self, user_payload):
+    return {
+        "nick": "foobarbaz",
+        "roles": ["11111", "22222", "33333", "44444"],
+        "joined_at": "2015-04-26T06:26:56.936000+00:00",
+        "premium_since": "2019-05-17T06:26:56.936000+00:00",
+        "avatar": "estrogen",
+        "deaf": False,
+        "mute": True,
+        "pending": False,
+        "user": user_payload,
+    }
+
+
+@pytest.fixture()
+def presence_activity_payload(custom_emoji_payload):
+    return {
+        "name": "an activity",
+        "type": 1,
+        "url": "https://69.420.owouwunyaa",
+        "created_at": 1584996792798,
+        "timestamps": {"start": 1584996792798, "end": 1999999792798},
+        "application_id": "40404040404040",
+        "details": "They are doing stuff",
+        "state": "STATED",
+        "emoji": custom_emoji_payload,
+        "party": {"id": "spotify:3234234234", "size": [2, 5]},
+        "assets": {
+            "large_image": "34234234234243",
+            "large_text": "LARGE TEXT",
+            "small_image": "3939393",
+            "small_text": "small text",
+        },
+        "secrets": {"join": "who's a good secret?", "spectate": "I'm a good secret", "match": "No."},
+        "instance": True,
+        "flags": 3,
+        "buttons": ["owo", "no"],
+    }
+
+
+@pytest.fixture()
+def member_presence_payload(user_payload, presence_activity_payload):
+    return {
+        "user": user_payload,
+        "activity": presence_activity_payload,
+        "guild_id": "44004040",
+        "status": "dnd",
+        "activities": [presence_activity_payload],
+        "client_status": {"desktop": "online", "mobile": "idle", "web": "dnd"},
+    }
+
+
+@pytest.fixture()
+def guild_role_payload(self):
+    return {
+        "id": "41771983423143936",
+        "name": "WE DEM BOYZZ!!!!!!",
+        "color": 3_447_003,
+        "hoist": True,
+        "unicode_emoji": "\N{OK HAND SIGN}",
+        "icon": "abc123hash",
+        "position": 0,
+        "permissions": "66321471",
+        "managed": False,
+        "mentionable": False,
+        "tags": {
+            "bot_id": "123",
+            "integration_id": "456",
+            "premium_subscriber": None,
+        },
+    }
+
+
+@pytest.fixture()
+def voice_state_payload(member_payload):
+    return {
+        "guild_id": "929292929292992",
+        "channel_id": "157733188964188161",
+        "user_id": "115590097100865541",
+        "member": member_payload,
+        "session_id": "90326bd25d71d39b9ef95b299e3872ff",
+        "deaf": True,
+        "mute": True,
+        "self_deaf": False,
+        "self_mute": True,
+        "self_stream": True,
+        "self_video": True,
+        "suppress": False,
+        "request_to_speak_timestamp": "2021-04-17T10:11:19.970105+00:00",
+    }
 
 
 def test__with_int_cast():
@@ -86,11 +278,364 @@ def test__deserialize_max_age_returns_null():
     assert entity_factory._deserialize_max_age(0) is None
 
 
-class TestEntityFactoryImpl:
+class TestGatewayGuildDefinition:
     @pytest.fixture()
-    def mock_app(self) -> traits.RESTAware:
-        return mock.MagicMock(traits.RESTAware)
+    def entity_factory_impl(self, mock_app) -> entity_factory.EntityFactoryImpl:
+        return hikari_test_helpers.mock_class_namespace(entity_factory.EntityFactoryImpl, slots_=False)(mock_app)
 
+    def test_id_property(self, entity_factory_impl):
+        guild_definition = entity_factory_impl.deserialize_gateway_guild({"id": "123123451234"})
+
+        assert guild_definition.id == 123123451234
+
+    def test_channels(
+        self, entity_factory_impl, guild_text_channel_payload, guild_voice_channel_payload, guild_news_channel_payload
+    ):
+        guild_definition = entity_factory_impl.deserialize_gateway_guild(
+            {
+                "id": "265828729970753537",
+                "channels": [guild_text_channel_payload, guild_voice_channel_payload, guild_news_channel_payload],
+            }
+        )
+
+        assert guild_definition.channels() == {
+            123: entity_factory_impl.deserialize_guild_text_channel(
+                guild_text_channel_payload, guild_id=snowflakes.Snowflake(265828729970753537)
+            ),
+            555: entity_factory_impl.deserialize_guild_voice_channel(
+                guild_voice_channel_payload, guild_id=snowflakes.Snowflake(265828729970753537)
+            ),
+            7777: entity_factory_impl.deserialize_guild_news_channel(
+                guild_news_channel_payload, guild_id=snowflakes.Snowflake(265828729970753537)
+            ),
+        }
+
+    def test_channels_returns_cached_values(self, entity_factory_impl):
+        guild_definition = entity_factory_impl.deserialize_gateway_guild({"id": "265828729970753537"})
+        mock_channel = object()
+        guild_definition._channels = {"123321": mock_channel}
+        entity_factory_impl.deserialize_guild_text_channel = mock.Mock()
+        entity_factory_impl.deserialize_guild_voice_channel = mock.Mock()
+        entity_factory_impl.deserialize_guild_news_channel = mock.Mock()
+
+        assert guild_definition.channels() == {"123321": mock_channel}
+
+        entity_factory_impl.deserialize_guild_text_channel.assert_not_called()
+        entity_factory_impl.deserialize_guild_voice_channel.assert_not_called()
+        entity_factory_impl.deserialize_guild_news_channel.assert_not_called()
+
+    def test_channels_ignores_unrecognised_channels(self, entity_factory_impl):
+        guild_definition = entity_factory_impl.deserialize_gateway_guild(
+            {"id": "9494949", "channels": [{"id": 123, "type": 1000}]}
+        )
+
+        assert guild_definition.channels() == {}
+
+    def test_emojis(self, entity_factory_impl, known_custom_emoji_payload):
+        guild_definition = entity_factory_impl.deserialize_gateway_guild(
+            {"id": "265828729970753537", "emojis": [known_custom_emoji_payload]},
+        )
+
+        assert guild_definition.emojis() == {
+            12345: entity_factory_impl.deserialize_known_custom_emoji(
+                known_custom_emoji_payload, guild_id=snowflakes.Snowflake(265828729970753537)
+            )
+        }
+
+    def test_emojis_returns_cached_values(self, entity_factory_impl):
+        mock_emoji = object()
+        entity_factory_impl.deserialize_known_custom_emoji = mock.Mock()
+        guild_definition = entity_factory_impl.deserialize_gateway_guild({"id": "265828729970753537"})
+        guild_definition._emojis = {"21323232": mock_emoji}
+
+        assert guild_definition.emojis() == {"21323232": mock_emoji}
+
+        entity_factory_impl.deserialize_known_custom_emoji.assert_not_called()
+
+    def test_guild(self, entity_factory_impl, mock_app):
+        guild_definition = entity_factory_impl.deserialize_gateway_guild(
+            {
+                "afk_channel_id": "99998888777766",
+                "afk_timeout": 1200,
+                "application_id": "39494949",
+                "banner": "1a2b3c",
+                "default_message_notifications": 1,
+                "description": "This is a server I guess, its a bit crap though",
+                "discovery_splash": "famfamFAMFAMfam",
+                "embed_channel_id": "9439394949",
+                "embed_enabled": True,
+                "explicit_content_filter": 2,
+                "features": ["ANIMATED_ICON", "MORE_EMOJI", "NEWS", "SOME_UNDOCUMENTED_FEATURE"],
+                "icon": "1a2b3c4d",
+                "id": "265828729970753537",
+                "joined_at": "2019-05-17T06:26:56.936000+00:00",
+                "large": False,
+                "max_members": 25000,
+                "max_presences": 250,
+                "max_video_channel_users": 25,
+                "member_count": 14,
+                "mfa_level": 1,
+                "name": "L33t guild",
+                "owner_id": "6969696",
+                "preferred_locale": "en-GB",
+                "premium_subscription_count": 1,
+                "premium_tier": 2,
+                "public_updates_channel_id": "33333333",
+                "rules_channel_id": "42042069",
+                "splash": "0ff0ff0ff",
+                "system_channel_flags": 3,
+                "system_channel_id": "19216801",
+                "unavailable": False,
+                "vanity_url_code": "loool",
+                "verification_level": 4,
+                "widget_channel_id": "9439394949",
+                "widget_enabled": True,
+                "nsfw_level": 0,
+            }
+        )
+
+        guild = guild_definition.guild()
+        assert guild.app is mock_app
+        assert guild.id == 265828729970753537
+        assert guild.name == "L33t guild"
+        assert guild.icon_hash == "1a2b3c4d"
+        assert guild.features == [
+            guild_models.GuildFeature.ANIMATED_ICON,
+            guild_models.GuildFeature.MORE_EMOJI,
+            guild_models.GuildFeature.NEWS,
+            "SOME_UNDOCUMENTED_FEATURE",
+        ]
+        assert guild.splash_hash == "0ff0ff0ff"
+        assert guild.discovery_splash_hash == "famfamFAMFAMfam"
+        assert guild.owner_id == 6969696
+        assert guild.afk_channel_id == 99998888777766
+        assert guild.afk_timeout == datetime.timedelta(seconds=1200)
+        assert guild.verification_level == guild_models.GuildVerificationLevel.VERY_HIGH
+        assert guild.default_message_notifications == guild_models.GuildMessageNotificationsLevel.ONLY_MENTIONS
+        assert guild.explicit_content_filter == guild_models.GuildExplicitContentFilterLevel.ALL_MEMBERS
+        assert guild.mfa_level == guild_models.GuildMFALevel.ELEVATED
+        assert guild.application_id == 39494949
+        assert guild.widget_channel_id == 9439394949
+        assert guild.is_widget_enabled is True
+        assert guild.system_channel_id == 19216801
+        assert guild.system_channel_flags == guild_models.GuildSystemChannelFlag(3)
+        assert guild.rules_channel_id == 42042069
+        assert guild.joined_at == datetime.datetime(2019, 5, 17, 6, 26, 56, 936000, tzinfo=datetime.timezone.utc)
+        assert guild.is_large is False
+        assert guild.member_count == 14
+        assert guild.max_video_channel_users == 25
+        assert guild.vanity_url_code == "loool"
+        assert guild.description == "This is a server I guess, its a bit crap though"
+        assert guild.banner_hash == "1a2b3c"
+        assert guild.premium_tier == guild_models.GuildPremiumTier.TIER_2
+        assert guild.premium_subscription_count == 1
+        assert guild.preferred_locale == "en-GB"
+        assert guild.public_updates_channel_id == 33333333
+        assert guild.nsfw_level == guild_models.GuildNSFWLevel.DEFAULT
+
+    def test_guild_with_unset_fields(self, entity_factory_impl):
+        guild_definition = entity_factory_impl.deserialize_gateway_guild(
+            {
+                "afk_channel_id": "99998888777766",
+                "afk_timeout": 1200,
+                "application_id": "39494949",
+                "banner": "1a2b3c",
+                "default_message_notifications": 1,
+                "description": "This is a server I guess, its a bit crap though",
+                "discovery_splash": "famfamFAMFAMfam",
+                "emojis": [],
+                "explicit_content_filter": 2,
+                "features": ["ANIMATED_ICON", "MORE_EMOJI", "NEWS", "SOME_UNDOCUMENTED_FEATURE"],
+                "icon": "1a2b3c4d",
+                "id": "265828729970753537",
+                "mfa_level": 1,
+                "name": "L33t guild",
+                "owner_id": "6969696",
+                "preferred_locale": "en-GB",
+                "premium_tier": 2,
+                "public_updates_channel_id": "33333333",
+                "roles": [],
+                "rules_channel_id": "42042069",
+                "splash": "0ff0ff0ff",
+                "system_channel_flags": 3,
+                "system_channel_id": "19216801",
+                "vanity_url_code": "loool",
+                "verification_level": 4,
+                "nsfw_level": 0,
+            },
+        )
+        guild = guild_definition.guild()
+        assert guild.joined_at is None
+        assert guild.is_large is None
+        assert guild.max_video_channel_users is None
+        assert guild.member_count is None
+        assert guild.premium_subscription_count is None
+        assert guild.widget_channel_id is None
+        assert guild.is_widget_enabled is None
+
+    def test_guild_with_null_fields(self, entity_factory_impl):
+        guild_definition = entity_factory_impl.deserialize_gateway_guild(
+            {
+                "afk_channel_id": None,
+                "afk_timeout": 1200,
+                "application_id": None,
+                "banner": None,
+                "channels": [],
+                "default_message_notifications": 1,
+                "description": None,
+                "discovery_splash": None,
+                "embed_channel_id": None,
+                "embed_enabled": True,
+                "emojis": [],
+                "explicit_content_filter": 2,
+                "features": ["ANIMATED_ICON", "MORE_EMOJI", "NEWS", "SOME_UNDOCUMENTED_FEATURE"],
+                "icon": None,
+                "id": "265828729970753537",
+                "joined_at": "2019-05-17T06:26:56.936000+00:00",
+                "large": False,
+                "max_members": 25000,
+                "max_presences": None,
+                "max_video_channel_users": 25,
+                "member_count": 14,
+                "members": [],
+                "mfa_level": 1,
+                "name": "L33t guild",
+                "owner_id": "6969696",
+                "permissions": 66_321_471,
+                "preferred_locale": "en-GB",
+                "premium_subscription_count": None,
+                "premium_tier": 2,
+                "presences": [],
+                "public_updates_channel_id": None,
+                "roles": [],
+                "rules_channel_id": None,
+                "splash": None,
+                "system_channel_flags": 3,
+                "system_channel_id": None,
+                "unavailable": False,
+                "vanity_url_code": None,
+                "verification_level": 4,
+                "voice_states": [],
+                "widget_channel_id": None,
+                "widget_enabled": True,
+                "nsfw_level": 0,
+            },
+        )
+        guild = guild_definition.guild()
+        assert guild.icon_hash is None
+        assert guild.splash_hash is None
+        assert guild.discovery_splash_hash is None
+        assert guild.afk_channel_id is None
+        assert guild.application_id is None
+        assert guild.widget_channel_id is None
+        assert guild.system_channel_id is None
+        assert guild.rules_channel_id is None
+        assert guild.vanity_url_code is None
+        assert guild.description is None
+        assert guild.banner_hash is None
+        assert guild.premium_subscription_count is None
+        assert guild.public_updates_channel_id is None
+
+    def test_guild_returns_cached_values(self, entity_factory_impl):
+        mock_guild = object()
+        entity_factory_impl.set_guild_attributes = mock.Mock()
+        guild_definition = entity_factory_impl.deserialize_gateway_guild({"id": "9393939"})
+        guild_definition._guild = mock_guild
+
+        assert guild_definition.guild() is mock_guild
+
+        entity_factory_impl.set_guild_attributes.assert_not_called()
+
+    def test_members(self, entity_factory_impl, member_payload):
+        guild_definition = entity_factory_impl.deserialize_gateway_guild(
+            {"id": "265828729970753537", "members": [member_payload]}
+        )
+
+        assert guild_definition.members() == {
+            115590097100865541: entity_factory_impl.deserialize_member(
+                member_payload, guild_id=snowflakes.Snowflake(265828729970753537)
+            )
+        }
+
+    def test_members_returns_cached_values(self, entity_factory_impl):
+        mock_member = object()
+        entity_factory_impl.deserialize_member = mock.Mock()
+        guild_definition = entity_factory_impl.deserialize_gateway_guild({"id": "92929292"})
+        guild_definition._members = {"93939393": mock_member}
+
+        assert guild_definition.members() == {"93939393": mock_member}
+
+        entity_factory_impl.deserialize_member.assert_not_called()
+
+    def test_presences(self, entity_factory_impl, member_presence_payload):
+        guild_definition = entity_factory_impl.deserialize_gateway_guild(
+            {"id": "265828729970753537", "presences": [member_presence_payload]}
+        )
+
+        assert guild_definition.presences() == {
+            115590097100865541: entity_factory_impl.deserialize_member_presence(
+                member_presence_payload, guild_id=snowflakes.Snowflake(265828729970753537)
+            )
+        }
+
+    def test_presences_returns_cached_values(self, entity_factory_impl):
+        mock_presence = object()
+        entity_factory_impl.deserialize_member_presence = mock.Mock()
+        guild_definition = entity_factory_impl.deserialize_gateway_guild({"id": "29292992"})
+        guild_definition._presences = {"3939393993": mock_presence}
+
+        assert guild_definition.presences() == {"3939393993": mock_presence}
+
+        entity_factory_impl.deserialize_member_presence.assert_not_called()
+
+    def test_roles(self, entity_factory_impl, guild_role_payload):
+        guild_definition = entity_factory_impl.deserialize_gateway_guild(
+            {"id": "265828729970753537", "roles": [guild_role_payload]}
+        )
+
+        assert guild_definition.roles() == {
+            41771983423143936: entity_factory_impl.deserialize_role(
+                guild_role_payload, guild_id=snowflakes.Snowflake(265828729970753537)
+            )
+        }
+
+    def test_roles_returns_cached_values(self, entity_factory_impl):
+        mock_role = object()
+        entity_factory_impl.deserialize_role = mock.Mock()
+        guild_definition = entity_factory_impl.deserialize_gateway_guild({"id": "9292929"})
+        guild_definition._roles = {"32132123123": mock_role}
+
+        assert guild_definition.roles() == {"32132123123": mock_role}
+
+        entity_factory_impl.deserialize_role.assert_not_called()
+
+    def test_voice_states(self, entity_factory_impl, member_payload, voice_state_payload):
+        guild_definition = entity_factory_impl.deserialize_gateway_guild(
+            {"id": "265828729970753537", "voice_states": [voice_state_payload], "members": [member_payload]}
+        )
+        assert guild_definition.voice_states() == {
+            115590097100865541: entity_factory_impl.deserialize_voice_state(
+                voice_state_payload,
+                guild_id=snowflakes.Snowflake(265828729970753537),
+                member=entity_factory_impl.deserialize_member(
+                    member_payload,
+                    guild_id=snowflakes.Snowflake(265828729970753537),
+                ),
+            )
+        }
+
+    def test_voice_states_returns_cached_values(self, entity_factory_impl):
+        mock_voice_state = object()
+        entity_factory_impl.deserialize_voice_state = mock.Mock()
+        guild_definition = entity_factory_impl.deserialize_gateway_guild({"id": "292929"})
+        guild_definition._voice_states = {"9393939393": mock_voice_state}
+
+        assert guild_definition.voice_states() == {"9393939393": mock_voice_state}
+
+        entity_factory_impl.deserialize_voice_state.assert_not_called()
+
+
+class TestEntityFactoryImpl:
     @pytest.fixture()
     def entity_factory_impl(self, mock_app) -> entity_factory.EntityFactoryImpl:
         return entity_factory.EntityFactoryImpl(app=mock_app)
@@ -763,10 +1308,6 @@ class TestEntityFactoryImpl:
         assert follow.channel_id == 41231
         assert follow.webhook_id == 939393
 
-    @pytest.fixture()
-    def permission_overwrite_payload(self):
-        return {"id": "4242", "type": 1, "allow": 65, "deny": 49152, "allow_new": "65", "deny_new": "49152"}
-
     @pytest.mark.parametrize("type", [0, 1])
     def test_deserialize_permission_overwrite(self, entity_factory_impl, type):
         permission_overwrite_payload = {
@@ -937,23 +1478,6 @@ class TestEntityFactoryImpl:
         )
         assert guild_category.parent_id is None
 
-    @pytest.fixture()
-    def guild_text_channel_payload(self, permission_overwrite_payload):
-        return {
-            "id": "123",
-            "guild_id": "567",
-            "name": "general",
-            "type": 0,
-            "position": 6,
-            "permission_overwrites": [permission_overwrite_payload],
-            "rate_limit_per_user": 2,
-            "nsfw": True,
-            "topic": "¯\\_(ツ)_/¯",
-            "last_message_id": "123456",
-            "last_pin_timestamp": "2020-05-27T15:58:51.545252+00:00",
-            "parent_id": "987",
-        }
-
     def test_deserialize_guild_text_channel(
         self, entity_factory_impl, mock_app, guild_text_channel_payload, permission_overwrite_payload
     ):
@@ -1016,22 +1540,6 @@ class TestEntityFactoryImpl:
         assert guild_text_channel.last_message_id is None
         assert guild_text_channel.last_pin_timestamp is None
         assert guild_text_channel.parent_id is None
-
-    @pytest.fixture()
-    def guild_news_channel_payload(self, permission_overwrite_payload):
-        return {
-            "id": "7777",
-            "guild_id": "123",
-            "name": "Important Announcements",
-            "type": 5,
-            "position": 0,
-            "permission_overwrites": [permission_overwrite_payload],
-            "nsfw": True,
-            "topic": "Super Important Announcements",
-            "last_message_id": "456",
-            "parent_id": "654",
-            "last_pin_timestamp": "2020-05-27T15:58:51.545252+00:00",
-        }
 
     def test_deserialize_guild_news_channel(
         self, entity_factory_impl, mock_app, guild_news_channel_payload, permission_overwrite_payload
@@ -1150,23 +1658,6 @@ class TestEntityFactoryImpl:
             }
         )
         assert store_chanel.parent_id is None
-
-    @pytest.fixture()
-    def guild_voice_channel_payload(self, permission_overwrite_payload):
-        return {
-            "id": "555",
-            "guild_id": "789",
-            "name": "Secret Developer Discussions",
-            "type": 2,
-            "nsfw": True,
-            "position": 4,
-            "permission_overwrites": [permission_overwrite_payload],
-            "bitrate": 64000,
-            "user_limit": 3,
-            "rtc_region": "europe",
-            "parent_id": "456",
-            "video_quality_mode": 1,
-        }
 
     def test_deserialize_guild_voice_channel(
         self, entity_factory_impl, mock_app, guild_voice_channel_payload, permission_overwrite_payload
@@ -1678,10 +2169,6 @@ class TestEntityFactoryImpl:
         assert emoji.name == "🤷"
         assert isinstance(emoji, emoji_models.UnicodeEmoji)
 
-    @pytest.fixture()
-    def custom_emoji_payload(self):
-        return {"id": "691225175349395456", "name": "test", "animated": True}
-
     def test_deserialize_custom_emoji(self, entity_factory_impl, mock_app, custom_emoji_payload):
         emoji = entity_factory_impl.deserialize_custom_emoji(custom_emoji_payload)
         assert emoji.id == snowflakes.Snowflake(691225175349395456)
@@ -1695,19 +2182,6 @@ class TestEntityFactoryImpl:
         emoji = entity_factory_impl.deserialize_custom_emoji({"id": "691225175349395456", "name": None})
         assert emoji.is_animated is False
         assert emoji.name is None
-
-    @pytest.fixture()
-    def known_custom_emoji_payload(self, user_payload):
-        return {
-            "id": "12345",
-            "name": "testing",
-            "animated": False,
-            "available": True,
-            "roles": ["123", "456"],
-            "user": user_payload,
-            "require_colons": True,
-            "managed": False,
-        }
 
     def test_deserialize_known_custom_emoji(
         self, entity_factory_impl, mock_app, user_payload, known_custom_emoji_payload
@@ -1870,20 +2344,6 @@ class TestEntityFactoryImpl:
 
         assert result == {"channel_id": "4312312", "description": "meow2"}
 
-    @pytest.fixture()
-    def member_payload(self, user_payload):
-        return {
-            "nick": "foobarbaz",
-            "roles": ["11111", "22222", "33333", "44444"],
-            "joined_at": "2015-04-26T06:26:56.936000+00:00",
-            "premium_since": "2019-05-17T06:26:56.936000+00:00",
-            "avatar": "estrogen",
-            "deaf": False,
-            "mute": True,
-            "pending": False,
-            "user": user_payload,
-        }
-
     def test_deserialize_member(self, entity_factory_impl, mock_app, member_payload, user_payload):
         member_payload = {**member_payload, "guild_id": "76543325"}
         member = entity_factory_impl.deserialize_member(member_payload)
@@ -1971,26 +2431,6 @@ class TestEntityFactoryImpl:
         )
         assert member.user is mock_user
         assert member.guild_id == 64234
-
-    @pytest.fixture()
-    def guild_role_payload(self):
-        return {
-            "id": "41771983423143936",
-            "name": "WE DEM BOYZZ!!!!!!",
-            "color": 3_447_003,
-            "hoist": True,
-            "unicode_emoji": "\N{OK HAND SIGN}",
-            "icon": "abc123hash",
-            "position": 0,
-            "permissions": "66321471",
-            "managed": False,
-            "mentionable": False,
-            "tags": {
-                "bot_id": "123",
-                "integration_id": "456",
-                "premium_subscriber": None,
-            },
-        }
 
     def test_deserialize_role(self, entity_factory_impl, mock_app, guild_role_payload):
         guild_role = entity_factory_impl.deserialize_role(guild_role_payload, guild_id=snowflakes.Snowflake(76534453))
@@ -2431,304 +2871,11 @@ class TestEntityFactoryImpl:
         assert guild.premium_subscription_count is None
         assert guild.public_updates_channel_id is None
 
-    @pytest.fixture()
-    def deserialize_gateway_guild_payload(
-        self,
-        guild_text_channel_payload,
-        guild_voice_channel_payload,
-        guild_news_channel_payload,
-        known_custom_emoji_payload,
-        member_payload,
-        member_presence_payload,
-        guild_role_payload,
-        voice_state_payload,
-    ):
-        return {
-            "afk_channel_id": "99998888777766",
-            "afk_timeout": 1200,
-            "application_id": "39494949",
-            "banner": "1a2b3c",
-            "channels": [guild_text_channel_payload, guild_voice_channel_payload, guild_news_channel_payload],
-            "default_message_notifications": 1,
-            "description": "This is a server I guess, its a bit crap though",
-            "discovery_splash": "famfamFAMFAMfam",
-            "embed_channel_id": "9439394949",
-            "embed_enabled": True,
-            "emojis": [known_custom_emoji_payload],
-            "explicit_content_filter": 2,
-            "features": ["ANIMATED_ICON", "MORE_EMOJI", "NEWS", "SOME_UNDOCUMENTED_FEATURE"],
-            "icon": "1a2b3c4d",
-            "id": "265828729970753537",
-            "joined_at": "2019-05-17T06:26:56.936000+00:00",
-            "large": False,
-            "max_members": 25000,
-            "max_presences": 250,
-            "max_video_channel_users": 25,
-            "member_count": 14,
-            "members": [member_payload],
-            "mfa_level": 1,
-            "name": "L33t guild",
-            "owner_id": "6969696",
-            "preferred_locale": "en-GB",
-            "premium_subscription_count": 1,
-            "premium_tier": 2,
-            "presences": [member_presence_payload],
-            "public_updates_channel_id": "33333333",
-            "roles": [guild_role_payload],
-            "rules_channel_id": "42042069",
-            "splash": "0ff0ff0ff",
-            "system_channel_flags": 3,
-            "system_channel_id": "19216801",
-            "unavailable": False,
-            "vanity_url_code": "loool",
-            "verification_level": 4,
-            "voice_states": [voice_state_payload],
-            "widget_channel_id": "9439394949",
-            "widget_enabled": True,
-            "nsfw_level": 0,
-        }
-
-    def test_deserialize_gateway_guild_with_all_resources_enabled(
-        self,
-        entity_factory_impl,
-        mock_app,
-        deserialize_gateway_guild_payload,
-        guild_text_channel_payload,
-        guild_voice_channel_payload,
-        guild_news_channel_payload,
-        known_custom_emoji_payload,
-        member_payload,
-        member_presence_payload,
-        guild_role_payload,
-        voice_state_payload,
-    ):
-        guild_definition = entity_factory_impl.deserialize_gateway_guild(
-            deserialize_gateway_guild_payload,
-            include_guild=True,
-            include_channels=True,
-            include_emojis=True,
-            include_members=True,
-            include_presences=True,
-            include_roles=True,
-            include_voice_states=True,
-        )
-        assert guild_definition.id == 265828729970753537
-        guild = guild_definition.guild
-        assert guild.app is mock_app
-        assert guild.id == 265828729970753537
-        assert guild.name == "L33t guild"
-        assert guild.icon_hash == "1a2b3c4d"
-        assert guild.features == [
-            guild_models.GuildFeature.ANIMATED_ICON,
-            guild_models.GuildFeature.MORE_EMOJI,
-            guild_models.GuildFeature.NEWS,
-            "SOME_UNDOCUMENTED_FEATURE",
-        ]
-        assert guild.splash_hash == "0ff0ff0ff"
-        assert guild.discovery_splash_hash == "famfamFAMFAMfam"
-        assert guild.owner_id == 6969696
-        assert guild.afk_channel_id == 99998888777766
-        assert guild.afk_timeout == datetime.timedelta(seconds=1200)
-        assert guild.verification_level == guild_models.GuildVerificationLevel.VERY_HIGH
-        assert guild.default_message_notifications == guild_models.GuildMessageNotificationsLevel.ONLY_MENTIONS
-        assert guild.explicit_content_filter == guild_models.GuildExplicitContentFilterLevel.ALL_MEMBERS
-        assert guild.mfa_level == guild_models.GuildMFALevel.ELEVATED
-        assert guild.application_id == 39494949
-        assert guild.widget_channel_id == 9439394949
-        assert guild.is_widget_enabled is True
-        assert guild.system_channel_id == 19216801
-        assert guild.system_channel_flags == guild_models.GuildSystemChannelFlag(3)
-        assert guild.rules_channel_id == 42042069
-        assert guild.joined_at == datetime.datetime(2019, 5, 17, 6, 26, 56, 936000, tzinfo=datetime.timezone.utc)
-        assert guild.is_large is False
-        assert guild.member_count == 14
-        assert guild.max_video_channel_users == 25
-        assert guild.vanity_url_code == "loool"
-        assert guild.description == "This is a server I guess, its a bit crap though"
-        assert guild.banner_hash == "1a2b3c"
-        assert guild.premium_tier == guild_models.GuildPremiumTier.TIER_2
-        assert guild.premium_subscription_count == 1
-        assert guild.preferred_locale == "en-GB"
-        assert guild.public_updates_channel_id == 33333333
-        assert guild.nsfw_level == guild_models.GuildNSFWLevel.DEFAULT
-
-        assert guild_definition.roles == {
-            41771983423143936: entity_factory_impl.deserialize_role(
-                guild_role_payload, guild_id=snowflakes.Snowflake(265828729970753537)
-            )
-        }
-        assert guild_definition.emojis == {
-            12345: entity_factory_impl.deserialize_known_custom_emoji(
-                known_custom_emoji_payload, guild_id=snowflakes.Snowflake(265828729970753537)
-            )
-        }
-        assert guild_definition.members == {
-            115590097100865541: entity_factory_impl.deserialize_member(
-                member_payload, guild_id=snowflakes.Snowflake(265828729970753537)
-            )
-        }
-        assert guild_definition.channels == {
-            123: entity_factory_impl.deserialize_guild_text_channel(
-                guild_text_channel_payload, guild_id=snowflakes.Snowflake(265828729970753537)
-            ),
-            555: entity_factory_impl.deserialize_guild_voice_channel(
-                guild_voice_channel_payload, guild_id=snowflakes.Snowflake(265828729970753537)
-            ),
-            7777: entity_factory_impl.deserialize_guild_news_channel(
-                guild_news_channel_payload, guild_id=snowflakes.Snowflake(265828729970753537)
-            ),
-        }
-        assert guild_definition.presences == {
-            115590097100865541: entity_factory_impl.deserialize_member_presence(
-                member_presence_payload, guild_id=snowflakes.Snowflake(265828729970753537)
-            )
-        }
-        assert guild_definition.voice_states == {
-            115590097100865541: entity_factory_impl.deserialize_voice_state(
-                voice_state_payload,
-                guild_id=snowflakes.Snowflake(265828729970753537),
-                member=entity_factory_impl.deserialize_member(
-                    member_payload,
-                    guild_id=snowflakes.Snowflake(265828729970753537),
-                ),
-            )
-        }
-
-    def test_deserialize_gateway_guild_with_no_resources_enabled(self, entity_factory_impl):
-        guild_definition = entity_factory_impl.deserialize_gateway_guild(
-            {"id": "123123"},
-            include_guild=False,
-            include_channels=False,
-            include_emojis=False,
-            include_members=False,
-            include_presences=False,
-            include_roles=False,
-            include_voice_states=False,
-        )
+    def test_deserialize_gateway_guild(self, entity_factory_impl):
+        guild_definition = entity_factory_impl.deserialize_gateway_guild({"id": "123123"})
 
         assert guild_definition.id == 123123
-        assert guild_definition.guild is None
-        assert guild_definition.channels is None
-        assert guild_definition.emojis is None
-        assert guild_definition.members is None
-        assert guild_definition.presences is None
-        assert guild_definition.roles is None
-        assert guild_definition.voice_states is None
-
-    def test_deserialize_gateway_guild_with_unset_fields(self, entity_factory_impl):
-        guild_definition = entity_factory_impl.deserialize_gateway_guild(
-            {
-                "afk_channel_id": "99998888777766",
-                "afk_timeout": 1200,
-                "application_id": "39494949",
-                "banner": "1a2b3c",
-                "default_message_notifications": 1,
-                "description": "This is a server I guess, its a bit crap though",
-                "discovery_splash": "famfamFAMFAMfam",
-                "emojis": [],
-                "explicit_content_filter": 2,
-                "features": ["ANIMATED_ICON", "MORE_EMOJI", "NEWS", "SOME_UNDOCUMENTED_FEATURE"],
-                "icon": "1a2b3c4d",
-                "id": "265828729970753537",
-                "mfa_level": 1,
-                "name": "L33t guild",
-                "owner_id": "6969696",
-                "preferred_locale": "en-GB",
-                "premium_tier": 2,
-                "public_updates_channel_id": "33333333",
-                "roles": [],
-                "rules_channel_id": "42042069",
-                "splash": "0ff0ff0ff",
-                "system_channel_flags": 3,
-                "system_channel_id": "19216801",
-                "vanity_url_code": "loool",
-                "verification_level": 4,
-                "nsfw_level": 0,
-            },
-            include_guild=True,
-        )
-        guild = guild_definition.guild
-        assert guild.joined_at is None
-        assert guild.is_large is None
-        assert guild.max_video_channel_users is None
-        assert guild.member_count is None
-        assert guild.premium_subscription_count is None
-        assert guild.widget_channel_id is None
-        assert guild.is_widget_enabled is None
-
-    def test_deserialize_gateway_guild_with_null_fields(self, entity_factory_impl):
-        guild_definition = entity_factory_impl.deserialize_gateway_guild(
-            {
-                "afk_channel_id": None,
-                "afk_timeout": 1200,
-                "application_id": None,
-                "banner": None,
-                "channels": [],
-                "default_message_notifications": 1,
-                "description": None,
-                "discovery_splash": None,
-                "embed_channel_id": None,
-                "embed_enabled": True,
-                "emojis": [],
-                "explicit_content_filter": 2,
-                "features": ["ANIMATED_ICON", "MORE_EMOJI", "NEWS", "SOME_UNDOCUMENTED_FEATURE"],
-                "icon": None,
-                "id": "265828729970753537",
-                "joined_at": "2019-05-17T06:26:56.936000+00:00",
-                "large": False,
-                "max_members": 25000,
-                "max_presences": None,
-                "max_video_channel_users": 25,
-                "member_count": 14,
-                "members": [],
-                "mfa_level": 1,
-                "name": "L33t guild",
-                "owner_id": "6969696",
-                "permissions": 66_321_471,
-                "preferred_locale": "en-GB",
-                "premium_subscription_count": None,
-                "premium_tier": 2,
-                "presences": [],
-                "public_updates_channel_id": None,
-                "roles": [],
-                "rules_channel_id": None,
-                "splash": None,
-                "system_channel_flags": 3,
-                "system_channel_id": None,
-                "unavailable": False,
-                "vanity_url_code": None,
-                "verification_level": 4,
-                "voice_states": [],
-                "widget_channel_id": None,
-                "widget_enabled": True,
-                "nsfw_level": 0,
-            },
-            include_guild=True,
-        )
-        guild = guild_definition.guild
-        assert guild.icon_hash is None
-        assert guild.splash_hash is None
-        assert guild.discovery_splash_hash is None
-        assert guild.afk_channel_id is None
-        assert guild.application_id is None
-        assert guild.widget_channel_id is None
-        assert guild.system_channel_id is None
-        assert guild.rules_channel_id is None
-        assert guild.vanity_url_code is None
-        assert guild.description is None
-        assert guild.banner_hash is None
-        assert guild.premium_subscription_count is None
-        assert guild.public_updates_channel_id is None
-
-    def test_deserialize_gateway_guild_ignores_unrecognised_channels(
-        self, entity_factory_impl, deserialize_gateway_guild_payload
-    ):
-        deserialize_gateway_guild_payload["channels"] = [{"id": 123, "type": 1000}]
-        guild_definition = entity_factory_impl.deserialize_gateway_guild(
-            deserialize_gateway_guild_payload, include_channels=True
-        )
-
-        assert guild_definition.channels == {}
+        assert guild_definition._payload == {"id": "123123"}
 
     ######################
     # INTERACTION MODELS #
@@ -4339,42 +4486,6 @@ class TestEntityFactoryImpl:
     # PRESENCE MODELS #
     ###################
 
-    @pytest.fixture()
-    def presence_activity_payload(self, custom_emoji_payload):
-        return {
-            "name": "an activity",
-            "type": 1,
-            "url": "https://69.420.owouwunyaa",
-            "created_at": 1584996792798,
-            "timestamps": {"start": 1584996792798, "end": 1999999792798},
-            "application_id": "40404040404040",
-            "details": "They are doing stuff",
-            "state": "STATED",
-            "emoji": custom_emoji_payload,
-            "party": {"id": "spotify:3234234234", "size": [2, 5]},
-            "assets": {
-                "large_image": "34234234234243",
-                "large_text": "LARGE TEXT",
-                "small_image": "3939393",
-                "small_text": "small text",
-            },
-            "secrets": {"join": "who's a good secret?", "spectate": "I'm a good secret", "match": "No."},
-            "instance": True,
-            "flags": 3,
-            "buttons": ["owo", "no"],
-        }
-
-    @pytest.fixture()
-    def member_presence_payload(self, user_payload, presence_activity_payload):
-        return {
-            "user": user_payload,
-            "activity": presence_activity_payload,
-            "guild_id": "44004040",
-            "status": "dnd",
-            "activities": [presence_activity_payload],
-            "client_status": {"desktop": "online", "mobile": "idle", "web": "dnd"},
-        }
-
     def test_deserialize_member_presence(
         self, entity_factory_impl, mock_app, member_presence_payload, custom_emoji_payload, user_payload
     ):
@@ -4716,20 +4827,6 @@ class TestEntityFactoryImpl:
     # USER MODELS #
     ###############
 
-    @pytest.fixture()
-    def user_payload(self):
-        return {
-            "id": "115590097100865541",
-            "username": "nyaa",
-            "avatar": "b3b24c6d7cbcdec129d5d537067061a8",
-            "banner": "a_221313e1e2edsncsncsmcndsc",
-            "accent_color": 231321,
-            "discriminator": "6127",
-            "bot": True,
-            "system": True,
-            "public_flags": int(user_models.UserFlag.EARLY_VERIFIED_DEVELOPER),
-        }
-
     def test_deserialize_user(self, entity_factory_impl, mock_app, user_payload):
         user = entity_factory_impl.deserialize_user(user_payload)
         assert user.app is mock_app
@@ -4824,24 +4921,6 @@ class TestEntityFactoryImpl:
     ################
     # VOICE MODELS #
     ################
-
-    @pytest.fixture()
-    def voice_state_payload(self, member_payload):
-        return {
-            "guild_id": "929292929292992",
-            "channel_id": "157733188964188161",
-            "user_id": "115590097100865541",
-            "member": member_payload,
-            "session_id": "90326bd25d71d39b9ef95b299e3872ff",
-            "deaf": True,
-            "mute": True,
-            "self_deaf": False,
-            "self_mute": True,
-            "self_stream": True,
-            "self_video": True,
-            "suppress": False,
-            "request_to_speak_timestamp": "2021-04-17T10:11:19.970105+00:00",
-        }
 
     def test_deserialize_voice_state_with_guild_id_in_payload(
         self, entity_factory_impl, mock_app, voice_state_payload, member_payload

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -117,7 +117,7 @@ def guild_news_channel_payload(permission_overwrite_payload):
 
 
 @pytest.fixture()
-def user_payload(self):
+def user_payload():
     return {
         "id": "115590097100865541",
         "username": "nyaa",
@@ -151,7 +151,7 @@ def known_custom_emoji_payload(user_payload):
 
 
 @pytest.fixture()
-def member_payload(self, user_payload):
+def member_payload(user_payload):
     return {
         "nick": "foobarbaz",
         "roles": ["11111", "22222", "33333", "44444"],
@@ -204,7 +204,7 @@ def member_presence_payload(user_payload, presence_activity_payload):
 
 
 @pytest.fixture()
-def guild_role_payload(self):
+def guild_role_payload():
     return {
         "id": "41771983423143936",
         "name": "WE DEM BOYZZ!!!!!!",

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -47,7 +47,6 @@ from hikari import users as user_models
 from hikari import voices as voice_models
 from hikari import webhooks as webhook_models
 from hikari.impl import entity_factory
-from hikari.interactions import command_interactions
 from hikari.interactions import base_interactions
 from hikari.interactions import command_interactions
 from hikari.interactions import component_interactions

--- a/tests/hikari/impl/test_event_factory.py
+++ b/tests/hikari/impl/test_event_factory.py
@@ -212,16 +212,21 @@ class TestEventFactoryImpl:
         mock_app.entity_factory.deserialize_gateway_guild.assert_called_once_with(mock_payload)
         assert isinstance(event, guild_events.GuildAvailableEvent)
         assert event.shard is mock_shard
-        assert event.guild is mock_app.entity_factory.deserialize_gateway_guild.return_value.guild.return_value
-        assert event.emojis is mock_app.entity_factory.deserialize_gateway_guild.return_value.emojis.return_value
-        assert event.roles is mock_app.entity_factory.deserialize_gateway_guild.return_value.roles.return_value
-        assert event.channels is mock_app.entity_factory.deserialize_gateway_guild.return_value.channels.return_value
-        assert event.members is mock_app.entity_factory.deserialize_gateway_guild.return_value.members.return_value
-        assert event.presences is mock_app.entity_factory.deserialize_gateway_guild.return_value.presences.return_value
-        assert (
-            event.voice_states
-            is mock_app.entity_factory.deserialize_gateway_guild.return_value.voice_states.return_value
-        )
+        guild_definition = mock_app.entity_factory.deserialize_gateway_guild.return_value
+        assert event.guild is guild_definition.guild.return_value
+        assert event.emojis is guild_definition.emojis.return_value
+        assert event.roles is guild_definition.roles.return_value
+        assert event.channels is guild_definition.channels.return_value
+        assert event.members is guild_definition.members.return_value
+        assert event.presences is guild_definition.presences.return_value
+        assert event.voice_states is guild_definition.voice_states.return_value
+        guild_definition.guild.assert_called_once_with()
+        guild_definition.emojis.assert_called_once_with()
+        guild_definition.roles.assert_called_once_with()
+        guild_definition.channels.assert_called_once_with()
+        guild_definition.members.assert_called_once_with()
+        guild_definition.presences.assert_called_once_with()
+        guild_definition.voice_states.assert_called_once_with()
 
     def test_deserialize_guild_join_event(self, event_factory, mock_app, mock_shard):
         mock_payload = mock.Mock(app=mock_app)
@@ -248,10 +253,14 @@ class TestEventFactoryImpl:
         mock_app.entity_factory.deserialize_gateway_guild.assert_called_once_with(mock_payload)
         assert isinstance(event, guild_events.GuildUpdateEvent)
         assert event.shard is mock_shard
-        assert event.guild is mock_app.entity_factory.deserialize_gateway_guild.return_value.guild.return_value
-        assert event.emojis is mock_app.entity_factory.deserialize_gateway_guild.return_value.emojis.return_value
-        assert event.roles is mock_app.entity_factory.deserialize_gateway_guild.return_value.roles.return_value
+        guild_definition = mock_app.entity_factory.deserialize_gateway_guild.return_value
+        assert event.guild is guild_definition.guild.return_value
+        assert event.emojis is guild_definition.emojis.return_value
+        assert event.roles is guild_definition.roles.return_value
         assert event.old_guild is mock_old_guild
+        guild_definition.guild.assert_called_once_with()
+        guild_definition.emojis.assert_called_once_with()
+        guild_definition.roles.assert_called_once_with()
 
     def test_deserialize_guild_leave_event(self, event_factory, mock_app, mock_shard):
         mock_payload = {"id": "43123123"}

--- a/tests/hikari/impl/test_event_factory.py
+++ b/tests/hikari/impl/test_event_factory.py
@@ -208,7 +208,7 @@ class TestEventFactoryImpl:
     def test_deserialize_guild_available_event(self, event_factory, mock_app, mock_shard):
         mock_payload = mock.Mock(app=mock_app)
 
-        event = event_factory.deserialize_guild_create_event(mock_shard, mock_payload)
+        event = event_factory.deserialize_guild_available_event(mock_shard, mock_payload)
         mock_app.entity_factory.deserialize_gateway_guild.assert_called_once_with(mock_payload)
         assert isinstance(event, guild_events.GuildAvailableEvent)
         assert event.shard is mock_shard

--- a/tests/hikari/impl/test_event_factory.py
+++ b/tests/hikari/impl/test_event_factory.py
@@ -208,26 +208,20 @@ class TestEventFactoryImpl:
     def test_deserialize_guild_available_event(self, event_factory, mock_app, mock_shard):
         mock_payload = mock.Mock(app=mock_app)
 
-        event = event_factory.deserialize_guild_available_event(mock_shard, mock_payload)
-        mock_app.entity_factory.deserialize_gateway_guild.assert_called_once_with(
-            mock_payload,
-            include_guild=True,
-            include_channels=True,
-            include_members=True,
-            include_presences=True,
-            include_voice_states=True,
-            include_emojis=True,
-            include_roles=True,
-        )
+        event = event_factory.deserialize_guild_create_event(mock_shard, mock_payload)
+        mock_app.entity_factory.deserialize_gateway_guild.assert_called_once_with(mock_payload)
         assert isinstance(event, guild_events.GuildAvailableEvent)
         assert event.shard is mock_shard
-        assert event.guild is mock_app.entity_factory.deserialize_gateway_guild.return_value.guild
-        assert event.emojis is mock_app.entity_factory.deserialize_gateway_guild.return_value.emojis
-        assert event.roles is mock_app.entity_factory.deserialize_gateway_guild.return_value.roles
-        assert event.channels is mock_app.entity_factory.deserialize_gateway_guild.return_value.channels
-        assert event.members is mock_app.entity_factory.deserialize_gateway_guild.return_value.members
-        assert event.presences is mock_app.entity_factory.deserialize_gateway_guild.return_value.presences
-        assert event.voice_states is mock_app.entity_factory.deserialize_gateway_guild.return_value.voice_states
+        assert event.guild is mock_app.entity_factory.deserialize_gateway_guild.return_value.guild.return_value
+        assert event.emojis is mock_app.entity_factory.deserialize_gateway_guild.return_value.emojis.return_value
+        assert event.roles is mock_app.entity_factory.deserialize_gateway_guild.return_value.roles.return_value
+        assert event.channels is mock_app.entity_factory.deserialize_gateway_guild.return_value.channels.return_value
+        assert event.members is mock_app.entity_factory.deserialize_gateway_guild.return_value.members.return_value
+        assert event.presences is mock_app.entity_factory.deserialize_gateway_guild.return_value.presences.return_value
+        assert (
+            event.voice_states
+            is mock_app.entity_factory.deserialize_gateway_guild.return_value.voice_states.return_value
+        )
 
     def test_deserialize_guild_join_event(self, event_factory, mock_app, mock_shard):
         mock_payload = mock.Mock(app=mock_app)
@@ -251,14 +245,12 @@ class TestEventFactoryImpl:
 
         event = event_factory.deserialize_guild_update_event(mock_shard, mock_payload, old_guild=mock_old_guild)
 
-        mock_app.entity_factory.deserialize_gateway_guild.assert_called_once_with(
-            mock_payload, include_guild=True, include_emojis=True, include_roles=True
-        )
+        mock_app.entity_factory.deserialize_gateway_guild.assert_called_once_with(mock_payload)
         assert isinstance(event, guild_events.GuildUpdateEvent)
         assert event.shard is mock_shard
-        assert event.guild is mock_app.entity_factory.deserialize_gateway_guild.return_value.guild
-        assert event.emojis is mock_app.entity_factory.deserialize_gateway_guild.return_value.emojis
-        assert event.roles is mock_app.entity_factory.deserialize_gateway_guild.return_value.roles
+        assert event.guild is mock_app.entity_factory.deserialize_gateway_guild.return_value.guild.return_value
+        assert event.emojis is mock_app.entity_factory.deserialize_gateway_guild.return_value.emojis.return_value
+        assert event.roles is mock_app.entity_factory.deserialize_gateway_guild.return_value.roles.return_value
         assert event.old_guild is mock_old_guild
 
     def test_deserialize_guild_leave_event(self, event_factory, mock_app, mock_shard):

--- a/tests/hikari/impl/test_event_factory.py
+++ b/tests/hikari/impl/test_event_factory.py
@@ -210,7 +210,16 @@ class TestEventFactoryImpl:
 
         event = event_factory.deserialize_guild_available_event(mock_shard, mock_payload)
 
-        mock_app.entity_factory.deserialize_gateway_guild.assert_called_once_with(mock_payload)
+        mock_app.entity_factory.deserialize_gateway_guild.assert_called_once_with(
+            mock_payload,
+            include_guild=True,
+            include_channels=True,
+            include_members=True,
+            include_presences=True,
+            include_voice_states=True,
+            include_emojis=True,
+            include_roles=True,
+        )
         assert isinstance(event, guild_events.GuildAvailableEvent)
         assert event.shard is mock_shard
         assert event.guild is mock_app.entity_factory.deserialize_gateway_guild.return_value.guild
@@ -243,7 +252,9 @@ class TestEventFactoryImpl:
 
         event = event_factory.deserialize_guild_update_event(mock_shard, mock_payload, old_guild=mock_old_guild)
 
-        mock_app.entity_factory.deserialize_gateway_guild.assert_called_once_with(mock_payload)
+        mock_app.entity_factory.deserialize_gateway_guild.assert_called_once_with(
+            mock_payload, include_guild=True, include_emojis=True, include_roles=True
+        )
         assert isinstance(event, guild_events.GuildUpdateEvent)
         assert event.shard is mock_shard
         assert event.guild is mock_app.entity_factory.deserialize_gateway_guild.return_value.guild

--- a/tests/hikari/impl/test_event_factory.py
+++ b/tests/hikari/impl/test_event_factory.py
@@ -209,7 +209,6 @@ class TestEventFactoryImpl:
         mock_payload = mock.Mock(app=mock_app)
 
         event = event_factory.deserialize_guild_available_event(mock_shard, mock_payload)
-
         mock_app.entity_factory.deserialize_gateway_guild.assert_called_once_with(
             mock_payload,
             include_guild=True,

--- a/tests/hikari/impl/test_event_manager.py
+++ b/tests/hikari/impl/test_event_manager.py
@@ -326,7 +326,7 @@ class TestEventManagerImpl:
         event_manager._cache.set_voice_state.assert_called_once_with(345)
 
         event_factory.deserialize_guild_join_event.assert_called_once_with(shard, payload)
-        entity_factory.deserialize_gateway_guild.assert_not_called()
+        event_factory.deserialize_gateway_guild.assert_not_called()
         event_factory.deserialize_guild_join_event.assert_called_once_with(shard, payload)
         event_manager.dispatch.assert_awaited_once_with(event)
 
@@ -390,7 +390,7 @@ class TestEventManagerImpl:
         event_factory.deserialize_guild_available_event.assert_called_once_with(shard, payload)
         event_manager.dispatch.assert_awaited_once_with(event)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_on_guild_create_stateful_and_not_dispatching_with_all_cache_components(
         self, event_manager, shard, entity_factory, event_factory
     ):
@@ -564,7 +564,6 @@ class TestEventManagerImpl:
         event_manager._cache.set_voice_state.assert_called_once_with(345)
 
         event_factory.deserialize_guild_join_event.assert_called_once_with(shard, payload)
-        event_manager.dispatch.assert_awaited_once_with(event)
 
     @pytest.mark.asyncio()
     async def test_on_guild_create_stateless_with_unavailable_field(

--- a/tests/hikari/impl/test_event_manager.py
+++ b/tests/hikari/impl/test_event_manager.py
@@ -611,7 +611,8 @@ class TestEventManagerImpl:
 
     @pytest.mark.asyncio()
     async def test_on_guild_integrations_update(self, event_manager, shard):
-        assert await event_manager.on_guild_integrations_update(shard, {}) is None
+        with pytest.raises(NotImplementedError):
+            await event_manager.on_guild_integrations_update(shard, {})
 
         event_manager.dispatch.assert_not_called()
 

--- a/tests/hikari/impl/test_event_manager.py
+++ b/tests/hikari/impl/test_event_manager.py
@@ -581,7 +581,9 @@ class TestEventManagerImpl:
             event_factory.deserialize_guild_available_event.return_value
         )
 
-    async def test_on_guild_create_stateless_and_dispatching(self, stateless_event_manager, shard, event_factory, entity_factory):
+    async def test_on_guild_create_stateless_and_dispatching(
+        self, stateless_event_manager, shard, event_factory, entity_factory
+    ):
         payload = {"id": "123123"}
         stateless_event_manager._enabled_for_event = mock.Mock(return_value=True)
 
@@ -594,9 +596,7 @@ class TestEventManagerImpl:
             [mock.call(guild_events.GuildAvailableEvent), mock.call(shard_events.MemberChunkEvent)]
         )
         entity_factory.deserialize_gateway_guild.assert_not_called()
-        event_factory.deserialize_guild_join_event.assert_called_once_with(
-            shard, payload
-        )
+        event_factory.deserialize_guild_join_event.assert_called_once_with(shard, payload)
         stateless_event_manager.dispatch.assert_awaited_once_with(
             event_factory.deserialize_guild_join_event.return_value
         )

--- a/tests/hikari/impl/test_event_manager.py
+++ b/tests/hikari/impl/test_event_manager.py
@@ -326,7 +326,7 @@ class TestEventManagerImpl:
         event_manager._cache.set_voice_state.assert_called_once_with(345)
 
         event_factory.deserialize_guild_join_event.assert_called_once_with(shard, payload)
-        event_manager._app.entity_factory.deserialize_gateway_guild.assert_not_called()
+        entity_factory.deserialize_gateway_guild.assert_not_called()
         event_factory.deserialize_guild_join_event.assert_called_once_with(shard, payload)
         event_manager.dispatch.assert_awaited_once_with(event)
 
@@ -502,7 +502,7 @@ class TestEventManagerImpl:
         )
 
         event_manager._enabled_for_event = mock.Mock(return_value=True)
-        event_manager._app.event_factory.deserialize_guild_join_event.return_value = event
+        event_factory.deserialize_guild_join_event.return_value = event
         event_manager._cache.settings.components = config.CacheComponents.MEMBERS
         shard.request_guild_members = mock.Mock()
 
@@ -531,7 +531,7 @@ class TestEventManagerImpl:
 
     @pytest.mark.asyncio()
     async def test_on_guild_create_when_request_chunks_when_not_dispatching_available_event(
-        self, stateless_event_manager, shard, entity_factory, event_factory
+        self, stateless_event_manager, shard, entity_factory, event_factory, event_manager
     ):
         payload = {"large": True, "id": 123}
 
@@ -557,8 +557,8 @@ class TestEventManagerImpl:
             _request_guild_members.return_value, name="987:123 guild create members request"
         )
 
-        stateless_event_manager._app.event_factory.deserialize_guild_join_event.assert_not_called()
-        stateless_event_manager._app.entity_factory.deserialize_gateway_guild.assert_not_called()
+        event_factory.deserialize_guild_join_event.assert_not_called()
+        entity_factory.deserialize_gateway_guild.assert_not_called()
 
         event_manager._cache.clear_voice_states_for_guild.assert_called_once_with(123)
         event_manager._cache.set_voice_state.assert_called_once_with(345)
@@ -581,12 +581,7 @@ class TestEventManagerImpl:
             event_factory.deserialize_guild_available_event.return_value
         )
 
-    @pytest.mark.asyncio()
-    async def test_on_guild_create_stateless_without_unavailable_field(
-        self, stateless_event_manager, shard, event_factory
-    ):
-        payload = {}
-    async def test_on_guild_create_stateless_and_dispatching(self, stateless_event_manager, shard, event_factory):
+    async def test_on_guild_create_stateless_and_dispatching(self, stateless_event_manager, shard, event_factory, entity_factory):
         payload = {"id": "123123"}
         stateless_event_manager._enabled_for_event = mock.Mock(return_value=True)
 
@@ -598,8 +593,8 @@ class TestEventManagerImpl:
         stateless_event_manager._enabled_for_event.assert_has_calls(
             [mock.call(guild_events.GuildAvailableEvent), mock.call(shard_events.MemberChunkEvent)]
         )
-        stateless_event_manager._app.entity_factory.deserialize_gateway_guild.assert_not_called()
-        stateless_event_manager._app.event_factory.deserialize_guild_join_event.assert_called_once_with(
+        entity_factory.deserialize_gateway_guild.assert_not_called()
+        event_factory.deserialize_guild_join_event.assert_called_once_with(
             shard, payload
         )
         stateless_event_manager.dispatch.assert_awaited_once_with(

--- a/tests/hikari/impl/test_event_manager_base.py
+++ b/tests/hikari/impl/test_event_manager_base.py
@@ -428,7 +428,7 @@ class TestEventManagerBase:
         manager = StubManager(
             mock.Mock(),
             0,
-            cache_settings=mock.Mock(components=config.CacheComponents.MEMBERS | config.CacheComponents.GUILD_CHANNELS),
+            cache_components=config.CacheComponents.MEMBERS | config.CacheComponents.GUILD_CHANNELS,
         )
         assert manager._consumers == {
             "foo": event_manager_base._Consumer(manager.on_foo, (shard_events.ShardEvent, base_events.Event), True),
@@ -464,7 +464,7 @@ class TestEventManagerBase:
             shard_events.ShardPayloadEvent,
         )
         expected_bat_events = (shard_events.MemberChunkEvent, shard_events.ShardEvent, base_events.Event)
-        manager = StubManager(mock.Mock(), 0, cache_settings=None)
+        manager = StubManager(mock.Mock(), 0, cache_components=config.CacheComponents.NONE)
         assert manager._consumers == {
             "foo": event_manager_base._Consumer(manager.on_foo, (shard_events.ShardEvent, base_events.Event), False),
             "bar": event_manager_base._Consumer(manager.on_bar, expected_bar_events, False),

--- a/tests/hikari/impl/test_event_manager_base.py
+++ b/tests/hikari/impl/test_event_manager_base.py
@@ -408,30 +408,152 @@ class TestEventManagerBase:
             async def on_bar(self, event):
                 raise NotImplementedError
 
+            @event_manager_base.filtered(shard_events.MemberChunkEvent, config.CacheComponents.MESSAGES)
+            async def on_bat(self, event):
+                raise NotImplementedError
+
             async def on_not_decorated(self, event):
                 raise NotImplementedError
 
             async def not_a_listener(self):
                 raise NotImplementedError
 
-        expected_foo_events = (shard_events.ShardEvent, base_events.Event)
         expected_bar_events = (
             shard_events.ShardStateEvent,
             shard_events.ShardEvent,
             base_events.Event,
             shard_events.ShardPayloadEvent,
         )
-        manager = StubManager(mock.Mock(), mock.Mock(intents=42))
+        expected_bat_events = (shard_events.MemberChunkEvent, shard_events.ShardEvent, base_events.Event)
+        manager = StubManager(
+            mock.Mock(),
+            0,
+            cache_settings=mock.Mock(components=config.CacheComponents.MEMBERS | config.CacheComponents.GUILD_CHANNELS),
+        )
         assert manager._consumers == {
-            "foo": event_manager_base._Consumer(manager.on_foo, config.CacheComponents.MEMBERS, expected_foo_events),
-            "bar": event_manager_base._Consumer(manager.on_bar, config.CacheComponents.NONE, expected_bar_events),
-            "not_decorated": event_manager_base._Consumer(
-                manager.on_not_decorated, undefined.UNDEFINED, undefined.UNDEFINED
-            ),
+            "foo": event_manager_base._Consumer(manager.on_foo, (shard_events.ShardEvent, base_events.Event), True),
+            "bar": event_manager_base._Consumer(manager.on_bar, expected_bar_events, False),
+            "bat": event_manager_base._Consumer(manager.on_bat, expected_bat_events, False),
+            "not_decorated": event_manager_base._Consumer(manager.on_not_decorated, undefined.UNDEFINED, True),
         }
+
+    def test___init___loads_consumers_when_cacheless(self):
+        class StubManager(event_manager_base.EventManagerBase):
+            @event_manager_base.filtered(shard_events.ShardEvent, config.CacheComponents.MEMBERS)
+            async def on_foo(self, event):
+                raise NotImplementedError
+
+            @event_manager_base.filtered((shard_events.ShardStateEvent, shard_events.ShardPayloadEvent))
+            async def on_bar(self, event):
+                raise NotImplementedError
+
+            @event_manager_base.filtered(shard_events.MemberChunkEvent, config.CacheComponents.MESSAGES)
+            async def on_bat(self, event):
+                raise NotImplementedError
+
+            async def on_not_decorated(self, event):
+                raise NotImplementedError
+
+            async def not_a_listener(self):
+                raise NotImplementedError
+
+        expected_bar_events = (
+            shard_events.ShardStateEvent,
+            shard_events.ShardEvent,
+            base_events.Event,
+            shard_events.ShardPayloadEvent,
+        )
+        expected_bat_events = (shard_events.MemberChunkEvent, shard_events.ShardEvent, base_events.Event)
+        manager = StubManager(mock.Mock(), 0, cache_settings=None)
+        assert manager._consumers == {
+            "foo": event_manager_base._Consumer(manager.on_foo, (shard_events.ShardEvent, base_events.Event), False),
+            "bar": event_manager_base._Consumer(manager.on_bar, expected_bar_events, False),
+            "bat": event_manager_base._Consumer(manager.on_bat, expected_bat_events, False),
+            "not_decorated": event_manager_base._Consumer(manager.on_not_decorated, undefined.UNDEFINED, False),
+        }
+
+    def test__clear_enabled_cache(self):
+        event_manager = hikari_test_helpers.mock_class_namespace(event_manager_base.EventManagerBase, init_=False)()
+        event_manager._enabled_consumers_cache = {object: object(), "ok": object()}
+
+        event_manager._clear_enabled_cache()
+
+        assert event_manager._enabled_consumers_cache == {}
+
+    def test__enabled_for_event_when_listener_registered(self, event_manager):
+        event_manager._listeners = {}
+
+    def test__enabled_for_event_when_waiter_registered(self, event_manager):
+        event_manager._listeners = {}
+
+    def test__enabled_for_event_when_not_registered(self, event_manager):
+        event_manager._listeners = {shard_events.ShardPayloadEvent: [], shard_events.MemberChunkEvent: []}
+
+        assert event_manager._enabled_for_event(shard_events.ShardStateEvent) is False
+
+    def test__enabled_for_consumer_when_event_types_is_undefined(self, event_manager):
+        consumer = mock.Mock(event_types=undefined.UNDEFINED)
+
+        assert event_manager._enabled_for_consumer(consumer) is True
+
+    def test__enabled_for_consumer_when_caching(self, event_manager):
+        consumer = mock.Mock(event_types=(), is_caching=True)
+
+        assert event_manager._enabled_for_consumer(consumer) is True
+
+    @pytest.mark.parametrize("cached_state", [False, True])
+    def test__enabled_for_consumer_when_consumer_state_cached(self, event_manager, cached_state):
+        consumer = mock.Mock(event_types=(), is_caching=False)
+        event_manager._enabled_consumers_cache[consumer] = cached_state
+
+        assert event_manager._enabled_for_consumer(consumer) is cached_state
+
+    def test__enabled_for_consumer_when_consumer_state_not_cached_and_listeners_present(self, event_manager):
+        event_manager._listeners[shard_events.MemberChunkEvent] = []
+        consumer = mock.Mock(
+            event_types=(shard_events.ShardEvent, shard_events.ShardPayloadEvent, shard_events.MemberChunkEvent),
+            is_caching=False,
+        )
+
+        result = event_manager._enabled_for_consumer(consumer)
+
+        assert result is True
+        assert event_manager._enabled_consumers_cache[consumer] is True
+
+    def test__enabled_for_consumer_when_consumer_state_not_cached_and_waiters_present(self, event_manager):
+        event_manager._waiters[shard_events.MemberChunkEvent] = []
+        consumer = mock.Mock(
+            event_types=(shard_events.ShardEvent, shard_events.ShardPayloadEvent, shard_events.MemberChunkEvent),
+            is_caching=False,
+        )
+
+        result = event_manager._enabled_for_consumer(consumer)
+
+        assert result is True
+        assert event_manager._enabled_consumers_cache[consumer] is True
+
+    def test__enabled_for_consumer_when_consumer_state_not_cached_and_not_enabled(self, event_manager):
+        consumer = mock.Mock(
+            event_types=(shard_events.ShardEvent, shard_events.ShardPayloadEvent, shard_events.MemberChunkEvent),
+            is_caching=False,
+        )
+
+        result = event_manager._enabled_for_consumer(consumer)
+
+        assert result is False
+        assert event_manager._enabled_consumers_cache[consumer] is False
+
+    def test__enabled_for_consumer_when_consumer_state_not_cached_and_no_event_types(self, event_manager):
+        consumer = mock.Mock(event_types=(), is_caching=False)
+
+        result = event_manager._enabled_for_consumer(consumer)
+
+        assert result is False
+        assert event_manager._enabled_consumers_cache[consumer] is False
 
     @pytest.mark.asyncio()
     async def test_consume_raw_event_when_KeyError(self, event_manager):
+        event_manager._enabled_for_event = mock.Mock(return_value=True)
         mock_payload = {"id": "3123123123"}
         mock_shard = mock.Mock(id=123)
         event_manager._handle_dispatch = mock.Mock()
@@ -447,9 +569,11 @@ class TestEventManagerBase:
         event_manager._event_factory.deserialize_shard_payload_event.assert_called_once_with(
             mock_shard, mock_payload, name="UNEXISTING_EVENT"
         )
+        event_manager._enabled_for_event.assert_called_once_with(shard_events.ShardPayloadEvent)
 
     @pytest.mark.asyncio()
     async def test_consume_raw_event_when_found(self, event_manager):
+        event_manager._enabled_for_event = mock.Mock(return_value=True)
         event_manager._handle_dispatch = mock.Mock()
         event_manager.dispatch = mock.Mock()
         on_existing_event = object()
@@ -471,43 +595,69 @@ class TestEventManagerBase:
         event_manager._event_factory.deserialize_shard_payload_event.assert_called_once_with(
             shard, payload, name="EXISTING_EVENT"
         )
+        event_manager._enabled_for_event.assert_called_once_with(shard_events.ShardPayloadEvent)
+
+    @pytest.mark.asyncio()
+    async def test_consume_raw_event_skips_raw_dispatch_when_not_enabled(self, event_manager):
+        event_manager._enabled_for_event = mock.Mock(return_value=False)
+        event_manager._handle_dispatch = mock.Mock()
+        event_manager.dispatch = mock.Mock()
+        on_existing_event = object()
+        event_manager._consumers = {"existing_event": on_existing_event}
+        shard = object()
+        payload = {"berp": "baz"}
+
+        with mock.patch("asyncio.create_task") as create_task:
+            event_manager.consume_raw_event("EXISTING_EVENT", shard, payload)
+
+        event_manager._handle_dispatch.assert_called_once_with(on_existing_event, shard, {"berp": "baz"})
+        create_task.assert_called_once_with(
+            event_manager._handle_dispatch(on_existing_event, shard, {"berp": "baz"}),
+            name="dispatch EXISTING_EVENT",
+        )
+        event_manager.dispatch.assert_not_called()
+        event_manager._event_factory.deserialize_shard_payload_event.vassert_not_called()
+        event_manager._enabled_for_event.assert_called_once_with(shard_events.ShardPayloadEvent)
 
     @pytest.mark.asyncio()
     async def test_handle_dispatch_invokes_callback(self, event_manager, event_loop):
-        callback = mock.AsyncMock()
+        event_manager._enabled_for_consumer = mock.Mock(return_value=True)
+        consumer = mock.AsyncMock()
         error_handler = mock.MagicMock()
         event_loop.set_exception_handler(error_handler)
         shard = object()
         pl = {"foo": "bar"}
 
-        await event_manager._handle_dispatch(callback, shard, pl)
+        await event_manager._handle_dispatch(consumer, shard, pl)
 
-        callback.assert_awaited_once_with(shard, pl)
+        consumer.callback.assert_awaited_once_with(shard, pl)
         error_handler.assert_not_called()
 
     @pytest.mark.asyncio()
     async def test_handle_dispatch_ignores_cancelled_errors(self, event_manager, event_loop):
-        callback = mock.AsyncMock(side_effect=asyncio.CancelledError)
+        event_manager._enabled_for_consumer = mock.Mock(return_value=True)
+        consumer = mock.AsyncMock(side_effect=asyncio.CancelledError)
         error_handler = mock.MagicMock()
         event_loop.set_exception_handler(error_handler)
         shard = object()
         pl = {"lorem": "ipsum"}
 
-        await event_manager._handle_dispatch(callback, shard, pl)
+        await event_manager._handle_dispatch(consumer, shard, pl)
 
         error_handler.assert_not_called()
 
     @pytest.mark.asyncio()
     async def test_handle_dispatch_handles_exceptions(self, event_manager, event_loop):
+        event_manager._enabled_for_consumer = mock.Mock(return_value=True)
         exc = Exception("aaaa!")
-        callback = mock.AsyncMock(side_effect=exc)
+        consumer = mock.Mock(callback=mock.AsyncMock(side_effect=exc))
         error_handler = mock.MagicMock()
         event_loop.set_exception_handler(error_handler)
         shard = object()
         pl = {"i like": "cats"}
 
         with mock.patch.object(asyncio, "current_task") as current_task:
-            await event_manager._handle_dispatch(callback, shard, pl)
+            await event_manager._handle_dispatch(consumer, shard, pl)
 
         error_handler.assert_called_once_with(
             event_loop,
@@ -517,6 +667,20 @@ class TestEventManagerBase:
                 "task": current_task(),
             },
         )
+
+    @pytest.mark.asyncio()
+    async def test_handle_dispatch_invokes_when_consumer_not_enabled(self, event_manager, event_loop):
+        event_manager._enabled_for_consumer = mock.Mock(return_value=False)
+        consumer = mock.Mock(callback=mock.AsyncMock(__name__="ok"))
+        error_handler = mock.MagicMock()
+        event_loop.set_exception_handler(error_handler)
+        shard = object()
+        pl = {"foo": "bar"}
+
+        await event_manager._handle_dispatch(consumer, shard, pl)
+
+        consumer.callback.assert_not_called()
+        error_handler.assert_not_called()
 
     def test_subscribe_when_callback_is_not_coroutine(self, event_manager):
         def test():
@@ -533,6 +697,8 @@ class TestEventManagerBase:
             event_manager.subscribe("test", test)
 
     def test_subscribe_when_event_type_not_in_listeners(self, event_manager):
+        event_manager._clear_enabled_cache = mock.Mock()
+
         async def test():
             ...
 
@@ -541,6 +707,7 @@ class TestEventManagerBase:
 
         assert event_manager._listeners == {member_events.MemberCreateEvent: [test]}
         check.assert_called_once_with(member_events.MemberCreateEvent, 1)
+        event_manager._clear_enabled_cache.assert_called_once_with()
 
     def test_subscribe_when_event_type_in_listeners(self, event_manager):
         async def test():
@@ -549,6 +716,7 @@ class TestEventManagerBase:
         async def test2():
             ...
 
+        event_manager._clear_enabled_cache = mock.Mock()
         event_manager._listeners[member_events.MemberCreateEvent] = [test2]
 
         with mock.patch.object(event_manager_base.EventManagerBase, "_check_intents") as check:
@@ -556,6 +724,7 @@ class TestEventManagerBase:
 
         assert event_manager._listeners == {member_events.MemberCreateEvent: [test2, test]}
         check.assert_called_once_with(member_events.MemberCreateEvent, 2)
+        event_manager._clear_enabled_cache.assert_not_called()
 
     def test__check_intents_when_no_intents_required(self, event_manager):
         event_manager._intents = intents.Intents.ALL
@@ -653,6 +822,7 @@ class TestEventManagerBase:
         async def test2():
             ...
 
+        event_manager._clear_enabled_cache = mock.Mock()
         event_manager._listeners = {
             member_events.MemberCreateEvent: [test, test2],
             member_events.MemberDeleteEvent: [test],
@@ -664,16 +834,19 @@ class TestEventManagerBase:
             member_events.MemberCreateEvent: [test2],
             member_events.MemberDeleteEvent: [test],
         }
+        event_manager._clear_enabled_cache.assert_not_called()
 
     def test_unsubscribe_when_event_type_when_list_empty_after_delete(self, event_manager):
         async def test():
             ...
 
+        event_manager._clear_enabled_cache = mock.Mock()
         event_manager._listeners = {member_events.MemberCreateEvent: [test], member_events.MemberDeleteEvent: [test]}
 
         event_manager.unsubscribe(member_events.MemberCreateEvent, test)
 
         assert event_manager._listeners == {member_events.MemberDeleteEvent: [test]}
+        event_manager._clear_enabled_cache.assert_called_once_with()
 
     def test_listen_when_no_params(self, event_manager):
         with pytest.raises(TypeError):


### PR DESCRIPTION
### Summary
This change looks into how we may be able to avoid deserializing event data when it isn't being listened to or used to set state to lower the inherent strain of shard dispatch. While intents can help with this by lowering the amount of events a bot receives, intents can't always be used to prevent unwanted events as some events just aren't covered by it and some of it's categories (such as GUILDS) are broad enough to have the potential to still lead to unnecessary events being received.

Another benefit this has over intents is that while intents are behaviour that's statically defined for the entire runtime of a shard, the behaviour of this filtering is dynamic and will shift based on what's being listened for and cached.

Due to the broad scope of the GUILD_CREATE and GUILD_UPDATE events, the raw consumer methods for these events were modified to internally filter based on the cache as well as also filtering based on registered event listeners (this was done in-favour of the generic filtering system used for other raw event consumers). This internal filtering allows the different entities present in these events to only be unmarshalled if they're specifically being cached when there's no listeners registered for the relevant guild events.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
