### PR TITLE
Add sending multiple embeds on create and edit message

### DIFF
--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -1308,7 +1308,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If this is `builtins.None` then any present embeds are removed.
             Otherwise, the new embed that was provided will be used as the
             replacement.
-        embeds : hikari.undefined.UndefinedNoneOr[hikari.embeds.Embed]
+        embeds : hikari.undefined.UndefinedNoneOr[typing.Sequence[hikari.embeds.Embed]]
             If provided, the embeds to set on the message. If
             `hikari.undefined.UNDEFINED`, the previous embed(s) are not changed.
             If this is `builtins.None` then any present embeds are removed.
@@ -2378,7 +2378,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If this is `builtins.None` then any present embeds are removed.
             Otherwise, the new embed that was provided will be used as the
             replacement.
-        embeds : hikari.undefined.UndefinedNoneOr[hikari.embeds.Embed]
+        embeds : hikari.undefined.UndefinedNoneOr[typing.Sequence[hikari.embeds.Embed]]
             If provided, the embeds to set on the message. If
             `hikari.undefined.UNDEFINED`, the previous embed(s) are not changed.
             If this is `builtins.None` then any present embeds are removed.

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -1092,7 +1092,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------------
         embed : hikari.undefined.UndefinedOr[hikari.embeds.Embed]
             If provided, the message embed.
-        embeds : hikari.undefined.UndefinedOr[hikari.embeds.Embed]
+        embeds : hikari.undefined.UndefinedOr[typing.Sequence[hikari.embeds.Embed]]
             If provided, the message embeds.
         attachment : hikari.undefined.UndefinedOr[hikari.files.Resourceish],
             If provided, the message attachment. This can be a resource,
@@ -2173,7 +2173,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------------
         embed : hikari.undefined.UndefinedOr[hikari.embeds.Embed]
             If provided, the message embed.
-        embeds : hikari.undefined.UndefinedOr[hikari.embeds.Embed]
+        embeds : hikari.undefined.UndefinedOr[typing.Sequence[hikari.embeds.Embed]]
             If provided, the message embeds.
         attachment : hikari.undefined.UndefinedOr[hikari.files.Resourceish],
             If provided, the message attachment. This can be a resource,

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -1053,6 +1053,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         content: undefined.UndefinedOr[typing.Any] = undefined.UNDEFINED,
         *,
         embed: undefined.UndefinedOr[embeds_.Embed] = undefined.UNDEFINED,
+        embeds: undefined.UndefinedOr[typing.Sequence[embeds_.Embed]] = undefined.UNDEFINED,
         attachment: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
         attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
         tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
@@ -1079,9 +1080,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             in the content. Any other value here will be cast to a
             `builtins.str`.
 
-            If this is a `hikari.embeds.Embed` and no `embed` kwarg is
-            provided, then this will instead update the embed. This allows for
-            simpler syntax when sending an embed alone.
+            If this is a `hikari.embeds.Embed` and no `embed` nor `embeds` kwarg
+            is provided, then this will instead update the embed. This allows
+            for simpler syntax when sending an embed alone.
 
             Likewise, if this is a `hikari.files.Resource`, then the
             content is instead treated as an attachment if no `attachment` and
@@ -1091,6 +1092,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------------
         embed : hikari.undefined.UndefinedOr[hikari.embeds.Embed]
             If provided, the message embed.
+        embeds : hikari.undefined.UndefinedOr[hikari.embeds.Embed]
+            If provided, the message embeds.
         attachment : hikari.undefined.UndefinedOr[hikari.files.Resourceish],
             If provided, the message attachment. This can be a resource,
             or string of a path on your computer or a URL.
@@ -1259,6 +1262,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         content: undefined.UndefinedOr[typing.Any] = undefined.UNDEFINED,
         *,
         embed: undefined.UndefinedNoneOr[embeds_.Embed] = undefined.UNDEFINED,
+        embeds: undefined.UndefinedNoneOr[typing.Sequence[embeds_.Embed]] = undefined.UNDEFINED,
         attachment: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
         attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
         replace_attachments: bool = False,
@@ -1289,8 +1293,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
             Any other value will be cast to a `builtins.str` before sending.
 
-            If this is a `hikari.embeds.Embed` and no `embed` kwarg is
-            provided or if this is a `hikari.files.Resourceish` and neither the
+            If this is a `hikari.embeds.Embed` and neither the `embed` or
+            `embeds` kwargs are provided or if this is a
+            `hikari.files.Resourceish` and neither the
             `attachment` or `attachments` kwargs are provided, the values will
             be overwritten. This allows for simpler syntax when sending an
             embed or an attachment alone.
@@ -1302,6 +1307,12 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             `hikari.undefined.UNDEFINED`, the previous embed, if
             present, is not changed. If this is `builtins.None`, then the embed
             is removed, if present. Otherwise, the new embed that was provided
+            will be used as the replacement.
+        embeds : hikari.undefined.UndefinedNoneOr[hikari.embeds.Embed]
+            If provided, the embeds to set on the message. If
+            `hikari.undefined.UNDEFINED`, the previous embeds if
+            present are not changed. If this is `builtins.None`, then the embeds
+            are removed ,if present. Otherwise, the new embeds that were provided
             will be used as the replacement.
         attachment : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
             If provided, the attachment to set on the message. If

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -1304,16 +1304,16 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------------
         embed : hikari.undefined.UndefinedNoneOr[hikari.embeds.Embed]
             If provided, the embed to set on the message. If
-            `hikari.undefined.UNDEFINED`, the previous embed, if
-            present, is not changed. If this is `builtins.None`, then the embed
-            is removed, if present. Otherwise, the new embed that was provided
-            will be used as the replacement.
+            `hikari.undefined.UNDEFINED`, the previous embed(s) are not changed.
+            If this is `builtins.None` then any present embeds are removed.
+            Otherwise, the new embed that was provided will be used as the
+            replacement.
         embeds : hikari.undefined.UndefinedNoneOr[hikari.embeds.Embed]
             If provided, the embeds to set on the message. If
-            `hikari.undefined.UNDEFINED`, the previous embeds if
-            present are not changed. If this is `builtins.None`, then the embeds
-            are removed ,if present. Otherwise, the new embeds that were provided
-            will be used as the replacement.
+            `hikari.undefined.UNDEFINED`, the previous embed(s) are not changed.
+            If this is `builtins.None` then any present embeds are removed.
+            Otherwise, the new embeds that were provided will be used as the
+            replacement.
         attachment : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
             If provided, the attachment to set on the message. If
             `hikari.undefined.UNDEFINED`, the previous attachment, if
@@ -2374,16 +2374,16 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------------
         embed : hikari.undefined.UndefinedNoneOr[hikari.embeds.Embed]
             If provided, the embed to set on the message. If
-            `hikari.undefined.UNDEFINED`, the previous embed, if
-            present, is not changed. If this is `builtins.None`, then the embed
-            is removed, if present. Otherwise, the new embed that was provided
-            will be used as the replacement.
+            `hikari.undefined.UNDEFINED`, the previous embed(s) are not changed.
+            If this is `builtins.None` then any present embeds are removed.
+            Otherwise, the new embed that was provided will be used as the
+            replacement.
         embeds : hikari.undefined.UndefinedNoneOr[hikari.embeds.Embed]
             If provided, the embeds to set on the message. If
-            `hikari.undefined.UNDEFINED`, the previous embeds if
-            present are not changed. If this is `builtins.None`, then the embeds
-            are removed ,if present. Otherwise, the new embeds that were provided
-            will be used as the replacement.
+            `hikari.undefined.UNDEFINED`, the previous embed(s) are not changed.
+            If this is `builtins.None` then any present embeds are removed.
+            Otherwise, the new embeds that were provided will be used as the
+            replacement.
         attachment : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
             If provided, the attachment to set on the message. If
             `hikari.undefined.UNDEFINED`, the previous attachment, if

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -61,7 +61,7 @@ from hikari.internal import routes
 if typing.TYPE_CHECKING:
     import datetime
 
-    from hikari import embeds
+    from hikari import embeds as embeds_
     from hikari import files
     from hikari import guilds
     from hikari import iterators
@@ -404,7 +404,8 @@ class TextChannel(PartialChannel, abc.ABC):
         self,
         content: undefined.UndefinedOr[typing.Any] = undefined.UNDEFINED,
         *,
-        embed: undefined.UndefinedOr[embeds.Embed] = undefined.UNDEFINED,
+        embed: undefined.UndefinedOr[embeds_.Embed] = undefined.UNDEFINED,
+        embeds: undefined.UndefinedOr[typing.Sequence[embeds_.Embed]] = undefined.UNDEFINED,
         attachment: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
         attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
         nonce: undefined.UndefinedOr[str] = undefined.UNDEFINED,
@@ -429,9 +430,9 @@ class TextChannel(PartialChannel, abc.ABC):
             in the content. Any other value here will be cast to a
             `builtins.str`.
 
-            If this is a `hikari.embeds.Embed` and no `embed` kwarg is
-            provided, then this will instead update the embed. This allows for
-            simpler syntax when sending an embed alone.
+            If this is a `hikari.embeds.Embed` and no `embed` nor `embeds` kwarg
+            is provided, then this will instead update the embed. This allows
+            for simpler syntax when sending an embed alone.
 
             Likewise, if this is a `hikari.files.Resource`, then the
             content is instead treated as an attachment if no `attachment` and
@@ -441,6 +442,8 @@ class TextChannel(PartialChannel, abc.ABC):
         ----------------
         embed : hikari.undefined.UndefinedOr[hikari.embeds.Embed]
             If provided, the message embed.
+        embeds : hikari.undefined.UndefinedOr[typing.Sequence[hikari.embeds.Embed]]
+            If provided, the message embeds.
         attachment : hikari.undefined.UndefinedOr[hikari.files.Resourceish],
             If provided, the message attachment. This can be a resource,
             or string of a path on your computer or a URL.
@@ -538,6 +541,7 @@ class TextChannel(PartialChannel, abc.ABC):
             channel=self.id,
             content=content,
             embed=embed,
+            embeds=embeds,
             attachment=attachment,
             attachments=attachments,
             nonce=nonce,

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -1652,7 +1652,7 @@ class RESTClientImpl(rest_api.RESTClient):
         if not undefined.count(embed, embeds):
             raise ValueError("You may only specify one of 'embed' or 'embeds', not both")
 
-        if embeds not in _NONE_OR_UNDEFINED and not isinstance(embeds, typing.Collection):
+        if embeds is not undefined.UNDEFINED and not isinstance(embeds, typing.Collection):
             raise TypeError(
                 "You passed a non collection to 'embeds', but this expects a collection. Maybe you meant to "
                 "use 'embed' (singular) instead?"

--- a/hikari/messages.py
+++ b/hikari/messages.py
@@ -702,6 +702,7 @@ class PartialMessage(snowflakes.Unique):
         content: undefined.UndefinedOr[typing.Any] = undefined.UNDEFINED,
         *,
         embed: undefined.UndefinedNoneOr[embeds_.Embed] = undefined.UNDEFINED,
+        embeds: undefined.UndefinedNoneOr[typing.Sequence[embeds_.Embed]] = undefined.UNDEFINED,
         attachment: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
         attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
         replace_attachments: bool = False,
@@ -720,18 +721,18 @@ class PartialMessage(snowflakes.Unique):
         Parameters
         ----------
         content : hikari.undefined.UndefinedOr[typing.Any]
-            The message content to update with. If
+            If provided, the message content to update with. If
             `hikari.undefined.UNDEFINED`, then the content will not
             be changed. If `builtins.None`, then the content will be removed.
 
             Any other value will be cast to a `builtins.str` before sending.
 
-            If this is a `hikari.embeds.Embed` and neither the
-            `embed` or `embeds` kwargs are provided or if this is a
-            `hikari.files.Resourceish` and neither the `attachment` or
-            `attachments` kwargs are provided, the values will be overwritten.
-            This allows for simpler syntax when sending an embed or an
-            attachment alone.
+            If this is a `hikari.embeds.Embed` and neither the `embed` or
+            `embeds` kwargs are provided or if this is a
+            `hikari.files.Resourceish` and neither the
+            `attachment` or `attachments` kwargs are provided, the values will
+            be overwritten. This allows for simpler syntax when sending an
+            embed or an attachment alone.
 
         Other Parameters
         ----------------
@@ -741,12 +742,12 @@ class PartialMessage(snowflakes.Unique):
             present, is not changed. If this is `builtins.None`, then the embed
             is removed, if present. Otherwise, the new embed that was provided
             will be used as the replacement.
-        attachment : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
-            If provided, the attachment to set on the message. If
-            `hikari.undefined.UNDEFINED`, the previous attachment, if
-            present, is not changed. If this is `builtins.None`, then the
-            attachment is removed, if present. Otherwise, the new attachment
-            that was provided will be attached.
+        embeds : hikari.undefined.UndefinedNoneOr[hikari.embeds.Embed]
+            If provided, the embeds to set on the message. If
+            `hikari.undefined.UNDEFINED`, the previous embeds if
+            present are not changed. If this is `builtins.None`, then the embeds
+            are removed ,if present. Otherwise, the new embeds that were provided
+            will be used as the replacement.
         attachments : hikari.undefined.UndefinedOr[typing.Sequence[hikari.files.Resourceish]]
             If provided, the attachments to set on the message. If
             `hikari.undefined.UNDEFINED`, the previous attachments, if
@@ -856,6 +857,7 @@ class PartialMessage(snowflakes.Unique):
             channel=self.channel_id,
             content=content,
             embed=embed,
+            embeds=embeds,
             attachment=attachment,
             attachments=attachments,
             replace_attachments=replace_attachments,
@@ -871,6 +873,7 @@ class PartialMessage(snowflakes.Unique):
         content: undefined.UndefinedOr[typing.Any] = undefined.UNDEFINED,
         *,
         embed: undefined.UndefinedOr[embeds_.Embed] = undefined.UNDEFINED,
+        embeds: undefined.UndefinedOr[typing.Sequence[embeds_.Embed]] = undefined.UNDEFINED,
         attachment: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
         attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
         nonce: undefined.UndefinedOr[str] = undefined.UNDEFINED,
@@ -897,9 +900,9 @@ class PartialMessage(snowflakes.Unique):
             in the content. Any other value here will be cast to a
             `builtins.str`.
 
-            If this is a `hikari.embeds.Embed` and no `embed` kwarg is
-            provided, then this will instead update the embed. This allows for
-            simpler syntax when sending an embed alone.
+            If this is a `hikari.embeds.Embed` and no `embed` nor `embeds` kwarg
+            is provided, then this will instead update the embed. This allows
+            for simpler syntax when sending an embed alone.
 
             Likewise, if this is a `hikari.files.Resource`, then the
             content is instead treated as an attachment if no `attachment` and
@@ -909,6 +912,8 @@ class PartialMessage(snowflakes.Unique):
         ----------------
         embed : hikari.undefined.UndefinedOr[hikari.embeds.Embed]
             If provided, the message embed.
+        embeds : hikari.undefined.UndefinedOr[typing.Sequence[hikari.embeds.Embed]]
+            If provided, the message embeds.
         attachment : hikari.undefined.UndefinedOr[hikari.files.Resourceish],
             If provided, the message attachment. This can be a resource,
             or string of a path on your computer or a URL.
@@ -1005,10 +1010,14 @@ class PartialMessage(snowflakes.Unique):
         if reply is True:
             reply = self
 
+        elif reply is False:
+            reply = undefined.UNDEFINED
+
         return await self.app.rest.create_message(
             channel=self.channel_id,
             content=content,
             embed=embed,
+            embeds=embeds,
             attachment=attachment,
             attachments=attachments,
             nonce=nonce,

--- a/hikari/messages.py
+++ b/hikari/messages.py
@@ -742,7 +742,7 @@ class PartialMessage(snowflakes.Unique):
             If this is `builtins.None` then any present embeds are removed.
             Otherwise, the new embed that was provided will be used as the
             replacement.
-        embeds : hikari.undefined.UndefinedNoneOr[hikari.embeds.Embed]
+        embeds : hikari.undefined.UndefinedNoneOr[typing.Sequence[hikari.embeds.Embed]]
             If provided, the embeds to set on the message. If
             `hikari.undefined.UNDEFINED`, the previous embed(s) are not changed.
             If this is `builtins.None` then any present embeds are removed.

--- a/hikari/messages.py
+++ b/hikari/messages.py
@@ -738,16 +738,16 @@ class PartialMessage(snowflakes.Unique):
         ----------------
         embed : hikari.undefined.UndefinedNoneOr[hikari.embeds.Embed]
             If provided, the embed to set on the message. If
-            `hikari.undefined.UNDEFINED`, the previous embed, if
-            present, is not changed. If this is `builtins.None`, then the embed
-            is removed, if present. Otherwise, the new embed that was provided
-            will be used as the replacement.
+            `hikari.undefined.UNDEFINED`, the previous embed(s) are not changed.
+            If this is `builtins.None` then any present embeds are removed.
+            Otherwise, the new embed that was provided will be used as the
+            replacement.
         embeds : hikari.undefined.UndefinedNoneOr[hikari.embeds.Embed]
             If provided, the embeds to set on the message. If
-            `hikari.undefined.UNDEFINED`, the previous embeds if
-            present are not changed. If this is `builtins.None`, then the embeds
-            are removed ,if present. Otherwise, the new embeds that were provided
-            will be used as the replacement.
+            `hikari.undefined.UNDEFINED`, the previous embed(s) are not changed.
+            If this is `builtins.None` then any present embeds are removed.
+            Otherwise, the new embeds that were provided will be used as the
+            replacement.
         attachments : hikari.undefined.UndefinedOr[typing.Sequence[hikari.files.Resourceish]]
             If provided, the attachments to set on the message. If
             `hikari.undefined.UNDEFINED`, the previous attachments, if

--- a/hikari/users.py
+++ b/hikari/users.py
@@ -41,7 +41,7 @@ from hikari.internal import routes
 
 if typing.TYPE_CHECKING:
     from hikari import channels
-    from hikari import embeds
+    from hikari import embeds as embeds_
     from hikari import files
     from hikari import guilds
     from hikari import messages
@@ -242,7 +242,8 @@ class PartialUser(snowflakes.Unique, abc.ABC):
         self,
         content: undefined.UndefinedOr[typing.Any] = undefined.UNDEFINED,
         *,
-        embed: undefined.UndefinedOr[embeds.Embed] = undefined.UNDEFINED,
+        embed: undefined.UndefinedOr[embeds_.Embed] = undefined.UNDEFINED,
+        embeds: undefined.UndefinedOr[typing.Sequence[embeds_.Embed]] = undefined.UNDEFINED,
         attachment: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
         attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
         nonce: undefined.UndefinedOr[str] = undefined.UNDEFINED,
@@ -267,18 +268,21 @@ class PartialUser(snowflakes.Unique, abc.ABC):
             in the content. Any other value here will be cast to a
             `builtins.str`.
 
-            If this is a `hikari.embeds.Embed` and no `embed` kwarg is
-            provided, then this will instead update the embed. This allows for
-            simpler syntax when sending an embed alone.
+            If this is a `hikari.embeds.Embed` and no `embed` nor `embeds` kwarg
+            is provided, then this will instead update the embed. This allows
+            for simpler syntax when sending an embed alone.
 
             Likewise, if this is a `hikari.files.Resource`, then the
             content is instead treated as an attachment if no `attachment` and
             no `attachments` kwargs are provided.
 
+
         Other Parameters
         ----------------
         embed : hikari.undefined.UndefinedOr[hikari.embeds.Embed]
             If provided, the message embed.
+        embeds : hikari.undefined.UndefinedOr[typing.Sequence[hikari.embeds.Embed]]
+            If provided, the message embeds.
         attachment : hikari.undefined.UndefinedOr[hikari.files.Resourceish],
             If provided, the message attachment. This can be a resource,
             or string of a path on your computer or a URL.
@@ -401,6 +405,7 @@ class PartialUser(snowflakes.Unique, abc.ABC):
             channel=channel_id,
             content=content,
             embed=embed,
+            embeds=embeds,
             attachment=attachment,
             attachments=attachments,
             nonce=nonce,
@@ -695,7 +700,8 @@ class OwnUser(UserImpl):
         self,
         content: undefined.UndefinedOr[typing.Any] = undefined.UNDEFINED,
         *,
-        embed: undefined.UndefinedOr[embeds.Embed] = undefined.UNDEFINED,
+        embed: undefined.UndefinedOr[embeds_.Embed] = undefined.UNDEFINED,
+        embeds: undefined.UndefinedOr[typing.Sequence[embeds_.Embed]] = undefined.UNDEFINED,
         attachment: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
         attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
         nonce: undefined.UndefinedOr[str] = undefined.UNDEFINED,

--- a/hikari/webhooks.py
+++ b/hikari/webhooks.py
@@ -355,7 +355,7 @@ class Webhook(snowflakes.Unique):
             If this is `builtins.None` then any present embeds are removed.
             Otherwise, the new embed that was provided will be used as the
             replacement.
-        embeds : hikari.undefined.UndefinedNoneOr[hikari.embeds.Embed]
+        embeds : hikari.undefined.UndefinedNoneOr[typing.Sequence[hikari.embeds.Embed]]
             If provided, the embeds to set on the message. If
             `hikari.undefined.UNDEFINED`, the previous embed(s) are not changed.
             If this is `builtins.None` then any present embeds are removed.

--- a/hikari/webhooks.py
+++ b/hikari/webhooks.py
@@ -351,16 +351,16 @@ class Webhook(snowflakes.Unique):
         ----------------
         embed : hikari.undefined.UndefinedNoneOr[hikari.embeds.Embed]
             If provided, the embed to set on the message. If
-            `hikari.undefined.UNDEFINED`, the previous embed, if
-            present, is not changed. If this is `builtins.None`, then the embed
-            is removed, if present. Otherwise, the new embed that was provided
-            will be used as the replacement.
+            `hikari.undefined.UNDEFINED`, the previous embed(s) are not changed.
+            If this is `builtins.None` then any present embeds are removed.
+            Otherwise, the new embed that was provided will be used as the
+            replacement.
         embeds : hikari.undefined.UndefinedNoneOr[hikari.embeds.Embed]
             If provided, the embeds to set on the message. If
-            `hikari.undefined.UNDEFINED`, the previous embeds if
-            present are not changed. If this is `builtins.None`, then the embeds
-            are removed ,if present. Otherwise, the new embeds that were provided
-            will be used as the replacement.
+            `hikari.undefined.UNDEFINED`, the previous embed(s) are not changed.
+            If this is `builtins.None` then any present embeds are removed.
+            Otherwise, the new embeds that were provided will be used as the
+            replacement.
         attachment : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
             If provided, the attachment to set on the message. If
             `hikari.undefined.UNDEFINED`, the previous attachment, if

--- a/tests/hikari/test_channels.py
+++ b/tests/hikari/test_channels.py
@@ -214,6 +214,7 @@ class TestTextChannel:
         model.app.rest.create_message = mock.AsyncMock()
         mock_attachment = object()
         mock_embed = object()
+        mock_embeds = object()
         mock_attachments = [object(), object(), object()]
         mock_reply = object()
 
@@ -224,6 +225,7 @@ class TestTextChannel:
             attachment=mock_attachment,
             attachments=mock_attachments,
             embed=mock_embed,
+            embeds=mock_embeds,
             reply=mock_reply,
             mentions_everyone=False,
             user_mentions=[123, 456],
@@ -239,6 +241,7 @@ class TestTextChannel:
             attachment=mock_attachment,
             attachments=mock_attachments,
             embed=mock_embed,
+            embeds=mock_embeds,
             reply=mock_reply,
             mentions_everyone=False,
             user_mentions=[123, 456],

--- a/tests/hikari/test_messages.py
+++ b/tests/hikari/test_messages.py
@@ -28,6 +28,7 @@ from hikari import emojis
 from hikari import guilds
 from hikari import messages
 from hikari import snowflakes
+from hikari import undefined
 from hikari import urls
 from hikari import users
 from hikari.internal import routes
@@ -164,11 +165,13 @@ class TestAsyncMessage:
         message.id = 123
         message.channel_id = 456
         embed = object()
+        embeds = [object(), object()]
         attachment = object()
         roles = [object()]
         await message.edit(
             content="test content",
             embed=embed,
+            embeds=embeds,
             attachment=attachment,
             attachments=[attachment, attachment],
             replace_attachments=True,
@@ -183,6 +186,7 @@ class TestAsyncMessage:
             channel=456,
             content="test content",
             embed=embed,
+            embeds=embeds,
             attachment=attachment,
             attachments=[attachment, attachment],
             replace_attachments=True,
@@ -198,6 +202,7 @@ class TestAsyncMessage:
         message.id = 123
         message.channel_id = 456
         embed = object()
+        embeds = [object(), object()]
         roles = [object()]
         attachment = object()
         attachments = [object()]
@@ -205,6 +210,7 @@ class TestAsyncMessage:
         await message.respond(
             content="test content",
             embed=embed,
+            embeds=embeds,
             attachment=attachment,
             attachments=attachments,
             nonce="nonce",
@@ -219,6 +225,7 @@ class TestAsyncMessage:
             channel=456,
             content="test content",
             embed=embed,
+            embeds=embeds,
             attachment=attachment,
             attachments=attachments,
             nonce="nonce",
@@ -235,12 +242,14 @@ class TestAsyncMessage:
         message.id = 123
         message.channel_id = 456
         embed = object()
+        embeds = [object()]
         roles = [object()]
         attachment = object()
         attachments = [object()]
         await message.respond(
             content="test content",
             embed=embed,
+            embeds=embeds,
             attachment=attachment,
             attachments=attachments,
             nonce="nonce",
@@ -255,6 +264,7 @@ class TestAsyncMessage:
             channel=456,
             content="test content",
             embed=embed,
+            embeds=embeds,
             attachment=attachment,
             attachments=attachments,
             nonce="nonce",
@@ -264,6 +274,27 @@ class TestAsyncMessage:
             user_mentions=False,
             role_mentions=roles,
             mentions_reply=True,
+        )
+
+    async def test_respond_when_reply_is_False(self, message):
+        message.app = mock.AsyncMock()
+        message.id = 123
+        message.channel_id = 456
+        await message.respond(reply=False)
+        message.app.rest.create_message.assert_awaited_once_with(
+            channel=456,
+            content=undefined.UNDEFINED,
+            embed=undefined.UNDEFINED,
+            embeds=undefined.UNDEFINED,
+            attachment=undefined.UNDEFINED,
+            attachments=undefined.UNDEFINED,
+            nonce=undefined.UNDEFINED,
+            tts=undefined.UNDEFINED,
+            reply=undefined.UNDEFINED,
+            mentions_everyone=undefined.UNDEFINED,
+            user_mentions=undefined.UNDEFINED,
+            role_mentions=undefined.UNDEFINED,
+            mentions_reply=undefined.UNDEFINED,
         )
 
     async def test_delete(self, message):

--- a/tests/hikari/test_users.py
+++ b/tests/hikari/test_users.py
@@ -49,6 +49,7 @@ class TestPartialUser:
     async def test_send_uses_cached_id(self, obj):
         obj.id = 4123123
         embed = object()
+        embeds = [object()]
         attachment = object()
         attachments = [object(), object()]
         user_mentions = [object(), object()]
@@ -62,6 +63,7 @@ class TestPartialUser:
         returned = await obj.send(
             content="test",
             embed=embed,
+            embeds=embeds,
             attachment=attachment,
             attachments=attachments,
             nonce="nonce",
@@ -81,6 +83,7 @@ class TestPartialUser:
             channel=obj.app.cache.get_dm_channel_id.return_value,
             content="test",
             embed=embed,
+            embeds=embeds,
             attachment=attachment,
             attachments=attachments,
             nonce="nonce",
@@ -96,6 +99,7 @@ class TestPartialUser:
     async def test_send_when_not_cached(self, obj):
         obj.id = 522234
         embed = object()
+        embeds = [object(), object()]
         attachment = object()
         attachments = [object(), object()]
         user_mentions = [object(), object()]
@@ -110,6 +114,7 @@ class TestPartialUser:
         returned = await obj.send(
             content="test",
             embed=embed,
+            embeds=embeds,
             attachment=attachment,
             attachments=attachments,
             nonce="nonce",
@@ -129,6 +134,7 @@ class TestPartialUser:
             channel=obj.fetch_dm_channel.return_value.id,
             content="test",
             embed=embed,
+            embeds=embeds,
             attachment=attachment,
             attachments=attachments,
             nonce="nonce",
@@ -144,6 +150,7 @@ class TestPartialUser:
     async def test_send_when_not_cache_aware(self, obj):
         obj.id = 522234
         embed = object()
+        embeds = [object(), object()]
         attachment = object()
         attachments = [object(), object()]
         user_mentions = [object(), object()]
@@ -157,6 +164,7 @@ class TestPartialUser:
         returned = await obj.send(
             content="test",
             embed=embed,
+            embeds=embeds,
             attachment=attachment,
             attachments=attachments,
             nonce="nonce",
@@ -175,6 +183,7 @@ class TestPartialUser:
             channel=obj.fetch_dm_channel.return_value.id,
             content="test",
             embed=embed,
+            embeds=embeds,
             attachment=attachment,
             attachments=attachments,
             nonce="nonce",


### PR DESCRIPTION
### Summary
Add sending multiple embeds on create and edit message
* Fix bug where execute_webhook(embeds=None) on the standard REST client implementation would lead to erroneous behaviour
* Fix bug where Message.respond(reply=False) would try to respond to a message with the ID 0

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
