### PR TITLE
Split iso8601_datetime_string_to_datetime into slow and fast

### DIFF
--- a/tests/hikari/hikari_test_helpers.py
+++ b/tests/hikari/hikari_test_helpers.py
@@ -155,21 +155,6 @@ def skip_on_system(os_name: str):
     return decorator
 
 
-def has_sem_open_impl():
-    try:
-        import multiprocessing
-
-        multiprocessing.RLock()
-    except ImportError:
-        return False
-    else:
-        return True
-
-
-def skip_if_no_sem_open(test):
-    return pytest.mark.skipif(not has_sem_open_impl(), reason="Your platform lacks a sem_open implementation")(test)
-
-
 async def idle(for_=REASONABLE_SLEEP_TIME, /):
     await asyncio.sleep(for_)
 
@@ -178,17 +163,6 @@ async def idle(for_=REASONABLE_SLEEP_TIME, /):
 def ensure_occurs_quickly():
     with async_timeout.timeout(REASONABLE_QUICK_RESPONSE_TIME):
         yield
-
-
-async def gather_all_tasks():
-    """Ensure all created tasks except the current are finished before asserting anything."""
-    await asyncio.gather(*(task for task in asyncio.all_tasks() if task is not asyncio.current_task()))
-
-
-def raiser(ex, should_raise=True):
-    """Stop lints complaining about unreachable code."""
-    if should_raise:
-        raise ex
 
 
 class AsyncContextManagerMock:

--- a/tests/hikari/impl/test_shard.py
+++ b/tests/hikari/impl/test_shard.py
@@ -323,7 +323,7 @@ class TestGatewayTransport:
                 url="https://some.url",
                 log_filterer=log_filterer,
             ):
-                hikari_test_helpers.raiser(errors.GatewayError("some reason"))
+                raise errors.GatewayError("some reason")
 
         mock_websocket.send_close.assert_awaited_once_with(
             code=errors.ShardCloseCode.UNEXPECTED_CONDITION, message=b"unexpected fatal client error :-("
@@ -363,7 +363,7 @@ class TestGatewayTransport:
                 url="https://some.url",
                 log_filterer=log_filterer,
             ):
-                hikari_test_helpers.raiser(ValueError("testing"))
+                raise ValueError("testing")
 
         mock_websocket.send_close.assert_awaited_once_with(
             code=errors.ShardCloseCode.UNEXPECTED_CONDITION, message=b"unexpected fatal client error :-("

--- a/tests/hikari/internal/test_time.py
+++ b/tests/hikari/internal/test_time.py
@@ -41,7 +41,7 @@ def test_parse_iso_8601_date_with_negative_timezone():
     assert offset == datetime.timedelta(hours=-2, minutes=-30)
 
 
-def test_parse_iso_8601_date_with_positive_timezone():
+def test_slow_parse_iso_8601_date_with_positive_timezone():
     string = "2019-10-10T05:22:33.023456+02:30"
     date = time.iso8601_datetime_string_to_datetime(string)
     assert date.year == 2019
@@ -91,6 +91,19 @@ def test_parse_iso_8601_date_with_no_fraction():
     assert date.minute == 22
     assert date.second == 33
     assert date.microsecond == 0
+
+
+def test_speedup_replaces_python_version_when_available():
+    try:
+        import ciso8601
+
+        assert time.fast_iso8601_datetime_string_to_datetime is ciso8601.parse_rfc3339
+        assert time.iso8601_datetime_string_to_datetime is ciso8601.parse_rfc3339
+    except ImportError:
+        # No speedups, test pure version has been setup correctly
+
+        assert time.fast_iso8601_datetime_string_to_datetime is None
+        assert time.iso8601_datetime_string_to_datetime is time.slow_iso8601_datetime_string_to_datetime
 
 
 def test_parse_discord_epoch_to_datetime():


### PR DESCRIPTION
### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Closes #617 
