### PR TITLE
Add TextableGuildChannel mixin class + improve typing around guild text channel operations

### DIFF
--- a/hikari/api/cache.py
+++ b/hikari/api/cache.py
@@ -299,12 +299,12 @@ class Cache(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_invite(self, code: invites.Inviteish, /) -> typing.Optional[invites.InviteWithMetadata]:
+    def get_invite(self, code: typing.Union[invites.InviteCode, str], /) -> typing.Optional[invites.InviteWithMetadata]:
         """Get an invite object from the cache.
 
         Parameters
         ----------
-        code : hikari.invites.Inviteish
+        code : typing.Union[hikari.invites.InviteCode, builtins.str]
             The object or string code of the invite to get from the cache.
 
         Returns
@@ -1001,12 +1001,14 @@ class MutableCache(Cache, abc.ABC):
         """
 
     @abc.abstractmethod
-    def delete_invite(self, code: invites.Inviteish, /) -> typing.Optional[invites.InviteWithMetadata]:
+    def delete_invite(
+        self, code: typing.Union[invites.InviteCode, str], /
+    ) -> typing.Optional[invites.InviteWithMetadata]:
         """Remove an invite object from the cache.
 
         Parameters
         ----------
-        code : hikari.invites.Inviteish
+        code : typing.Union[hikari.invites.InviteCode, builtins.str]
             Object or string code of the invite to remove from the cache.
 
         Returns

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -380,7 +380,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     async def edit_my_voice_state(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        channel: snowflakes.SnowflakeishOr[channels_.PartialChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.GuildVoiceChannel],
         *,
         suppress: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         request_to_speak: typing.Union[undefined.UndefinedType, bool, datetime.datetime] = undefined.UNDEFINED,
@@ -395,7 +395,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------
         guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
             Object or Id of the guild to edit a voice state in.
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildVoiceChannel]
             Object or Id of the channel to edit a voice state in.
 
         Other Parameters
@@ -445,7 +445,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     async def edit_voice_state(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        channel: snowflakes.SnowflakeishOr[channels_.PartialChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.GuildVoiceChannel],
         user: snowflakes.SnowflakeishOr[users.PartialUser],
         *,
         suppress: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
@@ -456,7 +456,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------
         guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
             Object or Id of the guild to edit a voice state in.
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildVoiceChannel]
             Object or Id of the channel to edit a voice state in.
         user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
             Object or Id of the user to to edit the voice state of.

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -380,7 +380,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     async def edit_my_voice_state(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        channel: snowflakes.SnowflakeishOr[channels_.GuildVoiceChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.GuildStageChannel],
         *,
         suppress: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         request_to_speak: typing.Union[undefined.UndefinedType, bool, datetime.datetime] = undefined.UNDEFINED,
@@ -395,7 +395,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------
         guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
             Object or Id of the guild to edit a voice state in.
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildVoiceChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildStageChannel]
             Object or Id of the channel to edit a voice state in.
 
         Other Parameters
@@ -445,7 +445,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     async def edit_voice_state(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        channel: snowflakes.SnowflakeishOr[channels_.GuildVoiceChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.GuildStageChannel],
         user: snowflakes.SnowflakeishOr[users.PartialUser],
         *,
         suppress: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
@@ -456,7 +456,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------
         guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
             Object or Id of the guild to edit a voice state in.
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildVoiceChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildStageChannel]
             Object or Id of the channel to edit a voice state in.
         user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
             Object or Id of the user to to edit the voice state of.

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -159,7 +159,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
             Likewise, the `hikari.channels.GuildChannel` can be used to
             determine if a channel is guild-bound, and
-            `hikari.channels.TextChannel` can be used to determine
+            `hikari.channels.TextableChannel` can be used to determine
             if the channel provides textual functionality to the application.
 
             You can check for these using the `builtins.isinstance`
@@ -395,7 +395,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------
         guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
             Object or Id of the guild to edit a voice state in.
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
             Object or Id of the channel to edit a voice state in.
 
         Other Parameters
@@ -456,7 +456,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------
         guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
             Object or Id of the guild to edit a voice state in.
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
             Object or Id of the channel to edit a voice state in.
         user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
             Object or Id of the user to to edit the voice state of.
@@ -757,7 +757,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     @abc.abstractmethod
     def trigger_typing(
-        self, channel: snowflakes.SnowflakeishOr[channels_.TextChannel]
+        self, channel: snowflakes.SnowflakeishOr[channels_.TextableChannel]
     ) -> special_endpoints.TypingIndicator:
         """Trigger typing in a text channel.
 
@@ -782,7 +782,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
             The channel to trigger typing in. This may be the object or
             the ID of an existing channel.
 
@@ -821,13 +821,13 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     @abc.abstractmethod
     async def fetch_pins(
-        self, channel: snowflakes.SnowflakeishOr[channels_.TextChannel]
+        self, channel: snowflakes.SnowflakeishOr[channels_.TextableChannel]
     ) -> typing.Sequence[messages_.Message]:
         """Fetch the pinned messages in this text channel.
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
             The channel to fetch pins from. This may be the object or
             the ID of an existing channel.
 
@@ -862,14 +862,14 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def pin_message(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
     ) -> None:
         """Pin an existing message in the given text channel.
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
             The channel to pin a message in. This may be the object or
             the ID of an existing channel.
         message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
@@ -903,14 +903,14 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def unpin_message(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
     ) -> None:
         """Unpin a given message from a given text channel.
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
             The channel to unpin a message in. This may be the object or
             the ID of an existing channel.
         message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
@@ -944,7 +944,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     def fetch_messages(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         *,
         before: undefined.UndefinedOr[snowflakes.SearchableSnowflakeishOr[snowflakes.Unique]] = undefined.UNDEFINED,
         after: undefined.UndefinedOr[snowflakes.SearchableSnowflakeishOr[snowflakes.Unique]] = undefined.UNDEFINED,
@@ -954,7 +954,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
             The channel to fetch messages in. This may be the object or
             the ID of an existing channel.
 
@@ -1020,14 +1020,14 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def fetch_message(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
     ) -> messages_.Message:
         """Fetch a specific message in the given text channel.
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
             The channel to fetch messages in. This may be the object or
             the ID of an existing channel.
         message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
@@ -1066,7 +1066,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def create_message(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         content: undefined.UndefinedOr[typing.Any] = undefined.UNDEFINED,
         *,
         embed: undefined.UndefinedOr[embeds_.Embed] = undefined.UNDEFINED,
@@ -1089,7 +1089,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
             The channel to create the message in.
         content : hikari.undefined.UndefinedOr[typing.Any]
             If provided, the message contents. If
@@ -1272,7 +1272,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def edit_message(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         content: undefined.UndefinedOr[typing.Any] = undefined.UNDEFINED,
         *,
@@ -1295,7 +1295,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
             The channel to create the message in. This may be
             the object or the ID of an existing channel.
         message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
@@ -1452,14 +1452,14 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def delete_message(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
     ) -> None:
         """Delete a given message in a given channel.
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
             The channel to delete the message in. This may be
             the object or the ID of an existing channel.
         message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
@@ -1493,7 +1493,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def delete_messages(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         messages: typing.Union[
             snowflakes.SnowflakeishOr[messages_.PartialMessage],
             snowflakes.SnowflakeishIterable[messages_.PartialMessage],
@@ -1505,7 +1505,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
             The channel to bulk delete the messages in. This may be
             the object or the ID of an existing channel.
         messages : typing.Union[hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage], hikari.snowflakes.SnowflakeishIterable[hikari.messages.PartialMessage]]
@@ -1550,7 +1550,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def add_reaction(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         emoji: emojis.Emojiish,
     ) -> None:
@@ -1558,9 +1558,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
             The channel where the message to add the reaction to is. This
-            may be a `hikari.channels.TextChannel` or the ID of an existing
+            may be a `hikari.channels.TextableChannel` or the ID of an existing
             channel.
         message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
             The message to add a reaction to. This may be the
@@ -1598,7 +1598,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def delete_my_reaction(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         emoji: emojis.Emojiish,
     ) -> None:
@@ -1606,7 +1606,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
             The channel where the message to delete the reaction from is.
             This may be the object or the ID of an existing channel.
         message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
@@ -1642,7 +1642,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def delete_all_reactions_for_emoji(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         emoji: emojis.Emojiish,
     ) -> None:
@@ -1650,7 +1650,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
             The channel where the message to delete the reactions from is.
             This may be the object or the ID of an existing channel.
         message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
@@ -1688,7 +1688,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def delete_reaction(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         emoji: emojis.Emojiish,
         user: snowflakes.SnowflakeishOr[users.PartialUser],
@@ -1700,7 +1700,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
             The channel where the message to delete the reaction from is.
             This may be the object or the ID of an existing channel.
         message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
@@ -1738,14 +1738,14 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def delete_all_reactions(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
     ) -> None:
         """Delete all reactions from a message.
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
             The channel where the message to delete all reactions from is.
             This may be the object or the ID of an existing channel.
         message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
@@ -1781,7 +1781,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     def fetch_reactions_for_emoji(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         emoji: emojis.Emojiish,
     ) -> iterators.LazyIterator[users.User]:
@@ -1789,7 +1789,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
             The channel where the message to delete all reactions from is.
             This may be the object or the ID of an existing channel.
         message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
@@ -1840,7 +1840,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def create_webhook(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         name: str,
         *,
         avatar: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
@@ -1850,7 +1850,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
             The channel where the webhook will be created. This may be
             the object or the ID of an existing channel.
         name : str
@@ -1947,15 +1947,15 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def fetch_channel_webhooks(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
     ) -> typing.Sequence[webhooks.PartialWebhook]:
         """Fetch all channel webhooks.
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
             The channel to fetch the webhooks for. This
-            may be a `hikari.channels.TextChannel` or the ID of an
+            may be a `hikari.channels.TextableChannel` or the ID of an
             existing channel.
 
         Returns
@@ -2035,7 +2035,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         token: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         name: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         avatar: undefined.UndefinedNoneOr[files.Resourceish] = undefined.UNDEFINED,
-        channel: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.TextChannel]] = undefined.UNDEFINED,
+        channel: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.TextableChannel]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> webhooks.PartialWebhook:
         """Edit a webhook.
@@ -2056,7 +2056,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         avatar : hikari.undefined.UndefinedNoneOr[hikari.files.Resourceish]
             If provided, the new webhook avatar. If `builtins.None`, will
             remove the webhook avatar.
-        channel : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]]
+        channel : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]]
             If provided, the text channel to move the webhook to.
         reason : hikari.undefined.UndefinedOr[builtins.str]
             If provided, the reason that will be recorded in the audit logs.

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -1840,7 +1840,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def create_webhook(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.WebhookChannelT],
         name: str,
         *,
         avatar: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
@@ -1850,7 +1850,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.WebhookChannelT]
             The channel where the webhook will be created. This may be
             the object or the ID of an existing channel.
         name : str
@@ -1947,16 +1947,16 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def fetch_channel_webhooks(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.WebhookChannelT],
     ) -> typing.Sequence[webhooks.PartialWebhook]:
         """Fetch all channel webhooks.
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
-            The channel to fetch the webhooks for. This
-            may be a `hikari.channels.TextableChannel` or the ID of an
-            existing channel.
+        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.WebhookChannelT]
+            The channel to fetch the webhooks for. This may be an instance of any
+            of the classes which are valid for `hikari.channels.WebhookChannelT`
+            or the ID of an existing channel.
 
         Returns
         -------
@@ -2035,7 +2035,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         token: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         name: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         avatar: undefined.UndefinedNoneOr[files.Resourceish] = undefined.UNDEFINED,
-        channel: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.TextableChannel]] = undefined.UNDEFINED,
+        channel: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.WebhookChannelT]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> webhooks.PartialWebhook:
         """Edit a webhook.
@@ -2056,7 +2056,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         avatar : hikari.undefined.UndefinedNoneOr[hikari.files.Resourceish]
             If provided, the new webhook avatar. If `builtins.None`, will
             remove the webhook avatar.
-        channel : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]]
+        channel : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.WebhookChannelT]]
             If provided, the text channel to move the webhook to.
         reason : hikari.undefined.UndefinedOr[builtins.str]
             If provided, the reason that will be recorded in the audit logs.

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -205,7 +205,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         video_quality_mode: undefined.UndefinedOr[typing.Union[channels_.VideoQualityMode, int]] = undefined.UNDEFINED,
         user_limit: undefined.UndefinedOr[int] = undefined.UNDEFINED,
         rate_limit_per_user: undefined.UndefinedOr[time.Intervalish] = undefined.UNDEFINED,
-        region: undefined.UndefinedOr[voices.VoiceRegionish] = undefined.UNDEFINED,
+        region: undefined.UndefinedOr[typing.Union[str, voices.VoiceRegion]] = undefined.UNDEFINED,
         permission_overwrites: undefined.UndefinedOr[
             typing.Sequence[channels_.PermissionOverwrite]
         ] = undefined.UNDEFINED,
@@ -240,7 +240,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If provided, the new user limit in the channel.
         rate_limit_per_user : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
             If provided, the new rate limit per user in the channel.
-        region : hikari.undefined.UndefinedOr[hikari.voices.VoiceRegionish]
+        region : hikari.undefined.UndefinedOr[typing.Union[builtins.str, hikari.voices.VoiceRegion]]
             If provided, the voice region to set for this channel. Passing
             `builtins.None` here will set it to "auto" mode where the used
             region will be decided based on the first person who connects to it
@@ -2607,12 +2607,12 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         """
 
     @abc.abstractmethod
-    async def fetch_invite(self, invite: invites.Inviteish) -> invites.Invite:
+    async def fetch_invite(self, invite: typing.Union[invites.InviteCode, str]) -> invites.Invite:
         """Fetch an existing invite.
 
         Parameters
         ----------
-        invite : hikari.invites.Inviteish
+        invite : typing.Union[hikari.invites.InviteCode, builtins.str]
             The invite to fetch. This may be an invite object or
             the code of an existing invite.
 
@@ -2643,12 +2643,12 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         """
 
     @abc.abstractmethod
-    async def delete_invite(self, invite: invites.Inviteish) -> invites.Invite:
+    async def delete_invite(self, invite: typing.Union[invites.InviteCode, str]) -> invites.Invite:
         """Delete an existing invite.
 
         Parameters
         ----------
-        invite : hikari.invites.Inviteish
+        invite : typing.Union[hikari.invites.InviteCode, builtins.str]
             The invite to delete. This may be an invite object or
             the code of an existing invite.
 
@@ -4101,7 +4101,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         permission_overwrites: undefined.UndefinedOr[
             typing.Sequence[channels_.PermissionOverwrite]
         ] = undefined.UNDEFINED,
-        region: undefined.UndefinedOr[voices.VoiceRegionish] = undefined.UNDEFINED,
+        region: undefined.UndefinedOr[typing.Union[voices.VoiceRegion, str]] = undefined.UNDEFINED,
         category: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.GuildCategory]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> channels_.GuildVoiceChannel:
@@ -4131,7 +4131,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If provided, the new video quality mode for the channel.
         permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
             If provided, the permission overwrites for the channel.
-        region : hikari.undefined.UndefinedOr[hikari.voices.VoiceRegionish]
+        region : hikari.undefined.UndefinedOr[typing.Union[hikari.voices.VoiceRegion, builtins.str]]
             If provided, the voice region to for this channel. Passing
             `builtins.None` here will set it to "auto" mode where the used
             region will be decided based on the first person who connects to it
@@ -4185,7 +4185,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         permission_overwrites: undefined.UndefinedOr[
             typing.Sequence[channels_.PermissionOverwrite]
         ] = undefined.UNDEFINED,
-        region: undefined.UndefinedOr[voices.VoiceRegionish] = undefined.UNDEFINED,
+        region: undefined.UndefinedOr[typing.Union[voices.VoiceRegion, str]] = undefined.UNDEFINED,
         category: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.GuildCategory]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> channels_.GuildStageChannel:
@@ -4213,7 +4213,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             servers.
         permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
             If provided, the permission overwrites for the channel.
-        region : hikari.undefined.UndefinedOr[hikari.voices.VoiceRegionish]
+        region : hikari.undefined.UndefinedOr[typing.Union[hikari.voices.VoiceRegion, builtins.str]]
             If provided, the voice region to for this channel. Passing
             `builtins.None` here will set it to "auto" mode where the used
             region will be decided based on the first person who connects to it
@@ -5794,7 +5794,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def create_guild_from_template(
         self,
-        template: templates.Templateish,
+        template: typing.Union[str, templates.Template],
         name: str,
         *,
         icon: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
@@ -5803,8 +5803,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        template: hikari.templates.Templateish
-            The objecr or code of the template to create a guild based on.
+        template : typing.Union[builtins.str, hikari.templates.Template]
+            The object or string code of the template to create a guild based on.
         name : builtins.str
             The new guilds name.
 
@@ -5848,7 +5848,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     async def delete_template(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        template: templates.Templateish,
+        template: typing.Union[str, templates.Template],
     ) -> templates.Template:
         """Delete a guild template.
 
@@ -5856,8 +5856,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------
         guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
             The guild to delete a template in.
-        template : hikari.templates.Templateish
-            Object or ID of the template to delete.
+        template : typing.Union[str, hikari.templates.Template]
+            Object or string code of the template to delete.
 
         Returns
         -------
@@ -5892,7 +5892,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     async def edit_template(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        template: templates.Templateish,
+        template: typing.Union[templates.Template, str],
         *,
         name: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         description: undefined.UndefinedNoneOr[str] = undefined.UNDEFINED,
@@ -5903,8 +5903,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------
         guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
             The guild to edit a template in.
-        template : hikari.templates.Templateish
-            Object or ID of the template to modify.
+        template : typing.Union[builtins.str, hikari.templates.Template]
+            Object or string code of the template to modify.
 
         Other Parameters
         ----------------
@@ -5943,12 +5943,12 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         """
 
     @abc.abstractmethod
-    async def fetch_template(self, template: templates.Templateish) -> templates.Template:
+    async def fetch_template(self, template: typing.Union[str, templates.Template]) -> templates.Template:
         """Fetch a guild template.
 
         Parameters
         ----------
-        template : hikari.templates.Templateish
+        template : typing.Union[builtins.str, hikari.templates.Template]
             The object or string code of the template to fetch.
 
         Returns
@@ -6021,7 +6021,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     async def sync_guild_template(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        template: templates.Templateish,
+        template: typing.Union[str, templates.Template],
     ) -> templates.Template:
         """Create a guild template.
 
@@ -6029,8 +6029,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------
         guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
             The guild to sync a template in.
-        template : hikari.templates.Templateish
-            Object or ID of the template to sync.
+        template : typing.Union[builtins.str, hikari.templates.Template]
+            Object or code of the template to sync.
 
         Returns
         -------

--- a/hikari/api/special_endpoints.py
+++ b/hikari/api/special_endpoints.py
@@ -434,7 +434,7 @@ class GuildBuilder(abc.ABC):
         permission_overwrites: undefined.UndefinedOr[
             typing.Collection[channels.PermissionOverwrite]
         ] = undefined.UNDEFINED,
-        region: undefined.UndefinedNoneOr[voices.VoiceRegionish],
+        region: undefined.UndefinedNoneOr[typing.Union[voices.VoiceRegion, str]],
         user_limit: undefined.UndefinedOr[int] = undefined.UNDEFINED,
     ) -> snowflakes.Snowflake:
         """Create a voice channel.
@@ -460,7 +460,7 @@ class GuildBuilder(abc.ABC):
             If provided, the new video quality mode for the channel.
         permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
             If provided, the permission overwrites for the channel.
-        region : hikari.undefined.UndefinedOr[hikari.voices.VoiceRegionish]
+        region : hikari.undefined.UndefinedOr[typing.Union[hikari.voices.VoiceRegion, builtins.str]]
              If provided, the voice region to for this channel. Passing
              `builtins.None` here will set it to "auto" mode where the used
              region will be decided based on the first person who connects to it
@@ -491,7 +491,7 @@ class GuildBuilder(abc.ABC):
         permission_overwrites: undefined.UndefinedOr[
             typing.Collection[channels.PermissionOverwrite]
         ] = undefined.UNDEFINED,
-        region: undefined.UndefinedNoneOr[voices.VoiceRegionish],
+        region: undefined.UndefinedNoneOr[typing.Union[voices.VoiceRegion, str]],
         user_limit: undefined.UndefinedOr[int] = undefined.UNDEFINED,
     ) -> snowflakes.Snowflake:
         """Create a stage channel.
@@ -515,7 +515,7 @@ class GuildBuilder(abc.ABC):
             servers.
         permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
             If provided, the permission overwrites for the channel.
-        region : hikari.undefined.UndefinedOr[hikari.voices.VoiceRegionish]
+        region : hikari.undefined.UndefinedOr[typing.Union[hikari.voices.VoiceRegion, builtins.str]]
              If provided, the voice region to for this channel. Passing
              `builtins.None` here will set it to "auto" mode where the used
              region will be decided based on the first person who connects to it

--- a/hikari/applications.py
+++ b/hikari/applications.py
@@ -276,7 +276,7 @@ class OwnConnection:
 class OwnGuild(guilds.PartialGuild):
     """Represents a user bound partial guild object."""
 
-    features: typing.Sequence[guilds.GuildFeatureish] = attr.field(eq=False, hash=False, repr=False)
+    features: typing.Sequence[typing.Union[str, guilds.GuildFeature]] = attr.field(eq=False, hash=False, repr=False)
     """A list of the features in this guild."""
 
     is_owner: bool = attr.field(eq=False, hash=False, repr=True)

--- a/hikari/audit_logs.py
+++ b/hikari/audit_logs.py
@@ -223,12 +223,12 @@ class MessagePinEntryInfo(BaseAuditLogEntryInfo):
     message_id: snowflakes.Snowflake = attr.field(repr=True)
     """The ID of the message that's being pinned or unpinned."""
 
-    async def fetch_channel(self) -> channels.TextChannel:
+    async def fetch_channel(self) -> channels.TextableChannel:
         """Fetch The channel where this message was pinned or unpinned.
 
         Returns
         -------
-        hikari.channels.TextChannel
+        hikari.channels.TextableChannel
             The channel where this message was pinned or unpinned.
 
         Raises
@@ -254,7 +254,7 @@ class MessagePinEntryInfo(BaseAuditLogEntryInfo):
             If an internal error occurs on Discord while handling the request.
         """
         channel = await self.app.rest.fetch_channel(self.channel_id)
-        assert isinstance(channel, channels.TextChannel)
+        assert isinstance(channel, channels.TextableChannel)
         return channel
 
     async def fetch_message(self) -> messages.Message:
@@ -319,12 +319,12 @@ class MessageDeleteEntryInfo(MessageBulkDeleteEntryInfo):
     channel_id: snowflakes.Snowflake = attr.field(repr=True)
     """The ID of guild text based channel where these message(s) were deleted."""
 
-    async def fetch_channel(self) -> channels.GuildTextChannel:
+    async def fetch_channel(self) -> channels.TextableGuildChannel:
         """Fetch the guild text based channel where these message(s) were deleted.
 
         Returns
         -------
-        hikari.channels.GuildTextChannel
+        hikari.channels.TextableGuildChannel
             The guild text based channel where these message(s) were deleted.
 
         Raises
@@ -350,7 +350,7 @@ class MessageDeleteEntryInfo(MessageBulkDeleteEntryInfo):
             If an internal error occurs on Discord while handling the request.
         """
         channel = await self.app.rest.fetch_channel(self.channel_id)
-        assert isinstance(channel, channels.GuildTextChannel)
+        assert isinstance(channel, channels.TextableGuildChannel)
         return channel
 
 

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -31,7 +31,8 @@ __all__: typing.List[str] = [
     "PermissionOverwrite",
     "PermissionOverwriteType",
     "PartialChannel",
-    "TextChannel",
+    "TextableChannel",
+    "TextableGuildChannel",
     "PrivateChannel",
     "DMChannel",
     "GroupDMChannel",
@@ -44,7 +45,6 @@ __all__: typing.List[str] = [
     "GuildStageChannel",
 ]
 
-import abc
 import typing
 
 import attr
@@ -380,8 +380,8 @@ class PartialChannel(snowflakes.Unique):
         return await self.app.rest.delete_channel(self.id)
 
 
-class TextChannel(PartialChannel, abc.ABC):
-    """A channel that can have text messages in it."""
+class TextableChannel(PartialChannel):
+    """Mixin class for a channel which can have text messages in it."""
 
     # This is a mixin, do not add slotted fields.
     __slots__: typing.Sequence[str] = ()
@@ -825,7 +825,7 @@ class PrivateChannel(PartialChannel):
 
 
 @attr.define(hash=True, kw_only=True, weakref_slot=False)
-class DMChannel(PrivateChannel, TextChannel):
+class DMChannel(PrivateChannel, TextableChannel):
     """Represents a direct message text channel that is between you and another user."""
 
     recipient: users.User = attr.field(eq=False, hash=False, repr=False)
@@ -845,7 +845,7 @@ class GroupDMChannel(PrivateChannel):
     """Represents a group direct message channel.
 
     !!! note
-        This doesn't have the methods found on `TextChannel` as bots cannot
+        This doesn't have the methods found on `TextableChannel` as bots cannot
         interact with a group DM that they own by sending or seeing messages in
         it.
     """
@@ -1216,6 +1216,13 @@ class GuildChannel(PartialChannel):
         )
 
 
+class TextableGuildChannel(GuildChannel, TextableChannel):
+    """Mixin class for any guild channel which can have text messages in it."""
+
+    # This is a mixin, do not add slotted fields.
+    __slots__: typing.Sequence[str] = ()
+
+
 @attr.define(hash=True, kw_only=True, weakref_slot=False)
 class GuildCategory(GuildChannel):
     """Represents a guild category channel.
@@ -1226,7 +1233,7 @@ class GuildCategory(GuildChannel):
 
 
 @attr.define(hash=True, kw_only=True, weakref_slot=False)
-class GuildTextChannel(GuildChannel, TextChannel):
+class GuildTextChannel(TextableGuildChannel):
     """Represents a guild text channel."""
 
     topic: typing.Optional[str] = attr.field(eq=False, hash=False, repr=False)
@@ -1261,7 +1268,7 @@ class GuildTextChannel(GuildChannel, TextChannel):
 
 
 @attr.define(hash=True, kw_only=True, weakref_slot=False)
-class GuildNewsChannel(GuildChannel, TextChannel):
+class GuildNewsChannel(TextableGuildChannel):
     """Represents an news channel."""
 
     topic: typing.Optional[str] = attr.field(eq=False, hash=False, repr=False)

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -43,6 +43,8 @@ __all__: typing.List[str] = [
     "GuildStoreChannel",
     "GuildVoiceChannel",
     "GuildStageChannel",
+    "WebhookChannelT",
+    "WebhookChannelTypes",
 ]
 
 import typing
@@ -1346,3 +1348,22 @@ class GuildStageChannel(GuildChannel):
 
     If this is `0`, then assume no limit.
     """
+
+
+WebhookChannelT = typing.Union[GuildTextChannel, GuildNewsChannel]
+"""Union of the channel types which incoming and follower webhooks can be attached to.
+
+The following types are in this:
+
+* `GuildTextChannel`
+* `GuildNewsChannel`
+"""
+
+WebhookChannelTypes = (GuildTextChannel, GuildNewsChannel)
+"""Tuple of the channel types which are valid for `WebhookChannelT`.
+
+This includes:
+
+* `GuildTextChannel`
+* `GuildNewsChannel`
+"""

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -1134,7 +1134,7 @@ class GuildChannel(PartialChannel):
         video_quality_mode: undefined.UndefinedOr[typing.Union[VideoQualityMode, int]] = undefined.UNDEFINED,
         user_limit: undefined.UndefinedOr[int] = undefined.UNDEFINED,
         rate_limit_per_user: undefined.UndefinedOr[time.Intervalish] = undefined.UNDEFINED,
-        region: undefined.UndefinedOr[voices.VoiceRegionish] = undefined.UNDEFINED,
+        region: undefined.UndefinedOr[typing.Union[voices.VoiceRegion, str]] = undefined.UNDEFINED,
         permission_overwrites: undefined.UndefinedOr[typing.Sequence[PermissionOverwrite]] = undefined.UNDEFINED,
         parent_category: undefined.UndefinedOr[snowflakes.SnowflakeishOr[GuildCategory]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
@@ -1159,7 +1159,7 @@ class GuildChannel(PartialChannel):
             If provided, the new user limit in the channel.
         rate_limit_per_user : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
             If provided, the new rate limit per user in the channel.
-        region : hikari.undefined.UndefinedOr[hikari.voices.VoiceRegionish]
+        region : hikari.undefined.UndefinedOr[typing.Union[hikari.voices.VoiceRegion, builtins.str]]
             If provided, the voice region to set for this channel. Passing
             `builtins.None` here will set it to "auto" mode where the used
             region will be decided based on the first person who connects to it

--- a/hikari/events/channel_events.py
+++ b/hikari/events/channel_events.py
@@ -775,7 +775,6 @@ class WebhookUpdateEvent(GuildChannelEvent):
     # <<inherited docstring from ChannelEvent>>.
 
     guild_id: snowflakes.Snowflake = attr.field()
-
     # <<inherited docstring from GuildChannelEvent>>.
 
     async def fetch_channel_webhooks(self) -> typing.Sequence[webhooks.PartialWebhook]:

--- a/hikari/events/channel_events.py
+++ b/hikari/events/channel_events.py
@@ -482,13 +482,13 @@ class PinsUpdateEvent(ChannelEvent, abc.ABC):
         """
 
     @abc.abstractmethod
-    async def fetch_channel(self) -> channels.TextChannel:
+    async def fetch_channel(self) -> channels.TextableChannel:
         """Perform an API call to fetch the details about this channel.
 
         Returns
         -------
-        hikari.channels.TextChannel
-            A derivative of `hikari.channels.TextChannel`. The actual
+        hikari.channels.TextableChannel
+            A derivative of `hikari.channels.TextableChannel`. The actual
             type will vary depending on the type of channel this event
             concerns.
         """
@@ -527,14 +527,14 @@ class GuildPinsUpdateEvent(PinsUpdateEvent, GuildChannelEvent):
     # <<inherited docstring from ChannelPinsUpdateEvent>>.
 
     @property
-    def channel(self) -> typing.Optional[channels.GuildTextChannel]:
+    def channel(self) -> typing.Optional[channels.TextableGuildChannel]:
         """Get the cached channel that this event relates to, if known.
 
         If not, return `builtins.None`.
 
         Returns
         -------
-        typing.Optional[hikari.channels.GuildTextChannel]
+        typing.Optional[hikari.channels.TextableGuildChannel]
             The cached channel this event relates to. If not known, this
             will return `builtins.None` instead.
         """
@@ -542,16 +542,16 @@ class GuildPinsUpdateEvent(PinsUpdateEvent, GuildChannelEvent):
             return None
 
         channel = self.app.cache.get_guild_channel(self.channel_id)
-        assert channel is None or isinstance(channel, channels.GuildTextChannel)
+        assert channel is None or isinstance(channel, channels.TextableGuildChannel)
         return channel
 
-    async def fetch_channel(self) -> channels.GuildTextChannel:
+    async def fetch_channel(self) -> channels.TextableGuildChannel:
         """Perform an API call to fetch the details about this channel.
 
         Returns
         -------
-        hikari.channels.GuildTextChannel
-            A derivative of `hikari.channels.GuildTextChannel`. The actual
+        hikari.channels.TextableGuildChannel
+            A derivative of `hikari.channels.TextableGuildChannel`. The actual
             type will vary depending on the type of channel this event
             concerns.
 
@@ -598,7 +598,6 @@ class DMPinsUpdateEvent(PinsUpdateEvent, DMChannelEvent):
     # <<inherited docstring from ChannelEvent>>.
 
     last_pin_timestamp: typing.Optional[datetime.datetime] = attr.field(repr=True)
-
     # <<inherited docstring from ChannelPinsUpdateEvent>>.
 
     async def fetch_channel(self) -> channels.DMChannel:

--- a/hikari/events/message_events.py
+++ b/hikari/events/message_events.py
@@ -245,12 +245,12 @@ class GuildMessageCreateEvent(MessageCreateEvent):
         return self.message.member
 
     @property
-    def channel(self) -> typing.Union[None, channels.GuildTextChannel, channels.GuildNewsChannel]:
+    def channel(self) -> typing.Optional[channels.TextableGuildChannel]:
         """Channel that the message was sent in, if known.
 
         Returns
         -------
-        typing.Union[builtins.None, hikari.channels.GuildTextChannel, hikari.channels.GuildNewsChannel]
+        typing.Optional[hikari.channels.TextableGuildChannel]
             The channel that the message was sent in, if known and cached,
             otherwise, `builtins.None`.
         """
@@ -259,8 +259,8 @@ class GuildMessageCreateEvent(MessageCreateEvent):
 
         channel = self.app.cache.get_guild_channel(self.channel_id)
         assert channel is None or isinstance(
-            channel, (channels.GuildNewsChannel, channels.GuildTextChannel)
-        ), f"Cached channel ID is not a GuildNewsChannel or a GuildTextChannel, but a {type(channel).__name__}!"
+            channel, channels.TextableGuildChannel
+        ), f"Cached channel ID is not a TextableGuildChannel, but a {type(channel).__name__}!"
         return channel
 
     @property
@@ -533,12 +533,12 @@ class GuildMessageUpdateEvent(MessageUpdateEvent):
         return None
 
     @property
-    def channel(self) -> typing.Union[None, channels.GuildTextChannel, channels.GuildNewsChannel]:
+    def channel(self) -> typing.Optional[channels.TextableGuildChannel]:
         """Channel that the message was sent in, if known.
 
         Returns
         -------
-        typing.Union[builtins.None, hikari.channels.GuildTextChannel, hikari.channels.GuildNewsChannel]
+        typing.Optional[hikari.channels.TextableGuildChannel]
             The channel that the message was sent in, if known and cached,
             otherwise, `builtins.None`.
         """
@@ -547,8 +547,8 @@ class GuildMessageUpdateEvent(MessageUpdateEvent):
 
         channel = self.app.cache.get_guild_channel(self.channel_id)
         assert channel is None or isinstance(
-            channel, (channels.GuildNewsChannel, channels.GuildTextChannel)
-        ), f"Cached channel ID is not a GuildNewsChannel or a GuildTextChannel, but a {type(channel).__name__}!"
+            channel, channels.TextableGuildChannel
+        ), f"Cached channel ID is not a TextableGuildChannel, but a {type(channel).__name__}!"
         return channel
 
     @property
@@ -708,26 +708,22 @@ class GuildMessageDeleteEvent(MessageDeleteEvent):
     # <<inherited docstring from ShardEvent>>
 
     @property
-    def channel(self) -> typing.Union[None, channels.GuildTextChannel, channels.GuildNewsChannel]:
+    def channel(self) -> typing.Optional[channels.TextableGuildChannel]:
         """Get the cached channel the messages were sent in, if known.
 
         Returns
         -------
-        typing.Union[builtins.None, hikari.channels.GuildTextChannel, hikari.channels.GuildNewsChannel]
+        typing.Optional[hikari.channels.TextableGuildChannel]
             The channel the messages were sent in, or `builtins.None` if not
             known/cached.
-
-            This otherwise will always be a `hikari.channels.GuildTextChannel`
-            if it is a normal message, or `hikari.channels.GuildNewsChannel` if
-            sent in an announcement channel.
         """
         if not isinstance(self.app, traits.CacheAware):
             return None
 
         channel = self.app.cache.get_guild_channel(self.channel_id)
         assert channel is None or isinstance(
-            channel, (channels.GuildNewsChannel, channels.GuildTextChannel)
-        ), f"Cached channel ID is not a GuildNewsChannel or a GuildTextChannel, but a {type(channel).__name__}!"
+            channel, channels.TextableGuildChannel
+        ), f"Cached channel ID is not a TextableGuildChannel, but a {type(channel).__name__}!"
         return channel
 
     @property

--- a/hikari/events/typing_events.py
+++ b/hikari/events/typing_events.py
@@ -102,12 +102,12 @@ class TypingEvent(shard_events.ShardEvent, abc.ABC):
         """
 
     @abc.abstractmethod
-    async def fetch_channel(self) -> channels.TextChannel:
+    async def fetch_channel(self) -> channels.TextableChannel:
         """Perform an API call to fetch an up-to-date image of this channel.
 
         Returns
         -------
-        hikari.channels.TextChannel
+        hikari.channels.TextableChannel
             The channel.
         """
 
@@ -173,12 +173,12 @@ class GuildTypingEvent(TypingEvent):
     """
 
     @property
-    def channel(self) -> typing.Union[channels.GuildTextChannel, channels.GuildNewsChannel, None]:
+    def channel(self) -> typing.Optional[channels.TextableGuildChannel]:
         """Get the cached channel object this typing event occurred in.
 
         Returns
         -------
-        typing.Union[hikari.channels.GuildTextChannel, hikari.channels.GuildNewsChannel, builtins.None]
+        typing.Optional[hikari.channels.TextableGuildChannel]
             The channel.
         """
         if not isinstance(self.app, traits.CacheAware):
@@ -186,8 +186,8 @@ class GuildTypingEvent(TypingEvent):
 
         channel = self.app.cache.get_guild_channel(self.channel_id)
         assert channel is None or isinstance(
-            channel, (channels.GuildTextChannel, channels.GuildNewsChannel)
-        ), f"expected GuildTextChannel or GuildNewsChannel from cache, got {channel}"
+            channel, channels.TextableGuildChannel
+        ), f"expected TextableGuildChannel from cache, got {channel}"
         return channel
 
     @property
@@ -211,18 +211,18 @@ class GuildTypingEvent(TypingEvent):
         # <<inherited docstring from TypingEvent>>.
         return self.user.id
 
-    async def fetch_channel(self) -> typing.Union[channels.GuildTextChannel, channels.GuildNewsChannel]:
+    async def fetch_channel(self) -> typing.Union[channels.TextableGuildChannel]:
         """Perform an API call to fetch an up-to-date image of this channel.
 
         Returns
         -------
-        typing.Union[hikari.channels.GuildTextChannel, hikari.channels.GuildNewsChannel]
+        typing.Union[hikari.channels.TextableGuildChannel]
             The channel.
         """
         channel = await self.app.rest.fetch_channel(self.channel_id)
         assert isinstance(
-            channel, (channels.GuildTextChannel, channels.GuildNewsChannel)
-        ), f"expected GuildTextChannel or GuildNewsChannel from API, got {channel}"
+            channel, channels.TextableGuildChannel
+        ), f"expected TextableGuildChannel from API, got {channel}"
         return channel
 
     async def fetch_guild(self) -> guilds.Guild:

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -31,7 +31,6 @@ __all__: typing.List[str] = [
     "GuildWidget",
     "Role",
     "GuildFeature",
-    "GuildFeatureish",
     "GuildSystemChannelFlag",
     "GuildMessageNotificationsLevel",
     "GuildExplicitContentFilterLevel",
@@ -170,15 +169,6 @@ class GuildFeature(str, enums.Enum):
 
     MORE_STICKERS = "MONETIZATION_ENABLED"
     """Guild has an increased custom stickers slots."""
-
-
-GuildFeatureish = typing.Union[str, GuildFeature]
-"""Type hint for possible guild features.
-
-Generally these will be of type `GuildFeature`, but undocumented or new
-fields may just be `builtins.str` until they are documented and amended to the
-library.
-"""
 
 
 @typing.final
@@ -2160,7 +2150,7 @@ class PartialGuild(snowflakes.Unique):
 class GuildPreview(PartialGuild):
     """A preview of a guild with the `GuildFeature.DISCOVERABLE` feature."""
 
-    features: typing.Sequence[GuildFeatureish] = attr.field(eq=False, hash=False, repr=False)
+    features: typing.Sequence[typing.Union[str, GuildFeature]] = attr.field(eq=False, hash=False, repr=False)
     """A list of the features in this guild."""
 
     splash_hash: typing.Optional[str] = attr.field(eq=False, hash=False, repr=False)
@@ -2264,7 +2254,7 @@ class GuildPreview(PartialGuild):
 class Guild(PartialGuild, abc.ABC):
     """A representation of a guild on Discord."""
 
-    features: typing.Sequence[GuildFeatureish] = attr.field(eq=False, hash=False, repr=False)
+    features: typing.Sequence[typing.Union[str, GuildFeature]] = attr.field(eq=False, hash=False, repr=False)
     """A list of the features in this guild."""
 
     application_id: typing.Optional[snowflakes.Snowflake] = attr.field(eq=False, hash=False, repr=False)

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -1861,7 +1861,7 @@ class PartialGuild(snowflakes.Unique):
         permission_overwrites: undefined.UndefinedOr[
             typing.Sequence[channels_.PermissionOverwrite]
         ] = undefined.UNDEFINED,
-        region: undefined.UndefinedOr[voices_.VoiceRegionish] = undefined.UNDEFINED,
+        region: undefined.UndefinedOr[typing.Union[voices_.VoiceRegion, str]] = undefined.UNDEFINED,
         category: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.GuildCategory]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> channels_.GuildVoiceChannel:
@@ -1891,7 +1891,7 @@ class PartialGuild(snowflakes.Unique):
             If provided, the new video quality mode for the channel.
         permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
             If provided, the permission overwrites for the channel.
-        region : hikari.undefined.UndefinedOr[hikari.voices.VoiceRegionish]
+        region : hikari.undefined.UndefinedOr[typing.Union[hikari.voices.VoiceRegion, builtins.str]]
             If provided, the voice region to for this channel. Passing
             `builtins.None` here will set it to "auto" mode where the used
             region will be decided based on the first person who connects to it
@@ -1955,7 +1955,7 @@ class PartialGuild(snowflakes.Unique):
         permission_overwrites: undefined.UndefinedOr[
             typing.Sequence[channels_.PermissionOverwrite]
         ] = undefined.UNDEFINED,
-        region: undefined.UndefinedOr[voices_.VoiceRegionish] = undefined.UNDEFINED,
+        region: undefined.UndefinedOr[typing.Union[voices_.VoiceRegion, str]] = undefined.UNDEFINED,
         category: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.GuildCategory]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> channels_.GuildStageChannel:
@@ -1980,7 +1980,7 @@ class PartialGuild(snowflakes.Unique):
             servers.
         permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
             If provided, the permission overwrites for the channel.
-        region : hikari.undefined.UndefinedOr[hikari.voices.VoiceRegionish]
+        region : hikari.undefined.UndefinedOr[typing.Union[hikari.voices.VoiceRegion, builtins.str]]
             If provided, the voice region to for this channel. Passing
             `builtins.None` here will set it to "auto" mode where the used
             region will be decided based on the first person who connects to it

--- a/hikari/impl/cache.py
+++ b/hikari/impl/cache.py
@@ -637,7 +637,9 @@ class CacheImpl(cache.MutableCache):
 
         return cache_utility.CacheMappingView(cached_invites, builder=self._build_invite)
 
-    def delete_invite(self, code: invites.Inviteish, /) -> typing.Optional[invites.InviteWithMetadata]:
+    def delete_invite(
+        self, code: typing.Union[invites.InviteCode, str], /
+    ) -> typing.Optional[invites.InviteWithMetadata]:
         if not self._is_cache_enabled_for(config.CacheComponents.INVITES):
             return None
 
@@ -659,7 +661,7 @@ class CacheImpl(cache.MutableCache):
 
         return self._build_invite(invite_data)
 
-    def get_invite(self, code: invites.Inviteish, /) -> typing.Optional[invites.InviteWithMetadata]:
+    def get_invite(self, code: typing.Union[invites.InviteCode, str], /) -> typing.Optional[invites.InviteWithMetadata]:
         if not self._is_cache_enabled_for(config.CacheComponents.INVITES):
             return None
 

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -114,7 +114,7 @@ class _GuildFields:
     id: snowflakes.Snowflake = attr.field()
     name: str = attr.field()
     icon_hash: str = attr.field()
-    features: typing.List[guild_models.GuildFeatureish] = attr.field()
+    features: typing.List[typing.Union[guild_models.GuildFeature, str]] = attr.field()
     splash_hash: typing.Optional[str] = attr.field()
     discovery_splash_hash: typing.Optional[str] = attr.field()
     owner_id: snowflakes.Snowflake = attr.field()

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -1620,7 +1620,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
     async def create_webhook(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.WebhookChannelT],
         name: str,
         *,
         avatar: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
@@ -1658,7 +1658,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
     async def fetch_channel_webhooks(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.WebhookChannelT],
     ) -> typing.Sequence[webhooks.PartialWebhook]:
         route = routes.GET_CHANNEL_WEBHOOKS.compile(channel=channel)
         response = await self._request(route)
@@ -1681,7 +1681,7 @@ class RESTClientImpl(rest_api.RESTClient):
         token: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         name: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         avatar: undefined.UndefinedNoneOr[files.Resourceish] = undefined.UNDEFINED,
-        channel: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.TextableChannel]] = undefined.UNDEFINED,
+        channel: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.WebhookChannelT]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> webhooks.PartialWebhook:
         if token is undefined.UNDEFINED:

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -969,7 +969,7 @@ class RESTClientImpl(rest_api.RESTClient):
     async def edit_my_voice_state(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        channel: snowflakes.SnowflakeishOr[channels_.PartialChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.GuildVoiceChannel],
         *,
         suppress: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         request_to_speak: typing.Union[undefined.UndefinedType, bool, datetime.datetime] = undefined.UNDEFINED,
@@ -993,7 +993,7 @@ class RESTClientImpl(rest_api.RESTClient):
     async def edit_voice_state(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        channel: snowflakes.SnowflakeishOr[channels_.PartialChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.GuildVoiceChannel],
         user: snowflakes.SnowflakeishOr[users.PartialUser],
         *,
         suppress: undefined.UndefinedOr[bool] = undefined.UNDEFINED,

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -1082,14 +1082,14 @@ class RESTClientImpl(rest_api.RESTClient):
         return self._entity_factory.deserialize_invite_with_metadata(response)
 
     def trigger_typing(
-        self, channel: snowflakes.SnowflakeishOr[channels_.TextChannel]
+        self, channel: snowflakes.SnowflakeishOr[channels_.TextableChannel]
     ) -> special_endpoints.TypingIndicator:
         return special_endpoints_impl.TypingIndicator(
             request_call=self._request, channel=channel, rest_closed_event=self._get_live_attributes().closed_event
         )
 
     async def fetch_pins(
-        self, channel: snowflakes.SnowflakeishOr[channels_.TextChannel]
+        self, channel: snowflakes.SnowflakeishOr[channels_.TextableChannel]
     ) -> typing.Sequence[messages_.Message]:
         route = routes.GET_CHANNEL_PINS.compile(channel=channel)
         response = await self._request(route)
@@ -1098,7 +1098,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
     async def pin_message(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
     ) -> None:
         route = routes.PUT_CHANNEL_PINS.compile(channel=channel, message=message)
@@ -1106,7 +1106,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
     async def unpin_message(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
     ) -> None:
         route = routes.DELETE_CHANNEL_PIN.compile(channel=channel, message=message)
@@ -1114,7 +1114,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
     def fetch_messages(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         *,
         before: undefined.UndefinedOr[snowflakes.SearchableSnowflakeishOr[snowflakes.Unique]] = undefined.UNDEFINED,
         after: undefined.UndefinedOr[snowflakes.SearchableSnowflakeishOr[snowflakes.Unique]] = undefined.UNDEFINED,
@@ -1157,7 +1157,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
     async def fetch_message(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
     ) -> messages_.Message:
         route = routes.GET_CHANNEL_MESSAGE.compile(channel=channel, message=message)
@@ -1267,7 +1267,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
     async def create_message(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         content: undefined.UndefinedOr[typing.Any] = undefined.UNDEFINED,
         *,
         embed: undefined.UndefinedOr[embeds_.Embed] = undefined.UNDEFINED,
@@ -1428,7 +1428,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
     async def edit_message(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         content: undefined.UndefinedOr[typing.Any] = undefined.UNDEFINED,
         *,
@@ -1467,7 +1467,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
     async def delete_message(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
     ) -> None:
         route = routes.DELETE_CHANNEL_MESSAGE.compile(channel=channel, message=message)
@@ -1475,7 +1475,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
     async def delete_messages(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         messages: typing.Union[
             snowflakes.SnowflakeishOr[messages_.PartialMessage],
             snowflakes.SnowflakeishIterable[messages_.PartialMessage],
@@ -1544,7 +1544,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
     async def add_reaction(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         emoji: emojis.Emojiish,
     ) -> None:
@@ -1557,7 +1557,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
     async def delete_my_reaction(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         emoji: emojis.Emojiish,
     ) -> None:
@@ -1570,7 +1570,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
     async def delete_all_reactions_for_emoji(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         emoji: emojis.Emojiish,
     ) -> None:
@@ -1583,7 +1583,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
     async def delete_reaction(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         emoji: emojis.Emojiish,
         user: snowflakes.SnowflakeishOr[users.PartialUser],
@@ -1598,7 +1598,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
     async def delete_all_reactions(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
     ) -> None:
         route = routes.DELETE_ALL_REACTIONS.compile(channel=channel, message=message)
@@ -1606,7 +1606,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
     def fetch_reactions_for_emoji(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         emoji: emojis.Emojiish,
     ) -> iterators.LazyIterator[users.User]:
@@ -1620,7 +1620,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
     async def create_webhook(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         name: str,
         *,
         avatar: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
@@ -1658,7 +1658,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
     async def fetch_channel_webhooks(
         self,
-        channel: snowflakes.SnowflakeishOr[channels_.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
     ) -> typing.Sequence[webhooks.PartialWebhook]:
         route = routes.GET_CHANNEL_WEBHOOKS.compile(channel=channel)
         response = await self._request(route)
@@ -1681,7 +1681,7 @@ class RESTClientImpl(rest_api.RESTClient):
         token: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         name: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         avatar: undefined.UndefinedNoneOr[files.Resourceish] = undefined.UNDEFINED,
-        channel: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.TextChannel]] = undefined.UNDEFINED,
+        channel: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.TextableChannel]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> webhooks.PartialWebhook:
         if token is undefined.UNDEFINED:

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -969,7 +969,7 @@ class RESTClientImpl(rest_api.RESTClient):
     async def edit_my_voice_state(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        channel: snowflakes.SnowflakeishOr[channels_.GuildVoiceChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.GuildStageChannel],
         *,
         suppress: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         request_to_speak: typing.Union[undefined.UndefinedType, bool, datetime.datetime] = undefined.UNDEFINED,
@@ -993,7 +993,7 @@ class RESTClientImpl(rest_api.RESTClient):
     async def edit_voice_state(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        channel: snowflakes.SnowflakeishOr[channels_.GuildVoiceChannel],
+        channel: snowflakes.SnowflakeishOr[channels_.GuildStageChannel],
         user: snowflakes.SnowflakeishOr[users.PartialUser],
         *,
         suppress: undefined.UndefinedOr[bool] = undefined.UNDEFINED,

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -911,7 +911,7 @@ class RESTClientImpl(rest_api.RESTClient):
         video_quality_mode: undefined.UndefinedOr[typing.Union[channels_.VideoQualityMode, int]] = undefined.UNDEFINED,
         user_limit: undefined.UndefinedOr[int] = undefined.UNDEFINED,
         rate_limit_per_user: undefined.UndefinedOr[time.Intervalish] = undefined.UNDEFINED,
-        region: undefined.UndefinedNoneOr[voices.VoiceRegionish] = undefined.UNDEFINED,
+        region: undefined.UndefinedNoneOr[typing.Union[voices.VoiceRegion, str]] = undefined.UNDEFINED,
         permission_overwrites: undefined.UndefinedOr[
             typing.Sequence[channels_.PermissionOverwrite]
         ] = undefined.UNDEFINED,
@@ -1841,7 +1841,7 @@ class RESTClientImpl(rest_api.RESTClient):
         assert isinstance(response, dict)
         return self._entity_factory.deserialize_gateway_bot_info(response)
 
-    async def fetch_invite(self, invite: invites.Inviteish) -> invites.Invite:
+    async def fetch_invite(self, invite: typing.Union[invites.InviteCode, str]) -> invites.Invite:
         route = routes.GET_INVITE.compile(invite_code=invite if isinstance(invite, str) else invite.code)
         query = data_binding.StringMapBuilder()
         query.put("with_counts", True)
@@ -1850,7 +1850,7 @@ class RESTClientImpl(rest_api.RESTClient):
         assert isinstance(response, dict)
         return self._entity_factory.deserialize_invite(response)
 
-    async def delete_invite(self, invite: invites.Inviteish) -> invites.Invite:
+    async def delete_invite(self, invite: typing.Union[invites.InviteCode, str]) -> invites.Invite:
         route = routes.DELETE_INVITE.compile(invite_code=invite if isinstance(invite, str) else invite.code)
         response = await self._request(route)
         assert isinstance(response, dict)
@@ -2326,7 +2326,7 @@ class RESTClientImpl(rest_api.RESTClient):
         permission_overwrites: undefined.UndefinedOr[
             typing.Sequence[channels_.PermissionOverwrite]
         ] = undefined.UNDEFINED,
-        region: undefined.UndefinedOr[voices.VoiceRegionish] = undefined.UNDEFINED,
+        region: undefined.UndefinedOr[typing.Union[voices.VoiceRegion, str]] = undefined.UNDEFINED,
         category: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.GuildCategory]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> channels_.GuildVoiceChannel:
@@ -2357,7 +2357,7 @@ class RESTClientImpl(rest_api.RESTClient):
         permission_overwrites: undefined.UndefinedOr[
             typing.Sequence[channels_.PermissionOverwrite]
         ] = undefined.UNDEFINED,
-        region: undefined.UndefinedOr[voices.VoiceRegionish] = undefined.UNDEFINED,
+        region: undefined.UndefinedOr[typing.Union[voices.VoiceRegion, str]] = undefined.UNDEFINED,
         category: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.GuildCategory]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> channels_.GuildStageChannel:
@@ -2414,7 +2414,7 @@ class RESTClientImpl(rest_api.RESTClient):
         permission_overwrites: undefined.UndefinedOr[
             typing.Sequence[channels_.PermissionOverwrite]
         ] = undefined.UNDEFINED,
-        region: undefined.UndefinedOr[voices.VoiceRegionish] = undefined.UNDEFINED,
+        region: undefined.UndefinedOr[typing.Union[voices.VoiceRegion, str]] = undefined.UNDEFINED,
         category: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.GuildCategory]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> channels_.GuildChannel:
@@ -2822,7 +2822,7 @@ class RESTClientImpl(rest_api.RESTClient):
         assert isinstance(response, dict)
         return self._entity_factory.deserialize_vanity_url(response)
 
-    async def fetch_template(self, template: templates.Templateish) -> templates.Template:
+    async def fetch_template(self, template: typing.Union[templates.Template, str]) -> templates.Template:
         template = template if isinstance(template, str) else template.code
         route = routes.GET_TEMPLATE.compile(template=template)
         response = await self._request(route)
@@ -2840,7 +2840,7 @@ class RESTClientImpl(rest_api.RESTClient):
     async def sync_guild_template(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        template: templates.Templateish,
+        template: typing.Union[templates.Template, str],
     ) -> templates.Template:
         template = template if isinstance(template, str) else template.code
         route = routes.PUT_GUILD_TEMPLATE.compile(guild=guild, template=template)
@@ -2850,7 +2850,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
     async def create_guild_from_template(
         self,
-        template: templates.Templateish,
+        template: typing.Union[str, templates.Template],
         name: str,
         *,
         icon: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
@@ -2887,7 +2887,7 @@ class RESTClientImpl(rest_api.RESTClient):
     async def edit_template(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        template: templates.Templateish,
+        template: typing.Union[str, templates.Template],
         *,
         name: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         description: undefined.UndefinedNoneOr[str] = undefined.UNDEFINED,
@@ -2905,7 +2905,7 @@ class RESTClientImpl(rest_api.RESTClient):
     async def delete_template(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        template: templates.Templateish,
+        template: typing.Union[str, templates.Template],
     ) -> templates.Template:
         template = template if isinstance(template, str) else template.code
         route = routes.DELETE_GUILD_TEMPLATE.compile(guild=guild, template=template)

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -94,7 +94,7 @@ class TypingIndicator(special_endpoints.TypingIndicator):
         request_call: typing.Callable[
             ..., typing.Coroutine[None, None, typing.Union[None, data_binding.JSONObject, data_binding.JSONArray]]
         ],
-        channel: snowflakes.SnowflakeishOr[channels.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels.TextableChannel],
         rest_closed_event: asyncio.Event,
     ) -> None:
         self._route = routes.POST_CHANNEL_TYPING.compile(channel=channel)
@@ -471,7 +471,7 @@ class MessageIterator(iterators.BufferedLazyIterator["messages.Message"]):
         request_call: typing.Callable[
             ..., typing.Coroutine[None, None, typing.Union[None, data_binding.JSONObject, data_binding.JSONArray]]
         ],
-        channel: snowflakes.SnowflakeishOr[channels.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels.TextableChannel],
         direction: str,
         first_id: undefined.UndefinedOr[str],
     ) -> None:
@@ -513,7 +513,7 @@ class ReactorIterator(iterators.BufferedLazyIterator["users.User"]):
         request_call: typing.Callable[
             ..., typing.Coroutine[None, None, typing.Union[None, data_binding.JSONObject, data_binding.JSONArray]]
         ],
-        channel: snowflakes.SnowflakeishOr[channels.TextChannel],
+        channel: snowflakes.SnowflakeishOr[channels.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages.PartialMessage],
         emoji: str,
     ) -> None:

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -393,7 +393,7 @@ class GuildBuilder(special_endpoints.GuildBuilder):
         permission_overwrites: undefined.UndefinedOr[
             typing.Collection[channels.PermissionOverwrite]
         ] = undefined.UNDEFINED,
-        region: undefined.UndefinedNoneOr[voices.VoiceRegionish],
+        region: undefined.UndefinedNoneOr[typing.Union[voices.VoiceRegion, str]],
         user_limit: undefined.UndefinedOr[int] = undefined.UNDEFINED,
     ) -> snowflakes.Snowflake:
         snowflake_id = self._new_snowflake()
@@ -428,7 +428,7 @@ class GuildBuilder(special_endpoints.GuildBuilder):
         permission_overwrites: undefined.UndefinedOr[
             typing.Collection[channels.PermissionOverwrite]
         ] = undefined.UNDEFINED,
-        region: undefined.UndefinedNoneOr[voices.VoiceRegionish],
+        region: undefined.UndefinedNoneOr[typing.Union[voices.VoiceRegion, str]],
         user_limit: undefined.UndefinedOr[int] = undefined.UNDEFINED,
     ) -> snowflakes.Snowflake:
         snowflake_id = self._new_snowflake()

--- a/hikari/invites.py
+++ b/hikari/invites.py
@@ -28,9 +28,9 @@ __all__: typing.List[str] = [
     "TargetType",
     "VanityURL",
     "InviteGuild",
+    "InviteCode",
     "Invite",
     "InviteWithMetadata",
-    "Inviteish",
 ]
 
 import abc
@@ -107,7 +107,7 @@ class VanityURL(InviteCode):
 class InviteGuild(guilds.PartialGuild):
     """Represents the partial data of a guild that is attached to invites."""
 
-    features: typing.Sequence[guilds.GuildFeatureish] = attr.field(eq=False, hash=False, repr=False)
+    features: typing.Sequence[typing.Union[guilds.GuildFeature, int]] = attr.field(eq=False, hash=False, repr=False)
     """A list of the features in this guild."""
 
     splash_hash: typing.Optional[str] = attr.field(eq=False, hash=False, repr=False)
@@ -340,12 +340,3 @@ class InviteWithMetadata(Invite):
             return self.max_uses - self.uses
 
         return None
-
-
-# TODO: converter to remove discord.gg part to allow URLs here too.
-Inviteish = typing.Union[str, InviteCode]
-"""Type hint for an invite, vanity URL, or invite code.
-
-This must be a representation of an invite that is a `builtins.str` containing
-the invite code, an `Invite`/`InviteWithMetadata`, or a `VanityURL` instance.
-"""

--- a/hikari/templates.py
+++ b/hikari/templates.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["Template", "TemplateGuild", "TemplateRole", "Templateish"]
+__all__: typing.List[str] = ["Template", "TemplateGuild", "TemplateRole"]
 
 import typing
 
@@ -176,7 +176,3 @@ class Template:
 
     def __str__(self) -> str:
         return f"https://discord.new/{self.code}"
-
-
-Templateish = typing.Union[str, Template]
-"""Type hint for a `Template` object or `builtin.str` template code."""

--- a/hikari/voices.py
+++ b/hikari/voices.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["VoiceRegion", "VoiceState", "VoiceRegionish"]
+__all__: typing.List[str] = ["VoiceRegion", "VoiceState"]
 
 import typing
 
@@ -130,10 +130,3 @@ class VoiceRegion:
 
     def __str__(self) -> str:
         return self.id
-
-
-VoiceRegionish = typing.Union[str, VoiceRegion]
-"""Type hint for a voice region or name of a voice region.
-
-Must be either a `VoiceRegion` or `builtins.str`.
-"""

--- a/hikari/webhooks.py
+++ b/hikari/webhooks.py
@@ -853,7 +853,7 @@ class ChannelFollowerWebhook(PartialWebhook):
         *,
         name: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         avatar: undefined.UndefinedNoneOr[files_.Resource[files_.AsyncReader]] = undefined.UNDEFINED,
-        channel: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.TextChannel]] = undefined.UNDEFINED,
+        channel: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.WebhookChannelT]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> ChannelFollowerWebhook:
         """Edit this webhook.
@@ -865,7 +865,7 @@ class ChannelFollowerWebhook(PartialWebhook):
         avatar : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
             If provided, the new avatar image. If `builtins.None`, then
             it is removed. If not specified, nothing is changed.
-        channel : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]]
+        channel : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.WebhookChannelT]]
             If provided, the object or ID of the new channel the given
             webhook should be moved to.
         reason : hikari.undefined.UndefinedOr[builtins.str]

--- a/hikari/webhooks.py
+++ b/hikari/webhooks.py
@@ -677,7 +677,7 @@ class IncomingWebhook(PartialWebhook, ExecutableWebhook):
         *,
         name: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         avatar: undefined.UndefinedNoneOr[files_.Resource[files_.AsyncReader]] = undefined.UNDEFINED,
-        channel: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.TextableChannel]] = undefined.UNDEFINED,
+        channel: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.WebhookChannelT]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         use_token: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
     ) -> IncomingWebhook:
@@ -690,7 +690,7 @@ class IncomingWebhook(PartialWebhook, ExecutableWebhook):
         avatar : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
             If provided, the new avatar image. If `builtins.None`, then
             it is removed. If not specified, nothing is changed.
-        channel : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]]
+        channel : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.WebhookChannelT]]
             If provided, the object or ID of the new channel the given
             webhook should be moved to.
         reason : hikari.undefined.UndefinedOr[builtins.str]

--- a/hikari/webhooks.py
+++ b/hikari/webhooks.py
@@ -677,7 +677,7 @@ class IncomingWebhook(PartialWebhook, ExecutableWebhook):
         *,
         name: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         avatar: undefined.UndefinedNoneOr[files_.Resource[files_.AsyncReader]] = undefined.UNDEFINED,
-        channel: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.TextChannel]] = undefined.UNDEFINED,
+        channel: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.TextableChannel]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         use_token: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
     ) -> IncomingWebhook:
@@ -690,7 +690,7 @@ class IncomingWebhook(PartialWebhook, ExecutableWebhook):
         avatar : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
             If provided, the new avatar image. If `builtins.None`, then
             it is removed. If not specified, nothing is changed.
-        channel : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.TextChannel]]
+        channel : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]]
             If provided, the object or ID of the new channel the given
             webhook should be moved to.
         reason : hikari.undefined.UndefinedOr[builtins.str]

--- a/hikari/webhooks.py
+++ b/hikari/webhooks.py
@@ -38,6 +38,7 @@ import typing
 
 import attr
 
+from hikari import channels as channels_
 from hikari import snowflakes
 from hikari import undefined
 from hikari import urls
@@ -46,7 +47,6 @@ from hikari.internal import enums
 from hikari.internal import routes
 
 if typing.TYPE_CHECKING:
-    from hikari import channels as channels_
     from hikari import embeds as embeds_
     from hikari import files
     from hikari import files as files_
@@ -756,6 +756,40 @@ class IncomingWebhook(PartialWebhook, ExecutableWebhook):
         assert isinstance(webhook, IncomingWebhook)
         return webhook
 
+    async def fetch_channel(self) -> channels_.WebhookChannelT:
+        """Fetch the channel this webhook is for.
+
+        Returns
+        -------
+        hikari.channels.WebhookChannelT
+            The object of the channel this webhook targets.
+
+        Raises
+        ------
+        hikari.errors.ForbiddenError
+            If you don't have access to the channel this webhook belongs to.
+        hikari.errors.NotFoundError
+            If the channel this message was created in does not exist.
+        hikari.errors.UnauthorizedError
+            If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
+        hikari.errors.RateLimitedError
+            Usually, Hikari will handle and retry on hitting
+            rate-limits automatically. This includes most bucket-specific
+            rate-limits and global rate-limits. In some rare edge cases,
+            however, Discord implements other undocumented rules for
+            rate-limiting, such as limits per attribute. These cannot be
+            detected or handled normally by Hikari due to their undocumented
+            nature, and will trigger this exception if they occur.
+        hikari.errors.InternalServerError
+            If an internal error occurs on Discord while handling the request.
+        """
+        channel = await self.app.rest.fetch_channel(self.channel_id)
+        assert isinstance(channel, channels_.WebhookChannelTypes)
+        return channel
+
     async def fetch_self(self, *, use_token: undefined.UndefinedOr[bool] = undefined.UNDEFINED) -> IncomingWebhook:
         """Fetch this webhook.
 
@@ -913,6 +947,40 @@ class ChannelFollowerWebhook(PartialWebhook):
         )
         assert isinstance(webhook, ChannelFollowerWebhook)
         return webhook
+
+    async def fetch_channel(self) -> channels_.WebhookChannelT:
+        """Fetch the channel this webhook is for.
+
+        Returns
+        -------
+        hikari.channels.WebhookChannelT
+            The object of the channel this webhook targets.
+
+        Raises
+        ------
+        hikari.errors.ForbiddenError
+            If you don't have access to the channel this webhook belongs to.
+        hikari.errors.NotFoundError
+            If the channel this message was created in does not exist.
+        hikari.errors.UnauthorizedError
+            If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
+        hikari.errors.RateLimitedError
+            Usually, Hikari will handle and retry on hitting
+            rate-limits automatically. This includes most bucket-specific
+            rate-limits and global rate-limits. In some rare edge cases,
+            however, Discord implements other undocumented rules for
+            rate-limiting, such as limits per attribute. These cannot be
+            detected or handled normally by Hikari due to their undocumented
+            nature, and will trigger this exception if they occur.
+        hikari.errors.InternalServerError
+            If an internal error occurs on Discord while handling the request.
+        """
+        channel = await self.app.rest.fetch_channel(self.channel_id)
+        assert isinstance(channel, channels_.WebhookChannelTypes)
+        return channel
 
     async def fetch_self(self) -> ChannelFollowerWebhook:
         """Fetch this webhook.

--- a/tests/hikari/test_channels.py
+++ b/tests/hikari/test_channels.py
@@ -188,7 +188,7 @@ class TestGroupDMChannel:
 class TestTextChannel:
     @pytest.fixture()
     def model(self, mock_app):
-        return hikari_test_helpers.mock_class_namespace(channels.TextChannel)(
+        return hikari_test_helpers.mock_class_namespace(channels.TextableChannel)(
             app=mock_app,
             id=snowflakes.Snowflake(12345679),
             name="foo1",

--- a/tests/hikari/test_webhooks.py
+++ b/tests/hikari/test_webhooks.py
@@ -22,6 +22,7 @@
 import mock
 import pytest
 
+from hikari import channels
 from hikari import undefined
 from hikari import webhooks
 from tests.hikari import hikari_test_helpers
@@ -337,6 +338,14 @@ class TestIncomingWebhook:
         )
 
     @pytest.mark.asyncio()
+    async def test_fetch_channel(self, webhook):
+        webhook.app.rest.fetch_channel.return_value = mock.Mock(channels.GuildTextChannel)
+
+        assert await webhook.fetch_channel() is webhook.app.rest.fetch_channel.return_value
+
+        webhook.app.rest.fetch_channel.assert_awaited_once_with(webhook.channel_id)
+
+    @pytest.mark.asyncio()
     async def test_fetch_self(self, webhook):
         webhook.token = None
         webhook.app.rest.fetch_webhook.return_value = mock.Mock(webhooks.IncomingWebhook)
@@ -420,6 +429,14 @@ class TestChannelFollowerWebhook:
         webhook.app.rest.edit_webhook.assert_awaited_once_with(
             987654321, name="hi", avatar=mock_avatar, channel=43123, reason="ok"
         )
+
+    @pytest.mark.asyncio()
+    async def test_fetch_channel(self, webhook):
+        webhook.app.rest.fetch_channel.return_value = mock.Mock(channels.GuildTextChannel)
+
+        assert await webhook.fetch_channel() is webhook.app.rest.fetch_channel.return_value
+
+        webhook.app.rest.fetch_channel.assert_awaited_once_with(webhook.channel_id)
 
     @pytest.mark.asyncio()
     async def test_fetch_self(self, webhook):


### PR DESCRIPTION
### Summary
* Rename TextChannel to TextableChannel + add TextableGuildChannel
  This fixes some typing issues where GuildTextChannel was being asserted and typed in a few scenarios where GuildNewsChannel and in the future thread channels would also be expected while also trying to lay out a better structure for handling guild channels which handle messages in-order to lower the chance of this kind of issue recurring
* Add WebhookChannelT union and WebhookChannelTypes to channels.py 
  This is used in the type hint for create_webhook, fetch_channel_webhooks, and edit_webhook in place of TextableChannel in-order to account for the fact that webhooks cannot be directly attached to thread channels.
* Improve typing for edit voice state rest methods to use GuildVoiceChannel rather than PartialChannel

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
This is a part of #623
