### PR TITLE
Remove the default max presences of 25000

### DIFF
--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -2991,8 +2991,11 @@ class RESTGuild(Guild):
     This will be `builtins.None` when creating a guild.
     """
 
-    max_presences: int = attr.field(eq=False, hash=False, repr=False)
-    """The maximum number of presences for the guild."""
+    max_presences: typing.Optional[int] = attr.field(eq=False, hash=False, repr=False)
+    """The maximum number of presences for the guild.
+
+    If `builtins.None`, then there is no limit.
+    """
 
     max_members: int = attr.field(eq=False, hash=False, repr=False)
     """The maximum number of members allowed in this guild."""

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -60,9 +60,8 @@ from hikari.internal import attr_extensions
 from hikari.internal import data_binding
 from hikari.internal import time
 
-_DEFAULT_MAX_PRESENCES: typing.Final[int] = 25000
-_LOGGER: typing.Final[logging.Logger] = logging.getLogger("hikari.entity_factory")
 _ValueT = typing.TypeVar("_ValueT")
+_LOGGER: typing.Final[logging.Logger] = logging.getLogger("hikari.entity_factory")
 
 
 def _with_int_cast(cast: typing.Callable[[int], _ValueT]) -> typing.Callable[[typing.Any], _ValueT]:
@@ -1371,10 +1370,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         max_members = int(payload["max_members"])
 
         raw_max_presences = payload["max_presences"]
-        if raw_max_presences is None:
-            max_presences = _DEFAULT_MAX_PRESENCES
-        else:
-            max_presences = int(raw_max_presences)
+        max_presences = int(raw_max_presences) if raw_max_presences is not None else None
 
         roles = {
             snowflakes.Snowflake(role["id"]): self.deserialize_role(role, guild_id=guild_fields.id)

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -2410,7 +2410,7 @@ class TestEntityFactoryImpl:
         assert guild.widget_channel_id is None
         assert guild.system_channel_id is None
         assert guild.rules_channel_id is None
-        assert guild.max_presences is entity_factory._DEFAULT_MAX_PRESENCES
+        assert guild.max_presences is None
         assert guild.vanity_url_code is None
         assert guild.description is None
         assert guild.banner_hash is None


### PR DESCRIPTION
### Summary
With the addition of the new relay infrastructure, this will always be None except for the largest of guilds

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

