### PR TITLE
Fix logic for asserting listeners to not error when using defaults for other arguments

### DIFF
--- a/changes/911.bugfix.md
+++ b/changes/911.bugfix.md
@@ -1,0 +1,1 @@
+Fix logic for asserting listeners to not error when using defaults for other arguments

--- a/hikari/impl/event_manager_base.py
+++ b/hikari/impl/event_manager_base.py
@@ -248,7 +248,7 @@ def _assert_is_listener(parameters: typing.Iterator[inspect.Parameter], /) -> No
     if next(parameters, None) is None:
         raise TypeError("Event listener must have one positional argument for the event object.")
 
-    if any(param.default is not inspect.Parameter.empty for param in parameters):
+    if any(param.default is inspect.Parameter.empty for param in parameters):
         raise TypeError("Only the first argument for a listener can be required, the event argument.")
 
 


### PR DESCRIPTION
### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
