### PR TITLE
Make `from_received_embed` private

### DIFF
--- a/hikari/embeds.py
+++ b/hikari/embeds.py
@@ -303,11 +303,8 @@ class Embed:
         "_fields",
     )
 
-    # Don't document this.
-    __pdoc__: typing.ClassVar[typing.Mapping[str, typing.Any]] = {"from_received_embed": False}
-
     @classmethod
-    def from_received_embed(
+    def _from_received_embed(
         cls,
         *,
         title: typing.Optional[str],
@@ -323,10 +320,6 @@ class Embed:
         footer: typing.Optional[EmbedFooter],
         fields: typing.Optional[typing.MutableSequence[EmbedField]],
     ) -> Embed:
-        """Generate an embed from the given attributes.
-
-        You should never call this.
-        """
         # Create an empty instance without the overhead of invoking the regular
         # constructor.
         embed: Embed = super().__new__(cls)

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -921,7 +921,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
                 )
                 fields.append(field)
 
-        return embed_models.Embed.from_received_embed(
+        return embed_models.Embed._from_received_embed(
             title=title,
             description=description,
             url=url,

--- a/hikari/internal/cache.py
+++ b/hikari/internal/cache.py
@@ -729,7 +729,7 @@ class MessageInteractionData(BaseData[messages.MessageInteraction]):
 
 
 def _copy_embed(embed: embeds_.Embed) -> embeds_.Embed:
-    return embeds_.Embed.from_received_embed(
+    return embeds_.Embed._from_received_embed(
         title=embed.title,
         description=embed.description,
         url=embed.url,

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -1531,7 +1531,7 @@ class TestEntityFactoryImpl:
         video_icon = embed_models.EmbedResource(resource=files.Bytes(b"whatevr", "sushi².mp4"))
 
         payload, resources = entity_factory_impl.serialize_embed(
-            embed_models.Embed.from_received_embed(
+            embed_models.Embed._from_received_embed(
                 title="Title",
                 description="Nyaa",
                 url="https://some-url",
@@ -1583,7 +1583,7 @@ class TestEntityFactoryImpl:
         author_icon = embed_models.EmbedResource(resource=files.URL("http://foobar.com"))
 
         payload, resources = entity_factory_impl.serialize_embed(
-            embed_models.Embed.from_received_embed(
+            embed_models.Embed._from_received_embed(
                 title="Title",
                 description="Nyaa",
                 url="https://some-url",
@@ -1623,7 +1623,7 @@ class TestEntityFactoryImpl:
 
     def test_serialize_embed_with_null_sub_fields(self, entity_factory_impl):
         payload, resources = entity_factory_impl.serialize_embed(
-            embed_models.Embed.from_received_embed(
+            embed_models.Embed._from_received_embed(
                 title="Title",
                 description="Nyaa",
                 url="https://some-url",


### PR DESCRIPTION
### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
#808: `pdoc` removed support for `__pdoc__`, meaning that there would be no way to stop it from being documented. This being said, making it private doesn't seem to raise any errors anywhere else, so it could be changed
