### PR TITLE
Move away from deprecated "reason" body field on ban member

### DIFF
--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -28,11 +28,7 @@ RESTful functionality.
 
 from __future__ import annotations
 
-__all__: typing.List[str] = [
-    "ClientCredentialsStrategy",
-    "RESTApp",
-    "RESTClientImpl",
-]
+__all__: typing.List[str] = ["ClientCredentialsStrategy", "RESTApp", "RESTClientImpl"]
 
 import asyncio
 import base64
@@ -2777,10 +2773,8 @@ class RESTClientImpl(rest_api.RESTClient):
     ) -> None:
         body = data_binding.JSONObjectBuilder()
         body.put("delete_message_days", delete_message_days)
-        # This endpoint specifies a reason in the body, specifically.
-        body.put("reason", reason)
         route = routes.PUT_GUILD_BAN.compile(guild=guild, user=user)
-        await self._request(route, json=body)
+        await self._request(route, json=body, reason=reason)
 
     ban_member = ban_user
 

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -2899,11 +2899,11 @@ class TestRESTClientImplAsync:
 
     async def test_ban_user(self, rest_client):
         expected_route = routes.PUT_GUILD_BAN.compile(guild=123, user=456)
-        expected_json = {"delete_message_days": 7, "reason": "because i can"}
+        expected_json = {"delete_message_days": 7}
         rest_client._request = mock.AsyncMock()
 
         await rest_client.ban_user(StubModel(123), StubModel(456), delete_message_days=7, reason="because i can")
-        rest_client._request.assert_awaited_once_with(expected_route, json=expected_json)
+        rest_client._request.assert_awaited_once_with(expected_route, json=expected_json, reason="because i can")
 
     async def test_unban_user(self, rest_client):
         expected_route = routes.DELETE_GUILD_BAN.compile(guild=123, user=456)


### PR DESCRIPTION
### Summary
Move away from deprecated "reason" body field on ban member

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
