### PR TITLE
Ensure hikari.File path points to an existing file

### DIFF
--- a/changes/829.bugfix.md
+++ b/changes/829.bugfix.md
@@ -1,0 +1,1 @@
+Ensure `hikari.File` paths point to a valid file

--- a/hikari/files.py
+++ b/hikari/files.py
@@ -48,6 +48,7 @@ import abc
 import asyncio
 import base64
 import concurrent.futures
+import errno
 import inspect
 import io
 import mimetypes
@@ -145,8 +146,16 @@ This may be one of:
 
 
 def ensure_path(pathish: Pathish) -> pathlib.Path:
-    """Convert a path-like object to a `pathlib.Path` instance."""
-    return pathlib.Path(pathish)
+    """Convert a path-like object to a `pathlib.Path` instance that points to an existing file."""
+    path = pathlib.Path(pathish)
+
+    if not path.exists():
+        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), str(path))
+
+    if path.is_dir():
+        raise IsADirectoryError(errno.EISDIR, os.strerror(errno.EISDIR), str(path))
+
+    return path
 
 
 def unwrap_bytes(data: Rawish) -> bytes:

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -1524,8 +1524,8 @@ class TestEntityFactoryImpl:
         assert embed.fields == []
 
     def test_serialize_embed_with_non_url_resources_provides_attachments(self, entity_factory_impl):
-        footer_icon = embed_models.EmbedResource(resource=files.File("cat.png"))
-        thumbnail = embed_models.EmbedImage(resource=files.File("dog.png"))
+        footer_icon = embed_models.EmbedResource(resource=files.Bytes(b"kung fu panda", "panda.pdf"))
+        thumbnail = embed_models.EmbedImage(resource=files.Bytes(b"", "ideas.txt"))
         image = embed_models.EmbedImage(resource=files.Bytes(b"potato kung fu", "sushi.pdf"))
         author_icon = embed_models.EmbedResource(resource=files.Bytes(b"potato kung fu^2", "sushi².jpg"))
         video_icon = embed_models.EmbedResource(resource=files.Bytes(b"whatevr", "sushi².mp4"))

--- a/tests/hikari/test_files.py
+++ b/tests/hikari/test_files.py
@@ -20,10 +20,41 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import pathlib
+
+import mock
 import pytest
 
 from hikari import files
 from tests.hikari import hikari_test_helpers
+
+
+class TestEnsurePath:
+    def test_when_doesnt_exists(self):
+        mock_path = mock.Mock(exists=mock.Mock(return_value=False))
+
+        with mock.patch.object(pathlib, "Path", return_value=mock_path) as pathlib_path:
+            with pytest.raises(FileNotFoundError):
+                files.ensure_path("cats.py")
+
+        pathlib_path.assert_called_once_with("cats.py")
+
+    def test_when_is_dir(self):
+        mock_path = mock.Mock(exists=mock.Mock(return_value=True), is_dir=mock.Mock(return_value=True))
+
+        with mock.patch.object(pathlib, "Path", return_value=mock_path) as pathlib_path:
+            with pytest.raises(IsADirectoryError):
+                files.ensure_path("cats.py")
+
+        pathlib_path.assert_called_once_with("cats.py")
+
+    def test_ensure_path(self):
+        mock_path = mock.Mock(exists=mock.Mock(return_value=True), is_dir=mock.Mock(return_value=False))
+
+        with mock.patch.object(pathlib, "Path", return_value=mock_path) as pathlib_path:
+            assert files.ensure_path("cats.py") is mock_path
+
+        pathlib_path.assert_called_once_with("cats.py")
 
 
 class TestAsyncReaderContextManager:


### PR DESCRIPTION
### Summary
Ensure hikari.File path points to an existing file

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Closes #826
