### PR TITLE
Add is_for_emoji methods to the relevant reaction events

### DIFF
--- a/hikari/events/reaction_events.py
+++ b/hikari/events/reaction_events.py
@@ -47,13 +47,13 @@ import typing
 
 import attr
 
+from hikari import emojis
 from hikari import intents
 from hikari.events import base_events
 from hikari.events import shard_events
 from hikari.internal import attr_extensions
 
 if typing.TYPE_CHECKING:
-    from hikari import emojis
     from hikari import guilds
     from hikari import snowflakes
     from hikari import traits
@@ -170,6 +170,23 @@ class ReactionAddEvent(ReactionEvent, abc.ABC):
             Whether the emoji which was added is animated.
         """
 
+    def is_for_emoji(self, emoji: typing.Union[emojis.Emoji, str], /) -> bool:
+        """Get whether the reaction event is for a specific emoji.
+
+        Parameters
+        ----------
+        emoji : typing.Union[hikari.emojis.Emoji, builtins.str]
+            The emoji to check.
+
+            Passing `builtins.str` here indicates a unicode emoji.
+
+        Returns
+        -------
+        builtins.bool
+            Whether the emoji is the one which was added.
+        """
+        return emoji.id == self.emoji_id if isinstance(emoji, emojis.CustomEmoji) else emoji == self.emoji_name
+
 
 @base_events.requires_intents(intents.Intents.GUILD_MESSAGE_REACTIONS, intents.Intents.DM_MESSAGE_REACTIONS)
 class ReactionDeleteEvent(ReactionEvent, abc.ABC):
@@ -216,6 +233,23 @@ class ReactionDeleteEvent(ReactionEvent, abc.ABC):
             `builtins.None`.
         """
 
+    def is_for_emoji(self, emoji: typing.Union[emojis.Emoji, str], /) -> bool:
+        """Get whether the reaction event is for a specific emoji.
+
+        Parameters
+        ----------
+        emoji : typing.Union[hikari.emojis.Emoji, builtins.str]
+            The emoji to check.
+
+            Passing `builtins.str` here indicates a unicode emoji.
+
+        Returns
+        -------
+        builtins.bool
+            Whether the emoji is the one which was removed.
+        """
+        return emoji.id == self.emoji_id if isinstance(emoji, emojis.CustomEmoji) else emoji == self.emoji_name
+
 
 @base_events.requires_intents(intents.Intents.GUILD_MESSAGE_REACTIONS, intents.Intents.DM_MESSAGE_REACTIONS)
 class ReactionDeleteAllEvent(ReactionEvent, abc.ABC):
@@ -257,6 +291,23 @@ class ReactionDeleteEmojiEvent(ReactionEvent, abc.ABC):
             ID of the emoji which was removed if it was a custom emoji or
             `builtins.None`.
         """
+
+    def is_for_emoji(self, emoji: typing.Union[emojis.Emoji, str], /) -> bool:
+        """Get whether the reaction event is for a specific emoji.
+
+        Parameters
+        ----------
+        emoji : typing.Union[hikari.emojis.Emoji, builtins.str]
+            The emoji to check.
+
+            Passing `builtins.str` here indicates a unicode emoji.
+
+        Returns
+        -------
+        builtins.bool
+            Whether the emoji is the one which was removed.
+        """
+        return emoji.id == self.emoji_id if isinstance(emoji, emojis.CustomEmoji) else emoji == self.emoji_name
 
 
 @attr_extensions.with_copy

--- a/tests/hikari/events/test_reaction_events.py
+++ b/tests/hikari/events/test_reaction_events.py
@@ -23,8 +23,130 @@
 import mock
 import pytest
 
+from hikari import emojis
 from hikari import guilds
 from hikari.events import reaction_events
+from tests.hikari import hikari_test_helpers
+
+
+class TestReactionAddEvent:
+    def test_is_for_emoji_when_custom_emoji_matches(self):
+        event = hikari_test_helpers.mock_class_namespace(reaction_events.ReactionAddEvent, emoji_id=333333)()
+
+        assert event.is_for_emoji(emojis.CustomEmoji(id=333333, name=None, is_animated=True))
+
+    def test_is_for_emoji_when_unicode_emoji_matches(self):
+        event = hikari_test_helpers.mock_class_namespace(reaction_events.ReactionAddEvent, emoji_name="🌲")()
+
+        assert event.is_for_emoji(emojis.UnicodeEmoji("🌲"))
+
+    @pytest.mark.parametrize(
+        ("emoji_id", "emoji_name", "emoji"),
+        [
+            (None, "hi", emojis.CustomEmoji(name=None, id=54123, is_animated=False)),
+            (123321, None, emojis.UnicodeEmoji("no u")),
+        ],
+    )
+    def test_is_for_emoji_when_wrong_emoji_type(self, emoji_id, emoji_name, emoji):
+        event = hikari_test_helpers.mock_class_namespace(
+            reaction_events.ReactionAddEvent, emoji_id=emoji_id, emoji_name=emoji_name
+        )()
+
+        assert event.is_for_emoji(emoji) is False
+
+    @pytest.mark.parametrize(
+        ("emoji_id", "emoji_name", "emoji"),
+        [
+            (None, "hi", emojis.UnicodeEmoji("bye")),
+            (123321, None, emojis.CustomEmoji(id=123312123, name=None, is_animated=False)),
+        ],
+    )
+    def test_is_for_emoji_when_emoji_miss_match(self, emoji_id, emoji_name, emoji):
+        event = hikari_test_helpers.mock_class_namespace(
+            reaction_events.ReactionAddEvent, emoji_id=emoji_id, emoji_name=emoji_name
+        )()
+
+        assert event.is_for_emoji(emoji) is False
+
+
+class TestReactionDeleteEvent:
+    def test_is_for_emoji_when_custom_emoji_matches(self):
+        event = hikari_test_helpers.mock_class_namespace(reaction_events.ReactionAddEvent, emoji_id=333)()
+
+        assert event.is_for_emoji(emojis.CustomEmoji(id=333, name=None, is_animated=True))
+
+    def test_is_for_emoji_when_unicode_emoji_matches(self):
+        event = hikari_test_helpers.mock_class_namespace(reaction_events.ReactionAddEvent, emoji_name="e")()
+
+        assert event.is_for_emoji(emojis.UnicodeEmoji("e"))
+
+    @pytest.mark.parametrize(
+        ("emoji_id", "emoji_name", "emoji"),
+        [
+            (None, "hasdi", emojis.CustomEmoji(name=None, id=3123, is_animated=False)),
+            (534123, None, emojis.UnicodeEmoji("nodfgdu")),
+        ],
+    )
+    def test_is_for_emoji_when_wrong_emoji_type(self, emoji_id, emoji_name, emoji):
+        event = hikari_test_helpers.mock_class_namespace(
+            reaction_events.ReactionAddEvent, emoji_id=emoji_id, emoji_name=emoji_name
+        )()
+
+        assert event.is_for_emoji(emoji) is False
+
+    @pytest.mark.parametrize(
+        ("emoji_id", "emoji_name", "emoji"),
+        [
+            (None, "hfdasi", emojis.UnicodeEmoji("bgye")),
+            (54123, None, emojis.CustomEmoji(id=34123, name=None, is_animated=False)),
+        ],
+    )
+    def test_is_for_emoji_when_emoji_miss_match(self, emoji_id, emoji_name, emoji):
+        event = hikari_test_helpers.mock_class_namespace(
+            reaction_events.ReactionAddEvent, emoji_id=emoji_id, emoji_name=emoji_name
+        )()
+
+        assert event.is_for_emoji(emoji) is False
+
+
+class TestReactionDeleteEmojiEvent:
+    def test_is_for_emoji_when_custom_emoji_matches(self):
+        event = hikari_test_helpers.mock_class_namespace(reaction_events.ReactionAddEvent, emoji_id=332223333)()
+
+        assert event.is_for_emoji(emojis.CustomEmoji(id=332223333, name=None, is_animated=True))
+
+    def test_is_for_emoji_when_unicode_emoji_matches(self):
+        event = hikari_test_helpers.mock_class_namespace(reaction_events.ReactionAddEvent, emoji_name="🌲e")()
+
+        assert event.is_for_emoji(emojis.UnicodeEmoji("🌲e"))
+
+    @pytest.mark.parametrize(
+        ("emoji_id", "emoji_name", "emoji"),
+        [
+            (None, "heeei", emojis.CustomEmoji(name=None, id=541123, is_animated=False)),
+            (1233211, None, emojis.UnicodeEmoji("no eeeu")),
+        ],
+    )
+    def test_is_for_emoji_when_wrong_emoji_type(self, emoji_id, emoji_name, emoji):
+        event = hikari_test_helpers.mock_class_namespace(
+            reaction_events.ReactionAddEvent, emoji_id=emoji_id, emoji_name=emoji_name
+        )()
+
+        assert event.is_for_emoji(emoji) is False
+
+    @pytest.mark.parametrize(
+        ("emoji_id", "emoji_name", "emoji"),
+        [
+            (None, "dsahi", emojis.UnicodeEmoji("bye321")),
+            (12331231, None, emojis.CustomEmoji(id=121233312123, name=None, is_animated=False)),
+        ],
+    )
+    def test_is_for_emoji_when_emoji_miss_match(self, emoji_id, emoji_name, emoji):
+        event = hikari_test_helpers.mock_class_namespace(
+            reaction_events.ReactionAddEvent, emoji_id=emoji_id, emoji_name=emoji_name
+        )()
+
+        assert event.is_for_emoji(emoji) is False
 
 
 class TestGuildReactionAddEvent:


### PR DESCRIPTION
### Summary
Add is_for_emoji methods to relevant reaction events, as suggested by @tandemdude 

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
