### PR TITLE
Allow for more relaxed arg type fallback in some overloaded signatures

### DIFF
--- a/changes/876.bugfix.md
+++ b/changes/876.bugfix.md
@@ -1,0 +1,1 @@
+Relaxed typing of methods with union entry specific specialisations through overloads.

--- a/hikari/api/interaction_server.py
+++ b/hikari/api/interaction_server.py
@@ -146,6 +146,13 @@ class InteractionServer(abc.ABC):
     ) -> typing.Optional[ListenerT[component_interactions.ComponentInteraction, _MessageResponseBuilderT]]:
         ...
 
+    @typing.overload
+    @abc.abstractmethod
+    def get_listener(
+        self, interaction_type: typing.Type[_InteractionT_co], /
+    ) -> typing.Optional[ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder]]:
+        ...
+
     @abc.abstractmethod
     def get_listener(
         self, interaction_type: typing.Type[_InteractionT_co], /
@@ -182,6 +189,18 @@ class InteractionServer(abc.ABC):
         self,
         interaction_type: typing.Type[component_interactions.ComponentInteraction],
         listener: typing.Optional[ListenerT[component_interactions.ComponentInteraction, _MessageResponseBuilderT]],
+        /,
+        *,
+        replace: bool = False,
+    ) -> None:
+        ...
+
+    @typing.overload
+    @abc.abstractmethod
+    def set_listener(
+        self,
+        interaction_type: typing.Type[_InteractionT_co],
+        listener: typing.Optional[ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder]],
         /,
         *,
         replace: bool = False,

--- a/hikari/api/special_endpoints.py
+++ b/hikari/api/special_endpoints.py
@@ -1544,9 +1544,14 @@ class ActionRowBuilder(ComponentBuilder, abc.ABC):
 
     @typing.overload
     @abc.abstractmethod
+    def add_button(self: _T, style: typing.Literal[messages.ButtonStyle.LINK, 5], url: str, /) -> LinkButtonBuilder[_T]:
+        ...
+
+    @typing.overload
+    @abc.abstractmethod
     def add_button(
-        self: _T, style: typing.Union[typing.Literal[messages.ButtonStyle.LINK], typing.Literal[5]], url: str, /
-    ) -> LinkButtonBuilder[_T]:
+        self: _T, style: typing.Union[int, messages.ButtonStyle], url_or_custom_id: str, /
+    ) -> ButtonBuilder[_T]:
         ...
 
     @abc.abstractmethod

--- a/hikari/api/special_endpoints.py
+++ b/hikari/api/special_endpoints.py
@@ -1551,13 +1551,13 @@ class ActionRowBuilder(ComponentBuilder, abc.ABC):
     @abc.abstractmethod
     def add_button(
         self: _T, style: typing.Union[int, messages.ButtonStyle], url_or_custom_id: str, /
-    ) -> ButtonBuilder[_T]:
+    ) -> typing.Union[LinkButtonBuilder[_T], InteractiveButtonBuilder[_T]]:
         ...
 
     @abc.abstractmethod
     def add_button(
         self: _T, style: typing.Union[int, messages.ButtonStyle], url_or_custom_id: str, /
-    ) -> ButtonBuilder[_T]:
+    ) -> typing.Union[LinkButtonBuilder[_T], InteractiveButtonBuilder[_T]]:
         """Add a button component to this action row builder.
 
         Parameters
@@ -1573,7 +1573,7 @@ class ActionRowBuilder(ComponentBuilder, abc.ABC):
 
         Returns
         -------
-        ButtonBuilder[Self]
+        typing.Union[LinkButtonBuilder[Self], InteractiveButtonBuilder[Self]]
             Button builder object.
             `ButtonBuilder.add_to_container` should be called to finalise the
             button.

--- a/hikari/impl/interaction_server.py
+++ b/hikari/impl/interaction_server.py
@@ -501,6 +501,12 @@ class InteractionServer(interaction_server.InteractionServer):
     ]:
         ...
 
+    @typing.overload
+    def get_listener(
+        self, interaction_type: typing.Type[_InteractionT_co], /
+    ) -> typing.Optional[interaction_server.ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder]]:
+        ...
+
     def get_listener(
         self, interaction_type: typing.Type[_InteractionT_co], /
     ) -> typing.Optional[interaction_server.ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder]]:
@@ -525,6 +531,19 @@ class InteractionServer(interaction_server.InteractionServer):
         interaction_type: typing.Type[component_interactions.ComponentInteraction],
         listener: typing.Optional[
             interaction_server.ListenerT[component_interactions.ComponentInteraction, _MessageResponseBuilderT]
+        ],
+        /,
+        *,
+        replace: bool = False,
+    ) -> None:
+        ...
+
+    @typing.overload
+    def set_listener(
+        self,
+        interaction_type: typing.Type[_InteractionT_co],
+        listener: typing.Optional[
+            interaction_server.ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder]
         ],
         /,
         *,

--- a/hikari/impl/rest_bot.py
+++ b/hikari/impl/rest_bot.py
@@ -587,10 +587,16 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
     ]:
         ...
 
+    @typing.overload
     def get_listener(
         self, interaction_type: typing.Type[_InteractionT_co], /
     ) -> typing.Optional[interaction_server_.ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder]]:
-        return self._server.get_listener(interaction_type)  # type: ignore[return-value, arg-type]
+        ...
+
+    def get_listener(
+        self, interaction_type: typing.Type[_InteractionT_co], /
+    ) -> typing.Optional[interaction_server_.ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder]]:
+        return self._server.get_listener(interaction_type)
 
     @typing.overload
     def set_listener(
@@ -618,6 +624,7 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
     ) -> None:
         ...
 
+    @typing.overload
     def set_listener(
         self,
         interaction_type: typing.Type[_InteractionT_co],
@@ -628,4 +635,16 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
         *,
         replace: bool = False,
     ) -> None:
-        self._server.set_listener(interaction_type, listener, replace=replace)  # type: ignore[arg-type]
+        ...
+
+    def set_listener(
+        self,
+        interaction_type: typing.Type[_InteractionT_co],
+        listener: typing.Optional[
+            interaction_server_.ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder]
+        ],
+        /,
+        *,
+        replace: bool = False,
+    ) -> None:
+        self._server.set_listener(interaction_type, listener, replace=replace)

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -1270,12 +1270,18 @@ class ActionRowBuilder(special_endpoints.ActionRowBuilder):
     @typing.overload
     def add_button(
         self: _ActionRowBuilderT, style: typing.Union[int, messages.ButtonStyle], url_or_custom_id: str, /
-    ) -> special_endpoints.ButtonBuilder[_ActionRowBuilderT]:
+    ) -> typing.Union[
+        special_endpoints.LinkButtonBuilder[_ActionRowBuilderT],
+        special_endpoints.InteractiveButtonBuilder[_ActionRowBuilderT],
+    ]:
         ...
 
     def add_button(
         self: _ActionRowBuilderT, style: typing.Union[int, messages.ButtonStyle], url_or_custom_id: str, /
-    ) -> special_endpoints.ButtonBuilder[_ActionRowBuilderT]:
+    ) -> typing.Union[
+        special_endpoints.LinkButtonBuilder[_ActionRowBuilderT],
+        special_endpoints.InteractiveButtonBuilder[_ActionRowBuilderT],
+    ]:
         self._assert_can_add_type(messages.ComponentType.BUTTON)
         if style in messages.InteractiveButtonTypes:
             return InteractiveButtonBuilder(container=self, style=style, custom_id=url_or_custom_id)

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -1261,10 +1261,16 @@ class ActionRowBuilder(special_endpoints.ActionRowBuilder):
     @typing.overload
     def add_button(
         self: _ActionRowBuilderT,
-        style: typing.Union[typing.Literal[messages.ButtonStyle.LINK], typing.Literal[5]],
+        style: typing.Literal[messages.ButtonStyle.LINK, 5],
         url: str,
         /,
     ) -> special_endpoints.LinkButtonBuilder[_ActionRowBuilderT]:
+        ...
+
+    @typing.overload
+    def add_button(
+        self: _ActionRowBuilderT, style: typing.Union[int, messages.ButtonStyle], url_or_custom_id: str, /
+    ) -> special_endpoints.ButtonBuilder[_ActionRowBuilderT]:
         ...
 
     def add_button(


### PR DESCRIPTION
### Summary
Allow for more relaxed arg type fallback in some overloaded signatures

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Closes #875