### PR TITLE
Split Webhook into type specific definitions

### DIFF
--- a/hikari/api/entity_factory.py
+++ b/hikari/api/entity_factory.py
@@ -1309,7 +1309,54 @@ class EntityFactory(abc.ABC):
     ##################
 
     @abc.abstractmethod
-    def deserialize_webhook(self, payload: data_binding.JSONObject) -> webhook_models.Webhook:
+    def deserialize_incoming_webhook(self, payload: data_binding.JSONObject) -> webhook_models.IncomingWebhook:
+        """Parse a raw payload from Discord into a incoming webhook object.
+
+        Parameters
+        ----------
+        payload : hikari.internal.data_binding.JSONObject
+            The JSON payload to deserialize.
+
+        Returns
+        -------
+        hikari.webhooks.IncomingWebhook
+            The parsed incoming webhook object.
+        """
+
+    @abc.abstractmethod
+    def deserialize_channel_follower_webhook(
+        self, payload: data_binding.JSONObject
+    ) -> webhook_models.ChannelFollowerWebhook:
+        """Parse a raw payload from Discord into a channel follower webhook object.
+
+        Parameters
+        ----------
+        payload : hikari.internal.data_binding.JSONObject
+            The JSON payload to deserialize.
+
+        Returns
+        -------
+        hikari.webhooks.ChannelFollowerWebhook
+            The parsed channel follower webhook object.
+        """
+
+    @abc.abstractmethod
+    def deserialize_application_webhook(self, payload: data_binding.JSONObject) -> webhook_models.ApplicationWebhook:
+        """Parse a raw payload from Discord into an application webhook object.
+
+        Parameters
+        ----------
+        payload : hikari.internal.data_binding.JSONObject
+            The JSON payload to deserialize.
+
+        Returns
+        -------
+        hikari.webhooks.ApplicationWebhook
+            The parsed application webhook object.
+        """
+
+    @abc.abstractmethod
+    def deserialize_webhook(self, payload: data_binding.JSONObject) -> webhook_models.PartialWebhook:
         """Parse a raw payload from Discord into a webhook object.
 
         Parameters
@@ -1319,6 +1366,6 @@ class EntityFactory(abc.ABC):
 
         Returns
         -------
-        hikari.webhooks.Webhook
+        hikari.webhooks.PartialWebhook
             The deserialized webhook object.
         """

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -1830,7 +1830,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         *,
         avatar: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-    ) -> webhooks.Webhook:
+    ) -> webhooks.IncomingWebhook:
         """Create webhook in a channel.
 
         Parameters
@@ -1851,7 +1851,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Returns
         -------
-        hikari.webhooks.Webhook
+        hikari.webhooks.IncomingWebhook
             The created webhook.
 
         Raises
@@ -1882,15 +1882,15 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def fetch_webhook(
         self,
-        webhook: snowflakes.SnowflakeishOr[webhooks.Webhook],
+        webhook: snowflakes.SnowflakeishOr[webhooks.PartialWebhook],
         *,
         token: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-    ) -> webhooks.Webhook:
+    ) -> webhooks.PartialWebhook:
         """Fetch an existing webhook.
 
         Parameters
         ----------
-        webhook : hikari.snowflakes.SnowflakeishOr[hikari.webhooks.Webhook]
+        webhook : hikari.snowflakes.SnowflakeishOr[hikari.webhooks.PartialWebhook]
             The webhook to fetch. This may be the object or the ID
             of an existing webhook.
 
@@ -1902,7 +1902,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Returns
         -------
-        hikari.webhooks.Webhook
+        hikari.webhooks.PartialWebhook
             The requested webhook.
 
         Raises
@@ -1933,7 +1933,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     async def fetch_channel_webhooks(
         self,
         channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
-    ) -> typing.Sequence[webhooks.Webhook]:
+    ) -> typing.Sequence[webhooks.PartialWebhook]:
         """Fetch all channel webhooks.
 
         Parameters
@@ -1945,7 +1945,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Returns
         -------
-        typing.Sequence[hikari.webhooks.Webhook]
+        typing.Sequence[hikari.webhooks.PartialWebhook]
             The fetched webhooks.
 
         Raises
@@ -1975,7 +1975,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     async def fetch_guild_webhooks(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-    ) -> typing.Sequence[webhooks.Webhook]:
+    ) -> typing.Sequence[webhooks.PartialWebhook]:
         """Fetch all guild webhooks.
 
         Parameters
@@ -1986,7 +1986,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Returns
         -------
-        typing.Sequence[hikari.webhooks.Webhook]
+        typing.Sequence[hikari.webhooks.PartialWebhook]
             The fetched webhooks.
 
         Raises
@@ -2015,19 +2015,19 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def edit_webhook(
         self,
-        webhook: snowflakes.SnowflakeishOr[webhooks.Webhook],
+        webhook: snowflakes.SnowflakeishOr[webhooks.PartialWebhook],
         *,
         token: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         name: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         avatar: undefined.UndefinedNoneOr[files.Resourceish] = undefined.UNDEFINED,
         channel: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.TextChannel]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-    ) -> webhooks.Webhook:
+    ) -> webhooks.PartialWebhook:
         """Edit a webhook.
 
         Parameters
         ----------
-        webhook : hikari.snowflakes.SnowflakeishOr[hikari.webhooks.Webhook]
+        webhook : hikari.snowflakes.SnowflakeishOr[hikari.webhooks.PartialWebhook]
             The webhook to edit. This may be the object or the
             ID of an existing webhook.
 
@@ -2049,7 +2049,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Returns
         -------
-        hikari.webhooks.Webhook
+        hikari.webhooks.PartialWebhook
             The edited webhook.
 
         Raises
@@ -2079,7 +2079,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def delete_webhook(
         self,
-        webhook: snowflakes.SnowflakeishOr[webhooks.Webhook],
+        webhook: snowflakes.SnowflakeishOr[webhooks.PartialWebhook],
         *,
         token: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> None:
@@ -2087,7 +2087,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        webhook : hikari.snowflakes.SnowflakeishOr[hikari.webhooks.Webhook]
+        webhook : hikari.snowflakes.SnowflakeishOr[hikari.webhooks.PartialWebhook]
             The webhook to delete. This may be the object or the
             ID of an existing webhook.
 

--- a/hikari/applications.py
+++ b/hikari/applications.py
@@ -629,7 +629,7 @@ class OAuth2AuthorizationToken(PartialOAuth2Token):
     refresh_token: int = attr.field(eq=False, hash=False, repr=False)
     """Refresh token used to obtain new access tokens with the same grant."""
 
-    webhook: typing.Optional[webhooks.Webhook] = attr.field(eq=False, hash=False, repr=True)
+    webhook: typing.Optional[webhooks.IncomingWebhook] = attr.field(eq=False, hash=False, repr=True)
     """Object of the webhook that was created.
 
     This will only be present if this token was authorized with the

--- a/hikari/audit_logs.py
+++ b/hikari/audit_logs.py
@@ -484,7 +484,7 @@ class AuditLog(typing.Sequence[AuditLogEntry]):
     users: typing.Mapping[snowflakes.Snowflake, users_.User] = attr.field(repr=False)
     """A mapping of the objects of users found in this audit log."""
 
-    webhooks: typing.Mapping[snowflakes.Snowflake, webhooks_.Webhook] = attr.field(repr=False)
+    webhooks: typing.Mapping[snowflakes.Snowflake, webhooks_.PartialWebhook] = attr.field(repr=False)
     """A mapping of the objects of webhooks found in this audit log."""
 
     @typing.overload

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -54,6 +54,7 @@ from hikari import snowflakes
 from hikari import traits
 from hikari import undefined
 from hikari import urls
+from hikari import webhooks
 from hikari.internal import attr_extensions
 from hikari.internal import enums
 from hikari.internal import routes
@@ -68,7 +69,6 @@ if typing.TYPE_CHECKING:
     from hikari import messages
     from hikari import users
     from hikari import voices
-    from hikari import webhooks
     from hikari.api import special_endpoints
     from hikari.internal import time
 
@@ -187,12 +187,12 @@ class ChannelFollow:
         assert isinstance(channel, (GuildTextChannel, GuildNewsChannel))
         return channel
 
-    async def fetch_webhook(self) -> webhooks.Webhook:
+    async def fetch_webhook(self) -> webhooks.ChannelFollowerWebhook:
         """Fetch the webhook attached to this follow.
 
         Returns
         -------
-        hikari.webhooks.Webhook
+        hikari.webhooks.ChannelFollowerWebhook
             The webhook attached to this follow.
 
         Raises
@@ -218,7 +218,9 @@ class ChannelFollow:
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
         """
-        return await self.app.rest.fetch_webhook(self.webhook_id)
+        webhook = await self.app.rest.fetch_webhook(self.webhook_id)
+        assert isinstance(webhook, webhooks.ChannelFollowerWebhook)
+        return webhook
 
     @property
     def channel(self) -> typing.Union[GuildNewsChannel, GuildTextChannel, None]:

--- a/hikari/events/channel_events.py
+++ b/hikari/events/channel_events.py
@@ -779,12 +779,12 @@ class WebhookUpdateEvent(GuildChannelEvent):
 
     # <<inherited docstring from GuildChannelEvent>>.
 
-    async def fetch_channel_webhooks(self) -> typing.Sequence[webhooks.Webhook]:
+    async def fetch_channel_webhooks(self) -> typing.Sequence[webhooks.PartialWebhook]:
         """Perform an API call to fetch the webhooks for this channel.
 
         Returns
         -------
-        typing.Sequence[hikari.webhooks.Webhook]
+        typing.Sequence[hikari.webhooks.PartialWebhook]
             The webhooks in this channel.
 
         Raises
@@ -811,12 +811,12 @@ class WebhookUpdateEvent(GuildChannelEvent):
         """
         return await self.app.rest.fetch_channel_webhooks(self.channel_id)
 
-    async def fetch_guild_webhooks(self) -> typing.Sequence[webhooks.Webhook]:
+    async def fetch_guild_webhooks(self) -> typing.Sequence[webhooks.PartialWebhook]:
         """Perform an API call to fetch the webhooks for this guild.
 
         Returns
         -------
-        typing.Sequence[hikari.webhooks.Webhook]
+        typing.Sequence[hikari.webhooks.PartialWebhook]
             The webhooks in this guild.
 
         Raises

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -1585,7 +1585,7 @@ class RESTClientImpl(rest_api.RESTClient):
         *,
         avatar: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-    ) -> webhooks.Webhook:
+    ) -> webhooks.IncomingWebhook:
         route = routes.POST_CHANNEL_WEBHOOKS.compile(channel=channel)
         body = data_binding.JSONObjectBuilder()
         body.put("name", name)
@@ -1597,14 +1597,14 @@ class RESTClientImpl(rest_api.RESTClient):
 
         response = await self._request(route, json=body, reason=reason)
         assert isinstance(response, dict)
-        return self._entity_factory.deserialize_webhook(response)
+        return self._entity_factory.deserialize_incoming_webhook(response)
 
     async def fetch_webhook(
         self,
-        webhook: snowflakes.SnowflakeishOr[webhooks.Webhook],
+        webhook: snowflakes.SnowflakeishOr[webhooks.PartialWebhook],
         *,
         token: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-    ) -> webhooks.Webhook:
+    ) -> webhooks.PartialWebhook:
         if token is undefined.UNDEFINED:
             route = routes.GET_WEBHOOK.compile(webhook=webhook)
             no_auth = False
@@ -1619,7 +1619,7 @@ class RESTClientImpl(rest_api.RESTClient):
     async def fetch_channel_webhooks(
         self,
         channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
-    ) -> typing.Sequence[webhooks.Webhook]:
+    ) -> typing.Sequence[webhooks.PartialWebhook]:
         route = routes.GET_CHANNEL_WEBHOOKS.compile(channel=channel)
         response = await self._request(route)
         assert isinstance(response, list)
@@ -1628,7 +1628,7 @@ class RESTClientImpl(rest_api.RESTClient):
     async def fetch_guild_webhooks(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-    ) -> typing.Sequence[webhooks.Webhook]:
+    ) -> typing.Sequence[webhooks.PartialWebhook]:
         route = routes.GET_GUILD_WEBHOOKS.compile(guild=guild)
         response = await self._request(route)
         assert isinstance(response, list)
@@ -1636,14 +1636,14 @@ class RESTClientImpl(rest_api.RESTClient):
 
     async def edit_webhook(
         self,
-        webhook: snowflakes.SnowflakeishOr[webhooks.Webhook],
+        webhook: snowflakes.SnowflakeishOr[webhooks.PartialWebhook],
         *,
         token: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         name: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         avatar: undefined.UndefinedNoneOr[files.Resourceish] = undefined.UNDEFINED,
         channel: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.TextChannel]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-    ) -> webhooks.Webhook:
+    ) -> webhooks.PartialWebhook:
         if token is undefined.UNDEFINED:
             route = routes.PATCH_WEBHOOK.compile(webhook=webhook)
             no_auth = False
@@ -1668,7 +1668,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
     async def delete_webhook(
         self,
-        webhook: snowflakes.SnowflakeishOr[webhooks.Webhook],
+        webhook: snowflakes.SnowflakeishOr[webhooks.PartialWebhook],
         *,
         token: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> None:

--- a/hikari/webhooks.py
+++ b/hikari/webhooks.py
@@ -24,7 +24,14 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["ExecutableWebhook", "WebhookType", "Webhook"]
+__all__: typing.List[str] = [
+    "ApplicationWebhook",
+    "ChannelFollowerWebhook",
+    "ExecutableWebhook",
+    "PartialWebhook",
+    "WebhookType",
+    "IncomingWebhook",
+]
 
 import abc
 import typing
@@ -58,6 +65,9 @@ class WebhookType(int, enums.Enum):
 
     CHANNEL_FOLLOWER = 2
     """Channel Follower webhook."""
+
+    APPLICATION = 3
+    """Application webhook (from the interactions flow)."""
 
 
 class ExecutableWebhook(abc.ABC):
@@ -207,7 +217,7 @@ class ExecutableWebhook(abc.ABC):
         hikari.errors.UnauthorizedError
             If you pass a token that's invalid for the target webhook.
         builtins.ValueError
-            If either `Webhook.token` is `builtins.None` or more than 100 unique
+            If either `ExecutableWebhook.token` is `builtins.None` or more than 100 unique
             objects/entities are passed for `role_mentions` or `user_mentions or
             if `token` is not available.
         builtins.TypeError
@@ -482,13 +492,8 @@ class ExecutableWebhook(abc.ABC):
 
 @attr_extensions.with_copy
 @attr.define(hash=True, kw_only=True, weakref_slot=False)
-class Webhook(snowflakes.Unique, ExecutableWebhook):
-    """Represents a webhook object on Discord.
-
-    This is an endpoint that can have messages sent to it using standard
-    HTTP requests, which enables external services that are not bots to
-    send informational messages to specific channels.
-    """
+class PartialWebhook(snowflakes.Unique):
+    """Base class for all webhook implementations."""
 
     app: traits.RESTAware = attr.field(
         repr=False, eq=False, hash=False, metadata={attr_extensions.SKIP_DEEP_COPY: True}
@@ -501,56 +506,17 @@ class Webhook(snowflakes.Unique, ExecutableWebhook):
     type: typing.Union[WebhookType, int] = attr.field(eq=False, hash=False, repr=True)
     """The type of the webhook."""
 
-    guild_id: typing.Optional[snowflakes.Snowflake] = attr.field(eq=False, hash=False, repr=True)
-    """The guild ID of the webhook."""
-
-    channel_id: snowflakes.Snowflake = attr.field(eq=False, hash=False, repr=True)
-    """The channel ID this webhook is for."""
-
-    author: typing.Optional[users_.User] = attr.field(eq=False, hash=False, repr=True)
-    """The user that created the webhook
-
-    !!! info
-        This will be `builtins.None` when getting a webhook with bot authorization rather
-        than the webhook's token.
-    """
-
-    name: typing.Optional[str] = attr.field(eq=False, hash=False, repr=True)
+    name: str = attr.field(eq=False, hash=False, repr=True)
     """The name of the webhook."""
 
     avatar_hash: typing.Optional[str] = attr.field(eq=False, hash=False, repr=False)
     """The avatar hash of the webhook."""
 
-    token: typing.Optional[str] = attr.field(eq=False, hash=False, repr=False)
-    """The token for the webhook.
-
-    !!! info
-        This is only available for incoming webhooks that are created in the
-        channel settings.
-    """
-
     application_id: typing.Optional[snowflakes.Snowflake] = attr.field(eq=False, hash=False, repr=False)
     """The ID of the application that created this webhook."""
 
-    source_channel: typing.Optional[channels_.PartialChannel] = attr.field(eq=False, hash=False, repr=True)
-    """The partial object of the channel a `CHANNEL_FOLLOWER` webhook is following.
-
-    Will be `builtins.None` for other webhook types.
-    """
-
-    source_guild: typing.Optional[guilds_.PartialGuild] = attr.field(eq=False, hash=False, repr=True)
-    """The partial object of the guild a `CHANNEL_FOLLOWER` webhook is following.
-
-    Will be `builtins.None` for other webhook types.
-    """
-
     def __str__(self) -> str:
         return self.name if self.name is not None else f"Unnamed webhook ID {self.id}"
-
-    @property
-    def webhook_id(self) -> snowflakes.Snowflake:
-        # <<inherited docstring from ExecutableWebhook>>.
-        return self.id
 
     @property
     def mention(self) -> str:
@@ -575,200 +541,6 @@ class Webhook(snowflakes.Unique, ExecutableWebhook):
             The mention string to use.
         """
         return f"<@{self.id}>"
-
-    async def delete(self, *, use_token: undefined.UndefinedOr[bool] = undefined.UNDEFINED) -> None:
-        """Delete this webhook.
-
-        Other Parameters
-        ----------------
-        use_token : hikari.undefined.UndefinedOr[builtins.bool]
-            If set to `builtins.True` then the webhook's token will be used for
-            this request; if set to `builtins.False` then bot authorization will
-            be used; if not specified then the webhook's token will be used for
-            the request if it's set else bot authorization.
-
-        Raises
-        ------
-        hikari.errors.NotFoundError
-            If this webhook is not found.
-        hikari.errors.ForbiddenError
-            If you either lack the `MANAGE_WEBHOOKS` permission or
-            are not a member of the guild this webhook belongs to.
-        builtins.ValueError
-            If `use_token` is passed as `builtins.True` when `Webhook.token` is
-            `builtins.None`.
-        """
-        if use_token:
-            if self.token is None:
-                raise ValueError("This webhook's token is unknown, so cannot be used")
-            token: undefined.UndefinedOr[str] = self.token
-        else:
-            token = undefined.UNDEFINED
-
-        await self.app.rest.delete_webhook(self.id, token=token)
-
-    async def edit(
-        self,
-        *,
-        name: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-        avatar: undefined.UndefinedNoneOr[files_.Resource[files_.AsyncReader]] = undefined.UNDEFINED,
-        channel: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.TextChannel]] = undefined.UNDEFINED,
-        reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-        use_token: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-    ) -> Webhook:
-        """Edit this webhook.
-
-        Other Parameters
-        ----------------
-        name : hikari.undefined.UndefinedOr[builtins.str]
-            If provided, the new name string.
-        avatar : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
-            If provided, the new avatar image. If `builtins.None`, then
-            it is removed. If not specified, nothing is changed.
-        channel : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]]
-            If provided, the object or ID of the new channel the given
-            webhook should be moved to.
-        reason : hikari.undefined.UndefinedOr[builtins.str]
-            If provided, the audit log reason explaining why the operation
-            was performed. This field will be used when using the webhook's
-            token rather than bot authorization.
-        use_token : hikari.undefined.UndefinedOr[builtins.bool]
-            If set to `builtins.True` then the webhook's token will be used for
-            this request; if set to `builtins.False` then bot authorization will
-            be used; if not specified then the webhook's token will be used for
-            the request if it's set else bot authorization.
-
-        Returns
-        -------
-        hikari.webhooks.Webhook
-            The updated webhook object.
-
-        Raises
-        ------
-        builtins.ValueError
-            If `use_token` is passed as `builtins.True` when `Webhook.token` is `builtins.None`.
-        hikari.errors.BadRequestError
-            If any invalid snowflake IDs are passed; a snowflake may be invalid
-            due to it being outside of the range of a 64 bit integer.
-        hikari.errors.NotFoundError
-            If either the webhook or the channel are not found.
-        hikari.errors.ForbiddenError
-            If you either lack the `MANAGE_WEBHOOKS` permission or
-            are not a member of the guild this webhook belongs to.
-        hikari.errors.UnauthorizedError
-            If you pass a token that's invalid for the target webhook.
-        hikari.errors.RateLimitTooLongError
-            Raised in the event that a rate limit occurs that is
-            longer than `max_rate_limit` when making a request.
-        hikari.errors.RateLimitedError
-            Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes most bucket-specific
-            rate-limits and global rate-limits. In some rare edge cases,
-            however, Discord implements other undocumented rules for
-            rate-limiting, such as limits per attribute. These cannot be
-            detected or handled normally by Hikari due to their undocumented
-            nature, and will trigger this exception if they occur.
-        hikari.errors.InternalServerError
-            If an internal error occurs on Discord while handling the request.
-        """  # noqa: E501 - Line too long
-        if use_token:
-            if self.token is None:
-                raise ValueError("This webhook's token is unknown, so cannot be used")
-            token: undefined.UndefinedOr[str] = self.token
-        else:
-            token = undefined.UNDEFINED
-
-        return await self.app.rest.edit_webhook(
-            self.id,
-            token=token,
-            name=name,
-            avatar=avatar,
-            channel=channel,
-            reason=reason,
-        )
-
-    async def fetch_channel(self) -> channels_.PartialChannel:
-        """Fetch the channel this webhook is for.
-
-        Returns
-        -------
-        hikari.channels.PartialChannel
-            The object of the channel this webhook targets.
-
-        Raises
-        ------
-        hikari.errors.ForbiddenError
-            If you don't have access to the channel this webhook belongs to.
-        hikari.errors.NotFoundError
-            If the channel this message was created in does not exist.
-        hikari.errors.UnauthorizedError
-            If you are unauthorized to make the request (invalid/missing token).
-        hikari.errors.RateLimitTooLongError
-            Raised in the event that a rate limit occurs that is
-            longer than `max_rate_limit` when making a request.
-        hikari.errors.RateLimitedError
-            Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes most bucket-specific
-            rate-limits and global rate-limits. In some rare edge cases,
-            however, Discord implements other undocumented rules for
-            rate-limiting, such as limits per attribute. These cannot be
-            detected or handled normally by Hikari due to their undocumented
-            nature, and will trigger this exception if they occur.
-        hikari.errors.InternalServerError
-            If an internal error occurs on Discord while handling the request.
-        """
-        return await self.app.rest.fetch_channel(self.channel_id)
-
-    async def fetch_self(self, *, use_token: undefined.UndefinedOr[bool] = undefined.UNDEFINED) -> Webhook:
-        """Fetch this webhook.
-
-        Other Parameters
-        ----------------
-        use_token : hikari.undefined.UndefinedOr[builtins.bool]
-            If set to `builtins.True` then the webhook's token will be used for
-            this request; if set to `builtins.False` then bot authorization will
-            be used; if not specified then the webhook's token will be used for
-            the request if it's set else bot authorization.
-
-        Returns
-        -------
-        hikari.webhooks.Webhook
-            The requested webhook object.
-
-        Raises
-        ------
-        builtins.ValueError
-            If `use_token` is passed as `builtins.True` when `Webhook.token`
-            is `builtins.None`.
-        hikari.errors.ForbiddenError
-            If you're not in the guild that owns this webhook or
-            lack the `MANAGE_WEBHOOKS` permission.
-        hikari.errors.NotFoundError
-            If the webhook is not found.
-        hikari.errors.UnauthorizedError
-            If you pass a token that's invalid for the target webhook.
-        hikari.errors.RateLimitTooLongError
-            Raised in the event that a rate limit occurs that is
-            longer than `max_rate_limit` when making a request.
-        hikari.errors.RateLimitedError
-            Usually, Hikari will handle and retry on hitting
-            rate-limits automatically. This includes most bucket-specific
-            rate-limits and global rate-limits. In some rare edge cases,
-            however, Discord implements other undocumented rules for
-            rate-limiting, such as limits per attribute. These cannot be
-            detected or handled normally by Hikari due to their undocumented
-            nature, and will trigger this exception if they occur.
-        hikari.errors.InternalServerError
-            If an internal error occurs on Discord while handling the request.
-        """
-        if use_token:
-            if self.token is None:
-                raise ValueError("This webhook's token is unknown, so cannot be used")
-            token: undefined.UndefinedOr[str] = self.token
-        else:
-            token = undefined.UNDEFINED
-
-        return await self.app.rest.fetch_webhook(self.id, token=token)
 
     @property
     def avatar(self) -> files_.URL:
@@ -829,3 +601,361 @@ class Webhook(snowflakes.Unique, ExecutableWebhook):
             size=size,
             file_format=ext,
         )
+
+
+@attr.define(hash=True, kw_only=True, weakref_slot=False)
+class IncomingWebhook(PartialWebhook, ExecutableWebhook):
+    """Represents an incoming webhook object on Discord.
+
+    This is an endpoint that can have messages sent to it using standard
+    HTTP requests, which enables external services that are not bots to
+    send informational messages to specific channels.
+    """
+
+    channel_id: snowflakes.Snowflake = attr.field(eq=False, hash=False, repr=True)
+    """The channel ID this webhook is for."""
+
+    guild_id: snowflakes.Snowflake = attr.field(eq=False, hash=False, repr=True)
+    """The guild ID of the webhook."""
+
+    author: typing.Optional[users_.User] = attr.field(eq=False, hash=False, repr=True)
+    """The user that created the webhook
+
+    !!! info
+        This will be `builtins.None` when fetched with the webhook's token
+        rather than bot authorization or when received within audit logs.
+    """
+
+    token: typing.Optional[str] = attr.field(eq=False, hash=False, repr=False)
+    """The token for the webhook.
+
+    !!! info
+        This is only available for incoming webhooks that are created in the
+        channel settings.
+    """
+
+    @property
+    def webhook_id(self) -> snowflakes.Snowflake:
+        # <<inherited docstring from ExecutableWebhook>>.
+        return self.id
+
+    async def delete(self, *, use_token: undefined.UndefinedOr[bool] = undefined.UNDEFINED) -> None:
+        """Delete this webhook.
+
+        Other Parameters
+        ----------------
+        use_token : hikari.undefined.UndefinedOr[builtins.bool]
+            If set to `builtins.True` then the webhook's token will be used for
+            this request; if set to `builtins.False` then bot authorization will
+            be used; if not specified then the webhook's token will be used for
+            the request if it's set else bot authorization.
+
+        Raises
+        ------
+        hikari.errors.NotFoundError
+            If this webhook is not found.
+        hikari.errors.ForbiddenError
+            If you either lack the `MANAGE_WEBHOOKS` permission or
+            are not a member of the guild this webhook belongs to.
+        builtins.ValueError
+            If `use_token` is passed as `builtins.True` when `IncomingWebhook.token` is
+            `builtins.None`.
+        """
+        token: undefined.UndefinedOr[str] = undefined.UNDEFINED
+        if use_token:
+            if self.token is None:
+                raise ValueError("This webhook's token is unknown, so cannot be used")
+            token = self.token
+
+        elif use_token is undefined.UNDEFINED and self.token:
+            token = self.token
+
+        await self.app.rest.delete_webhook(self.id, token=token)
+
+    async def edit(
+        self,
+        *,
+        name: undefined.UndefinedOr[str] = undefined.UNDEFINED,
+        avatar: undefined.UndefinedNoneOr[files_.Resource[files_.AsyncReader]] = undefined.UNDEFINED,
+        channel: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.TextChannel]] = undefined.UNDEFINED,
+        reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
+        use_token: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
+    ) -> IncomingWebhook:
+        """Edit this webhook.
+
+        Other Parameters
+        ----------------
+        name : hikari.undefined.UndefinedOr[builtins.str]
+            If provided, the new name string.
+        avatar : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
+            If provided, the new avatar image. If `builtins.None`, then
+            it is removed. If not specified, nothing is changed.
+        channel : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]]
+            If provided, the object or ID of the new channel the given
+            webhook should be moved to.
+        reason : hikari.undefined.UndefinedOr[builtins.str]
+            If provided, the audit log reason explaining why the operation
+            was performed. This field will be used when using the webhook's
+            token rather than bot authorization.
+        use_token : hikari.undefined.UndefinedOr[builtins.bool]
+            If set to `builtins.True` then the webhook's token will be used for
+            this request; if set to `builtins.False` then bot authorization will
+            be used; if not specified then the webhook's token will be used for
+            the request if it's set else bot authorization.
+
+        Returns
+        -------
+        IncomingWebhook
+            The updated webhook object.
+
+        Raises
+        ------
+        builtins.ValueError
+            If `use_token` is passed as `builtins.True` when `IncomingWebhook.token` is `builtins.None`.
+        hikari.errors.BadRequestError
+            If any invalid snowflake IDs are passed; a snowflake may be invalid
+            due to it being outside of the range of a 64 bit integer.
+        hikari.errors.NotFoundError
+            If either the webhook or the channel are not found.
+        hikari.errors.ForbiddenError
+            If you either lack the `MANAGE_WEBHOOKS` permission or
+            are not a member of the guild this webhook belongs to.
+        hikari.errors.UnauthorizedError
+            If you pass a token that's invalid for the target webhook.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
+        hikari.errors.RateLimitedError
+            Usually, Hikari will handle and retry on hitting
+            rate-limits automatically. This includes most bucket-specific
+            rate-limits and global rate-limits. In some rare edge cases,
+            however, Discord implements other undocumented rules for
+            rate-limiting, such as limits per attribute. These cannot be
+            detected or handled normally by Hikari due to their undocumented
+            nature, and will trigger this exception if they occur.
+        hikari.errors.InternalServerError
+            If an internal error occurs on Discord while handling the request.
+        """  # noqa: E501 - Line too long
+        token: undefined.UndefinedOr[str] = undefined.UNDEFINED
+        if use_token:
+            if self.token is None:
+                raise ValueError("This webhook's token is unknown, so cannot be used")
+            token = self.token
+
+        elif use_token is undefined.UNDEFINED and self.token:
+            token = self.token
+
+        webhook = await self.app.rest.edit_webhook(
+            self.id,
+            token=token,
+            name=name,
+            avatar=avatar,
+            channel=channel,
+            reason=reason,
+        )
+        assert isinstance(webhook, IncomingWebhook)
+        return webhook
+
+    async def fetch_self(self, *, use_token: undefined.UndefinedOr[bool] = undefined.UNDEFINED) -> IncomingWebhook:
+        """Fetch this webhook.
+
+        Other Parameters
+        ----------------
+        use_token : hikari.undefined.UndefinedOr[builtins.bool]
+            If set to `builtins.True` then the webhook's token will be used for
+            this request; if set to `builtins.False` then bot authorization will
+            be used; if not specified then the webhook's token will be used for
+            the request if it's set else bot authorization.
+
+        Returns
+        -------
+        IncomingWebhook
+            The requested webhook object.
+
+        Raises
+        ------
+        builtins.ValueError
+            If `use_token` is passed as `builtins.True` when `Webhook.token`
+            is `builtins.None`.
+        hikari.errors.ForbiddenError
+            If you're not in the guild that owns this webhook or
+            lack the `MANAGE_WEBHOOKS` permission.
+        hikari.errors.NotFoundError
+            If the webhook is not found.
+        hikari.errors.UnauthorizedError
+            If you pass a token that's invalid for the target webhook.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
+        hikari.errors.RateLimitedError
+            Usually, Hikari will handle and retry on hitting
+            rate-limits automatically. This includes most bucket-specific
+            rate-limits and global rate-limits. In some rare edge cases,
+            however, Discord implements other undocumented rules for
+            rate-limiting, such as limits per attribute. These cannot be
+            detected or handled normally by Hikari due to their undocumented
+            nature, and will trigger this exception if they occur.
+        hikari.errors.InternalServerError
+            If an internal error occurs on Discord while handling the request.
+        """
+        token: undefined.UndefinedOr[str] = undefined.UNDEFINED
+        if use_token:
+            if self.token is None:
+                raise ValueError("This webhook's token is unknown, so cannot be used")
+            token = self.token
+
+        elif use_token is undefined.UNDEFINED and self.token:
+            token = self.token
+
+        webhook = await self.app.rest.fetch_webhook(self.id, token=token)
+        assert isinstance(webhook, IncomingWebhook)
+        return webhook
+
+
+@attr.define(hash=True, kw_only=True, weakref_slot=False)
+class ChannelFollowerWebhook(PartialWebhook):
+    """Represents a channel follower webhook object on Discord."""
+
+    channel_id: snowflakes.Snowflake = attr.field(eq=False, hash=False, repr=True)
+    """The channel ID this webhook is for."""
+
+    guild_id: snowflakes.Snowflake = attr.field(eq=False, hash=False, repr=True)
+    """The guild ID of the webhook."""
+
+    author: typing.Optional[users_.User] = attr.field(eq=False, hash=False, repr=True)
+    """The user that created the webhook
+
+    !!! info
+        This will be `builtins.None` when received within an audit log.
+    """
+
+    source_channel: channels_.PartialChannel = attr.field(eq=False, hash=False, repr=True)
+    """The partial object of the channel this webhook is following."""
+
+    source_guild: guilds_.PartialGuild = attr.field(eq=False, hash=False, repr=True)
+    """The partial object of the guild this webhook is following."""
+
+    async def delete(self) -> None:
+        """Delete this webhook.
+
+        Raises
+        ------
+        hikari.errors.NotFoundError
+            If this webhook is not found.
+        hikari.errors.ForbiddenError
+            If you either lack the `MANAGE_WEBHOOKS` permission or
+            are not a member of the guild this webhook belongs to.
+        """
+        await self.app.rest.delete_webhook(self.id)
+
+    async def edit(
+        self,
+        *,
+        name: undefined.UndefinedOr[str] = undefined.UNDEFINED,
+        avatar: undefined.UndefinedNoneOr[files_.Resource[files_.AsyncReader]] = undefined.UNDEFINED,
+        channel: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.TextChannel]] = undefined.UNDEFINED,
+        reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
+    ) -> ChannelFollowerWebhook:
+        """Edit this webhook.
+
+        Other Parameters
+        ----------------
+        name : hikari.undefined.UndefinedOr[builtins.str]
+            If provided, the new name string.
+        avatar : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
+            If provided, the new avatar image. If `builtins.None`, then
+            it is removed. If not specified, nothing is changed.
+        channel : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]]
+            If provided, the object or ID of the new channel the given
+            webhook should be moved to.
+        reason : hikari.undefined.UndefinedOr[builtins.str]
+            If provided, the audit log reason explaining why the operation
+            was performed. This field will be used when using the webhook's
+            token rather than bot authorization.
+
+        Returns
+        -------
+        hikari.webhooks.ChannelFollowerWebhook
+            The updated webhook object.
+
+        Raises
+        ------
+        hikari.errors.BadRequestError
+            If any invalid snowflake IDs are passed; a snowflake may be invalid
+            due to it being outside of the range of a 64 bit integer.
+        hikari.errors.NotFoundError
+            If either the webhook or the channel are not found.
+        hikari.errors.ForbiddenError
+            If you either lack the `MANAGE_WEBHOOKS` permission or
+            are not a member of the guild this webhook belongs to.
+        hikari.errors.UnauthorizedError
+            If you pass a token that's invalid for the target webhook.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
+        hikari.errors.RateLimitedError
+            Usually, Hikari will handle and retry on hitting
+            rate-limits automatically. This includes most bucket-specific
+            rate-limits and global rate-limits. In some rare edge cases,
+            however, Discord implements other undocumented rules for
+            rate-limiting, such as limits per attribute. These cannot be
+            detected or handled normally by Hikari due to their undocumented
+            nature, and will trigger this exception if they occur.
+        hikari.errors.InternalServerError
+            If an internal error occurs on Discord while handling the request.
+        """  # noqa: E501 - Line too long
+        webhook = await self.app.rest.edit_webhook(
+            self.id,
+            name=name,
+            avatar=avatar,
+            channel=channel,
+            reason=reason,
+        )
+        assert isinstance(webhook, ChannelFollowerWebhook)
+        return webhook
+
+    async def fetch_self(self) -> ChannelFollowerWebhook:
+        """Fetch this webhook.
+
+        Returns
+        -------
+        hikari.webhooks.ChannelFollowerWebhook
+            The requested webhook object.
+
+        Raises
+        ------
+        hikari.errors.ForbiddenError
+            If you're not in the guild that owns this webhook or
+            lack the `MANAGE_WEBHOOKS` permission.
+        hikari.errors.NotFoundError
+            If the webhook is not found.
+        hikari.errors.UnauthorizedError
+            If you pass a token that's invalid for the target webhook.
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
+        hikari.errors.RateLimitedError
+            Usually, Hikari will handle and retry on hitting
+            rate-limits automatically. This includes most bucket-specific
+            rate-limits and global rate-limits. In some rare edge cases,
+            however, Discord implements other undocumented rules for
+            rate-limiting, such as limits per attribute. These cannot be
+            detected or handled normally by Hikari due to their undocumented
+            nature, and will trigger this exception if they occur.
+        hikari.errors.InternalServerError
+            If an internal error occurs on Discord while handling the request.
+        """
+        webhook = await self.app.rest.fetch_webhook(self.id)
+        assert isinstance(webhook, ChannelFollowerWebhook)
+        return webhook
+
+
+@attr.define(hash=True, kw_only=True, weakref_slot=False)
+class ApplicationWebhook(PartialWebhook):
+    """Represents an application webhook object on Discord.
+
+    This is from the interactions flow.
+    """
+
+    application_id: snowflakes.Snowflake
+    # <<inherited docstring from PartialWebhook>>.

--- a/hikari/webhooks.py
+++ b/hikari/webhooks.py
@@ -957,5 +957,5 @@ class ApplicationWebhook(PartialWebhook):
     This is from the interactions flow.
     """
 
-    application_id: snowflakes.Snowflake
+    application_id: snowflakes.Snowflake = attr.ib()
     # <<inherited docstring from PartialWebhook>>.

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -1811,7 +1811,7 @@ class TestRESTClientImplAsync:
         expected_route = routes.POST_CHANNEL_WEBHOOKS.compile(channel=123)
         rest_client._request = mock.AsyncMock(return_value={"id": "456"})
         expected_json = {"name": "test webhook", "avatar": "some data"}
-        rest_client._entity_factory.deserialize_webhook = mock.Mock(return_value=webhook)
+        rest_client._entity_factory.deserialize_incoming_webhook = mock.Mock(return_value=webhook)
 
         returned = await rest_client.create_webhook(
             StubModel(123), "test webhook", avatar="someavatar.png", reason="why not"
@@ -1819,18 +1819,18 @@ class TestRESTClientImplAsync:
         assert returned is webhook
 
         rest_client._request.assert_awaited_once_with(expected_route, json=expected_json, reason="why not")
-        rest_client._entity_factory.deserialize_webhook.assert_called_once_with({"id": "456"})
+        rest_client._entity_factory.deserialize_incoming_webhook.assert_called_once_with({"id": "456"})
 
     async def test_create_webhook_without_optionals(self, rest_client):
         webhook = StubModel(456)
         expected_route = routes.POST_CHANNEL_WEBHOOKS.compile(channel=123)
         expected_json = {"name": "test webhook"}
         rest_client._request = mock.AsyncMock(return_value={"id": "456"})
-        rest_client._entity_factory.deserialize_webhook = mock.Mock(return_value=webhook)
+        rest_client._entity_factory.deserialize_incoming_webhook = mock.Mock(return_value=webhook)
 
         assert await rest_client.create_webhook(StubModel(123), "test webhook") is webhook
         rest_client._request.assert_awaited_once_with(expected_route, json=expected_json, reason=undefined.UNDEFINED)
-        rest_client._entity_factory.deserialize_webhook.assert_called_once_with({"id": "456"})
+        rest_client._entity_factory.deserialize_incoming_webhook.assert_called_once_with({"id": "456"})
 
     async def test_fetch_webhook(self, rest_client):
         webhook = StubModel(123)

--- a/tests/hikari/test_channels.py
+++ b/tests/hikari/test_channels.py
@@ -30,6 +30,7 @@ from hikari import permissions
 from hikari import snowflakes
 from hikari import undefined
 from hikari import users
+from hikari import webhooks
 from tests.hikari import hikari_test_helpers
 
 
@@ -54,15 +55,14 @@ class TestChannelFollow:
 
     @pytest.mark.asyncio()
     async def test_fetch_webhook(self, mock_app):
-        mock_webhook = object()
-        mock_app.rest.fetch_webhook = mock.AsyncMock(return_value=mock_webhook)
+        mock_app.rest.fetch_webhook = mock.AsyncMock(return_value=mock.Mock(webhooks.ChannelFollowerWebhook))
         follow = channels.ChannelFollow(
             webhook_id=snowflakes.Snowflake(54123123), app=mock_app, channel_id=snowflakes.Snowflake(94949494)
         )
 
         result = await follow.fetch_webhook()
 
-        assert result is mock_webhook
+        assert result is mock_app.rest.fetch_webhook.return_value
         mock_app.rest.fetch_webhook.assert_awaited_once_with(54123123)
 
     def test_channel(self, mock_app):

--- a/tests/hikari/test_webhooks.py
+++ b/tests/hikari/test_webhooks.py
@@ -102,7 +102,7 @@ class TestExecutableWebhook:
 
         assert returned is returned_message
 
-        executable_webhook.app.rest.fetch_webhook_message.assert_called_once_with(
+        executable_webhook.app.rest.fetch_webhook_message.assert_awaited_once_with(
             executable_webhook.webhook_id, token=executable_webhook.token, message=message
         )
 
@@ -171,22 +171,16 @@ class TestExecutableWebhook:
             assert await executable_webhook.delete_message(987)
 
 
-class TestWebhook:
+class TestPartialWebhook:
     @pytest.fixture()
     def webhook(self):
-        return webhooks.Webhook(
-            app=mock.Mock(),
+        return webhooks.PartialWebhook(
+            app=mock.Mock(rest=mock.AsyncMock()),
             id=987654321,
             type=webhooks.WebhookType.CHANNEL_FOLLOWER,
-            guild_id=123,
-            channel_id=456,
-            author=None,
             name="not a webhook",
-            avatar_hash=None,
-            token="abc123bca",
+            avatar_hash="hoook",
             application_id=None,
-            source_channel=object(),
-            source_guild=object(),
         )
 
     def test_str(self, webhook):
@@ -196,5 +190,242 @@ class TestWebhook:
         webhook.name = None
         assert str(webhook) == "Unnamed webhook ID 987654321"
 
+    def test_mention_property(self, webhook):
+        assert webhook.mention == "<@987654321>"
+
+    def test_avatar_property(self, webhook):
+        assert webhook.avatar == webhook.make_avatar_url()
+
+    def test_avatar_property_when_default(self, webhook):
+        webhook.avatar_hash = None
+
+        assert webhook.avatar == webhook.default_avatar
+
+    def test_default_avatar(self, webhook):
+        assert webhook.default_avatar.url == "https://cdn.discordapp.com/embed/avatars/0.png"
+
+    def test_make_avatar_url(self, webhook):
+        result = webhook.make_avatar_url(ext="jpeg", size=2048)
+
+        assert result.url == "https://cdn.discordapp.com/avatars/987654321/hoook.jpeg?size=2048"
+
+    def test_make_avatar_url_when_no_avatar(self, webhook):
+        webhook.avatar_hash = None
+
+        assert webhook.make_avatar_url() is None
+
+
+class TestIncomingWebhook:
+    @pytest.fixture()
+    def webhook(self):
+        return webhooks.IncomingWebhook(
+            app=mock.Mock(rest=mock.AsyncMock()),
+            id=987654321,
+            type=webhooks.WebhookType.CHANNEL_FOLLOWER,
+            guild_id=123,
+            channel_id=456,
+            author=None,
+            name="not a webhook",
+            avatar_hash=None,
+            token="abc123bca",
+            application_id=None,
+        )
+
     def test_webhook_id_property(self, webhook):
         assert webhook.webhook_id is webhook.id
+
+    @pytest.mark.asyncio()
+    async def test_delete(self, webhook):
+        webhook.token = None
+
+        await webhook.delete()
+
+        webhook.app.rest.delete_webhook.assert_awaited_once_with(987654321, token=undefined.UNDEFINED)
+
+    @pytest.mark.asyncio()
+    async def test_delete_uses_token_property(self, webhook):
+        webhook.token = "123321"
+
+        await webhook.delete()
+
+        webhook.app.rest.delete_webhook.assert_awaited_once_with(987654321, token="123321")
+
+    @pytest.mark.asyncio()
+    async def test_delete_use_token_is_true(self, webhook):
+        webhook.token = "322312"
+
+        await webhook.delete(use_token=True)
+
+        webhook.app.rest.delete_webhook.assert_awaited_once_with(987654321, token="322312")
+
+    @pytest.mark.asyncio()
+    async def test_delete_use_token_is_true_without_token(self, webhook):
+        webhook.token = None
+
+        with pytest.raises(ValueError, match="This webhook's token is unknown, so cannot be used"):
+            await webhook.delete(use_token=True)
+
+        webhook.app.rest.delete_webhook.assert_not_called()
+
+    @pytest.mark.asyncio()
+    async def test_delete_use_token_is_false(self, webhook):
+        webhook.token = "322312"
+
+        await webhook.delete(use_token=False)
+
+        webhook.app.rest.delete_webhook.assert_awaited_once_with(987654321, token=undefined.UNDEFINED)
+
+    @pytest.mark.asyncio()
+    async def test_edit(self, webhook):
+        webhook.token = None
+        webhook.app.rest.edit_webhook.return_value = mock.Mock(webhooks.IncomingWebhook)
+        mock_avatar = object()
+
+        result = await webhook.edit(name="OK", avatar=mock_avatar, channel=33333, reason="byebye")
+
+        assert result is webhook.app.rest.edit_webhook.return_value
+        webhook.app.rest.edit_webhook.assert_awaited_once_with(
+            987654321, token=undefined.UNDEFINED, name="OK", avatar=mock_avatar, channel=33333, reason="byebye"
+        )
+
+    @pytest.mark.asyncio()
+    async def test_edit_uses_token_property(self, webhook):
+        webhook.token = "aye"
+        webhook.app.rest.edit_webhook.return_value = mock.Mock(webhooks.IncomingWebhook)
+        mock_avatar = object()
+
+        result = await webhook.edit(name="bye", avatar=mock_avatar, channel=33333, reason="byebye")
+
+        assert result is webhook.app.rest.edit_webhook.return_value
+        webhook.app.rest.edit_webhook.assert_awaited_once_with(
+            987654321, token="aye", name="bye", avatar=mock_avatar, channel=33333, reason="byebye"
+        )
+
+    @pytest.mark.asyncio()
+    async def test_edit_when_use_token_is_true(self, webhook):
+        webhook.token = "owoowow"
+        webhook.app.rest.edit_webhook.return_value = mock.Mock(webhooks.IncomingWebhook)
+        mock_avatar = object()
+
+        result = await webhook.edit(use_token=True, name="hiu", avatar=mock_avatar, channel=231, reason="sus")
+
+        assert result is webhook.app.rest.edit_webhook.return_value
+        webhook.app.rest.edit_webhook.assert_awaited_once_with(
+            987654321, token="owoowow", name="hiu", avatar=mock_avatar, channel=231, reason="sus"
+        )
+
+    @pytest.mark.asyncio()
+    async def test_edit_when_use_token_is_true_and_no_token(self, webhook):
+        webhook.token = None
+
+        with pytest.raises(ValueError, match="This webhook's token is unknown, so cannot be used"):
+            await webhook.edit(use_token=True)
+
+        webhook.app.rest.edit_webhook.assert_not_called()
+
+    @pytest.mark.asyncio()
+    async def test_edit_when_use_token_is_false(self, webhook):
+        webhook.token = "owoowow"
+        webhook.app.rest.edit_webhook.return_value = mock.Mock(webhooks.IncomingWebhook)
+        mock_avatar = object()
+
+        result = await webhook.edit(use_token=False, name="eee", avatar=mock_avatar, channel=231, reason="rrr")
+
+        assert result is webhook.app.rest.edit_webhook.return_value
+        webhook.app.rest.edit_webhook.assert_awaited_once_with(
+            987654321, token=undefined.UNDEFINED, name="eee", avatar=mock_avatar, channel=231, reason="rrr"
+        )
+
+    @pytest.mark.asyncio()
+    async def test_fetch_self(self, webhook):
+        webhook.token = None
+        webhook.app.rest.fetch_webhook.return_value = mock.Mock(webhooks.IncomingWebhook)
+
+        result = await webhook.fetch_self()
+
+        assert result is webhook.app.rest.fetch_webhook.return_value
+        webhook.app.rest.fetch_webhook.assert_awaited_once_with(987654321, token=undefined.UNDEFINED)
+
+    @pytest.mark.asyncio()
+    async def test_fetch_self_uses_token_property(self, webhook):
+        webhook.token = "no gnomo"
+        webhook.app.rest.fetch_webhook.return_value = mock.Mock(webhooks.IncomingWebhook)
+
+        result = await webhook.fetch_self()
+
+        assert result is webhook.app.rest.fetch_webhook.return_value
+        webhook.app.rest.fetch_webhook.assert_awaited_once_with(987654321, token="no gnomo")
+
+    @pytest.mark.asyncio()
+    async def test_fetch_self_when_use_token_is_true(self, webhook):
+        webhook.token = "no momo"
+        webhook.app.rest.fetch_webhook.return_value = mock.Mock(webhooks.IncomingWebhook)
+
+        result = await webhook.fetch_self(use_token=True)
+
+        assert result is webhook.app.rest.fetch_webhook.return_value
+        webhook.app.rest.fetch_webhook.assert_awaited_once_with(987654321, token="no momo")
+
+    @pytest.mark.asyncio()
+    async def test_fetch_self_when_use_token_is_true_without_token_property(self, webhook):
+        webhook.token = None
+
+        with pytest.raises(ValueError, match="This webhook's token is unknown, so cannot be used"):
+            await webhook.fetch_self(use_token=True)
+
+        webhook.app.rest.fetch_webhook.assert_not_called()
+
+    @pytest.mark.asyncio()
+    async def test_fetch_self_when_use_token_is_false(self, webhook):
+        webhook.token = "no momo"
+        webhook.app.rest.fetch_webhook.return_value = mock.Mock(webhooks.IncomingWebhook)
+
+        result = await webhook.fetch_self(use_token=False)
+
+        assert result is webhook.app.rest.fetch_webhook.return_value
+        webhook.app.rest.fetch_webhook.assert_awaited_once_with(987654321, token=undefined.UNDEFINED)
+
+
+class TestChannelFollowerWebhook:
+    @pytest.fixture()
+    def webhook(self):
+        return webhooks.ChannelFollowerWebhook(
+            app=mock.Mock(rest=mock.AsyncMock()),
+            id=987654321,
+            type=webhooks.WebhookType.CHANNEL_FOLLOWER,
+            guild_id=123,
+            channel_id=456,
+            author=None,
+            name="not a webhook",
+            avatar_hash=None,
+            application_id=None,
+            source_channel=object(),
+            source_guild=object(),
+        )
+
+    @pytest.mark.asyncio()
+    async def test_delete(self, webhook):
+        await webhook.delete()
+
+        webhook.app.rest.delete_webhook.assert_awaited_once_with(987654321)
+
+    @pytest.mark.asyncio()
+    async def test_edit(self, webhook):
+        mock_avatar = object()
+        webhook.app.rest.edit_webhook.return_value = mock.Mock(webhooks.ChannelFollowerWebhook)
+
+        result = await webhook.edit(name="hi", avatar=mock_avatar, channel=43123, reason="ok")
+
+        assert result is webhook.app.rest.edit_webhook.return_value
+        webhook.app.rest.edit_webhook.assert_awaited_once_with(
+            987654321, name="hi", avatar=mock_avatar, channel=43123, reason="ok"
+        )
+
+    @pytest.mark.asyncio()
+    async def test_fetch_self(self, webhook):
+        webhook.app.rest.fetch_webhook.return_value = mock.Mock(webhooks.ChannelFollowerWebhook)
+
+        result = await webhook.fetch_self()
+
+        assert result is webhook.app.rest.fetch_webhook.return_value
+        webhook.app.rest.fetch_webhook.assert_awaited_once_with(987654321)


### PR DESCRIPTION
### Summary
Split Webhook into type specific definitions

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Closes #608