### PR TITLE
Remove outdated gateway related create message limit warnings

### DIFF
--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -1176,10 +1176,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             nature, and will trigger this exception if they occur.
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
-
-        !!! warning
-            You are expected to make a connection to the gateway and identify
-            once before being able to use this endpoint for a bot.
         """  # noqa: E501 - Line too long
 
     @abc.abstractmethod

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -533,10 +533,6 @@ class TextChannel(PartialChannel, abc.ABC):
             `role_mentions` or `user_mentions`.
         builtins.TypeError
             If both `attachment` and `attachments` are specified.
-
-        !!! warning
-            You are expected to make a connection to the gateway and identify
-            once before being able to use this endpoint for a bot.
         """  # noqa: E501 - Line too long
         return await self.app.rest.create_message(
             channel=self.id,

--- a/hikari/messages.py
+++ b/hikari/messages.py
@@ -1001,10 +1001,6 @@ class PartialMessage(snowflakes.Unique):
             `role_mentions` or `user_mentions`.
         builtins.TypeError
             If both `attachment` and `attachments` are specified.
-
-        !!! warning
-            You are expected to make a connection to the gateway and identify
-            once before being able to use this endpoint for a bot.
         """  # noqa: E501 - Line too long
         if reply is True:
             reply = self

--- a/hikari/users.py
+++ b/hikari/users.py
@@ -389,10 +389,6 @@ class PartialUser(snowflakes.Unique, abc.ABC):
             nature, and will trigger this exception if they occur.
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
-
-        !!! warning
-            You are expected to make a connection to the gateway and identify
-            once before being able to use this endpoint for a bot.
         """  # noqa: E501 - Line too long
         channel = await self.fetch_dm_channel()
 


### PR DESCRIPTION
### Summary
Remove outdated gateway create message limit
This was removed in https://github.com/discord/discord-api-docs/commit/5f4decb7c488064d469188bc631e23fef7adf6ae#diff-160acb4654c611c67c4ee46b2ce5dda2be82212af8d1d00cd0256ef6edda1e95


### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
