### PR TITLE
Improve 50035 400 error reprs

### DIFF
--- a/hikari/errors.py
+++ b/hikari/errors.py
@@ -477,8 +477,8 @@ class BadRequestError(ClientHTTPResponseError):
         value = super().__str__()
         if self.errors:
             value += "\n" + data_binding.dump_json(self.errors, indent=2)
-            self._cached_str = value
 
+        self._cached_str = value
         return value
 
 

--- a/hikari/errors.py
+++ b/hikari/errors.py
@@ -57,13 +57,13 @@ import typing
 import attr
 
 from hikari.internal import attr_extensions
+from hikari.internal import data_binding
 from hikari.internal import enums
 
 if typing.TYPE_CHECKING:
     from hikari import intents as intents_
     from hikari import messages
     from hikari import snowflakes
-    from hikari.internal import data_binding
     from hikari.internal import routes
 
 
@@ -459,6 +459,27 @@ class BadRequestError(ClientHTTPResponseError):
 
     status: http.HTTPStatus = attr.field(default=http.HTTPStatus.BAD_REQUEST, init=False)
     """The HTTP status code for the response."""
+
+    errors: typing.Optional[typing.Dict[str, data_binding.JSONObject]] = attr.field(default=None, kw_only=True)
+    """Dict of field specific errors.
+
+    For more information, this error format is loosely defined at
+    https://discord.com/developers/docs/reference#error-messages and is commonly
+    returned for 50035 errors.
+    """
+
+    _cached_str: str = attr.field(default=None, init=False)
+
+    def __str__(self) -> str:
+        if self._cached_str:
+            return self._cached_str
+
+        value = super().__str__()
+        if self.errors:
+            value += "\n" + data_binding.dump_json(self.errors, indent=2)
+            self._cached_str = value
+
+        return value
 
 
 @attr.define(auto_exc=True, repr=False, weakref_slot=False)

--- a/hikari/errors.py
+++ b/hikari/errors.py
@@ -461,7 +461,7 @@ class BadRequestError(ClientHTTPResponseError):
     """The HTTP status code for the response."""
 
     errors: typing.Optional[typing.Dict[str, data_binding.JSONObject]] = attr.field(default=None, kw_only=True)
-    """Dict of field specific errors.
+    """Dict of top level field names to field specific error paths.
 
     For more information, this error format is loosely defined at
     https://discord.com/developers/docs/reference#error-messages and is commonly

--- a/hikari/internal/data_binding.py
+++ b/hikari/internal/data_binding.py
@@ -83,7 +83,7 @@ if typing.TYPE_CHECKING:
     JSONDecodeError: typing.Type[Exception] = Exception
     """Exception raised when loading an invalid JSON string"""
 
-    def dump_json(_: typing.Union[JSONArray, JSONObject], /) -> str:
+    def dump_json(_: typing.Union[JSONArray, JSONObject], /, *, indent: int = ...) -> str:
         """Convert a Python type to a JSON string."""
 
     def load_json(_: typing.AnyStr, /) -> typing.Union[JSONArray, JSONObject]:


### PR DESCRIPTION
### Summary
This adds the loosely documented "errors" mapping on some error responses (see https://discord.com/developers/docs/reference#error-messages for ref) to BadRequestError

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
