### PR TITLE
Fix ActionRowBuilder inner-type assertion

### DIFF
--- a/changes/912.bugfix.md
+++ b/changes/912.bugfix.md
@@ -1,0 +1,1 @@
+Fix error message given by action row when a conflicted type is added.

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -1244,7 +1244,9 @@ class ActionRowBuilder(special_endpoints.ActionRowBuilder):
 
     def _assert_can_add_type(self, type_: messages.ComponentType, /) -> None:
         if self._stored_type is not None and self._stored_type != type_:
-            raise ValueError(f"{type_} component type cannot be added to a container which already holds {type_}")
+            raise ValueError(
+                f"{type_} component type cannot be added to a container which already holds {self._stored_type}"
+            )
 
         self._stored_type = type_
 


### PR DESCRIPTION
### Summary
Fix ActionRowBuilder inner-type assertion

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
