### PR TITLE
Consistency fixes for `__all__` usages

### DIFF
--- a/hikari/api/interaction_server.py
+++ b/hikari/api/interaction_server.py
@@ -23,7 +23,7 @@
 """Provides an interface for Interaction REST server API implementations to follow."""
 from __future__ import annotations
 
-__all__: typing.Sequence[str] = ["ListenerT", "Response", "InteractionServer"]
+__all__: typing.List[str] = ["ListenerT", "Response", "InteractionServer"]
 
 import abc
 import typing

--- a/hikari/events/interaction_events.py
+++ b/hikari/events/interaction_events.py
@@ -23,7 +23,7 @@
 """Events fired for interaction related changes."""
 from __future__ import annotations
 
-__all__: typing.Sequence[str] = [
+__all__: typing.List[str] = [
     "CommandEvent",
     "CommandCreateEvent",
     "CommandUpdateEvent",

--- a/hikari/files.py
+++ b/hikari/files.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__ = [
+__all__: typing.List[str] = [
     "ensure_path",
     "ensure_resource",
     "unwrap_bytes",

--- a/hikari/impl/interaction_server.py
+++ b/hikari/impl/interaction_server.py
@@ -23,7 +23,7 @@
 """Standard implementation of a REST based interactions server."""
 from __future__ import annotations
 
-__all__: typing.Sequence[str] = ["InteractionServer"]
+__all__: typing.List[str] = ["InteractionServer"]
 
 import asyncio
 import logging

--- a/hikari/impl/rest_bot.py
+++ b/hikari/impl/rest_bot.py
@@ -23,7 +23,7 @@
 """Standard implementations of a Interaction based REST-only bot."""
 from __future__ import annotations
 
-__all__: typing.Sequence[str] = ["RESTBot"]
+__all__: typing.List[str] = ["RESTBot"]
 
 import asyncio
 import logging

--- a/hikari/internal/ed25519.py
+++ b/hikari/internal/ed25519.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.Sequence[str] = ["VerifyBuilderT", "VerifierT", "build_ed25519_verifier"]
+__all__: typing.List[str] = ["VerifyBuilderT", "VerifierT", "build_ed25519_verifier"]
 
 import typing
 

--- a/hikari/internal/mentions.py
+++ b/hikari/internal/mentions.py
@@ -23,7 +23,7 @@
 """Utility functions used for managing mentions on Discord."""
 from __future__ import annotations
 
-__all__: typing.Sequence[str] = ["generate_allowed_mentions"]
+__all__: typing.List[str] = ["generate_allowed_mentions"]
 
 import typing
 


### PR DESCRIPTION
### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
