### PR TITLE
Prevent double linking embed resources, which causes them to upload twice

### DIFF
--- a/changes/788.bugfix.md
+++ b/changes/788.bugfix.md
@@ -1,0 +1,2 @@
+Prevent double linking embed resources, which causes them to upload twice
+- This was caused by attempting to move the resource from one embed to another


### PR DESCRIPTION
### Summary
Thanks to @zykrahgaming for pointing out this bug to me on Discord

The issue itself was embed resources wrapping around other embed resources (you can achive this by passing the footer icon of one embed to `set_footer` in another), which lead the deserialize process to count it as 2 resources, thus uploading twice

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
None
