### PR TITLE
Add min_value and max_value to CommandOption

### DIFF
--- a/changes/920.feature.md
+++ b/changes/920.feature.md
@@ -1,0 +1,1 @@
+Add min_value and max_value to `CommandOption`

--- a/hikari/commands.py
+++ b/hikari/commands.py
@@ -146,10 +146,10 @@ class CommandOption:
     If `builtins.None`, then all channel types will be accepted.
     """
 
-    min_value: typing.Optional[float] = attr.field(default=None, repr=False)
+    min_value: typing.Union[int, float, None] = attr.field(default=None, repr=False)
     """The minimum value permitted (inclusive)"""
 
-    max_value: typing.Optional[float] = attr.field(default=None, repr=False)
+    max_value: typing.Union[int, float, None] = attr.field(default=None, repr=False)
     """The minimum value permitted (inclusive)"""
 
 

--- a/hikari/commands.py
+++ b/hikari/commands.py
@@ -147,10 +147,16 @@ class CommandOption:
     """
 
     min_value: typing.Union[int, float, None] = attr.field(default=None, repr=False)
-    """The minimum value permitted (inclusive)"""
+    """The minimum value permitted (inclusive)
+    
+    If the option type is `hikari.commands.OptionType.INTEGER` than this must be an `builtins.int`.
+    """
 
     max_value: typing.Union[int, float, None] = attr.field(default=None, repr=False)
-    """The minimum value permitted (inclusive)"""
+    """The minimum value permitted (inclusive)
+    
+    If the option type is `hikari.commands.OptionType.INTEGER` than this must be an `builtins.int`.
+    """
 
 
 @attr_extensions.with_copy

--- a/hikari/commands.py
+++ b/hikari/commands.py
@@ -148,13 +148,13 @@ class CommandOption:
 
     min_value: typing.Union[int, float, None] = attr.field(default=None, repr=False)
     """The minimum value permitted (inclusive)
-    
+
     If the option type is `hikari.commands.OptionType.INTEGER` than this must be an `builtins.int`.
     """
 
     max_value: typing.Union[int, float, None] = attr.field(default=None, repr=False)
     """The minimum value permitted (inclusive)
-    
+
     If the option type is `hikari.commands.OptionType.INTEGER` than this must be an `builtins.int`.
     """
 

--- a/hikari/commands.py
+++ b/hikari/commands.py
@@ -147,15 +147,17 @@ class CommandOption:
     """
 
     min_value: typing.Union[int, float, None] = attr.field(default=None, repr=False)
-    """The minimum value permitted (inclusive)
+    """The minimum value permitted (inclusive).
 
-    If the option type is `hikari.commands.OptionType.INTEGER` than this must be an `builtins.int`.
+    This will be `builtins.int` if the type of the option is `hikari.commands.OptionType.INTEGER`
+    and `builtins.float` if the type is `hikari.commands.OptionType.NUMBER`. 
     """
 
     max_value: typing.Union[int, float, None] = attr.field(default=None, repr=False)
-    """The minimum value permitted (inclusive)
+    """The maximum value permitted (inclusive).
 
-    If the option type is `hikari.commands.OptionType.INTEGER` than this must be an `builtins.int`.
+    This will be `builtins.int` if the type of the option is `hikari.commands.OptionType.INTEGER`
+    and `builtins.float` if the type is `hikari.commands.OptionType.NUMBER`. 
     """
 
 

--- a/hikari/commands.py
+++ b/hikari/commands.py
@@ -150,14 +150,14 @@ class CommandOption:
     """The minimum value permitted (inclusive).
 
     This will be `builtins.int` if the type of the option is `hikari.commands.OptionType.INTEGER`
-    and `builtins.float` if the type is `hikari.commands.OptionType.NUMBER`. 
+    and `builtins.float` if the type is `hikari.commands.OptionType.NUMBER`.
     """
 
     max_value: typing.Union[int, float, None] = attr.field(default=None, repr=False)
     """The maximum value permitted (inclusive).
 
     This will be `builtins.int` if the type of the option is `hikari.commands.OptionType.INTEGER`
-    and `builtins.float` if the type is `hikari.commands.OptionType.NUMBER`. 
+    and `builtins.float` if the type is `hikari.commands.OptionType.NUMBER`.
     """
 
 

--- a/hikari/commands.py
+++ b/hikari/commands.py
@@ -146,6 +146,12 @@ class CommandOption:
     If `builtins.None`, then all channel types will be accepted.
     """
 
+    min_value: typing.Optional[float] = attr.field(default=None, repr=False)
+    """The minimum value permitted (inclusive)"""
+
+    max_value: typing.Optional[float] = attr.field(default=None, repr=False)
+    """The minimum value permitted (inclusive)"""
+
 
 @attr_extensions.with_copy
 @attr.define(hash=True, kw_only=True, weakref_slot=False)

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -1916,14 +1916,12 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         if option.options is not None:
             payload["options"] = [self.serialize_command_option(suboption) for suboption in option.options]
 
+        # because discord does not allow floating point min and max values with integer options we have to round
+        is_integer = option.type is commands.OptionType.INTEGER
         if option.min_value is not None:
-            payload["min_value"] = (
-                math.ceil(option.min_value) if option.type is commands.OptionType.INTEGER else option.min_value
-            )
+            payload["min_value"] = math.ceil(option.min_value) if is_integer else option.min_value
         if option.max_value is not None:
-            payload["max_value"] = (
-                math.floor(option.max_value) if option.type is commands.OptionType.INTEGER else option.max_value
-            )
+            payload["max_value"] = math.floor(option.max_value) if is_integer else option.max_value
 
         return payload
 

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -28,7 +28,6 @@ __all__: typing.List[str] = ["EntityFactoryImpl"]
 
 import datetime
 import logging
-import math
 import typing
 
 import attr

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -28,6 +28,7 @@ __all__: typing.List[str] = ["EntityFactoryImpl"]
 
 import datetime
 import logging
+import math
 import typing
 
 import attr
@@ -1690,6 +1691,8 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             choices=choices,
             options=suboptions,
             channel_types=channel_types,
+            min_value=payload.get("min_value"),
+            max_value=payload.get("max_value"),
         )
 
     def deserialize_command(
@@ -1912,6 +1915,15 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
 
         if option.options is not None:
             payload["options"] = [self.serialize_command_option(suboption) for suboption in option.options]
+
+        if option.min_value is not None:
+            payload["min_value"] = (
+                math.ceil(option.min_value) if option.type is commands.OptionType.INTEGER else option.min_value
+            )
+        if option.max_value is not None:
+            payload["max_value"] = (
+                math.floor(option.max_value) if option.type is commands.OptionType.INTEGER else option.max_value
+            )
 
         return payload
 

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -1916,12 +1916,10 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         if option.options is not None:
             payload["options"] = [self.serialize_command_option(suboption) for suboption in option.options]
 
-        # because discord does not allow floating point min and max values with integer options we have to round
-        is_integer = option.type is commands.OptionType.INTEGER
         if option.min_value is not None:
-            payload["min_value"] = math.ceil(option.min_value) if is_integer else option.min_value
+            payload["min_value"] = option.min_value
         if option.max_value is not None:
-            payload["max_value"] = math.floor(option.max_value) if is_integer else option.max_value
+            payload["max_value"] = option.max_value
 
         return payload
 

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -3139,23 +3139,23 @@ class TestEntityFactoryImpl:
 
     def test_serialize_command_option_with_min_and_max_value(self, entity_factory_impl):
         option = commands.CommandOption(
-            type=commands.OptionType.INTEGER,
+            type=commands.OptionType.FLOAT,
             name="a name",
             description="go away",
             is_required=True,
             min_value=1.2,
-            max_value=9.99,
+            max_value=9.999,
         )
 
         result = entity_factory_impl.serialize_command_option(option)
 
         assert result == {
-            "type": 4,
+            "type": 10,
             "name": "a name",
             "description": "go away",
             "required": True,
-            "min_value": 2,
-            "max_value": 9,
+            "min_value": 1.2,
+            "max_value": 9.999,
         }
 
     def test_serialize_command_option_with_choices(self, entity_factory_impl):

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -2719,6 +2719,8 @@ class TestEntityFactoryImpl:
                     "description": "42",
                     "channel_types": [0, 1, 2],
                     "required": True,
+                    "min_value": 0,
+                    "max_value": 10,
                     "options": [
                         {
                             "type": 6,
@@ -2758,6 +2760,8 @@ class TestEntityFactoryImpl:
             channel_models.ChannelType.DM,
             channel_models.ChannelType.GUILD_VOICE,
         ]
+        assert option.min_value == 0
+        assert option.max_value == 10
 
         assert len(option.options) == 1
         suboption = option.options[0]
@@ -3131,6 +3135,27 @@ class TestEntityFactoryImpl:
             "description": "go away",
             "required": True,
             "channel_types": [13, 0, 100],
+        }
+
+    def test_serialize_command_option_with_min_and_max_value(self, entity_factory_impl):
+        option = commands.CommandOption(
+            type=commands.OptionType.INTEGER,
+            name="a name",
+            description="go away",
+            is_required=True,
+            min_value=1.2,
+            max_value=9.99,
+        )
+
+        result = entity_factory_impl.serialize_command_option(option)
+
+        assert result == {
+            "type": 4,
+            "name": "a name",
+            "description": "go away",
+            "required": True,
+            "min_value": 2,
+            "max_value": 9,
         }
 
     def test_serialize_command_option_with_choices(self, entity_factory_impl):


### PR DESCRIPTION
### Summary
Add min_value and max_value to CommandOption. 

Reference: https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed. (it's taking so long 😭)
- [x] I have made unittests according to the code I have added/modified/deleted.
