### PR TITLE
Use Signature's eval_str argument in resolve_signature (3.10+ specific)

### DIFF
--- a/hikari/internal/reflect.py
+++ b/hikari/internal/reflect.py
@@ -28,6 +28,7 @@ __all__: typing.List[str] = ["resolve_signature"]
 
 import functools
 import inspect
+import sys
 import typing
 
 if typing.TYPE_CHECKING:
@@ -56,6 +57,9 @@ def resolve_signature(func: typing.Callable[..., typing.Any]) -> inspect.Signatu
         A `inspect.Signature` object with all forward reference annotations
         resolved.
     """
+    if sys.version_info >= (3, 10):
+        return inspect.signature(func, eval_str=True)
+
     signature = inspect.signature(func)
     resolved_typehints = typing.get_type_hints(func)
     params = []


### PR DESCRIPTION
### Summary
Use Signature's eval_str argument in resolve_signature (3.10+ specific)

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
