### PR TITLE
remove settability from Unique.id's interface + small refactor

### DIFF
--- a/hikari/applications.py
+++ b/hikari/applications.py
@@ -347,10 +347,6 @@ class TeamMember(users.User):
     def id(self) -> snowflakes.Snowflake:
         return self.user.id
 
-    @id.setter
-    def id(self, value: snowflakes.Snowflake) -> typing.NoReturn:
-        raise TypeError("Cannot mutate the ID of a member")
-
     @property
     def is_bot(self) -> bool:
         return self.user.is_bot

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -734,12 +734,8 @@ class GuildChannel(PartialChannel):
 
         This may be `builtins.None` if the shard count is not known.
         """
-        try:
-            shard_count = getattr(self.app, "shard_count")
-            assert isinstance(shard_count, int), f"shard_count attr was expected to be int, but got {shard_count}"
-            return snowflakes.calculate_shard_id(shard_count, self.guild_id)
-        except (TypeError, AttributeError, NameError):
-            pass
+        if isinstance(self.app, traits.ShardAware):
+            return snowflakes.calculate_shard_id(self.app, self.guild_id)
 
         return None
 

--- a/hikari/embeds.py
+++ b/hikari/embeds.py
@@ -733,13 +733,8 @@ class Embed:
         if name is None and url is None and icon is None:
             self._author = None
         else:
-            self._author = EmbedAuthor()
-            self._author.name = name
-            self._author.url = url
-            if icon is not None:
-                self._author.icon = EmbedResourceWithProxy(resource=files.ensure_resource(icon))
-            else:
-                self._author.icon = None
+            real_icon = EmbedResourceWithProxy(resource=files.ensure_resource(icon)) if icon is not None else None
+            self._author = EmbedAuthor(name=name, url=url, icon=real_icon)
         return self
 
     def set_footer(self, *, text: typing.Optional[str], icon: typing.Optional[files.Resourceish] = None) -> Embed:
@@ -787,12 +782,8 @@ class Embed:
 
             self._footer = None
         else:
-            self._footer = EmbedFooter()
-            self._footer.text = text
-            if icon is not None:
-                self._footer.icon = EmbedResourceWithProxy(resource=files.ensure_resource(icon))
-            else:
-                self._footer.icon = None
+            real_icon = EmbedResourceWithProxy(resource=files.ensure_resource(icon)) if icon is not None else None
+            self._footer = EmbedFooter(icon=real_icon, text=text)
         return self
 
     def set_image(self, image: typing.Optional[files.Resourceish] = None, /) -> Embed:

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -383,10 +383,6 @@ class Member(users.User):
     def id(self) -> snowflakes.Snowflake:
         return self.user.id
 
-    @id.setter
-    def id(self, value: snowflakes.Snowflake) -> None:
-        raise TypeError("Cannot mutate the ID of a member")
-
     @property
     def is_bot(self) -> bool:
         return self.user.is_bot

--- a/hikari/snowflakes.py
+++ b/hikari/snowflakes.py
@@ -124,11 +124,6 @@ class Unique(abc.ABC):
             The snowflake ID of this object.
         """
 
-    # TODO: make immutable interface, as this is a major risk to consistent hash codes.
-    @id.setter
-    def id(self, value: Snowflake) -> None:
-        """Set the ID on this entity."""
-
     @property
     def created_at(self) -> datetime.datetime:
         """When the object was created."""

--- a/tests/hikari/test_applications.py
+++ b/tests/hikari/test_applications.py
@@ -57,10 +57,6 @@ class TestTeamMember:
     def test_id_property(self, model):
         assert model.id is model.user.id
 
-    def test_id_setter(self, model):
-        with pytest.raises(TypeError, match="Cannot mutate the ID of a member"):
-            model.id = 42
-
     def test_is_bot_property(self, model):
         assert model.is_bot is model.user.is_bot
 

--- a/tests/hikari/test_channels.py
+++ b/tests/hikari/test_channels.py
@@ -269,15 +269,8 @@ class TestGuildChannel:
             parent_id=None,
         )
 
-    @pytest.mark.parametrize("error", [TypeError, AttributeError, NameError])
-    def test_shard_id_property_when_guild_id_error_raised(self, model, error):
-        class BrokenApp:
-            def __getattr__(self, name):
-                if name == "shard_count":
-                    raise error
-                return mock.Mock()
-
-        model.app = BrokenApp()
+    def test_shard_id_property_when_not_shard_aware(self, model):
+        model.app = None
 
         assert model.shard_id is None
 

--- a/tests/hikari/test_guilds.py
+++ b/tests/hikari/test_guilds.py
@@ -178,10 +178,6 @@ class TestMember:
     def test_id_property(self, model, mock_user):
         assert model.id is mock_user.id
 
-    def test_id_setter_property(self, model):
-        with pytest.raises(TypeError):
-            model.id = 456
-
     def test_username_property(self, model, mock_user):
         assert model.username is mock_user.username
 


### PR DESCRIPTION
### Summary
* remove settability from Unique.id's interface 
* Switch GuildChannel.shard_id from a try except to a trait bound instance check

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
