### PR TITLE
Remove ability to set the `rest_url` to connect to

### DIFF
--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -170,11 +170,6 @@ class BotApp(traits.BotAware):
     proxy_settings : typing.Optional[config.ProxySettings]
         Custom proxy settings to use with network-layer logic
         in your application to get through an HTTP-proxy.
-    rest_url : typing.Optional[builtins.str]
-        Defaults to the Discord REST API URL if `builtins.None`. Can be
-        overridden if you are attempting to point to an unofficial endpoint, or
-        if you are attempting to mock/stub the Discord API for any reason.
-        Generally you do not want to change this.
 
     !!! note
         `force_color` will always take precedence over `allow_color`.
@@ -243,7 +238,6 @@ class BotApp(traits.BotAware):
         logs: typing.Union[None, int, str, typing.Dict[str, typing.Any]] = "INFO",
         max_rate_limit: float = 300,
         proxy_settings: typing.Optional[config.ProxySettings] = None,
-        rest_url: typing.Optional[str] = None,
     ) -> None:
         # Beautification and logging
         ux.init_logging(logs, allow_color, force_color)
@@ -282,7 +276,6 @@ class BotApp(traits.BotAware):
             http_settings=self._http_settings,
             max_rate_limit=max_rate_limit,
             proxy_settings=self._proxy_settings,
-            rest_url=rest_url,
             token=token,
             token_type=applications.TokenType.BOT,
         )

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -282,9 +282,6 @@ class RESTApp(traits.ExecutorAware):
     proxy_settings : typing.Optional[hikari.config.ProxySettings]
         Proxy settings to use. If `builtins.None` then no proxy configuration
         will be used.
-    url : typing.Optional[builtins.str]
-        The base URL for the API. You can generally leave this as being
-        `builtins.None` and the correct default API base URL will be generated.
 
     !!! note
         This event loop will be bound to a connector when the first call
@@ -296,7 +293,6 @@ class RESTApp(traits.ExecutorAware):
         "_http_settings",
         "_max_rate_limit",
         "_proxy_settings",
-        "_url",
     )
 
     def __init__(
@@ -306,13 +302,11 @@ class RESTApp(traits.ExecutorAware):
         http_settings: typing.Optional[config.HTTPSettings] = None,
         max_rate_limit: float = 300,
         proxy_settings: typing.Optional[config.ProxySettings] = None,
-        url: typing.Optional[str] = None,
     ) -> None:
         self._http_settings = config.HTTPSettings() if http_settings is None else http_settings
         self._proxy_settings = config.ProxySettings() if proxy_settings is None else proxy_settings
         self._executor = executor
         self._max_rate_limit = max_rate_limit
-        self._url = url
 
     @property
     def executor(self) -> typing.Optional[concurrent.futures.Executor]:
@@ -345,7 +339,6 @@ class RESTApp(traits.ExecutorAware):
             proxy_settings=self._proxy_settings,
             token=token,
             token_type=token_type,
-            rest_url=self._url,
         )
 
         return rest_client
@@ -378,9 +371,6 @@ class RESTClientImpl(rest_api.RESTClient):
     token_type : typing.Union[builtins.str, hikari.applications.TokenType, builtins.None]
         The type of token in use. If no token is used, this can be ignored and
         left to the default value. This can be `"Bot"` or `"Bearer"`.
-    rest_url : builtins.str
-        The HTTP API base URL. This can contain format-string specifiers to
-        interpolate information such as API version in use.
     """
 
     __slots__: typing.Sequence[str] = (
@@ -393,7 +383,6 @@ class RESTClientImpl(rest_api.RESTClient):
         "_executor",
         "_http_settings",
         "_proxy_settings",
-        "_rest_url",
         "_token",
     )
 
@@ -417,7 +406,6 @@ class RESTClientImpl(rest_api.RESTClient):
         proxy_settings: config.ProxySettings,
         token: typing.Union[str, None, rest_api.TokenStrategy],
         token_type: typing.Union[applications.TokenType, str, None],
-        rest_url: typing.Optional[str],
     ) -> None:
         self.buckets = buckets_.RESTBucketManager(max_rate_limit)
         # We've been told in DAPI that this is per token.
@@ -440,8 +428,6 @@ class RESTClientImpl(rest_api.RESTClient):
 
         else:
             self._token = token
-
-        self._rest_url = rest_url if rest_url is not None else urls.REST_API_URL
 
     @property
     def http_settings(self) -> config.HTTPSettings:
@@ -563,7 +549,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
         headers.put(_X_AUDIT_LOG_REASON_HEADER, reason)
 
-        url = compiled_route.create_url(self._rest_url)
+        url = compiled_route.create_url(urls.REST_API_URL)
         while True:
             try:
                 uuid = time.uuid()

--- a/tests/hikari/impl/test_bot.py
+++ b/tests/hikari/impl/test_bot.py
@@ -145,7 +145,6 @@ class TestBotApp:
                 logs="DEBUG",
                 max_rate_limit=200,
                 proxy_settings=proxy_settings,
-                rest_url="somewhere.com",
             )
 
         assert bot._http_settings is http_settings
@@ -167,7 +166,6 @@ class TestBotApp:
             http_settings=bot._http_settings,
             max_rate_limit=200,
             proxy_settings=bot._proxy_settings,
-            rest_url="somewhere.com",
             token="token",
             token_type=applications.TokenType.BOT,
         )

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -41,7 +41,6 @@ from hikari import invites
 from hikari import permissions
 from hikari import snowflakes
 from hikari import undefined
-from hikari import urls
 from hikari import users
 from hikari.api import rest as rest_api
 from hikari.impl import buckets
@@ -254,7 +253,6 @@ def rest_app():
         http_settings=mock.Mock(spec_set=config.HTTPSettings),
         max_rate_limit=float("inf"),
         proxy_settings=mock.Mock(spec_set=config.ProxySettings),
-        url="https://some.url",
     )
 
 
@@ -294,7 +292,6 @@ class TestRESTApp:
             proxy_settings=rest_app._proxy_settings,
             token="token",
             token_type="Type",
-            rest_url=rest_app._url,
         )
 
 
@@ -316,7 +313,6 @@ def rest_client(rest_client_class):
         proxy_settings=mock.Mock(spec=config.ProxySettings),
         token="some_token",
         token_type="tYpe",
-        rest_url="https://some.where/api/v3",
         executor=mock.Mock(),
         entity_factory=mock.Mock(),
     )
@@ -381,7 +377,6 @@ class TestRESTClientImpl:
                 proxy_settings=mock.Mock(),
                 token=None,
                 token_type=None,
-                rest_url=None,
                 executor=None,
                 entity_factory=None,
             )
@@ -396,7 +391,6 @@ class TestRESTClientImpl:
                 proxy_settings=mock.Mock(),
                 token=mock.Mock(rest_api.TokenStrategy),
                 token_type="ooga booga",
-                rest_url=None,
                 executor=None,
                 entity_factory=None,
             )
@@ -408,7 +402,6 @@ class TestRESTClientImpl:
             proxy_settings=mock.Mock(),
             token=None,
             token_type=None,
-            rest_url=None,
             executor=None,
             entity_factory=None,
         )
@@ -421,37 +414,10 @@ class TestRESTClientImpl:
             proxy_settings=mock.Mock(),
             token="some_token",
             token_type="tYpe",
-            rest_url=None,
             executor=None,
             entity_factory=None,
         )
         assert obj._token == "Type some_token"
-
-    def test__init__when_rest_url_is_None_generates_url_using_default_url(self):
-        obj = rest.RESTClientImpl(
-            http_settings=mock.Mock(),
-            max_rate_limit=float("inf"),
-            proxy_settings=mock.Mock(),
-            token=None,
-            token_type=None,
-            rest_url=None,
-            executor=None,
-            entity_factory=None,
-        )
-        assert obj._rest_url == urls.REST_API_URL
-
-    def test__init__when_rest_url_is_not_None_generates_url_using_given_url(self):
-        obj = rest.RESTClientImpl(
-            http_settings=mock.Mock(),
-            max_rate_limit=float("inf"),
-            proxy_settings=mock.Mock(),
-            token=None,
-            token_type=None,
-            rest_url="https://some.where/api/v2",
-            executor=None,
-            entity_factory=None,
-        )
-        assert obj._rest_url == "https://some.where/api/v2"
 
     def test___enter__(self, rest_client):
         # flake8 gets annoyed if we use "with" here so here's a hacky alternative


### PR DESCRIPTION
### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
