### PR TITLE
Improve typing/strictness of Emoji classes

### DIFF
--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -1573,8 +1573,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------------
         emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]]
             ID of the custom emoji to react with.
-            This should only be provided when the custom emoji's name is passed
-            for `emoji` as a `builtins.str`.
+            This should only be provided when a custom emoji's name is passed
+            for `emoji`.
 
         Raises
         ------
@@ -1628,8 +1628,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------------
         emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]]
             ID of the custom emoji to remove your reaction for.
-            This should only be provided when the custom emoji's name is passed
-            for `emoji` as a `builtins.str`.
+            This should only be provided when a custom emoji's name is passed
+            for `emoji`.
 
         Raises
         ------
@@ -1680,8 +1680,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------------
         emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]]
             ID of the custom emoji to remove all the reactions for.
-            This should only be provided when the custom emoji's name is passed
-            for `emoji` as a `builtins.str`.
+            This should only be provided when a custom emoji's name is passed
+            for `emoji`.
 
         Raises
         ------
@@ -1740,8 +1740,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------------
         emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]]
             ID of the custom emoji to react with.
-            This should only be provided when the custom emoji's name is passed
-            for `emoji` as a `builtins.str`.
+            This should only be provided when a custom emoji's name is passed
+            for `emoji`.
 
         Raises
         ------
@@ -1837,8 +1837,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------------
         emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]]
             ID of the custom emoji to get the reactions for.
-            This should only be provided when the custom emoji's name is passed
-            for `emoji` as a `builtins.str`.
+            This should only be provided when a custom emoji's name is passed
+            for `emoji`.
 
         Returns
         -------

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -1552,7 +1552,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         self,
         channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
-        emoji: emojis.Emojiish,
+        emoji: typing.Union[str, emojis.Emoji],
+        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.UnicodeEmoji]] = undefined.UNDEFINED,
     ) -> None:
         """Add a reaction emoji to a message in a given channel.
 
@@ -1565,8 +1566,15 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
             The message to add a reaction to. This may be the
             object or the ID of an existing message.
-        emoji : hikari.emojis.Emojiish
-            The emoji to react to the message with.
+        emoji : typing.Union[builtins.str, hikari.emojis.Emoji]
+            Object or name of the emoji to react with.
+
+        Other Parameters
+        ----------------
+        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.UnicodeEmoji]]
+            ID of the custom emoji to react with.
+            This should only be provided when the custom emoji's name is passed
+            for `emoji` as a `builtins.str`.
 
         Raises
         ------
@@ -1600,7 +1608,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         self,
         channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
-        emoji: emojis.Emojiish,
+        emoji: typing.Union[str, emojis.Emoji],
+        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.UnicodeEmoji]] = undefined.UNDEFINED,
     ) -> None:
         """Delete a reaction that your application user created.
 
@@ -1612,8 +1621,15 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
             The message to delete a reaction from. This may be the
             object or the ID of an existing message.
-        emoji : hikari.emojis.Emojiish
-            The emoji to remove your reaction from.
+        emoji : typing.Union[builtins.str, hikari.emojis.Emoji]
+            Object or name of the emoji to remove your reaction for.
+
+        Other Parameters
+        ----------------
+        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.UnicodeEmoji]]
+            ID of the custom emoji to remove your reaction for.
+            This should only be provided when the custom emoji's name is passed
+            for `emoji` as a `builtins.str`.
 
         Raises
         ------
@@ -1644,7 +1660,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         self,
         channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
-        emoji: emojis.Emojiish,
+        emoji: typing.Union[str, emojis.Emoji],
+        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.UnicodeEmoji]] = undefined.UNDEFINED,
     ) -> None:
         """Delete all reactions for a single emoji on a given message.
 
@@ -1656,8 +1673,15 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
             The message to delete a reactions from. This may be the
             object or the ID of an existing message.
-        emoji : hikari.emojis.Emojiish
-            The emoji to delete all reactions from.
+        emoji : typing.Union[builtins.str, hikari.emojis.Emoji]
+            Object or name of the emoji to remove all the reactions for.
+
+        Other Parameters
+        ----------------
+        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.UnicodeEmoji]]
+            ID of the custom emoji to remove all the reactions for.
+            This should only be provided when the custom emoji's name is passed
+            for `emoji` as a `builtins.str`.
 
         Raises
         ------
@@ -1690,8 +1714,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         self,
         channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
-        emoji: emojis.Emojiish,
         user: snowflakes.SnowflakeishOr[users.PartialUser],
+        emoji: typing.Union[str, emojis.Emoji],
+        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.UnicodeEmoji]] = undefined.UNDEFINED,
     ) -> None:
         """Delete a reaction from a message.
 
@@ -1706,8 +1731,17 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
             The message to delete a reaction from. This may be the
             object or the ID of an existing message.
-        emoji : hikari.emojis.Emojiish
-            The emoji to delete all reactions from.
+        user: hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+            Object or ID of the user to remove the reaction of.
+        emoji : typing.Union[builtins.str, hikari.emojis.Emoji]
+            Object or name of the emoji to react with.
+
+        Other Parameters
+        ----------------
+        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.UnicodeEmoji]]
+            ID of the custom emoji to react with.
+            This should only be provided when the custom emoji's name is passed
+            for `emoji` as a `builtins.str`.
 
         Raises
         ------
@@ -1783,7 +1817,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         self,
         channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
-        emoji: emojis.Emojiish,
+        emoji: typing.Union[str, emojis.Emoji],
+        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.UnicodeEmoji]] = undefined.UNDEFINED,
     ) -> iterators.LazyIterator[users.User]:
         """Fetch reactions for an emoji from a message.
 
@@ -1795,8 +1830,15 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
             The message to delete all reaction from. This may be the
             object or the ID of an existing message.
-        emoji : hikari.emojis.Emojiish
-            The emoji to filter reactions by.
+        emoji : typing.Union[builtins.str, hikari.emojis.Emoji]
+            Object or name of the emoji to get the reactions for.
+
+        Other Parameters
+        ----------------
+        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.UnicodeEmoji]]
+            ID of the custom emoji to get the reactions for.
+            This should only be provided when the custom emoji's name is passed
+            for `emoji` as a `builtins.str`.
 
         Returns
         -------

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -1553,7 +1553,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         emoji: typing.Union[str, emojis.Emoji],
-        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.UnicodeEmoji]] = undefined.UNDEFINED,
+        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.CustomEmoji]] = undefined.UNDEFINED,
     ) -> None:
         """Add a reaction emoji to a message in a given channel.
 
@@ -1571,7 +1571,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Other Parameters
         ----------------
-        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.UnicodeEmoji]]
+        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]]
             ID of the custom emoji to react with.
             This should only be provided when the custom emoji's name is passed
             for `emoji` as a `builtins.str`.
@@ -1609,7 +1609,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         emoji: typing.Union[str, emojis.Emoji],
-        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.UnicodeEmoji]] = undefined.UNDEFINED,
+        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.CustomEmoji]] = undefined.UNDEFINED,
     ) -> None:
         """Delete a reaction that your application user created.
 
@@ -1626,7 +1626,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Other Parameters
         ----------------
-        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.UnicodeEmoji]]
+        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]]
             ID of the custom emoji to remove your reaction for.
             This should only be provided when the custom emoji's name is passed
             for `emoji` as a `builtins.str`.
@@ -1661,7 +1661,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         emoji: typing.Union[str, emojis.Emoji],
-        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.UnicodeEmoji]] = undefined.UNDEFINED,
+        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.CustomEmoji]] = undefined.UNDEFINED,
     ) -> None:
         """Delete all reactions for a single emoji on a given message.
 
@@ -1678,7 +1678,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Other Parameters
         ----------------
-        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.UnicodeEmoji]]
+        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]]
             ID of the custom emoji to remove all the reactions for.
             This should only be provided when the custom emoji's name is passed
             for `emoji` as a `builtins.str`.
@@ -1716,7 +1716,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         user: snowflakes.SnowflakeishOr[users.PartialUser],
         emoji: typing.Union[str, emojis.Emoji],
-        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.UnicodeEmoji]] = undefined.UNDEFINED,
+        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.CustomEmoji]] = undefined.UNDEFINED,
     ) -> None:
         """Delete a reaction from a message.
 
@@ -1738,7 +1738,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Other Parameters
         ----------------
-        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.UnicodeEmoji]]
+        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]]
             ID of the custom emoji to react with.
             This should only be provided when the custom emoji's name is passed
             for `emoji` as a `builtins.str`.
@@ -1818,7 +1818,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         emoji: typing.Union[str, emojis.Emoji],
-        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.UnicodeEmoji]] = undefined.UNDEFINED,
+        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.CustomEmoji]] = undefined.UNDEFINED,
     ) -> iterators.LazyIterator[users.User]:
         """Fetch reactions for an emoji from a message.
 
@@ -1835,7 +1835,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Other Parameters
         ----------------
-        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.UnicodeEmoji]]
+        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]]
             ID of the custom emoji to get the reactions for.
             This should only be provided when the custom emoji's name is passed
             for `emoji` as a `builtins.str`.

--- a/hikari/emojis.py
+++ b/hikari/emojis.py
@@ -105,9 +105,7 @@ class Emoji(files.WebResource, abc.ABC):
         return UnicodeEmoji.parse(string)
 
 
-@attr_extensions.with_copy
-@attr.define(hash=True, weakref_slot=False)
-class UnicodeEmoji(Emoji):
+class UnicodeEmoji(str, Emoji):
     """Represents a unicode emoji.
 
     !!! warning
@@ -126,33 +124,27 @@ class UnicodeEmoji(Emoji):
         removed in a future release after a deprecation period.
     """
 
-    name: str = attr.field(repr=True, hash=True)
-    """The code points that form the emoji."""
+    __slots__: typing.Sequence[str] = []
 
-    def __str__(self) -> str:
-        return self.name
-
-    def __eq__(self, other: typing.Any) -> bool:
-        if isinstance(other, Emoji):
-            return self.name == other.name
-        if isinstance(other, str):
-            return self.name == other
-        return False
+    @property
+    def name(self) -> str:
+        """Return the code points which form the emoji."""
+        return self
 
     @property
     @typing.final
     def url_name(self) -> str:
-        return self.name
+        return self
 
     @property
     def mention(self) -> str:
-        return self.name
+        return self
 
     @property
     @typing.final
     def codepoints(self) -> typing.Sequence[int]:
         """Integer codepoints that make up this emoji, as UTF-8."""
-        return [ord(c) for c in self.name]
+        return [ord(c) for c in self]
 
     @property
     def filename(self) -> str:
@@ -198,25 +190,25 @@ class UnicodeEmoji(Emoji):
     #     This returns the name of each codepoint. If only one codepoint exists,
     #     then this will only have one item in the resulting sequence.
     #     """
-    #     return [unicodedata.name(c) for c in self.name]
+    #     return [unicodedata.name(c) for c in self]
 
     @property
     @typing.final
     def unicode_escape(self) -> str:
         """Get the unicode escape string for this emoji."""
-        return bytes(self.name, "unicode_escape").decode("utf-8")
+        return bytes(self, "unicode_escape").decode("utf-8")
 
     @classmethod
     @typing.final
     def parse_codepoints(cls, codepoint: int, *codepoints: int) -> UnicodeEmoji:
         """Create a unicode emoji from one or more UTF-32 codepoints."""
-        return cls(name="".join(map(chr, (codepoint, *codepoints))))
+        return cls("".join(map(chr, (codepoint, *codepoints))))
 
     @classmethod
     @typing.final
     def parse_unicode_escape(cls, escape: str) -> UnicodeEmoji:
         """Create a unicode emoji from a unicode escape string."""
-        return cls(name=str(escape.encode("utf-8"), "unicode_escape"))
+        return cls(escape.encode("utf-8"), "unicode_escape")
 
     @classmethod
     @typing.final
@@ -238,7 +230,7 @@ class UnicodeEmoji(Emoji):
         # for i, codepoint in enumerate(string, start=1):
         #     unicodedata.name(codepoint)
 
-        return cls(name=string)
+        return cls(string)
 
 
 @attr_extensions.with_copy
@@ -277,7 +269,7 @@ class CustomEmoji(snowflakes.Unique, Emoji):
     """Whether the emoji is animated."""
 
     def __str__(self) -> str:
-        return self.name
+        return self.mention
 
     @property
     def filename(self) -> str:

--- a/hikari/emojis.py
+++ b/hikari/emojis.py
@@ -124,7 +124,7 @@ class UnicodeEmoji(str, Emoji):
         removed in a future release after a deprecation period.
     """
 
-    __slots__: typing.Sequence[str] = []
+    __slots__: typing.Sequence[str] = ()
 
     @property
     def name(self) -> str:

--- a/hikari/emojis.py
+++ b/hikari/emojis.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["Emoji", "UnicodeEmoji", "CustomEmoji", "KnownCustomEmoji", "Emojiish"]
+__all__: typing.List[str] = ["Emoji", "UnicodeEmoji", "CustomEmoji", "KnownCustomEmoji"]
 
 import abc
 import re
@@ -362,17 +362,3 @@ class KnownCustomEmoji(CustomEmoji):
 
     May be `builtins.False` due to a loss of Sever Boosts on the emoji's guild.
     """
-
-
-Emojiish = typing.Union[str, Emoji]
-r"""Type hint representing a string emoji or an `Emoji`-derived object.
-
-Examples include:
-
-- Unicode emoji strings, such as `"\N{OK HAND SIGN}"`, `"\N{OK HAND SIGN}"`,
-    `"\U0001f44c"`.
-- Custom emoji names in the format `name:id`, such as
-    `"rosaThonk:733073048646713364"`.
-- Derivative instances of `Emoji`, i.e. `UnicodeEmoji`, `CustomEmoji` and
-    `KnownCustomEmoji`.
-"""

--- a/hikari/emojis.py
+++ b/hikari/emojis.py
@@ -302,6 +302,23 @@ class CustomEmoji(snowflakes.Unique, Emoji):
 
     @classmethod
     def parse(cls, string: str, /) -> CustomEmoji:
+        """Parse a given emoji mention string into a custom emoji object.
+
+        Parameters
+        ----------
+        string : builtins.str
+            The emoji mention to parse.
+
+        Returns
+        -------
+        CustomEmoji
+            The parsed emoji object.
+
+        Raises
+        ------
+        builtins.ValueError
+            If a mention is given that has an invalid format.
+        """
         if emoji_match := _CUSTOM_EMOJI_REGEX.match(string):
             return CustomEmoji(
                 id=snowflakes.Snowflake(emoji_match.group("id")),

--- a/hikari/events/reaction_events.py
+++ b/hikari/events/reaction_events.py
@@ -133,14 +133,41 @@ class ReactionAddEvent(ReactionEvent, abc.ABC):
 
     @property
     @abc.abstractmethod
-    def emoji(self) -> emojis.Emoji:
-        """Emoji that was added.
+    def emoji_name(self) -> typing.Union[emojis.UnicodeEmoji, str, None]:
+        """Name of the emoji which was added if known.
+
+        !!! note
+            This will be `builtins.None` when the relevant custom emoji's data
+            is not available (e.g. the emoji has been deleted).
 
         Returns
         -------
-        hikari.emojis.Emoji
-            The `hikari.emojis.UnicodeEmoji` or
-            `hikari.emojis.CustomEmoji` that was added to the message.
+        typing.Union[hikari.emojis.UnicodeEmoji, builtins.str, builtins.None]
+            Either the string name of the custom emoji which was added
+            or the object of the `hikari.emojis.UnicodeEmoji` which was added.
+        """
+
+    @property
+    @abc.abstractmethod
+    def emoji_id(self) -> typing.Optional[snowflakes.Snowflake]:
+        """ID of the emoji which was added if it is custom.
+
+        Returns
+        -------
+        typing.Optional[hikari.snowflakes.Snowflake]
+            ID of the emoji which was added if it was a custom emoji or
+            `builtins.None`.
+        """
+
+    @property
+    @abc.abstractmethod
+    def is_animated(self) -> bool:
+        """Whether the emoji which was added is animated.
+
+        Returns
+        -------
+        builtins.bool
+            Whether the emoji which was added is animated.
         """
 
 
@@ -163,15 +190,30 @@ class ReactionDeleteEvent(ReactionEvent, abc.ABC):
 
     @property
     @abc.abstractmethod
-    def emoji(self) -> emojis.Emoji:
-        """Emoji that was removed.
+    def emoji_name(self) -> typing.Union[emojis.UnicodeEmoji, str, None]:
+        """Name of the emoji which was removed.
+
+        !!! note
+            This will be `builtins.None` when the relevant custom emoji's data
+            is not available (e.g. the emoji has been deleted).
 
         Returns
         -------
-        hikari.emojis.Emoji
-            The `hikari.emojis.UnicodeEmoji` or
-            `hikari.emojis.CustomEmoji` that was removed from the
-            message.
+        typing.Union[hikari.emojis.UnicodeEmoji, builtins.str, builtins.None]
+            Either the string name of the custom emoji which was removed
+            or the object of the `hikari.emojis.UnicodeEmoji` which was removed.
+        """
+
+    @property
+    @abc.abstractmethod
+    def emoji_id(self) -> typing.Optional[snowflakes.Snowflake]:
+        """ID of the emoji which was removed if it was custom.
+
+        Returns
+        -------
+        typing.Optional[hikari.snowflakes.Snowflake]
+            ID of the emoji which was removed if it was a custom emoji or
+            `builtins.None`.
         """
 
 
@@ -190,15 +232,30 @@ class ReactionDeleteEmojiEvent(ReactionEvent, abc.ABC):
 
     @property
     @abc.abstractmethod
-    def emoji(self) -> emojis.Emoji:
-        """Emoji that was removed.
+    def emoji_name(self) -> typing.Union[emojis.UnicodeEmoji, str, None]:
+        """Name of the emoji which was removed if known.
+
+        !!! note
+            This will be `builtins.None` when the relevant custom emoji's data
+            is not available (e.g. the emoji has been deleted).
 
         Returns
         -------
-        hikari.emojis.Emoji
-            The `hikari.emojis.UnicodeEmoji` or
-            `hikari.emojis.CustomEmoji` that was removed from the
-            message.
+        typing.Union[hikari.emojis.UnicodeEmoji, builtins.str, builtins.None]
+            Either the string name of the custom emoji which was removed
+            or the object of the `hikari.emojis.UnicodeEmoji` which was removed.
+        """
+
+    @property
+    @abc.abstractmethod
+    def emoji_id(self) -> typing.Optional[snowflakes.Snowflake]:
+        """ID of the emoji which was removed if it was custom.
+
+        Returns
+        -------
+        typing.Optional[hikari.snowflakes.Snowflake]
+            ID of the emoji which was removed if it was a custom emoji or
+            `builtins.None`.
         """
 
 
@@ -226,7 +283,13 @@ class GuildReactionAddEvent(GuildReactionEvent, ReactionAddEvent):
     message_id: snowflakes.Snowflake = attr.field()
     # <<inherited docstring from ReactionEvent>>.
 
-    emoji: emojis.Emoji = attr.field()
+    emoji_name: typing.Union[str, emojis.UnicodeEmoji, None] = attr.field()
+    # <<inherited docstring from ReactionAddEvent>>.
+
+    emoji_id: typing.Optional[snowflakes.Snowflake] = attr.field()
+    # <<inherited docstring from ReactionAddEvent>>.
+
+    is_animated: bool = attr.field()
     # <<inherited docstring from ReactionAddEvent>>.
 
     @property
@@ -258,7 +321,7 @@ class GuildReactionDeleteEvent(GuildReactionEvent, ReactionDeleteEvent):
     # <<inherited docstring from ShardEvent>>.
 
     user_id: snowflakes.Snowflake = attr.field()
-    # <<inherited docstring from ReactionAddEvent>>.
+    # <<inherited docstring from ReactionDeleteEvent>>.
 
     guild_id: snowflakes.Snowflake = attr.field()
     # <<inherited docstring from GuildReactionEvent>>.
@@ -269,7 +332,10 @@ class GuildReactionDeleteEvent(GuildReactionEvent, ReactionDeleteEvent):
     message_id: snowflakes.Snowflake = attr.field()
     # <<inherited docstring from ReactionEvent>>.
 
-    emoji: emojis.Emoji = attr.field()
+    emoji_name: typing.Union[str, emojis.UnicodeEmoji, None] = attr.field()
+    # <<inherited docstring from ReactionDeleteEvent>>.
+
+    emoji_id: typing.Optional[snowflakes.Snowflake] = attr.field()
     # <<inherited docstring from ReactionDeleteEvent>>.
 
 
@@ -294,7 +360,10 @@ class GuildReactionDeleteEmojiEvent(GuildReactionEvent, ReactionDeleteEmojiEvent
     message_id: snowflakes.Snowflake = attr.field()
     # <<inherited docstring from ReactionEvent>>.
 
-    emoji: emojis.Emoji = attr.field()
+    emoji_name: typing.Union[str, emojis.UnicodeEmoji, None] = attr.field()
+    # <<inherited docstring from ReactionDeleteEmojiEvent>>.
+
+    emoji_id: typing.Optional[snowflakes.Snowflake] = attr.field()
     # <<inherited docstring from ReactionDeleteEmojiEvent>>.
 
 
@@ -341,7 +410,13 @@ class DMReactionAddEvent(DMReactionEvent, ReactionAddEvent):
     message_id: snowflakes.Snowflake = attr.field()
     # <<inherited docstring from ReactionEvent>>.
 
-    emoji: emojis.Emoji = attr.field()
+    emoji_name: typing.Union[str, emojis.UnicodeEmoji, None] = attr.field()
+    # <<inherited docstring from ReactionAddEvent>>.
+
+    emoji_id: typing.Optional[snowflakes.Snowflake] = attr.field()
+    # <<inherited docstring from ReactionAddEvent>>.
+
+    is_animated: bool = attr.field()
     # <<inherited docstring from ReactionAddEvent>>.
 
 
@@ -358,7 +433,7 @@ class DMReactionDeleteEvent(DMReactionEvent, ReactionDeleteEvent):
     # <<inherited docstring from ShardEvent>>.
 
     user_id: snowflakes.Snowflake = attr.field()
-    # <<inherited docstring from ReactionAddEvent>>.
+    # <<inherited docstring from ReactionDeleteEvent>>.
 
     channel_id: snowflakes.Snowflake = attr.field()
     # <<inherited docstring from ReactionEvent>>.
@@ -366,7 +441,10 @@ class DMReactionDeleteEvent(DMReactionEvent, ReactionDeleteEvent):
     message_id: snowflakes.Snowflake = attr.field()
     # <<inherited docstring from ReactionEvent>>.
 
-    emoji: emojis.Emoji = attr.field()
+    emoji_name: typing.Union[str, emojis.UnicodeEmoji, None] = attr.field()
+    # <<inherited docstring from ReactionDeleteEvent>>.
+
+    emoji_id: typing.Optional[snowflakes.Snowflake] = attr.field()
     # <<inherited docstring from ReactionDeleteEvent>>.
 
 
@@ -388,7 +466,10 @@ class DMReactionDeleteEmojiEvent(DMReactionEvent, ReactionDeleteEmojiEvent):
     message_id: snowflakes.Snowflake = attr.field()
     # <<inherited docstring from ReactionEvent>>.
 
-    emoji: emojis.Emoji = attr.field()
+    emoji_name: typing.Union[str, emojis.UnicodeEmoji, None] = attr.field()
+    # <<inherited docstring from ReactionDeleteEmojiEvent>>.
+
+    emoji_id: typing.Optional[snowflakes.Snowflake] = attr.field()
     # <<inherited docstring from ReactionDeleteEmojiEvent>>.
 
 

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -1191,8 +1191,8 @@ class WelcomeChannel:
     """The emoji shown in the welcome screen channel if set to a unicode emoji.
 
     !!! warning
-        While this may also be provided for custom emojis, it isn't guaranteed and
-        may also sometimes even be wrong for custom emojis.
+        While it may also be present for custom emojis, this is neither guaranteed
+        to be provided nor accurate.
     """
 
     emoji_id: typing.Optional[snowflakes.Snowflake] = attr.field(default=None, kw_only=True, hash=False, repr=True)

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -1185,8 +1185,18 @@ class WelcomeChannel:
     description: str = attr.field(hash=False, repr=False)
     """The description shown for this channel."""
 
-    emoji: typing.Optional[emojis_.Emoji] = attr.field(default=None, kw_only=True, hash=False, repr=True)
-    """The emoji shown in the welcome screen channel if set else `builtins.None`."""
+    emoji_name: typing.Union[str, emojis_.UnicodeEmoji, None] = attr.field(
+        default=None, kw_only=True, hash=False, repr=True
+    )
+    """The emoji shown in the welcome screen channel if set to a unicode emoji.
+
+    !!! warning
+        While this may also be provided for custom emojis, it isn't guaranteed and
+        may also sometimes even be wrong for custom emojis.
+    """
+
+    emoji_id: typing.Optional[snowflakes.Snowflake] = attr.field(default=None, kw_only=True, hash=False, repr=True)
+    """ID of the emoji shown in the welcome screen channel if it's set to a custom emoji."""
 
 
 @attr_extensions.with_copy

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -1103,9 +1103,8 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             emoji_id = snowflakes.Snowflake(raw_emoji_id) if raw_emoji_id else None
 
             emoji_name: typing.Union[None, emoji_models.UnicodeEmoji, str]
-            if emoji_name := channel_payload["emoji_name"]:
-                if not emoji_id:
-                    emoji_name = emoji_models.UnicodeEmoji(emoji_name)
+            if (emoji_name := channel_payload["emoji_name"]) and not emoji_id:
+                emoji_name = emoji_models.UnicodeEmoji(emoji_name)
 
             channels.append(
                 guild_models.WelcomeChannel(

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -1100,16 +1100,12 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
 
         for channel_payload in payload["welcome_channels"]:
             raw_emoji_id = channel_payload["emoji_id"]
-            emoji_name: typing.Union[str, emoji_models.UnicodeEmoji, None] = None
-            raw_emoji_name = channel_payload["emoji_name"]
-            emoji_id = None
+            emoji_id = snowflakes.Snowflake(raw_emoji_id) if raw_emoji_id else None
 
-            if raw_emoji_name is not None:
-                if raw_emoji_id is not None:
-                    emoji_id = snowflakes.Snowflake(raw_emoji_id)
-                    emoji_name = raw_emoji_name
-                else:
-                    emoji_name = emoji_models.UnicodeEmoji(raw_emoji_name)
+            emoji_name: typing.Union[None, emoji_models.UnicodeEmoji, str]
+            if emoji_name := channel_payload["emoji_name"]:
+                if not emoji_id:
+                    emoji_name = emoji_models.UnicodeEmoji(emoji_name)
 
             channels.append(
                 guild_models.WelcomeChannel(

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -1025,7 +1025,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
     ################
 
     def deserialize_unicode_emoji(self, payload: data_binding.JSONObject) -> emoji_models.UnicodeEmoji:
-        return emoji_models.UnicodeEmoji(name=payload["name"])
+        return emoji_models.UnicodeEmoji(payload["name"])
 
     def deserialize_custom_emoji(self, payload: data_binding.JSONObject) -> emoji_models.CustomEmoji:
         return emoji_models.CustomEmoji(

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -1125,7 +1125,6 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
 
         if welcome_channel.emoji_id is not None:
             payload["emoji_id"] = str(welcome_channel.emoji_id)
-            # TODO: do we need to include the name in this scenario?
 
         elif welcome_channel.emoji_name is not None:
             payload["emoji_name"] = str(welcome_channel.emoji_name)

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -1524,7 +1524,7 @@ class RESTClientImpl(rest_api.RESTClient):
     @staticmethod
     def _transform_emoji_to_url_format(
         emoji: typing.Union[str, emojis.Emoji],
-        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.UnicodeEmoji]],
+        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.CustomEmoji]],
         /,
     ) -> str:
         if isinstance(emoji, emojis.Emoji):
@@ -1543,7 +1543,7 @@ class RESTClientImpl(rest_api.RESTClient):
         channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         emoji: typing.Union[str, emojis.Emoji],
-        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.UnicodeEmoji]] = undefined.UNDEFINED,
+        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.CustomEmoji]] = undefined.UNDEFINED,
     ) -> None:
         route = routes.PUT_MY_REACTION.compile(
             emoji=self._transform_emoji_to_url_format(emoji, emoji_id),
@@ -1557,7 +1557,7 @@ class RESTClientImpl(rest_api.RESTClient):
         channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         emoji: typing.Union[str, emojis.Emoji],
-        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.UnicodeEmoji]] = undefined.UNDEFINED,
+        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.CustomEmoji]] = undefined.UNDEFINED,
     ) -> None:
         route = routes.DELETE_MY_REACTION.compile(
             emoji=self._transform_emoji_to_url_format(emoji, emoji_id),
@@ -1571,7 +1571,7 @@ class RESTClientImpl(rest_api.RESTClient):
         channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         emoji: typing.Union[str, emojis.Emoji],
-        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.UnicodeEmoji]] = undefined.UNDEFINED,
+        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.CustomEmoji]] = undefined.UNDEFINED,
     ) -> None:
         route = routes.DELETE_REACTION_EMOJI.compile(
             emoji=self._transform_emoji_to_url_format(emoji, emoji_id),
@@ -1586,7 +1586,7 @@ class RESTClientImpl(rest_api.RESTClient):
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         user: snowflakes.SnowflakeishOr[users.PartialUser],
         emoji: typing.Union[str, emojis.Emoji],
-        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.UnicodeEmoji]] = undefined.UNDEFINED,
+        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.CustomEmoji]] = undefined.UNDEFINED,
     ) -> None:
         route = routes.DELETE_REACTION_USER.compile(
             emoji=self._transform_emoji_to_url_format(emoji, emoji_id),
@@ -1609,7 +1609,7 @@ class RESTClientImpl(rest_api.RESTClient):
         channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         emoji: typing.Union[str, emojis.Emoji],
-        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.UnicodeEmoji]] = undefined.UNDEFINED,
+        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.CustomEmoji]] = undefined.UNDEFINED,
     ) -> iterators.LazyIterator[users.User]:
         return special_endpoints_impl.ReactorIterator(
             entity_factory=self._entity_factory,

--- a/hikari/internal/cache.py
+++ b/hikari/internal/cache.py
@@ -453,7 +453,7 @@ class KnownCustomEmojiData(BaseData[emojis.KnownCustomEmoji]):
     """A data model for storing known custom emoji data in an in-memory cache."""
 
     id: snowflakes.Snowflake = attr.field()
-    name: typing.Optional[str] = attr.field()
+    name: str = attr.field()
     is_animated: bool = attr.field()
     guild_id: snowflakes.Snowflake = attr.field()
     role_ids: typing.Tuple[snowflakes.Snowflake, ...] = attr.field()

--- a/hikari/messages.py
+++ b/hikari/messages.py
@@ -1080,18 +1080,45 @@ class PartialMessage(snowflakes.Unique):
         """
         await self.app.rest.delete_message(self.channel_id, self.id)
 
-    async def add_reaction(self, emoji: emojis_.Emojiish) -> None:
+    @typing.overload
+    async def add_reaction(
+        self,
+        emoji: typing.Union[str, emojis_.Emoji],
+    ) -> None:
+        ...
+
+    @typing.overload
+    async def add_reaction(
+        self,
+        emoji: str,
+        emoji_id: snowflakes.SnowflakeishOr[emojis_.UnicodeEmoji],
+    ) -> None:
+        ...
+
+    async def add_reaction(
+        self,
+        emoji: typing.Union[str, emojis_.Emoji],
+        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis_.UnicodeEmoji]] = undefined.UNDEFINED,
+    ) -> None:
         r"""Add a reaction to this message.
 
         Parameters
         ----------
-        emoji : hikari.emojis.Emojiish
-            The emoji to add. This may be a unicode emoji string, the
-            `name:id` of a custom emoji, or a subclass of
-            `hikari.emojis.Emoji`.
+        emoji: typing.Union[builtins.str, hikari.emojis.Emoji]
+            Object or name of the emoji to react with.
 
             Note that if the emoji is an `hikari.emojis.CustomEmoji`
             and is not from a guild the bot user is in, then this will fail.
+
+        Other Parameters
+        ----------------
+        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.UnicodeEmoji]]
+            ID of the custom emoji to react with.
+            This should only be provided when the custom emoji's name is passed
+            for `emoji` as a `builtins.str`.
+
+            Note that this will fail if the emoji is from a guild the bot isn't
+            in.
 
         Examples
         --------
@@ -1102,12 +1129,8 @@ class PartialMessage(snowflakes.Unique):
         # Using a unicode emoji name.
         await message.add_reaction("\N{OK HAND SIGN}")
 
-        # Using the `name:id` format.
-        await message.add_reaction("rooAYAYA:705837374319493284")
-
-        # Using a raw custom emoji mention (unanimated and animated)
-        await message.add_reaction("<:rooAYAYA:705837374319493284>")
-        await message.add_reaction("<a:rooAYAYA:705837374319493284>")
+        # Using the name and id.
+        await message.add_reaction("rooAYAYA", 705837374319493284)
 
         # Using an Emoji-derived object.
         await message.add_reaction(some_emoji_object)
@@ -1129,11 +1152,31 @@ class PartialMessage(snowflakes.Unique):
             guild you are not part of if no one else has previously
             reacted with the same emoji.
         """
-        await self.app.rest.add_reaction(channel=self.channel_id, message=self.id, emoji=emoji)
+        await self.app.rest.add_reaction(channel=self.channel_id, message=self.id, emoji=emoji, emoji_id=emoji_id)
+
+    @typing.overload
+    async def remove_reaction(
+        self,
+        emoji: typing.Union[str, emojis_.Emoji],
+        *,
+        user: undefined.UndefinedOr[snowflakes.SnowflakeishOr[users_.PartialUser]] = undefined.UNDEFINED,
+    ) -> None:
+        ...
+
+    @typing.overload
+    async def remove_reaction(
+        self,
+        emoji: str,
+        emoji_id: snowflakes.SnowflakeishOr[emojis_.UnicodeEmoji],
+        *,
+        user: undefined.UndefinedOr[snowflakes.SnowflakeishOr[users_.PartialUser]] = undefined.UNDEFINED,
+    ) -> None:
+        ...
 
     async def remove_reaction(
         self,
-        emoji: emojis_.Emojiish,
+        emoji: typing.Union[str, emojis_.Emoji],
+        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis_.UnicodeEmoji]] = undefined.UNDEFINED,
         *,
         user: undefined.UndefinedOr[snowflakes.SnowflakeishOr[users_.PartialUser]] = undefined.UNDEFINED,
     ) -> None:
@@ -1141,11 +1184,15 @@ class PartialMessage(snowflakes.Unique):
 
         Parameters
         ----------
-        emoji : hikari.emojis.Emojiish
-            The emoji to remove.
+        emoji : typing.Union[builtins.str, hikari.emojis.Emoji]
+            Object or name of the emoji to remove the reaction for.
 
         Other Parameters
         ----------------
+        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.UnicodeEmoji]]
+            ID of the custom emoji to remove the reaction for.
+            This should only be provided when the custom emoji's name is passed
+            for `emoji` as a `builtins.str`.
         user : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]]
             The user of the reaction to remove. If unspecified, then the bot's
             reaction is removed instead.
@@ -1160,9 +1207,8 @@ class PartialMessage(snowflakes.Unique):
             # reaction.
             await message.remove_reaction("\N{OK HAND SIGN}", some_user)
 
-            # Using a raw custom emoji mention (unanimated and animated)
-            await message.remove_reaction("<:rooAYAYA:705837374319493284>", some_user)
-            await message.remove_reaction("<a:rooAYAYA:705837374319493284>", some_user)
+            # Using the name and id.
+            await message.add_reaction("rooAYAYA", 705837374319493284)
 
             # Using an Emoji object and removing a specific user from this
             # reaction.
@@ -1185,18 +1231,49 @@ class PartialMessage(snowflakes.Unique):
             found.
         """
         if user is undefined.UNDEFINED:
-            await self.app.rest.delete_my_reaction(channel=self.channel_id, message=self.id, emoji=emoji)
+            await self.app.rest.delete_my_reaction(
+                channel=self.channel_id, message=self.id, emoji=emoji, emoji_id=emoji_id
+            )
         else:
-            await self.app.rest.delete_reaction(channel=self.channel_id, message=self.id, emoji=emoji, user=user)
+            await self.app.rest.delete_reaction(
+                channel=self.channel_id, message=self.id, emoji=emoji, emoji_id=emoji_id, user=user
+            )
 
-    async def remove_all_reactions(self, emoji: undefined.UndefinedOr[emojis_.Emojiish] = undefined.UNDEFINED) -> None:
+    @typing.overload
+    async def remove_all_reactions(self) -> None:
+        ...
+
+    @typing.overload
+    async def remove_all_reactions(
+        self,
+        emoji: typing.Union[str, emojis_.Emoji],
+    ) -> None:
+        ...
+
+    @typing.overload
+    async def remove_all_reactions(
+        self,
+        emoji: typing.Union[str, emojis_.UnicodeEmoji],
+        emoji_id: snowflakes.SnowflakeishOr[emojis_.UnicodeEmoji],
+    ) -> None:
+        ...
+
+    async def remove_all_reactions(
+        self,
+        emoji: undefined.UndefinedOr[typing.Union[str, emojis_.Emoji]] = undefined.UNDEFINED,
+        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis_.UnicodeEmoji]] = undefined.UNDEFINED,
+    ) -> None:
         r"""Remove all users' reactions for a specific emoji from the message.
 
         Other Parameters
         ----------------
-        emoji : hikari.undefined.UndefinedOr[hikari.emojis.Emojiish]
-            The emoji to remove all reactions for. If not specified, then all
-            emojis are removed.
+        emoji : hikari.undefined.UndefinedOr[typing.Union[builtins.str, hikari.emojis.Emoji]]
+            Object or name of the emoji to get the reactions for. If not specified
+            then all reactions are removed.
+        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.UnicodeEmoji]]
+            ID of the custom emoji to react with.
+            This should only be provided when the custom emoji's name is passed
+            for `emoji` as a `builtins.str`.
 
         Example
         --------
@@ -1204,9 +1281,8 @@ class PartialMessage(snowflakes.Unique):
             # reaction.
             await message.remove_all_reactions("\N{OK HAND SIGN}")
 
-            # Using a raw custom emoji mention (unanimated and animated)
-            await message.remove_all_reactions("<:rooAYAYA:705837374319493284>")
-            await message.remove_all_reactions("<a:rooAYAYA:705837374319493284>")
+            # Using the name and id.
+            await message.add_reaction("rooAYAYA", 705837374319493284)
 
             # Removing all reactions entirely.
             await message.remove_all_reactions()
@@ -1227,7 +1303,9 @@ class PartialMessage(snowflakes.Unique):
         if emoji is undefined.UNDEFINED:
             await self.app.rest.delete_all_reactions(channel=self.channel_id, message=self.id)
         else:
-            await self.app.rest.delete_all_reactions_for_emoji(channel=self.channel_id, message=self.id, emoji=emoji)
+            await self.app.rest.delete_all_reactions_for_emoji(
+                channel=self.channel_id, message=self.id, emoji=emoji, emoji_id=emoji_id
+            )
 
 
 @attr.define(hash=True, kw_only=True, weakref_slot=False, auto_attribs=False)

--- a/hikari/messages.py
+++ b/hikari/messages.py
@@ -1091,14 +1091,14 @@ class PartialMessage(snowflakes.Unique):
     async def add_reaction(
         self,
         emoji: str,
-        emoji_id: snowflakes.SnowflakeishOr[emojis_.UnicodeEmoji],
+        emoji_id: snowflakes.SnowflakeishOr[emojis_.CustomEmoji],
     ) -> None:
         ...
 
     async def add_reaction(
         self,
         emoji: typing.Union[str, emojis_.Emoji],
-        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis_.UnicodeEmoji]] = undefined.UNDEFINED,
+        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis_.CustomEmoji]] = undefined.UNDEFINED,
     ) -> None:
         r"""Add a reaction to this message.
 
@@ -1112,7 +1112,7 @@ class PartialMessage(snowflakes.Unique):
 
         Other Parameters
         ----------------
-        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.UnicodeEmoji]]
+        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]]
             ID of the custom emoji to react with.
             This should only be provided when the custom emoji's name is passed
             for `emoji` as a `builtins.str`.
@@ -1167,7 +1167,7 @@ class PartialMessage(snowflakes.Unique):
     async def remove_reaction(
         self,
         emoji: str,
-        emoji_id: snowflakes.SnowflakeishOr[emojis_.UnicodeEmoji],
+        emoji_id: snowflakes.SnowflakeishOr[emojis_.CustomEmoji],
         *,
         user: undefined.UndefinedOr[snowflakes.SnowflakeishOr[users_.PartialUser]] = undefined.UNDEFINED,
     ) -> None:
@@ -1176,7 +1176,7 @@ class PartialMessage(snowflakes.Unique):
     async def remove_reaction(
         self,
         emoji: typing.Union[str, emojis_.Emoji],
-        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis_.UnicodeEmoji]] = undefined.UNDEFINED,
+        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis_.CustomEmoji]] = undefined.UNDEFINED,
         *,
         user: undefined.UndefinedOr[snowflakes.SnowflakeishOr[users_.PartialUser]] = undefined.UNDEFINED,
     ) -> None:
@@ -1189,7 +1189,7 @@ class PartialMessage(snowflakes.Unique):
 
         Other Parameters
         ----------------
-        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.UnicodeEmoji]]
+        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]]
             ID of the custom emoji to remove the reaction for.
             This should only be provided when the custom emoji's name is passed
             for `emoji` as a `builtins.str`.
@@ -1253,15 +1253,15 @@ class PartialMessage(snowflakes.Unique):
     @typing.overload
     async def remove_all_reactions(
         self,
-        emoji: typing.Union[str, emojis_.UnicodeEmoji],
-        emoji_id: snowflakes.SnowflakeishOr[emojis_.UnicodeEmoji],
+        emoji: str,
+        emoji_id: snowflakes.SnowflakeishOr[emojis_.CustomEmoji],
     ) -> None:
         ...
 
     async def remove_all_reactions(
         self,
         emoji: undefined.UndefinedOr[typing.Union[str, emojis_.Emoji]] = undefined.UNDEFINED,
-        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis_.UnicodeEmoji]] = undefined.UNDEFINED,
+        emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis_.CustomEmoji]] = undefined.UNDEFINED,
     ) -> None:
         r"""Remove all users' reactions for a specific emoji from the message.
 
@@ -1270,7 +1270,7 @@ class PartialMessage(snowflakes.Unique):
         emoji : hikari.undefined.UndefinedOr[typing.Union[builtins.str, hikari.emojis.Emoji]]
             Object or name of the emoji to get the reactions for. If not specified
             then all reactions are removed.
-        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.UnicodeEmoji]]
+        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]]
             ID of the custom emoji to react with.
             This should only be provided when the custom emoji's name is passed
             for `emoji` as a `builtins.str`.

--- a/hikari/messages.py
+++ b/hikari/messages.py
@@ -1114,8 +1114,8 @@ class PartialMessage(snowflakes.Unique):
         ----------------
         emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]]
             ID of the custom emoji to react with.
-            This should only be provided when the custom emoji's name is passed
-            for `emoji` as a `builtins.str`.
+            This should only be provided when a custom emoji's name is passed
+            for `emoji`.
 
             Note that this will fail if the emoji is from a guild the bot isn't
             in.
@@ -1191,8 +1191,8 @@ class PartialMessage(snowflakes.Unique):
         ----------------
         emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]]
             ID of the custom emoji to remove the reaction for.
-            This should only be provided when the custom emoji's name is passed
-            for `emoji` as a `builtins.str`.
+            This should only be provided when a custom emoji's name is passed
+            for `emoji`.
         user : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]]
             The user of the reaction to remove. If unspecified, then the bot's
             reaction is removed instead.
@@ -1272,8 +1272,8 @@ class PartialMessage(snowflakes.Unique):
             then all reactions are removed.
         emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]]
             ID of the custom emoji to react with.
-            This should only be provided when the custom emoji's name is passed
-            for `emoji` as a `builtins.str`.
+            This should only be provided when a custom emoji's name is passed
+            for `emoji`.
 
         Example
         --------

--- a/tests/hikari/events/test_reaction_events.py
+++ b/tests/hikari/events/test_reaction_events.py
@@ -31,7 +31,6 @@ class TestGuildReactionAddEvent:
     @pytest.fixture()
     def event(self):
         return reaction_events.GuildReactionAddEvent(
-
             shard=object(),
             member=mock.MagicMock(guilds.Member),
             channel_id=123,

--- a/tests/hikari/events/test_reaction_events.py
+++ b/tests/hikari/events/test_reaction_events.py
@@ -31,7 +31,14 @@ class TestGuildReactionAddEvent:
     @pytest.fixture()
     def event(self):
         return reaction_events.GuildReactionAddEvent(
-            shard=object(), member=mock.MagicMock(guilds.Member), channel_id=123, message_id=456, emoji="👌"
+
+            shard=object(),
+            member=mock.MagicMock(guilds.Member),
+            channel_id=123,
+            message_id=456,
+            emoji_name="👌",
+            emoji_id=None,
+            is_animated=False,
         )
 
     def test_app_property(self, event):

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -1821,33 +1821,41 @@ class TestEntityFactoryImpl:
 
         assert welcome_screen.channels[0].channel_id == 87656344532234
         assert welcome_screen.channels[0].description == "Follow for nothing"
-        assert isinstance(welcome_screen.channels[0].emoji, emoji_models.UnicodeEmoji)
-        assert welcome_screen.channels[0].emoji.name == "📡"
-        assert isinstance(welcome_screen.channels[1].emoji, emoji_models.CustomEmoji)
-        assert welcome_screen.channels[1].emoji.name == "dogGoesMeow"
-        assert welcome_screen.channels[1].emoji.id == 31231351234
-        assert welcome_screen.channels[1].emoji.is_animated is None
+
+        assert isinstance(welcome_screen.channels[0].emoji_name, emoji_models.UnicodeEmoji)
+        assert welcome_screen.channels[0].emoji_name == "📡"
+        assert welcome_screen.channels[0].emoji_id is None
+
+        assert not isinstance(welcome_screen.channels[1].emoji_name, emoji_models.UnicodeEmoji)
+        assert welcome_screen.channels[1].emoji_name == "dogGoesMeow"
+        assert welcome_screen.channels[1].emoji_id == 31231351234
 
     def test_serialize_welcome_channel_with_custom_emoji(self, entity_factory_impl, mock_app):
         channel = guild_models.WelcomeChannel(
             channel_id=snowflakes.Snowflake(431231),
             description="meow",
-            emoji=emoji_models.CustomEmoji(id=snowflakes.Snowflake(564123), name="boom", is_animated=None),
+            emoji_id=snowflakes.Snowflake(564123),
+            emoji_name="boom",
         )
         result = entity_factory_impl.serialize_welcome_channel(channel)
 
-        assert result == {"channel_id": "431231", "description": "meow", "emoji_id": "564123", "emoji_name": "boom"}
+        assert result == {"channel_id": "431231", "description": "meow", "emoji_id": "564123"}
 
     def test_serialize_welcome_channel_with_unicode_emoji(self, entity_factory_impl, mock_app):
         channel = guild_models.WelcomeChannel(
-            channel_id=snowflakes.Snowflake(4312311), description="meow1", emoji=emoji_models.UnicodeEmoji("a")
+            channel_id=snowflakes.Snowflake(4312311),
+            description="meow1",
+            emoji_name=emoji_models.UnicodeEmoji("a"),
+            emoji_id=None,
         )
         result = entity_factory_impl.serialize_welcome_channel(channel)
 
         assert result == {"channel_id": "4312311", "description": "meow1", "emoji_name": "a"}
 
     def test_serialize_welcome_channel_with_no_emoji(self, entity_factory_impl, mock_app):
-        channel = guild_models.WelcomeChannel(channel_id=snowflakes.Snowflake(4312312), description="meow2", emoji=None)
+        channel = guild_models.WelcomeChannel(
+            channel_id=snowflakes.Snowflake(4312312), description="meow2", emoji_id=None, emoji_name=None
+        )
         result = entity_factory_impl.serialize_welcome_channel(channel)
 
         assert result == {"channel_id": "4312312", "description": "meow2"}

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -1811,6 +1811,7 @@ class TestEntityFactoryImpl:
                     "emoji_id": None,
                     "emoji_name": None,
                 },
+                {"channel_id": "92929292929", "description": "hi there", "emoji_id": "49494949", "emoji_name": None},
             ],
         }
 
@@ -1829,6 +1830,12 @@ class TestEntityFactoryImpl:
         assert not isinstance(welcome_screen.channels[1].emoji_name, emoji_models.UnicodeEmoji)
         assert welcome_screen.channels[1].emoji_name == "dogGoesMeow"
         assert welcome_screen.channels[1].emoji_id == 31231351234
+
+        assert welcome_screen.channels[2].emoji_name is None
+        assert welcome_screen.channels[2].emoji_id is None
+
+        assert welcome_screen.channels[3].emoji_name is None
+        assert welcome_screen.channels[3].emoji_id == 49494949
 
     def test_serialize_welcome_channel_with_custom_emoji(self, entity_factory_impl, mock_app):
         channel = guild_models.WelcomeChannel(

--- a/tests/hikari/test_emojis.py
+++ b/tests/hikari/test_emojis.py
@@ -29,7 +29,6 @@ class TestEmoji:
     @pytest.mark.parametrize(
         ("input", "output"),
         [
-            ("12345", emojis.CustomEmoji(id=snowflakes.Snowflake(12345), name=None, is_animated=None)),
             ("<:foo:12345>", emojis.CustomEmoji(id=snowflakes.Snowflake(12345), name="foo", is_animated=False)),
             ("<bar:foo:12345>", emojis.CustomEmoji(id=snowflakes.Snowflake(12345), name="foo", is_animated=False)),
             ("<a:foo:12345>", emojis.CustomEmoji(id=snowflakes.Snowflake(12345), name="foo", is_animated=True)),
@@ -71,14 +70,9 @@ class TestCustomEmoji:
         emoji = emojis.CustomEmoji(id=snowflakes.Snowflake(12345), name="peepoSad", is_animated=True)
         assert str(emoji) == "peepoSad"
 
-    def test_str_operator_when_name_is_None(self):
-        emoji = emojis.CustomEmoji(id=snowflakes.Snowflake(12345), name=None, is_animated=True)
-        assert str(emoji) == "Unnamed emoji ID 12345"
-
     @pytest.mark.parametrize(
         ("input", "output"),
         [
-            ("12345", emojis.CustomEmoji(id=snowflakes.Snowflake(12345), name=None, is_animated=None)),
             ("<:foo:12345>", emojis.CustomEmoji(id=snowflakes.Snowflake(12345), name="foo", is_animated=False)),
             ("<bar:foo:12345>", emojis.CustomEmoji(id=snowflakes.Snowflake(12345), name="foo", is_animated=False)),
             ("<a:foo:12345>", emojis.CustomEmoji(id=snowflakes.Snowflake(12345), name="foo", is_animated=True)),
@@ -88,5 +82,5 @@ class TestCustomEmoji:
         assert emojis.CustomEmoji.parse(input) == output
 
     def test_parse_unhappy_path(self):
-        with pytest.raises(ValueError, match="Expected an emoji ID or emoji mention"):
+        with pytest.raises(ValueError, match="Expected an emoji mention"):
             emojis.CustomEmoji.parse("xxx")

--- a/tests/hikari/test_emojis.py
+++ b/tests/hikari/test_emojis.py
@@ -32,12 +32,10 @@ class TestEmoji:
             ("<:foo:12345>", emojis.CustomEmoji(id=snowflakes.Snowflake(12345), name="foo", is_animated=False)),
             ("<bar:foo:12345>", emojis.CustomEmoji(id=snowflakes.Snowflake(12345), name="foo", is_animated=False)),
             ("<a:foo:12345>", emojis.CustomEmoji(id=snowflakes.Snowflake(12345), name="foo", is_animated=True)),
-            ("\N{OK HAND SIGN}", emojis.UnicodeEmoji(name="\N{OK HAND SIGN}")),
+            ("\N{OK HAND SIGN}", emojis.UnicodeEmoji("\N{OK HAND SIGN}")),
             (
                 "\N{REGIONAL INDICATOR SYMBOL LETTER G}\N{REGIONAL INDICATOR SYMBOL LETTER B}",
-                emojis.UnicodeEmoji(
-                    name="\N{REGIONAL INDICATOR SYMBOL LETTER G}\N{REGIONAL INDICATOR SYMBOL LETTER B}"
-                ),
+                emojis.UnicodeEmoji("\N{REGIONAL INDICATOR SYMBOL LETTER G}\N{REGIONAL INDICATOR SYMBOL LETTER B}"),
             ),
         ],
     )
@@ -47,17 +45,15 @@ class TestEmoji:
 
 class TestUnicodeEmoji:
     def test_str_operator(self):
-        assert emojis.UnicodeEmoji(name="\N{OK HAND SIGN}") == "\N{OK HAND SIGN}"
+        assert emojis.UnicodeEmoji("\N{OK HAND SIGN}") == "\N{OK HAND SIGN}"
 
     @pytest.mark.parametrize(
         ("input", "output"),
         [
-            ("\N{OK HAND SIGN}", emojis.UnicodeEmoji(name="\N{OK HAND SIGN}")),
+            ("\N{OK HAND SIGN}", emojis.UnicodeEmoji("\N{OK HAND SIGN}")),
             (
                 "\N{REGIONAL INDICATOR SYMBOL LETTER G}\N{REGIONAL INDICATOR SYMBOL LETTER B}",
-                emojis.UnicodeEmoji(
-                    name="\N{REGIONAL INDICATOR SYMBOL LETTER G}\N{REGIONAL INDICATOR SYMBOL LETTER B}"
-                ),
+                emojis.UnicodeEmoji("\N{REGIONAL INDICATOR SYMBOL LETTER G}\N{REGIONAL INDICATOR SYMBOL LETTER B}"),
             ),
         ],
     )
@@ -68,7 +64,7 @@ class TestUnicodeEmoji:
 class TestCustomEmoji:
     def test_str_operator_when_populated_name(self):
         emoji = emojis.CustomEmoji(id=snowflakes.Snowflake(12345), name="peepoSad", is_animated=True)
-        assert str(emoji) == "peepoSad"
+        assert str(emoji) == emoji.mention
 
     @pytest.mark.parametrize(
         ("input", "output"),

--- a/tests/hikari/test_emojis.py
+++ b/tests/hikari/test_emojis.py
@@ -44,8 +44,39 @@ class TestEmoji:
 
 
 class TestUnicodeEmoji:
-    def test_str_operator(self):
-        assert emojis.UnicodeEmoji("\N{OK HAND SIGN}") == "\N{OK HAND SIGN}"
+    @pytest.fixture()
+    def emoji(self):
+        return emojis.UnicodeEmoji("\N{OK HAND SIGN}")
+
+    def test_name_property(self, emoji):
+        assert emoji.name == emoji
+
+    def test_url_name_property(self, emoji):
+        assert emoji.url_name == emoji
+
+    def test_mention_property(self, emoji):
+        assert emoji.mention == emoji
+
+    def test_codepoints_property(self, emoji):
+        assert emoji.codepoints == [128076]
+
+    def test_filename_property(self, emoji):
+        assert emoji.filename == "1f44c.png"
+
+    def test_url_property(self, emoji):
+        assert emoji.url == "https://raw.githubusercontent.com/twitter/twemoji/master/assets/72x72/1f44c.png"
+
+    def test_unicode_escape_property(self, emoji):
+        assert emoji.unicode_escape == "\\U0001f44c"
+
+    def test_parse_codepoints(self, emoji):
+        assert emojis.UnicodeEmoji.parse_codepoints(128076) == emoji
+
+    def test_parse_unicode_escape(self, emoji):
+        assert emojis.UnicodeEmoji.parse_unicode_escape("\\U0001f44c") == emoji
+
+    def test_str_operator(self, emoji):
+        assert str(emoji) == emoji
 
     @pytest.mark.parametrize(
         ("input", "output"),
@@ -62,6 +93,31 @@ class TestUnicodeEmoji:
 
 
 class TestCustomEmoji:
+    @pytest.fixture()
+    def emoji(self):
+        return emojis.CustomEmoji(id=3213452, name="ok", is_animated=False)
+
+    def test_filename_property(self, emoji):
+        assert emoji.filename == "3213452.png"
+
+    def test_filename_property_when_animated(self, emoji):
+        emoji.is_animated = True
+        assert emoji.filename == "3213452.gif"
+
+    def test_url_name_property(self, emoji):
+        assert emoji.url_name == "ok:3213452"
+
+    def test_mention_property(self, emoji):
+        assert emoji.mention == "<:ok:3213452>"
+
+    def test_mention_property_when_animated(self, emoji):
+        emoji.is_animated = True
+
+        assert emoji.mention == "<a:ok:3213452>"
+
+    def test_url_property(self, emoji):
+        assert emoji.url == "https://cdn.discordapp.com/emojis/3213452.png"
+
     def test_str_operator_when_populated_name(self):
         emoji = emojis.CustomEmoji(id=snowflakes.Snowflake(12345), name="peepoSad", is_animated=True)
         assert str(emoji) == emoji.mention

--- a/tests/hikari/test_messages.py
+++ b/tests/hikari/test_messages.py
@@ -310,23 +310,27 @@ class TestAsyncMessage:
         message.app = mock.AsyncMock()
         message.id = 123
         message.channel_id = 456
-        await message.add_reaction("👌")
-        message.app.rest.add_reaction.assert_awaited_once_with(channel=456, message=123, emoji="👌")
+        await message.add_reaction("👌", 123123)
+        message.app.rest.add_reaction.assert_awaited_once_with(channel=456, message=123, emoji="👌", emoji_id=123123)
 
     async def test_remove_reaction(self, message):
         message.app = mock.AsyncMock()
         message.id = 123
         message.channel_id = 456
-        await message.remove_reaction("👌")
-        message.app.rest.delete_my_reaction.assert_awaited_once_with(channel=456, message=123, emoji="👌")
+        await message.remove_reaction("👌", 341231)
+        message.app.rest.delete_my_reaction.assert_awaited_once_with(
+            channel=456, message=123, emoji="👌", emoji_id=341231
+        )
 
     async def test_remove_reaction_with_user(self, message):
         message.app = mock.AsyncMock()
         user = object()
         message.id = 123
         message.channel_id = 456
-        await message.remove_reaction("👌", user=user)
-        message.app.rest.delete_reaction.assert_awaited_once_with(channel=456, message=123, emoji="👌", user=user)
+        await message.remove_reaction("👌", 31231, user=user)
+        message.app.rest.delete_reaction.assert_awaited_once_with(
+            channel=456, message=123, emoji="👌", emoji_id=31231, user=user
+        )
 
     async def test_remove_all_reactions(self, message):
         message.app = mock.AsyncMock()
@@ -339,5 +343,7 @@ class TestAsyncMessage:
         message.app = mock.AsyncMock()
         message.id = 123
         message.channel_id = 456
-        await message.remove_all_reactions("👌")
-        message.app.rest.delete_all_reactions_for_emoji.assert_awaited_once_with(channel=456, message=123, emoji="👌")
+        await message.remove_all_reactions("👌", emoji_id=65655)
+        message.app.rest.delete_all_reactions_for_emoji.assert_awaited_once_with(
+            channel=456, message=123, emoji="👌", emoji_id=65655
+        )


### PR DESCRIPTION
### Summary
Improve typing of Emoji classes
* Make CustomEmoji (and therefore also Emoji) more strict
* Flatten down reaction event models and guild WelcomeChannel + document special case behaviour on them directly.
* Remove Emoji.is_mentionable as it is no longer relevant.

This also removes cases where CustomEmoji.filename, CustomEmoji.mention, CustomEmoji.url_name and CustomEmoji.url would return potentially invalid data if a field was None.

* For CustomEmoji.mention there was a partner CustomEmoji.is_mentionable field which was probably intended to indicate whether CustomEmoji.mention would return data which is guaranteed to be valid or not but this behaviour wasn't documented.
* When CustomEmoji.url_name would return `"None:{emoji.id}"` while this technically works under current behaviour (as the emoji name is currently ignored for custom emojis in the reaction endpoint paths) this behaviour isn't guaranteed and may break down the line (see https://github.com/discord/discord-api-docs/issues/2653#issuecomment-786276283 ).

This also fixes a bug where a WelcomeChannel with emoji_id set but emoji_name left as null would be treated as if it doesn't have any emoji set during deserialization

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
