### PR TITLE
Reset shard backoff if nothing went wrong when shutting down

### DIFF
--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -803,6 +803,9 @@ class GatewayShardImpl(shard.GatewayShard):
                     last_started_at = time.monotonic()
                     should_restart = await self._run_once()
 
+                    # Since nothing went wrong, we can reset the backoff
+                    backoff.reset()
+
                     if not should_restart:
                         self._logger.info("shard has disconnected and shut down normally")
                         return


### PR DESCRIPTION
### Summary
I have observed after a personal outage that the shard will not reset the backoff if nothing went wrong, causing it to later wait the maximum backoff in the future:

![image](https://user-images.githubusercontent.com/29100934/120435997-aa932e00-c37e-11eb-9a6e-5f07fe7e6998.png)
Between detecting we have an invalid session and then acquiring a new one, it should have waited the first backoff, not the maximum one.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

