### PR TITLE
Improve typing for messages and message update methods

### DIFF
--- a/changes/783.bugfix.md
+++ b/changes/783.bugfix.md
@@ -1,0 +1,7 @@
+Improve typing for message objects and message update methods
+- Fix the use of `typing.Optional` where `undefined.UndefinedOr` should have been used
+- Remove trying to acquire guild_id from the cached channel on PartialMessage
+  - Instead, clearly document the issue Discord imposes by not sending the guild_id
+- `is_webhook` will now return `undefined.UNDEFINED` if the information is not available 
+- Fix logic in `is_human` to account for the changes in the typing
+- Set `PartialMessage.member` to `undefined.UNDEFINED` when Discord edit the message to display an embed/attachment

--- a/tests/hikari/events/test_message_events.py
+++ b/tests/hikari/events/test_message_events.py
@@ -120,7 +120,10 @@ class TestMessageUpdateEvent:
 
     @pytest.mark.parametrize(
         ("author", "expected_id"),
-        [(mock.Mock(spec_set=users.User, id=91827), 91827), (None, None)],
+        [
+            (mock.Mock(spec_set=users.User, id=91827), 91827),
+            (undefined.UNDEFINED, undefined.UNDEFINED),
+        ],
     )
     def test_author_id_property(self, event, author, expected_id):
         event.message.author = author
@@ -141,18 +144,18 @@ class TestMessageUpdateEvent:
         assert event.is_bot is is_bot
 
     def test_is_bot_property_if_no_author(self, event):
-        event.message.author = None
-        assert event.is_bot is None
+        event.message.author = undefined.UNDEFINED
+        assert event.is_bot is undefined.UNDEFINED
 
     @pytest.mark.parametrize(
         ("author", "webhook_id", "expected_is_human"),
         [
             (mock.Mock(spec_set=users.User, is_bot=True), 123, False),
-            (mock.Mock(spec_set=users.User, is_bot=True), None, False),
+            (mock.Mock(spec_set=users.User, is_bot=True), undefined.UNDEFINED, False),
             (mock.Mock(spec_set=users.User, is_bot=False), 123, False),
-            (mock.Mock(spec_set=users.User, is_bot=False), None, True),
-            (None, 123, False),
-            (None, None, None),
+            (mock.Mock(spec_set=users.User, is_bot=False), undefined.UNDEFINED, True),
+            (undefined.UNDEFINED, 123, False),
+            (undefined.UNDEFINED, undefined.UNDEFINED, undefined.UNDEFINED),
         ],
     )
     def test_is_human_property(self, event, author, webhook_id, expected_is_human):

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -3816,10 +3816,10 @@ class TestEntityFactoryImpl:
     def test_deserialize_partial_message_with_partial_fields(self, entity_factory_impl, message_payload):
         message_payload["content"] = ""
         message_payload["edited_timestamp"] = None
-        message_payload["member"] = None
         message_payload["application"]["primary_sku_id"] = None
         message_payload["application"]["icon"] = None
         message_payload["referenced_message"] = None
+        del message_payload["member"]
         del message_payload["message_reference"]["message_id"]
         del message_payload["message_reference"]["guild_id"]
         del message_payload["application"]["cover_image"]
@@ -3829,7 +3829,7 @@ class TestEntityFactoryImpl:
         assert partial_message.content is None
         assert partial_message.edited_timestamp is None
         assert partial_message.guild_id is not None
-        assert partial_message.member is None
+        assert partial_message.member is undefined.UNDEFINED
         assert partial_message.application.primary_sku_id is None
         assert partial_message.application.icon_hash is None
         assert partial_message.application.cover_image_hash is None
@@ -3844,7 +3844,7 @@ class TestEntityFactoryImpl:
         assert partial_message.id == 123
         assert partial_message.channel_id == 456
         assert partial_message.guild_id is None
-        assert partial_message.author is None
+        assert partial_message.author is undefined.UNDEFINED
         assert partial_message.member is None
         assert partial_message.content is undefined.UNDEFINED
         assert partial_message.timestamp is undefined.UNDEFINED

--- a/tests/hikari/test_messages.py
+++ b/tests/hikari/test_messages.py
@@ -166,21 +166,6 @@ class TestMessage:
         message.channel_id = 456
         assert message.make_link(None) == "https://discord.com/channels/@me/456/789"
 
-    def test_guild_id_when_guild_is_not_none(self, message):
-        message._guild_id = 123
-
-        assert message.guild_id == 123
-
-    def test_guild_id_when_guild_is_none(self, message):
-        message.app = mock.Mock()
-        message._guild_id = None
-        message.channel_id = 890
-        message.app.cache.get_guild_channel = mock.Mock(return_value=mock.Mock(guild_id=456))
-
-        assert message.guild_id == 456
-
-        message.app.cache.get_guild_channel.assert_called_once_with(890)
-
 
 @pytest.mark.asyncio()
 class TestAsyncMessage:


### PR DESCRIPTION
### Summary
Thanks to @Le0Developer for bringing up the initial issue of  `is_webhook` always being `True` for `MessageUpdateEvent` in the Discord server.

This had me investigate and opened up a whole can of worms where I found inconsistencies and bugs in code and documentation fixes.

##### Changes
- Fix the use of `typing.Optional` where `undefined.UndefinedOr` should have been used.
- Remove trying to acquire `guild_id` from the cached channel on `PartialMessage`
  - Instead, clearly document the issue Discord imposes by not sending the `guild_id`
- `is_webhook` can now return `undefined.UNDEFINED` if the information is not available
- Fix logic in `is_human` to account for the changes in types
- Set `PartialMessage.member` to `undefined.UNDEFINED` when Discord edit the message to display an embed/attachment

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
None
