### PR TITLE
Pass in the unwrapped bytes instead

### DIFF
--- a/hikari/files.py
+++ b/hikari/files.py
@@ -180,7 +180,7 @@ def ensure_resource(url_or_resource: Resourceish, /) -> Resource[AsyncReader]:
     if isinstance(url_or_resource, RAWISH_TYPES):
         data = unwrap_bytes(url_or_resource)
         filename = generate_filename_from_details(mimetype=None, extension=None, data=data)
-        return typing.cast("Resource[AsyncReader]", Bytes(url_or_resource, filename))
+        return typing.cast("Resource[AsyncReader]", Bytes(data, filename))
 
     if isinstance(url_or_resource, Resource):
         return url_or_resource


### PR DESCRIPTION
### Summary
This simple PR fixes an issue where a 0-byte attachment is sent as opposed to the actual attachment. This happens because the *wrapped bytes* object has been consumed by `unwrap_bytes` function so that EOF's reached, yet it's passed again on to `hikari.Bytes`.

Context: https://discord.com/channels/574921006817476608/727982024660615198/849576917891285024

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.
