### PR TITLE
CommandInteractionOption typing fix

### DIFF
--- a/hikari/interactions/commands.py
+++ b/hikari/interactions/commands.py
@@ -367,7 +367,7 @@ class CommandInteractionOption:
     type: typing.Union[OptionType, int] = attr.field(repr=True)
     """Type of this option."""
 
-    value: typing.Optional[typing.Union[str, int, bool]] = attr.field(repr=True)
+    value: typing.Union[str, int, bool, None] = attr.field(repr=True)
     """Value provided for this option.
 
     Either `CommandInteractionOption.value` or `CommandInteractionOption.options`

--- a/hikari/interactions/commands.py
+++ b/hikari/interactions/commands.py
@@ -367,7 +367,7 @@ class CommandInteractionOption:
     type: typing.Union[OptionType, int] = attr.field(repr=True)
     """Type of this option."""
 
-    value: typing.Optional[typing.Sequence[typing.Union[str, int, bool]]] = attr.field(repr=True)
+    value: typing.Optional[typing.Union[str, int, bool]] = attr.field(repr=True)
     """Value provided for this option.
 
     Either `CommandInteractionOption.value` or `CommandInteractionOption.options`


### PR DESCRIPTION
### Summary
Command options only have 1 value

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
