### PR TITLE
Add has method to permissions

### DIFF
--- a/hikari/permissions.py
+++ b/hikari/permissions.py
@@ -270,6 +270,9 @@ class Permissions(enums.Flag):
     USE_PRIVATE_THREADS = 1 << 36
     """Allows for creating and participating in private threads."""
 
+    def has(self, permission: Permissions) -> bool:
+        return bool(self & permission)
+
     @classmethod
     def all_permissions(cls) -> Permissions:
         """Get an instance of `Permissions` with all the known permissions.

--- a/hikari/permissions.py
+++ b/hikari/permissions.py
@@ -271,6 +271,18 @@ class Permissions(enums.Flag):
     """Allows for creating and participating in private threads."""
 
     def has(self, permission: Permissions) -> bool:
+        """Check if this permissions has another permission.
+
+        Parameters
+        ----------
+        permission : Permissions
+            The permission to check.
+
+        Returns
+        -------
+        bool
+            Whether this permissions instance has the permission.
+        """
         return bool(self & permission)
 
     @classmethod


### PR DESCRIPTION
### Summary
Add a `has` method to the permissions enum. It's confusing for beginners to do:
```py
bool(permissions_1 & permissions_2)
```
and this should make that easier.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

