### PR TITLE
Fix CDN properties not ending with "_url"

### DIFF
--- a/hikari/invites.py
+++ b/hikari/invites.py
@@ -182,7 +182,7 @@ class InviteGuild(guilds.PartialGuild):
         )
 
     @property
-    def banner(self) -> typing.Optional[files.URL]:
+    def banner_url(self) -> typing.Optional[files.URL]:
         """Banner URL for the guild, if set."""
         return self.make_banner_url()
 

--- a/hikari/webhooks.py
+++ b/hikari/webhooks.py
@@ -543,19 +543,20 @@ class PartialWebhook(snowflakes.Unique):
         return f"<@{self.id}>"
 
     @property
-    def avatar(self) -> files_.URL:
-        """URL for this webhook's custom avatar or default avatar.
+    def avatar_url(self) -> typing.Optional[files_.URL]:
+        """URL for this webhook's avatar, if set.
 
-        If the webhook has a custom avatar, a URL to this is returned. Otherwise
-        a URL to the default avatar is provided instead.
+        May be `builtins.None` if no avatar is set. In this case, you should use
+        `default_avatar_url` instead.
         """
-        return self.make_avatar_url() or self.default_avatar
+        return self.make_avatar_url()
 
     @property
-    def default_avatar(self) -> files_.URL:
-        """URL for this webhook's default avatar.
+    def default_avatar_url(self) -> files_.URL:
+        """Avatar URL for the user, if they have one set.
 
-        This is used if no avatar is set.
+        May be `builtins.None` if no custom avatar is set. In this case, you
+        should use `default_avatar_url` instead.
         """
         return routes.CDN_DEFAULT_USER_AVATAR.compile_to_file(
             urls.CDN_URL,

--- a/tests/hikari/test_webhooks.py
+++ b/tests/hikari/test_webhooks.py
@@ -194,16 +194,11 @@ class TestPartialWebhook:
     def test_mention_property(self, webhook):
         assert webhook.mention == "<@987654321>"
 
-    def test_avatar_property(self, webhook):
-        assert webhook.avatar == webhook.make_avatar_url()
+    def test_avatar_url_property(self, webhook):
+        assert webhook.avatar_url == webhook.make_avatar_url()
 
-    def test_avatar_property_when_default(self, webhook):
-        webhook.avatar_hash = None
-
-        assert webhook.avatar == webhook.default_avatar
-
-    def test_default_avatar(self, webhook):
-        assert webhook.default_avatar.url == "https://cdn.discordapp.com/embed/avatars/0.png"
+    def test_default_avatar_url(self, webhook):
+        assert webhook.default_avatar_url.url == "https://cdn.discordapp.com/embed/avatars/0.png"
 
     def test_make_avatar_url(self, webhook):
         result = webhook.make_avatar_url(ext="jpeg", size=2048)


### PR DESCRIPTION
### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
