### PR TITLE
Remove return from subscribe calls

### DIFF
--- a/hikari/api/event_manager.py
+++ b/hikari/api/event_manager.py
@@ -161,7 +161,7 @@ class EventManager(abc.ABC):
     # For the sake of UX, I will check this at runtime instead and let the
     # user use a static type checker.
     @abc.abstractmethod
-    def subscribe(self, event_type: typing.Type[typing.Any], callback: CallbackT[typing.Any]) -> CallbackT[typing.Any]:
+    def subscribe(self, event_type: typing.Type[typing.Any], callback: CallbackT[typing.Any]) -> None:
         """Subscribe a given callback to a given event type.
 
         Parameters
@@ -188,11 +188,6 @@ class EventManager(abc.ABC):
 
         bot.subscribe(MessageCreateEvent, on_message)
         ```
-
-        Returns
-        -------
-        typing.Callable[[T], typing.Coroutine[typing.Any, typing.Any, builtins.None]
-            The event callback that was passed in.
 
         See Also
         --------

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -862,10 +862,8 @@ class BotApp(traits.BotAware):
         self._check_if_alive()
         return self._event_manager.stream(event_type, timeout=timeout, limit=limit)
 
-    def subscribe(
-        self, event_type: typing.Type[typing.Any], callback: event_manager_.CallbackT[typing.Any]
-    ) -> event_manager_.CallbackT[typing.Any]:
-        return self._event_manager.subscribe(event_type, callback)
+    def subscribe(self, event_type: typing.Type[typing.Any], callback: event_manager_.CallbackT[typing.Any]) -> None:
+        self._event_manager.subscribe(event_type, callback)
 
     def unsubscribe(self, event_type: typing.Type[typing.Any], callback: event_manager_.CallbackT[typing.Any]) -> None:
         self._event_manager.unsubscribe(event_type, callback)

--- a/hikari/impl/event_manager_base.py
+++ b/hikari/impl/event_manager_base.py
@@ -97,7 +97,7 @@ class EventManagerBase(event_manager.EventManager):
         callback: event_manager.CallbackT[event_manager.EventT_co],
         *,
         _nested: int = 0,
-    ) -> event_manager.CallbackT[event_manager.EventT_co]:
+    ) -> None:
         if not issubclass(event_type, base_events.Event):
             raise TypeError("Cannot subscribe to a non-Event type")
 
@@ -120,8 +120,6 @@ class EventManagerBase(event_manager.EventManager):
         )
 
         self._listeners[event_type].append(callback)  # type: ignore[arg-type]
-
-        return callback
 
     def _check_intents(self, event_type: typing.Type[event_manager.EventT_co], nested: int) -> None:
         # Collection of combined bitfield combinations of intents that

--- a/tests/hikari/impl/test_event_manager_base.py
+++ b/tests/hikari/impl/test_event_manager_base.py
@@ -165,7 +165,7 @@ class TestEventManagerBase:
             ...
 
         with mock.patch.object(event_manager_base.EventManagerBase, "_check_intents") as check:
-            assert event_manager.subscribe(member_events.MemberCreateEvent, test, _nested=1) == test
+            event_manager.subscribe(member_events.MemberCreateEvent, test, _nested=1)
 
         assert event_manager._listeners == {member_events.MemberCreateEvent: [test]}
         check.assert_called_once_with(member_events.MemberCreateEvent, 1)
@@ -180,7 +180,7 @@ class TestEventManagerBase:
         event_manager._listeners[member_events.MemberCreateEvent] = [test2]
 
         with mock.patch.object(event_manager_base.EventManagerBase, "_check_intents") as check:
-            assert event_manager.subscribe(member_events.MemberCreateEvent, test, _nested=2) == test
+            event_manager.subscribe(member_events.MemberCreateEvent, test, _nested=2)
 
         assert event_manager._listeners == {member_events.MemberCreateEvent: [test2, test]}
         check.assert_called_once_with(member_events.MemberCreateEvent, 2)


### PR DESCRIPTION
### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
