### PR TITLE
introduce REST filled DM Channel ID cache resource

### DIFF
--- a/hikari/api/cache.py
+++ b/hikari/api/cache.py
@@ -79,6 +79,34 @@ class Cache(abc.ABC):
     __slots__: typing.Sequence[str] = ()
 
     @abc.abstractmethod
+    def get_dm_channel_id(
+        self, user: snowflakes.SnowflakeishOr[users.PartialUser], /
+    ) -> typing.Optional[snowflakes.Snowflake]:
+        """Get the DM channel ID for a user.
+
+        Parameters
+        ----------
+        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+            Objet or ID of the user to get the DM channel ID for.
+
+        Returns
+        -------
+        typing.Optional[hikari.snowflakes.Snowflake]
+            ID of the DM channel which was found cached for the supplied user or
+            `builtins.None`.
+        """
+
+    @abc.abstractmethod
+    def get_dm_channel_ids_view(self) -> CacheView[snowflakes.Snowflake, snowflakes.Snowflake]:
+        """Get a view of the cached DM channel IDs.
+
+        Returns
+        -------
+        CacheView[hikari.snowflakes.Snowflake, hikari.snowflakes.Snowflake]
+            Cache view of user IDs to DM channel IDs.
+        """
+
+    @abc.abstractmethod
     def get_emoji(
         self, emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji], /
     ) -> typing.Optional[emojis.KnownCustomEmoji]:
@@ -637,6 +665,52 @@ class MutableCache(Cache, abc.ABC):
     @abc.abstractmethod
     def clear(self) -> None:
         """Clear the full cache."""
+
+    @abc.abstractmethod
+    def clear_dm_channel_ids(self) -> CacheView[snowflakes.Snowflake, snowflakes.Snowflake]:
+        """Remove all the cached DM channel IDs.
+
+        Returns
+        -------
+        CacheView[hikari.snowflakes.Snowflake, hikari.snowflakes.Snowflake]
+            Cache view of user IDs to DM channel IDs which were cleared from
+            the cache.
+        """
+
+    @abc.abstractmethod
+    def delete_dm_channel_id(
+        self, user: snowflakes.SnowflakeishOr[users.PartialUser], /
+    ) -> typing.Optional[snowflakes.Snowflake]:
+        """Remove a DM channel ID from the cache.
+
+        Parameters
+        ----------
+        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+            Object or ID of the user to remove the cached DM channel ID for.
+
+        Returns
+        -------
+        typing.Optional[hikari.snowflakes.Snowflake]
+            The DM channel ID which was removed from the cache if found, else
+            `builtins.None`.
+        """
+
+    @abc.abstractmethod
+    def set_dm_channel_id(
+        self,
+        user: snowflakes.SnowflakeishOr[users.PartialUser],
+        channel: snowflakes.SnowflakeishOr[channels.PartialChannel],
+        /,
+    ) -> None:
+        """Add a DM channel ID to the cache.
+
+        Parameters
+        ----------
+        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+            Object or ID of the user to add a DM channel ID to the cache for.
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+            Object or ID of the DM channel to add to the cache.
+        """
 
     @abc.abstractmethod
     def clear_emojis(self) -> CacheView[snowflakes.Snowflake, emojis.KnownCustomEmoji]:

--- a/hikari/applications.py
+++ b/hikari/applications.py
@@ -59,7 +59,6 @@ from hikari.internal import routes
 if typing.TYPE_CHECKING:
     import datetime
 
-    from hikari import channels
     from hikari import files
     from hikari import permissions as permissions_
     from hikari import traits
@@ -366,9 +365,6 @@ class TeamMember(users.User):
     @property
     def username(self) -> str:
         return self.user.username
-
-    async def fetch_dm_channel(self) -> channels.DMChannel:
-        return await self.user.fetch_dm_channel()
 
     def __str__(self) -> str:
         return str(self.user)

--- a/hikari/config.py
+++ b/hikari/config.py
@@ -428,7 +428,21 @@ class CacheComponents(enums.Flag):
     MESSAGES = 1 << 8
     """Enables the messages cache."""
 
-    ALL = GUILDS | GUILD_CHANNELS | MEMBERS | ROLES | INVITES | EMOJIS | PRESENCES | VOICE_STATES | MESSAGES
+    DM_CHANNEL_IDS = 1 << 10
+    """Enables the DM channel IDs cache."""
+
+    ALL = (
+        GUILDS
+        | GUILD_CHANNELS
+        | MEMBERS
+        | ROLES
+        | INVITES
+        | EMOJIS
+        | PRESENCES
+        | VOICE_STATES
+        | MESSAGES
+        | DM_CHANNEL_IDS
+    )
     """Fully enables the cache."""
 
 

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -510,9 +510,6 @@ class Member(users.User):
         """
         return await self.user.app.rest.fetch_member(self.guild_id, self.user.id)
 
-    async def fetch_dm_channel(self) -> channels_.DMChannel:
-        return await self.user.fetch_dm_channel()
-
     async def ban(
         self,
         *,

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -277,6 +277,7 @@ class BotApp(traits.BotAware):
 
         # RESTful API.
         self._rest = rest_impl.RESTClientImpl(
+            cache=self._cache,
             entity_factory=self._entity_factory,
             executor=self._executor,
             http_settings=self._http_settings,

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -1832,7 +1832,6 @@ class RESTClientImpl(rest_api.RESTClient):
         await self._request(route)
 
     async def create_dm_channel(self, user: snowflakes.SnowflakeishOr[users.PartialUser], /) -> channels_.DMChannel:
-        user = snowflakes.Snowflake(user)
         route = routes.POST_MY_CHANNELS.compile()
         body = data_binding.JSONObjectBuilder()
         body.put_snowflake("recipient_id", user)

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -91,6 +91,7 @@ if typing.TYPE_CHECKING:
     from hikari import templates
     from hikari import voices
     from hikari import webhooks
+    from hikari.api import cache as cache_api
     from hikari.api import entity_factory as entity_factory_
 
 _LOGGER: typing.Final[logging.Logger] = logging.getLogger("hikari.rest")
@@ -342,6 +343,7 @@ class RESTApp(traits.ExecutorAware):
         entity_factory = entity_factory_impl.EntityFactoryImpl(provider)
 
         rest_client = RESTClientImpl(
+            cache=None,
             entity_factory=entity_factory,
             executor=self._executor,
             http_settings=self._http_settings,
@@ -390,6 +392,7 @@ class RESTClientImpl(rest_api.RESTClient):
     __slots__: typing.Sequence[str] = (
         "buckets",
         "global_rate_limit",
+        "_cache",
         "_client_session",
         "_closed_event",
         "_tcp_connector",
@@ -414,6 +417,7 @@ class RESTClientImpl(rest_api.RESTClient):
     def __init__(
         self,
         *,
+        cache: typing.Optional[cache_api.MutableCache],
         entity_factory: entity_factory_.EntityFactory,
         executor: typing.Optional[concurrent.futures.Executor],
         http_settings: config.HTTPSettings,
@@ -427,6 +431,7 @@ class RESTClientImpl(rest_api.RESTClient):
         # We've been told in DAPI that this is per token.
         self.global_rate_limit = rate_limits.ManualRateLimiter()
 
+        self._cache = cache
         self._client_session: typing.Optional[aiohttp.ClientSession] = None
         self._tcp_connector: typing.Optional[aiohttp.TCPConnector] = None
         self._closed_event = asyncio.Event()
@@ -791,7 +796,13 @@ class RESTClientImpl(rest_api.RESTClient):
         route = routes.GET_CHANNEL.compile(channel=channel)
         response = await self._request(route)
         assert isinstance(response, dict)
-        return self._entity_factory.deserialize_channel(response)
+        result = self._entity_factory.deserialize_channel(response)
+
+        if result.type is channels_.ChannelType.DM and self._cache:
+            assert isinstance(result, channels_.DMChannel)
+            self._cache.set_dm_channel_id(result.recipient.id, result.id)
+
+        return result
 
     async def edit_channel(
         self,

--- a/hikari/internal/cache.py
+++ b/hikari/internal/cache.py
@@ -983,7 +983,7 @@ def copy_guild_channel(channel: ChannelT) -> ChannelT:
 
 
 class Cache3DMappingView(CacheMappingView[snowflakes.Snowflake, cache.CacheView[KeyT, ValueT]]):
-    """A special case of the Mapping View which avoids copying the already immutable views contained within it."""
+    """A special case of the Mapping View which avoids copying the immutable values contained within it."""
 
     __slots__: typing.Sequence[str] = ()
 

--- a/hikari/users.py
+++ b/hikari/users.py
@@ -32,6 +32,7 @@ import typing
 import attr
 
 from hikari import snowflakes
+from hikari import traits
 from hikari import undefined
 from hikari import urls
 from hikari.internal import attr_extensions
@@ -44,7 +45,6 @@ if typing.TYPE_CHECKING:
     from hikari import files
     from hikari import guilds
     from hikari import messages
-    from hikari import traits
 
 
 @typing.final
@@ -180,7 +180,6 @@ class PartialUser(snowflakes.Unique, abc.ABC):
             The mention string to use.
         """
 
-    @abc.abstractmethod
     async def fetch_dm_channel(self) -> channels.DMChannel:
         """Fetch the DM channel for this user.
 
@@ -209,6 +208,7 @@ class PartialUser(snowflakes.Unique, abc.ABC):
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
         """
+        return await self.app.rest.create_dm_channel(self.id)
 
     async def fetch_self(self) -> User:
         """Get this user's up-to-date object by performing an API call.
@@ -390,10 +390,15 @@ class PartialUser(snowflakes.Unique, abc.ABC):
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
         """  # noqa: E501 - Line too long
-        channel = await self.fetch_dm_channel()
+        channel_id = None
+        if isinstance(self.app, traits.CacheAware):
+            channel_id = self.app.cache.get_dm_channel_id(self.id)
+
+        if channel_id is None:
+            channel_id = (await self.fetch_dm_channel()).id
 
         return await self.app.rest.create_message(
-            channel=channel.id,
+            channel=channel_id,
             content=content,
             embed=embed,
             attachment=attachment,
@@ -572,16 +577,6 @@ class PartialUserImpl(PartialUser):
 
     flags: undefined.UndefinedOr[UserFlag] = attr.field(eq=False, hash=False)
     """Public flags for this user."""
-
-    _dm_channel: typing.Optional[channels.DMChannel] = attr.field(
-        eq=False, hash=False, init=False, repr=False, default=None
-    )
-
-    async def fetch_dm_channel(self) -> channels.DMChannel:
-        if self._dm_channel is None:
-            self._dm_channel = await self.app.rest.create_dm_channel(self.id)
-
-        return self._dm_channel
 
     @property
     def mention(self) -> str:

--- a/tests/hikari/impl/test_bot.py
+++ b/tests/hikari/impl/test_bot.py
@@ -162,6 +162,7 @@ class TestBotApp:
         voice.assert_called_once_with(bot)
         assert bot._rest is rest.return_value
         rest.assert_called_once_with(
+            cache=bot._cache,
             entity_factory=bot._entity_factory,
             executor=executor,
             http_settings=bot._http_settings,

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -287,6 +287,7 @@ class TestRESTApp:
             rest_app.acquire(token="token", token_type="Type")
 
         mock_client.assert_called_once_with(
+            cache=None,
             entity_factory=_entity_factory(),
             executor=rest_app._executor,
             http_settings=rest_app._http_settings,
@@ -309,8 +310,14 @@ def rest_client_class():
 
 
 @pytest.fixture()
-def rest_client(rest_client_class):
+def mock_cache():
+    return mock.Mock()
+
+
+@pytest.fixture()
+def rest_client(rest_client_class, mock_cache):
     obj = rest_client_class(
+        cache=mock_cache,
         http_settings=mock.Mock(spec=config.HTTPSettings),
         max_rate_limit=float("inf"),
         proxy_settings=mock.Mock(spec=config.ProxySettings),
@@ -376,6 +383,7 @@ class TestRESTClientImpl:
     def test__init__passes_max_rate_limit(self):
         with mock.patch.object(buckets, "RESTBucketManager") as bucket:
             rest.RESTClientImpl(
+                cache=None,
                 http_settings=mock.Mock(),
                 max_rate_limit=float("inf"),
                 proxy_settings=mock.Mock(),
@@ -391,6 +399,7 @@ class TestRESTClientImpl:
     def test__init__when_token_strategy_passed_with_token_type(self):
         with pytest.raises(ValueError, match="Token type should be handled by the token strategy"):
             rest.RESTClientImpl(
+                cache=None,
                 http_settings=mock.Mock(),
                 max_rate_limit=float("inf"),
                 proxy_settings=mock.Mock(),
@@ -403,6 +412,7 @@ class TestRESTClientImpl:
 
     def test__init__when_token_is_None_sets_token_to_None(self):
         obj = rest.RESTClientImpl(
+            cache=None,
             http_settings=mock.Mock(),
             max_rate_limit=float("inf"),
             proxy_settings=mock.Mock(),
@@ -416,6 +426,7 @@ class TestRESTClientImpl:
 
     def test__init__when_token_and_token_type_is_not_None_generates_token_with_type(self):
         obj = rest.RESTClientImpl(
+            cache=None,
             http_settings=mock.Mock(),
             max_rate_limit=float("inf"),
             proxy_settings=mock.Mock(),
@@ -429,6 +440,7 @@ class TestRESTClientImpl:
 
     def test__init__when_rest_url_is_None_generates_url_using_default_url(self):
         obj = rest.RESTClientImpl(
+            cache=None,
             http_settings=mock.Mock(),
             max_rate_limit=float("inf"),
             proxy_settings=mock.Mock(),
@@ -442,6 +454,7 @@ class TestRESTClientImpl:
 
     def test__init__when_rest_url_is_not_None_generates_url_using_given_url(self):
         obj = rest.RESTClientImpl(
+            cache=None,
             http_settings=mock.Mock(),
             max_rate_limit=float("inf"),
             proxy_settings=mock.Mock(),
@@ -1284,6 +1297,29 @@ class TestRESTClientImplAsync:
         assert await rest_client.fetch_channel(StubModel(123)) == mock_object
         rest_client._request.assert_awaited_once_with(expected_route)
         rest_client._entity_factory.deserialize_channel.assert_called_once_with(rest_client._request.return_value)
+
+    async def test_fetch_channel_with_dm_channel_when_cacheful(self, rest_client, mock_cache):
+        expected_route = routes.GET_CHANNEL.compile(channel=123)
+        mock_object = mock.Mock(spec=channels.DMChannel, type=channels.ChannelType.DM)
+        rest_client._entity_factory.deserialize_channel = mock.Mock(return_value=mock_object)
+        rest_client._request = mock.AsyncMock(return_value={"payload": "NO"})
+
+        assert await rest_client.fetch_channel(StubModel(123)) == mock_object
+        rest_client._request.assert_awaited_once_with(expected_route)
+        rest_client._entity_factory.deserialize_channel.assert_called_once_with(rest_client._request.return_value)
+        mock_cache.set_dm_channel_id.assert_called_once_with(mock_object.recipient.id, mock_object.id)
+
+    async def test_fetch_channel_with_dm_channel_when_cacheless(self, rest_client, mock_cache):
+        expected_route = routes.GET_CHANNEL.compile(channel=123)
+        mock_object = mock.Mock(spec=channels.DMChannel, type=channels.ChannelType.DM)
+        rest_client._cache = None
+        rest_client._entity_factory.deserialize_channel = mock.Mock(return_value=mock_object)
+        rest_client._request = mock.AsyncMock(return_value={"payload": "NO"})
+
+        assert await rest_client.fetch_channel(StubModel(123)) == mock_object
+        rest_client._request.assert_awaited_once_with(expected_route)
+        rest_client._entity_factory.deserialize_channel.assert_called_once_with(rest_client._request.return_value)
+        mock_cache.set_dm_channel_id.assert_not_called()
 
     async def test_edit_channel(self, rest_client):
         expected_route = routes.PATCH_CHANNEL.compile(channel=123)

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -2049,16 +2049,30 @@ class TestRESTClientImplAsync:
         await rest_client.leave_guild(StubModel(123))
         rest_client._request.assert_awaited_once_with(expected_route)
 
-    async def test_create_dm_channel(self, rest_client):
-        dm_channel = StubModel(123)
+    async def test_create_dm_channel(self, rest_client, mock_cache):
+        dm_channel = StubModel(43234)
         expected_route = routes.POST_MY_CHANNELS.compile()
         expected_json = {"recipient_id": "123"}
-        rest_client._request = mock.AsyncMock(return_value={"id": "123"})
+        rest_client._request = mock.AsyncMock(return_value={"id": "43234"})
         rest_client._entity_factory.deserialize_dm = mock.Mock(return_value=dm_channel)
 
         assert await rest_client.create_dm_channel(StubModel(123)) == dm_channel
         rest_client._request.assert_awaited_once_with(expected_route, json=expected_json)
-        rest_client._entity_factory.deserialize_dm.assert_called_once_with({"id": "123"})
+        rest_client._entity_factory.deserialize_dm.assert_called_once_with({"id": "43234"})
+        mock_cache.set_dm_channel_id.assert_called_once_with(123, dm_channel.id)
+
+    async def test_create_dm_channel_when_cacheless(self, rest_client, mock_cache):
+        rest_client._cache = None
+        dm_channel = StubModel(43234)
+        expected_route = routes.POST_MY_CHANNELS.compile()
+        expected_json = {"recipient_id": "123"}
+        rest_client._request = mock.AsyncMock(return_value={"id": "43234"})
+        rest_client._entity_factory.deserialize_dm = mock.Mock(return_value=dm_channel)
+
+        assert await rest_client.create_dm_channel(StubModel(123)) == dm_channel
+        rest_client._request.assert_awaited_once_with(expected_route, json=expected_json)
+        rest_client._entity_factory.deserialize_dm.assert_called_once_with({"id": "43234"})
+        mock_cache.set_dm_channel_id.assert_not_called()
 
     async def test_fetch_application(self, rest_client):
         application = StubModel(123)

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -2051,15 +2051,16 @@ class TestRESTClientImplAsync:
 
     async def test_create_dm_channel(self, rest_client, mock_cache):
         dm_channel = StubModel(43234)
+        user = StubModel(123)
         expected_route = routes.POST_MY_CHANNELS.compile()
         expected_json = {"recipient_id": "123"}
         rest_client._request = mock.AsyncMock(return_value={"id": "43234"})
         rest_client._entity_factory.deserialize_dm = mock.Mock(return_value=dm_channel)
 
-        assert await rest_client.create_dm_channel(StubModel(123)) == dm_channel
+        assert await rest_client.create_dm_channel(user) == dm_channel
         rest_client._request.assert_awaited_once_with(expected_route, json=expected_json)
         rest_client._entity_factory.deserialize_dm.assert_called_once_with({"id": "43234"})
-        mock_cache.set_dm_channel_id.assert_called_once_with(123, dm_channel.id)
+        mock_cache.set_dm_channel_id.assert_called_once_with(user, dm_channel.id)
 
     async def test_create_dm_channel_when_cacheless(self, rest_client, mock_cache):
         rest_client._cache = None

--- a/tests/hikari/test_applications.py
+++ b/tests/hikari/test_applications.py
@@ -73,14 +73,6 @@ class TestTeamMember:
     def test_username_property(self, model):
         assert model.username is model.user.username
 
-    @pytest.mark.asyncio
-    async def test_fetch_dm_channel(self, model):
-        model.user.fetch_dm_channel = mock.AsyncMock()
-
-        result = await model.fetch_dm_channel()
-        assert result is model.user.fetch_dm_channel.return_value
-        model.user.fetch_dm_channel.assert_awaited_once()
-
     def test_str_operator(self):
         mock_team_member = mock.Mock(
             applications.TeamMember, user=mock.Mock(users.User, __str__=mock.Mock(return_value="mario#1234"))

--- a/tests/hikari/test_guilds.py
+++ b/tests/hikari/test_guilds.py
@@ -209,13 +209,6 @@ class TestMember:
         assert result is mock_user.make_avatar_url.return_value
 
     @pytest.mark.asyncio
-    async def test_fetch_dm_channel(self, model, mock_user):
-        mock_user.fetch_dm_channel = mock.AsyncMock()
-        result = await model.fetch_dm_channel()
-        mock_user.fetch_dm_channel.assert_awaited_once_with()
-        assert result is mock_user.fetch_dm_channel.return_value
-
-    @pytest.mark.asyncio
     async def test_fetch_self(self, model):
         model.user.app.rest.fetch_member = mock.AsyncMock()
 


### PR DESCRIPTION

### Summary
introduce REST filled DM Channel ID cache resource
* Remove caching DM channel objects on user objects in favour of new cache resource

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
