### PR TITLE
Delay initialisation of BotApp._closing_event and use it as ._closed

### DIFF
--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -355,12 +355,6 @@ class BotApp(traits.BotAware):
         if not self._is_alive:
             raise errors.ComponentStateConflictError("bot is not running so it cannot be interacted with")
 
-    def _get_closing_event(self) -> asyncio.Event:
-        if not self._closing_event:
-            self._closing_event = asyncio.Event()
-
-        return self._closing_event
-
     async def close(self, force: bool = True) -> None:
         """Kill the application by shutting all components down."""
         if self._closing_event and not self._closing_event.is_set():

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -417,7 +417,7 @@ class BotApp(traits.BotAware):
         self._check_if_alive()
 
         awaitables: typing.List[typing.Awaitable[typing.Any]] = [s.join() for s in self._shards.values()]
-        if until_close and self._closing_event:  # If the closing event isn't set then this is already going away.
+        if until_close and self._closing_event:  # If closing event is None then this is already going away.
             awaitables.append(self._closing_event.wait())
 
         await aio.first_completed(*awaitables)

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -361,7 +361,7 @@ class BotApp(traits.BotAware):
             _LOGGER.debug("bot requested to shutdown [force:%s]", force)
             self._closing_event.set()
 
-        if not self._closing_event or not force:
+        if not self._closing_event or not force:  # If closing event is None then this is already closing.
             return
 
         self._closing_event = None
@@ -417,7 +417,7 @@ class BotApp(traits.BotAware):
         self._check_if_alive()
 
         awaitables: typing.List[typing.Awaitable[typing.Any]] = [s.join() for s in self._shards.values()]
-        if until_close and self._closing_event:  # If closing event is None then this is already going away.
+        if until_close and self._closing_event:  # If closing event is None then this is already closing.
             awaitables.append(self._closing_event.wait())
 
         await aio.first_completed(*awaitables)

--- a/tests/hikari/impl/test_bot.py
+++ b/tests/hikari/impl/test_bot.py
@@ -279,25 +279,20 @@ class TestBotApp:
     @pytest.mark.asyncio
     async def test_close_when_not_force(self, bot, event_manager):
         bot._closing_event = mock.Mock(is_set=mock.Mock(return_value=True))
-        bot._closed = False
         bot._is_alive = True
 
         await bot.close(force=False)
 
         bot._closing_event.set.assert_called_once_with()
-        assert bot._closed is False
         assert bot._is_alive is True
 
     @pytest.mark.asyncio
     async def test_close_when_already_closed(self, bot, event_manager):
-        bot._closing_event = mock.Mock(is_set=mock.Mock(return_value=True))
-        bot._closed = True
+        bot._closing_event = None
         bot._is_alive = True
 
         await bot.close(force=True)
 
-        bot._closing_event.set.assert_called_once_with()
-        assert bot._closed is True
         assert bot._is_alive is True
 
     @pytest.mark.asyncio
@@ -334,8 +329,7 @@ class TestBotApp:
         event_manager.dispatch = mock.AsyncMock()
         rest.close = AwaitMock()
         voice.close = AwaitMock()
-        bot._closing_event = mock.Mock(is_set=mock.Mock(return_value=False))
-        bot._closed = False
+        bot._closing_event = closing_event = mock.Mock(is_set=mock.Mock(return_value=False))
         bot._is_alive = True
         error = RuntimeError()
         shard0 = mock.Mock(id=0, close=AwaitMock())
@@ -347,8 +341,8 @@ class TestBotApp:
             await bot.close(force=True)
 
         # Closing event and args
-        bot._closing_event.set.assert_called_once_with()
-        assert bot._closed is True
+        closing_event.set.assert_called_once_with()
+        assert bot._closing_event is None
         assert bot._is_alive is False
 
         # Closing components


### PR DESCRIPTION
### Summary
Delay initialisation of BotApp._closing_event and use it as ._closed
* This also solves the potential issue where BotApp._closed was never re-set to `False` once a bot was re-started

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
This contributes to #625 