### PR TITLE
Fix `embeds` type error in edit_message, fix `embeds` JSON serialize …

### DIFF
--- a/changes/779.bugfix.md
+++ b/changes/779.bugfix.md
@@ -1,0 +1,3 @@
+Fix passing `embeds` arguments in `create_interaction_response` and `edit_initial_response` endpoints
+- Fix deserialization of embeds in `create_interaction_response`
+- Fix `TypeErrors` raised in `edit_initial_response` when passing a list of embeds

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -258,7 +258,7 @@ class _RESTProvider(traits.RESTAware):
         return self._rest().proxy_settings
 
 
-_NONE_OR_UNDEFINED: typing.Final[typing.Set[undefined.UndefinedOr[None]]] = {None, undefined.UNDEFINED}
+_NONE_OR_UNDEFINED: typing.Final[typing.Tuple[None, undefined.UndefinedType]] = (None, undefined.UNDEFINED)
 
 
 class RESTApp(traits.ExecutorAware):
@@ -1239,7 +1239,7 @@ class RESTClientImpl(rest_api.RESTClient):
                 "meant to use 'collection' (singular) instead?"
             )
 
-        if embeds is not undefined.UNDEFINED and not isinstance(embeds, typing.Collection):
+        if embeds not in _NONE_OR_UNDEFINED and not isinstance(embeds, typing.Collection):
             raise TypeError(
                 "You passed a non collection to 'embeds', but this expects a collection. Maybe you meant to "
                 "use 'embed' (singular) instead?"
@@ -3353,7 +3353,7 @@ class RESTClientImpl(rest_api.RESTClient):
                 "meant to use 'collection' (singular) instead?"
             )
 
-        if embeds is not undefined.UNDEFINED and not isinstance(embeds, typing.Collection):
+        if embeds not in _NONE_OR_UNDEFINED and not isinstance(embeds, typing.Collection):
             raise TypeError(
                 "You passed a non collection to 'embeds', but this expects a collection. Maybe you meant to "
                 "use 'embed' (singular) instead?"
@@ -3396,7 +3396,7 @@ class RESTClientImpl(rest_api.RESTClient):
             embed_payloads: data_binding.JSONArray = []
             for embed in embeds:
                 serialized_embed, attachments = self._entity_factory.serialize_embed(embed)
-                embed_payloads.append(embed)
+                embed_payloads.append(serialized_embed)
                 if attachments:
                     raise ValueError("Cannot send an embed with attachments in a slash command's initial response")
 


### PR DESCRIPTION
…error in `create_interaction_response`

### Summary
Fixes 2 issues with the `embeds` parameter
* Serialization was failing due to the wrong variable being utilized in the `create_interaction_response` method
* Passing `embeds` to `edit_initial_response` was failing due to the list attempting to be checked if contained in a set, which raises an error remarking that lists are unhashable

nox passes ok on my system