### PR TITLE
Fix reference messages not being fully deleted

### DIFF
--- a/changes/910.bugfix.md
+++ b/changes/910.bugfix.md
@@ -1,0 +1,1 @@
+Fix reference messages not being fully deleted, which could cause a memory leak

--- a/hikari/impl/cache.py
+++ b/hikari/impl/cache.py
@@ -1473,8 +1473,13 @@ class CacheImpl(cache.MutableCache):
             if guild_record:
                 self._garbage_collect_member(guild_record, message.object.member, decrement=1)
 
-        if message.object.referenced_message:
-            self._garbage_collect_message(message.object.referenced_message, decrement=1)
+        referenced_message = message.object.referenced_message
+        if not referenced_message and message.object.message_reference and message.object.message_reference.id:
+            msg_id = message.object.message_reference.id
+            referenced_message = self._message_entries.get(msg_id) or self._referenced_messages.get(msg_id)
+
+        if referenced_message:
+            self._garbage_collect_message(referenced_message, decrement=1)
 
         if message.object.mentions.users:
             for user in message.object.mentions.users.values():


### PR DESCRIPTION
Thanks to @norinorin for finding the bug and providing the patch!

*The patch was submitted with explicit permission from them*

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Closes #904