### PR TITLE
Consistency between the usage of sequence and collection in typing

### DIFF
--- a/hikari/events/base_events.py
+++ b/hikari/events/base_events.py
@@ -69,7 +69,7 @@ class Event(abc.ABC):
         """
 
 
-def get_required_intents_for(event_type: typing.Type[Event]) -> typing.Collection[intents.Intents]:
+def get_required_intents_for(event_type: typing.Type[Event]) -> typing.Sequence[intents.Intents]:
     """Retrieve the intents that are required to listen to an event type.
 
     Parameters
@@ -79,12 +79,12 @@ def get_required_intents_for(event_type: typing.Type[Event]) -> typing.Collectio
 
     Returns
     -------
-    typing.Collection[hikari.intents.Intents]
-        Collection of acceptable subset combinations of intent needed to
+    typing.Sequence[hikari.intents.Intents]
+        Sequence of acceptable subset combinations of intent needed to
         be able to receive the given event type.
     """
     result = getattr(event_type, REQUIRED_INTENTS_ATTR, ())
-    assert isinstance(result, typing.Collection)
+    assert isinstance(result, typing.Sequence)
     return result
 
 

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -503,7 +503,7 @@ class GatewayBot(traits.GatewayBotAware):
 
     def get_listeners(
         self, event_type: typing.Type[event_manager_.EventT_co], /, *, polymorphic: bool = True
-    ) -> typing.Collection[event_manager_.CallbackT[event_manager_.EventT_co]]:
+    ) -> typing.Sequence[event_manager_.CallbackT[event_manager_.EventT_co]]:
         """Get the listeners for a given event type, if there are any.
 
         Parameters
@@ -519,8 +519,8 @@ class GatewayBot(traits.GatewayBotAware):
 
         Returns
         -------
-        typing.Collection[typing.Callable[[T], typing.Coroutine[typing.Any, typing.Any, builtins.None]]
-            A copy of the collection of listeners for the event. Will return
+        typing.Sequence[typing.Callable[[T], typing.Coroutine[typing.Any, typing.Any, builtins.None]]
+            A copy of the sequence of listeners for the event. Will return
             an empty collection if nothing is registered.
 
             `T` must be a subclass of `hikari.events.base_events.Event`.

--- a/hikari/impl/event_manager_base.py
+++ b/hikari/impl/event_manager_base.py
@@ -320,7 +320,7 @@ class EventManagerBase(event_manager_.EventManager):
         /,
         *,
         polymorphic: bool = True,
-    ) -> typing.Collection[event_manager_.CallbackT[event_manager_.EventT_co]]:
+    ) -> typing.Sequence[event_manager_.CallbackT[event_manager_.EventT_co]]:
         if polymorphic:
             listeners: typing.List[event_manager_.CallbackT[event_manager_.EventT_co]] = []
             for subscribed_event_type, subscribed_listeners in self._listeners.items():

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -1238,19 +1238,19 @@ class RESTClientImpl(rest_api.RESTClient):
         if not undefined.any_undefined(embed, embeds):
             raise ValueError("You may only specify one of 'embed' or 'embeds', not both")
 
-        if attachments is not undefined.UNDEFINED and not isinstance(attachments, typing.Collection):
+        if attachments is not undefined.UNDEFINED and not isinstance(attachments, typing.Sequence):
             raise TypeError(
                 "You passed a non-collection to 'attachments', but this expects a collection. Maybe you meant to "
                 "use 'attachment' (singular) instead?"
             )
 
-        if components is not undefined.UNDEFINED and not isinstance(components, typing.Collection):
+        if components is not undefined.UNDEFINED and not isinstance(components, typing.Sequence):
             raise TypeError(
                 "You passed a non-collection to 'components', but this expects a collection. Maybe you meant to "
                 "use 'component' (singular) instead?"
             )
 
-        if embeds not in _NONE_OR_UNDEFINED and not isinstance(embeds, typing.Collection):
+        if embeds not in _NONE_OR_UNDEFINED and not isinstance(embeds, typing.Sequence):
             raise TypeError(
                 "You passed a non-collection to 'embeds', but this expects a collection. Maybe you meant to "
                 "use 'embed' (singular) instead?"
@@ -1405,19 +1405,19 @@ class RESTClientImpl(rest_api.RESTClient):
         if not undefined.any_undefined(embed, embeds):
             raise ValueError("You may only specify one of 'embed' or 'embeds', not both")
 
-        if attachments is not undefined.UNDEFINED and not isinstance(attachments, typing.Collection):
+        if attachments is not undefined.UNDEFINED and not isinstance(attachments, typing.Sequence):
             raise TypeError(
                 "You passed a non-collection to 'attachments', but this expects a collection. Maybe you meant to "
                 "use 'attachment' (singular) instead?"
             )
 
-        if components is not undefined.UNDEFINED and not isinstance(components, typing.Collection):
+        if components is not undefined.UNDEFINED and not isinstance(components, typing.Sequence):
             raise TypeError(
                 "You passed a non-collection to 'components', but this expects a collection. Maybe you meant to "
                 "use 'component' (singular) instead?"
             )
 
-        if embeds not in _NONE_OR_UNDEFINED and not isinstance(embeds, typing.Collection):
+        if embeds not in _NONE_OR_UNDEFINED and not isinstance(embeds, typing.Sequence):
             raise TypeError(
                 "You passed a non-collection to 'embeds', but this expects a collection. Maybe you meant to "
                 "use 'embed' (singular) instead?"
@@ -3401,13 +3401,13 @@ class RESTClientImpl(rest_api.RESTClient):
         if not undefined.any_undefined(embed, embeds):
             raise ValueError("You may only specify one of 'embed' or 'embeds', not both")
 
-        if components is not undefined.UNDEFINED and not isinstance(components, typing.Collection):
+        if components is not undefined.UNDEFINED and not isinstance(components, typing.Sequence):
             raise TypeError(
                 "You passed a non-collection to 'components', but this expects a collection. Maybe you meant to "
                 "use 'component' (singular) instead?"
             )
 
-        if embeds not in _NONE_OR_UNDEFINED and not isinstance(embeds, typing.Collection):
+        if embeds not in _NONE_OR_UNDEFINED and not isinstance(embeds, typing.Sequence):
             raise TypeError(
                 "You passed a non-collection to 'embeds', but this expects a collection. Maybe you meant to "
                 "use 'embed' (singular) instead?"

--- a/hikari/internal/mentions.py
+++ b/hikari/internal/mentions.py
@@ -77,14 +77,14 @@ def generate_allowed_mentions(
 
     if user_mentions is True:
         parsed_mentions.append("users")
-    elif isinstance(user_mentions, typing.Collection):
+    elif isinstance(user_mentions, typing.Sequence):
         # Duplicates will cause discord to error.
         ids = {str(int(u)) for u in user_mentions}
         allowed_mentions["users"] = list(ids)
 
     if role_mentions is True:
         parsed_mentions.append("roles")
-    elif isinstance(role_mentions, typing.Collection):
+    elif isinstance(role_mentions, typing.Sequence):
         # Duplicates will cause discord to error.
         ids = {str(int(r)) for r in role_mentions}
         allowed_mentions["roles"] = list(ids)

--- a/hikari/iterators.py
+++ b/hikari/iterators.py
@@ -100,7 +100,7 @@ class All(typing.Generic[ValueT]):
 
     __slots__: typing.Sequence[str] = ("conditions",)
 
-    def __init__(self, conditions: typing.Collection[typing.Callable[[ValueT], bool]]) -> None:
+    def __init__(self, conditions: typing.Sequence[typing.Callable[[ValueT], bool]]) -> None:
         self.conditions = conditions
 
     def __bool__(self) -> bool:


### PR DESCRIPTION
### Summary
* Fix checking against `typing.Collection` where the type was `typing.Sequence`
* Change uses of `typing.Collection` to `typing.Sequence`
   * Reason behind this change is that `typing.Sequence` reflects more what we are returning type wise (a read-only sequence)

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
None
