### PR TITLE
Cython speedups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ pip-wheel-metadata/
 *.o
 *.pyd
 
+# Cython builds
+cython/
+
 # Tox/Nox-generated files
 .[nt]ox/
 

--- a/pipelines/utils.nox.py
+++ b/pipelines/utils.nox.py
@@ -28,6 +28,7 @@ from pipelines import nox
 TRASH = [
     ".nox",
     "build",
+    "cython",
     "dist",
     "hikari.egg-info",
     "public",
@@ -44,6 +45,8 @@ def purge(_: nox.Session) -> None:
     """Delete any nox-generated files."""
     for trash in TRASH:
         print("Removing", trash)
+
+        # TODO: Check if file exists before attempting to remove to remove the ignores
         try:
             os.remove(trash)
         except:


### PR DESCRIPTION
### Summary
Provide cython generated speedups. For now this feature will be opt-in with the use of `HIKARI_EXTENSIONS` environment variable. This will later be replaced with an opt-out by making the use of `HIKARI_NO_EXTENSIONS`

Example:
```
HIKARI_EXTENSIONS=1 pip install hikari
```

#### TODO
- [ ] Cythonized test runs
- [ ] Cythonize before package release
- [ ] Profile and optimize further
  - Decide whether to use .pxd (type annotations) or .pyx (full rewrite of files in Cython)

### Checklist
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Closes #535
