### PR TITLE
Remove application command events

### DIFF
--- a/hikari/api/event_factory.py
+++ b/hikari/api/event_factory.py
@@ -467,69 +467,6 @@ class EventFactory(abc.ABC):
     ######################
 
     @abc.abstractmethod
-    def deserialize_command_create_event(
-        self,
-        shard: gateway_shard.GatewayShard,
-        payload: data_binding.JSONObject,
-    ) -> interaction_events.CommandCreateEvent:
-        """Parse a raw payload from Discord into a command create event object.
-
-        Parameters
-        ----------
-        shard : hikari.api.shard.GatewayShard
-            The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
-            The dict payload to parse.
-
-        Returns
-        -------
-        hikari.events.interaction_events.CommandCreateEvent
-            The parsed command create event object.
-        """
-
-    @abc.abstractmethod
-    def deserialize_command_update_event(
-        self,
-        shard: gateway_shard.GatewayShard,
-        payload: data_binding.JSONObject,
-    ) -> interaction_events.CommandUpdateEvent:
-        """Parse a raw payload from Discord into a command update event object.
-
-        Parameters
-        ----------
-        shard : hikari.api.shard.GatewayShard
-            The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
-            The dict payload to parse.
-
-        Returns
-        -------
-        hikari.events.interaction_events.CommandUpdateEvent
-            The parsed command update event object.
-        """
-
-    @abc.abstractmethod
-    def deserialize_command_delete_event(
-        self,
-        shard: gateway_shard.GatewayShard,
-        payload: data_binding.JSONObject,
-    ) -> interaction_events.CommandDeleteEvent:
-        """Parse a raw payload from Discord into a command delete event object.
-
-        Parameters
-        ----------
-        shard : hikari.api.shard.GatewayShard
-            The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
-            The dict payload to parse.
-
-        Returns
-        -------
-        hikari.events.interaction_events.CommandDeleteEvent
-            The parsed command delete event object.
-        """
-
-    @abc.abstractmethod
     def deserialize_interaction_create_event(
         self,
         shard: gateway_shard.GatewayShard,

--- a/hikari/events/interaction_events.py
+++ b/hikari/events/interaction_events.py
@@ -24,14 +24,9 @@
 from __future__ import annotations
 
 __all__: typing.List[str] = [
-    "CommandEvent",
-    "CommandCreateEvent",
-    "CommandUpdateEvent",
-    "CommandDeleteEvent",
     "InteractionCreateEvent",
 ]
 
-import abc
 import typing
 
 import attr
@@ -40,81 +35,9 @@ from hikari.events import shard_events
 from hikari.internal import attr_extensions
 
 if typing.TYPE_CHECKING:
-    from hikari import commands
     from hikari import traits
     from hikari.api import shard as gateway_shard
     from hikari.interactions import base_interactions
-
-
-class CommandEvent(shard_events.ShardEvent, abc.ABC):
-    """Base class of events fired for changes to application commands."""
-
-    @property
-    def app(self) -> traits.RESTAware:
-        # <<inherited docstring from Event>>.
-        return self.command.app
-
-    @property
-    @abc.abstractmethod
-    def command(self) -> commands.Command:
-        """Object of the command this event is for.
-
-        Returns
-        -------
-        hikari.commands.Command
-            The command this event is for.
-        """
-
-
-@attr_extensions.with_copy
-@attr.define(kw_only=True, weakref_slot=False)
-class CommandCreateEvent(CommandEvent):
-    """Event fired when a command is created relevant to the current bot.
-
-    !!! note
-        This includes applications created by other bots which share a guild
-        with the current bot.
-    """
-
-    shard: gateway_shard.GatewayShard = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
-    # <<docstring inherited from ShardEvent>>.
-
-    command: commands.Command = attr.field(repr=True)
-    # <<inherited docstring from CommandEvent>>.
-
-
-@attr_extensions.with_copy
-@attr.define(kw_only=True, weakref_slot=False)
-class CommandUpdateEvent(CommandEvent):
-    """Event fired when a command is updated relevant to the current bot.
-
-    !!! note
-        This includes applications created by other bots which share a guild
-        with the current bot.
-    """
-
-    shard: gateway_shard.GatewayShard = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
-    # <<docstring inherited from ShardEvent>>.
-
-    command: commands.Command = attr.field(repr=True)
-    # <<inherited docstring from CommandEvent>>.
-
-
-@attr_extensions.with_copy
-@attr.define(kw_only=True, weakref_slot=False)
-class CommandDeleteEvent(CommandEvent):
-    """Event fired when a command is deleted relevant to the current bot.
-
-    !!! note
-        This includes applications created by other bots which share a guild
-        with the current bot.
-    """
-
-    shard: gateway_shard.GatewayShard = attr.field(metadata={attr_extensions.SKIP_DEEP_COPY: True})
-    # <<docstring inherited from ShardEvent>>.
-
-    command: commands.Command = attr.field(repr=True)
-    # <<inherited docstring from CommandEvent>>.
 
 
 @attr_extensions.with_copy

--- a/hikari/impl/event_factory.py
+++ b/hikari/impl/event_factory.py
@@ -344,33 +344,6 @@ class EventFactoryImpl(event_factory.EventFactory):
     # INTERACTION EVENTS #
     ######################
 
-    def deserialize_command_create_event(
-        self,
-        shard: gateway_shard.GatewayShard,
-        payload: data_binding.JSONObject,
-    ) -> interaction_events.CommandCreateEvent:
-        return interaction_events.CommandCreateEvent(
-            shard=shard, command=self._app.entity_factory.deserialize_command(payload)
-        )
-
-    def deserialize_command_update_event(
-        self,
-        shard: gateway_shard.GatewayShard,
-        payload: data_binding.JSONObject,
-    ) -> interaction_events.CommandUpdateEvent:
-        return interaction_events.CommandUpdateEvent(
-            shard=shard, command=self._app.entity_factory.deserialize_command(payload)
-        )
-
-    def deserialize_command_delete_event(
-        self,
-        shard: gateway_shard.GatewayShard,
-        payload: data_binding.JSONObject,
-    ) -> interaction_events.CommandDeleteEvent:
-        return interaction_events.CommandDeleteEvent(
-            shard=shard, command=self._app.entity_factory.deserialize_command(payload)
-        )
-
     def deserialize_interaction_create_event(
         self,
         shard: gateway_shard.GatewayShard,

--- a/hikari/impl/event_manager.py
+++ b/hikari/impl/event_manager.py
@@ -489,24 +489,6 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         """See https://discord.com/developers/docs/topics/gateway#webhooks-update for more info."""
         await self.dispatch(self._event_factory.deserialize_webhook_update_event(shard, payload))
 
-    async def on_application_command_create(
-        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
-    ) -> None:
-        """See https://discord.com/developers/docs/topics/gateway#application-command-create for more info."""
-        await self.dispatch(self._event_factory.deserialize_command_create_event(shard, payload))
-
-    async def on_application_command_update(
-        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
-    ) -> None:
-        """See https://discord.com/developers/docs/topics/gateway#application-command-update for more info."""
-        await self.dispatch(self._event_factory.deserialize_command_update_event(shard, payload))
-
-    async def on_application_command_delete(
-        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
-    ) -> None:
-        """See https://discord.com/developers/docs/topics/gateway#application-command-delete for more info."""
-        await self.dispatch(self._event_factory.deserialize_command_delete_event(shard, payload))
-
     async def on_interaction_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway#interaction-create for more info."""
         await self.dispatch(self._event_factory.deserialize_interaction_create_event(shard, payload))

--- a/tests/hikari/events/test_interaction_events.py
+++ b/tests/hikari/events/test_interaction_events.py
@@ -23,14 +23,6 @@
 import mock
 
 from hikari.events import interaction_events
-from tests.hikari import hikari_test_helpers
-
-
-class TestCommandEvent:
-    def test_app_property(self):
-        mock_event = hikari_test_helpers.mock_class_namespace(interaction_events.CommandEvent, command=mock.Mock())()
-
-        assert mock_event.app is mock_event.command.app
 
 
 class TestInteractionCreateEvent:

--- a/tests/hikari/impl/test_event_factory.py
+++ b/tests/hikari/impl/test_event_factory.py
@@ -449,36 +449,6 @@ class TestEventFactoryImpl:
     # INTERACTION EVENTS #
     ######################
 
-    def test_deserialize_command_create_event(self, event_factory, mock_app, mock_shard):
-        payload = {"id": "123"}
-
-        result = event_factory.deserialize_command_create_event(mock_shard, payload)
-
-        mock_app.entity_factory.deserialize_command.assert_called_once_with(payload)
-        assert result.shard is mock_shard
-        assert result.command is mock_app.entity_factory.deserialize_command.return_value
-        assert isinstance(result, interaction_events.CommandCreateEvent)
-
-    def test_deserialize_command_update_event(self, event_factory, mock_app, mock_shard):
-        payload = {"id": "12344"}
-
-        result = event_factory.deserialize_command_update_event(mock_shard, payload)
-
-        mock_app.entity_factory.deserialize_command.assert_called_once_with(payload)
-        assert result.shard is mock_shard
-        assert result.command is mock_app.entity_factory.deserialize_command.return_value
-        assert isinstance(result, interaction_events.CommandUpdateEvent)
-
-    def test_deserialize_command_delete_event(self, event_factory, mock_app, mock_shard):
-        payload = {"id": "1561232344"}
-
-        result = event_factory.deserialize_command_delete_event(mock_shard, payload)
-
-        mock_app.entity_factory.deserialize_command.assert_called_once_with(payload)
-        assert result.shard is mock_shard
-        assert result.command is mock_app.entity_factory.deserialize_command.return_value
-        assert isinstance(result, interaction_events.CommandDeleteEvent)
-
     def test_deserialize_interaction_create_event(self, event_factory, mock_app, mock_shard):
         payload = {"id": "1561232344"}
 

--- a/tests/hikari/impl/test_event_manager.py
+++ b/tests/hikari/impl/test_event_manager.py
@@ -1046,33 +1046,6 @@ class TestEventManagerImpl:
         event_manager.dispatch.assert_awaited_once_with(event)
 
     @pytest.mark.asyncio()
-    async def test_on_application_command_create(self, event_manager, shard, event_factory):
-        payload = {"id": "4544333334dd44"}
-
-        await event_manager.on_application_command_create(shard, payload)
-
-        event_factory.deserialize_command_create_event.assert_called_once_with(shard, payload)
-        event_manager.dispatch.assert_awaited_once_with(event_factory.deserialize_command_create_event.return_value)
-
-    @pytest.mark.asyncio()
-    async def test_on_application_command_update(self, event_manager, shard, event_factory):
-        payload = {"id": "454433333444"}
-
-        await event_manager.on_application_command_update(shard, payload)
-
-        event_factory.deserialize_command_update_event.assert_called_once_with(shard, payload)
-        event_manager.dispatch.assert_awaited_once_with(event_factory.deserialize_command_update_event.return_value)
-
-    @pytest.mark.asyncio()
-    async def test_on_application_command_delete(self, event_manager, shard, event_factory):
-        payload = {"id": "4544444"}
-
-        await event_manager.on_application_command_delete(shard, payload)
-
-        event_factory.deserialize_command_delete_event.assert_called_once_with(shard, payload)
-        event_manager.dispatch.assert_awaited_once_with(event_factory.deserialize_command_delete_event.return_value)
-
-    @pytest.mark.asyncio()
     async def test_on_interaction_create(self, event_manager, shard, event_factory):
         payload = {"id": "123"}
 


### PR DESCRIPTION
### Summary
This pr removes events related to application commands as a discord developer said these events aren't supposed to sent to  bots. Source:  https://github.com/discord/discord-api-docs/pull/3691

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [X] I have run `nox` and all the pipelines have passed.
- [X] I have made unittests according to the code I have added/modified/deleted.
