### PR TITLE
Add sticker methods to PartialGuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 *This file was added at the beginning of the development of version 2.0.0.dev102, so nothing before that is documented.*
 
 ## [Unreleased]
+### Added
+ - Sticker methods to PartialGuild.
+
+### Changed
+ - Fix errors in rest sticker method docstrings.

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -3706,7 +3706,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         Parameters
         ----------
         sticker : snowflakes.SnowflakeishOr[stickers.PartialSticker]
-            The sticker to fetch.
+            The sticker to fetch. This can be a sticker object or the
+            ID of an existing sticker.
 
         Returns
         -------
@@ -3743,7 +3744,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         Parameters
         ----------
         guild : snowflakes.SnowflakeishOr[stickers.PartialGuild]
-            The guild to request stickers for.
+            The guild to request stickers for. This can be a guild object or the
+            ID of an existing guild.
 
         Returns
         -------
@@ -3784,9 +3786,11 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         Parameters
         ----------
         guild : snowflakes.SnowflakeishOr[stickers.PartialGuild]
-            The guild the sticker is in.
+            The guild the sticker is in. This can be a guild object or the
+            ID of an existing guild.
         sticker : snowflakes.SnowflakeishOr[stickers.PartialSticker]
-            The sticker to fetch.
+            The sticker to fetch. This can be a sticker object or the
+            ID of an existing sticker.
 
         Returns
         -------
@@ -3901,7 +3905,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         Parameters
         ----------
         guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
-            The guild to edit the emoji on. This can be a guild object or the
+            The guild to edit the sticker on. This can be a guild object or the
             ID of an existing guild.
         sticker : hikari.snowflakes.SnowflakeishOr[hikari.stickers.PartialSticker]
             The sticker to edit. This can be a sticker object or the ID of an
@@ -3964,7 +3968,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
             The guild to delete the sticker on. This can be a guild object or
             the ID of an existing guild.
-        sticker : hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]
+        sticker : hikari.snowflakes.SnowflakeishOr[hikari.stickers.PartialSticker]
             The sticker to delete. This can be a sticker object or the ID
             of an existing sticker.
 

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -60,6 +60,7 @@ import attr
 
 from hikari import channels as channels_
 from hikari import snowflakes
+from hikari import stickers
 from hikari import traits
 from hikari import undefined
 from hikari import urls
@@ -1631,6 +1632,247 @@ class PartialGuild(snowflakes.Unique):
             If an internal error occurs on Discord while handling the request.
         """
         return await self.app.rest.fetch_emoji(self.id, emoji)
+
+    async def fetch_stickers(self) -> typing.Sequence[stickers.GuildSticker]:
+        """Fetch the stickers of the guild.
+
+        Returns
+        -------
+        typing.Sequence[hikari.stickers.GuildSticker]
+            The requested stickers.
+
+        Raises
+        ------
+        hikari.errors.ForbiddenError
+            If you are not part of the server.
+        hikari.errors.NotFoundError
+            If the guild is not found.
+        hikari.errors.UnauthorizedError
+            If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
+        hikari.errors.RateLimitedError
+            Usually, Hikari will handle and retry on hitting
+            rate-limits automatically. This includes most bucket-specific
+            rate-limits and global rate-limits. In some rare edge cases,
+            however, Discord implements other undocumented rules for
+            rate-limiting, such as limits per attribute. These cannot be
+            detected or handled normally by Hikari due to their undocumented
+            nature, and will trigger this exception if they occur.
+        hikari.errors.InternalServerError
+            If an internal error occurs on Discord while handling the request.
+        """
+        return await self.app.rest.fetch_guild_stickers(self.id)
+
+    async def fetch_sticker(self, sticker: snowflakes.SnowflakeishOr[stickers.PartialSticker]) -> stickers.GuildSticker:
+        """Fetch a sticker from the guild.
+
+        Parameters
+        ----------
+        sticker : snowflakes.SnowflakeishOr[hikari.stickers.PartialSticker]
+            The sticker to fetch. This can be a sticker object or the
+            ID of an existing sticker.
+
+        Returns
+        -------
+        hikari.stickers.GuildSticker
+            The requested sticker.
+
+        Raises
+        ------
+        hikari.errors.ForbiddenError
+            If you are not part of the server.
+        hikari.errors.NotFoundError
+            If the guild or the sticker are not found.
+        hikari.errors.UnauthorizedError
+            If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
+        hikari.errors.RateLimitedError
+            Usually, Hikari will handle and retry on hitting
+            rate-limits automatically. This includes most bucket-specific
+            rate-limits and global rate-limits. In some rare edge cases,
+            however, Discord implements other undocumented rules for
+            rate-limiting, such as limits per attribute. These cannot be
+            detected or handled normally by Hikari due to their undocumented
+            nature, and will trigger this exception if they occur.
+        hikari.errors.InternalServerError
+            If an internal error occurs on Discord while handling the request.
+        """
+        return await self.app.rest.fetch_guild_sticker(self.id, sticker)
+
+    async def create_sticker(
+        self,
+        name: str,
+        tag: str,
+        image: files.Resourceish,
+        *,
+        description: undefined.UndefinedOr[str] = undefined.UNDEFINED,
+        reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
+    ) -> stickers.GuildSticker:
+        """Create a sticker in a guild.
+
+        Parameters
+        ----------
+        name : builtins.str
+            The name for the sticker.
+        tag : builtins.str
+            The tag for the sticker.
+        image : hikari.files.Resourceish
+            The 320x320 image for the sticker. Maximum upload size is 500kb.
+            This can be a still or an animated PNG or a Lottie.
+
+            !!! note
+                Lottie support is only available for verified and partnered
+                servers.
+
+        Other Parameters
+        ----------------
+        description: hikari.undefined.UndefinedOr[builtins.str]
+            If provided, the description of the sticker.
+        reason : hikari.undefined.UndefinedOr[builtins.str]
+            If provided, the reason that will be recorded in the audit logs.
+            Maximum of 512 characters.
+
+        Returns
+        -------
+        hikari.stickers.GuildSticker
+            The created sticker.
+
+        Raises
+        ------
+        hikari.errors.BadRequestError
+            If any of the fields that are passed have an invalid value or
+            if there are no more spaces for the sticker in the guild.
+        hikari.errors.ForbiddenError
+            If you are missing `MANAGE_EMOJIS_AND_STICKERS` in the server.
+        hikari.errors.NotFoundError
+            If the guild is not found.
+        hikari.errors.UnauthorizedError
+            If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
+        hikari.errors.RateLimitedError
+            Usually, Hikari will handle and retry on hitting
+            rate-limits automatically. This includes most bucket-specific
+            rate-limits and global rate-limits. In some rare edge cases,
+            however, Discord implements other undocumented rules for
+            rate-limiting, such as limits per attribute. These cannot be
+            detected or handled normally by Hikari due to their undocumented
+            nature, and will trigger this exception if they occur.
+        hikari.errors.InternalServerError
+            If an internal error occurs on Discord while handling the request.
+        """
+        return await self.app.rest.create_sticker(self.id, name, tag, image, description=description, reason=reason)
+
+    async def edit_sticker(
+        self,
+        sticker: snowflakes.SnowflakeishOr[stickers.PartialSticker],
+        *,
+        name: undefined.UndefinedOr[str] = undefined.UNDEFINED,
+        description: undefined.UndefinedOr[str] = undefined.UNDEFINED,
+        tag: undefined.UndefinedOr[str] = undefined.UNDEFINED,
+        reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
+    ) -> stickers.GuildSticker:
+        """Edit a sticker in a guild.
+
+        Parameters
+        ----------
+        sticker : hikari.snowflakes.SnowflakeishOr[hikari.stickers.PartialSticker]
+            The sticker to edit. This can be a sticker object or the ID of an
+            existing sticker.
+
+        Other Parameters
+        ----------------
+        name : hikari.undefined.UndefinedOr[builtins.str]
+            If provided, the new name for the sticker.
+        description : hikari.undefined.UndefinedOr[builtins.str]
+            If provided, the new description for the sticker.
+        tag : hikari.undefined.UndefinedOr[builtins.str]
+            If provided, the new sticker tag.
+        reason : hikari.undefined.UndefinedOr[builtins.str]
+            If provided, the reason that will be recorded in the audit logs.
+            Maximum of 512 characters.
+
+        Returns
+        -------
+        hikari.stickers.GuildSticker
+            The edited sticker.
+
+        Raises
+        ------
+        hikari.errors.BadRequestError
+            If any of the fields that are passed have an invalid value.
+        hikari.errors.ForbiddenError
+            If you are missing `MANAGE_EMOJIS_AND_STICKERS` in the server.
+        hikari.errors.NotFoundError
+            If the guild or the sticker are not found.
+        hikari.errors.UnauthorizedError
+            If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
+        hikari.errors.RateLimitedError
+            Usually, Hikari will handle and retry on hitting
+            rate-limits automatically. This includes most bucket-specific
+            rate-limits and global rate-limits. In some rare edge cases,
+            however, Discord implements other undocumented rules for
+            rate-limiting, such as limits per attribute. These cannot be
+            detected or handled normally by Hikari due to their undocumented
+            nature, and will trigger this exception if they occur.
+        hikari.errors.InternalServerError
+            If an internal error occurs on Discord while handling the request.
+        """
+        return await self.app.rest.edit_sticker(
+            self.id, sticker, name=name, description=description, tag=tag, reason=reason
+        )
+
+    async def delete_sticker(
+        self,
+        sticker: snowflakes.SnowflakeishOr[stickers.PartialSticker],
+        *,
+        reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
+    ) -> None:
+        """Delete a sticker in a guild.
+
+        Parameters
+        ----------
+        sticker : hikari.snowflakes.SnowflakeishOr[hikari.stickers.PartialSticker]
+            The sticker to delete. This can be a sticker object or the ID
+            of an existing sticker.
+
+        Other Parameters
+        ----------------
+        reason : hikari.undefined.UndefinedOr[builtins.str]
+            If provided, the reason that will be recorded in the audit logs.
+            Maximum of 512 characters.
+
+        Raises
+        ------
+        hikari.errors.ForbiddenError
+            If you are missing `MANAGE_EMOJIS_AND_STICKERS` in the server.
+        hikari.errors.NotFoundError
+            If the guild or the sticker are not found.
+        hikari.errors.UnauthorizedError
+            If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
+        hikari.errors.RateLimitedError
+            Usually, Hikari will handle and retry on hitting
+            rate-limits automatically. This includes most bucket-specific
+            rate-limits and global rate-limits. In some rare edge cases,
+            however, Discord implements other undocumented rules for
+            rate-limiting, such as limits per attribute. These cannot be
+            detected or handled normally by Hikari due to their undocumented
+            nature, and will trigger this exception if they occur.
+        hikari.errors.InternalServerError
+            If an internal error occurs on Discord while handling the request.
+        """
+        return await self.app.rest.delete_sticker(self.id, sticker, reason=reason)
 
     async def create_category(
         self,

--- a/tests/hikari/test_guilds.py
+++ b/tests/hikari/test_guilds.py
@@ -530,6 +530,73 @@ class TestPartialGuild:
         assert emoji is model.app.rest.fetch_emoji.return_value
 
     @pytest.mark.asyncio()
+    async def test_fetch_stickers(self, model):
+        model.app.rest.fetch_guild_stickers = mock.AsyncMock()
+
+        stickers = await model.fetch_stickers()
+
+        model.app.rest.fetch_guild_stickers.assert_awaited_once_with(model.id)
+        assert stickers is model.app.rest.fetch_guild_stickers.return_value
+
+    @pytest.mark.asyncio()
+    async def test_fetch_sticker(self, model):
+        model.app.rest.fetch_guild_sticker = mock.AsyncMock()
+
+        sticker = await model.fetch_sticker(6969)
+
+        model.app.rest.fetch_guild_sticker.assert_awaited_once_with(model.id, 6969)
+        assert sticker is model.app.rest.fetch_guild_sticker.return_value
+
+    @pytest.mark.asyncio()
+    async def test_create_sticker(self, model):
+        model.app.rest.create_sticker = mock.AsyncMock()
+        file = object()
+
+        sticker = await model.create_sticker("NewSticker", "funny", file)
+
+        model.app.rest.create_sticker.assert_awaited_once_with(
+            90210,
+            "NewSticker",
+            "funny",
+            file,
+            description=undefined.UNDEFINED,
+            reason=undefined.UNDEFINED,
+        )
+
+        assert sticker is model.app.rest.create_sticker.return_value
+
+    @pytest.mark.asyncio()
+    async def test_edit_sticker(self, model):
+        model.app.rest.edit_sticker = mock.AsyncMock()
+
+        sticker = await model.edit_sticker(4567, name="Brilliant", tag="parmesan", description="amazing")
+
+        model.app.rest.edit_sticker.assert_awaited_once_with(
+            90210,
+            4567,
+            name="Brilliant",
+            tag="parmesan",
+            description="amazing",
+            reason=undefined.UNDEFINED,
+        )
+
+        assert sticker is model.app.rest.edit_sticker.return_value
+
+    @pytest.mark.asyncio()
+    async def test_delete_sticker(self, model):
+        model.app.rest.delete_sticker = mock.AsyncMock()
+
+        sticker = await model.delete_sticker(951)
+
+        model.app.rest.delete_sticker.assert_awaited_once_with(
+            90210,
+            951,
+            reason=undefined.UNDEFINED,
+        )
+
+        assert sticker is model.app.rest.delete_sticker.return_value
+
+    @pytest.mark.asyncio()
     async def test_create_category(self, model):
         model.app.rest.create_guild_category = mock.AsyncMock()
 


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->
This pull request adds a few methods onto `hikari.guilds.PartialGuild`.
 - fetch_sticker
 - fetch_stickers
 - create_sticker
 - edit_sticker
 - delete_sticker

In addition, there were some mistakes in `hikari.api.rest` docstrings for the sticker methods which have been corrected.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
Related to #400 
