### PR TITLE
Fix PartialSticker.image_url not passing the hash as a string

### DIFF
--- a/changes/930.bugfix.md
+++ b/changes/930.bugfix.md
@@ -1,0 +1,1 @@
+Fix `PartialSticker.image_url` not passing the hash as a string

--- a/hikari/internal/routes.py
+++ b/hikari/internal/routes.py
@@ -556,7 +556,7 @@ CDN_TEAM_ICON: typing.Final[CDNRoute] = CDNRoute("/team-icons/{team_id}/{hash}",
 # undocumented on the Discord docs.
 CDN_CHANNEL_ICON: typing.Final[CDNRoute] = CDNRoute("/channel-icons/{channel_id}/{hash}", {PNG, *JPEG_JPG, WEBP})
 
-CDN_STICKER: typing.Final[CDNRoute] = CDNRoute("/stickers/{hash}", {PNG, LOTTIE}, sizable=False)
+CDN_STICKER: typing.Final[CDNRoute] = CDNRoute("/stickers/{sticker_id}", {PNG, LOTTIE}, sizable=False)
 CDN_STICKER_PACK_BANNER: typing.Final[CDNRoute] = CDNRoute(
     "/app-assets/710982414301790216/store/{hash}", {PNG, *JPEG_JPG, WEBP}
 )

--- a/hikari/stickers.py
+++ b/hikari/stickers.py
@@ -157,7 +157,7 @@ class PartialSticker(snowflakes.Unique):
         """
         ext = "json" if self.format_type is StickerFormatType.LOTTIE else "png"
 
-        return routes.CDN_STICKER.compile_to_file(urls.CDN_URL, hash=self.id, file_format=ext)
+        return routes.CDN_STICKER.compile_to_file(urls.CDN_URL, sticker_id=self.id, file_format=ext)
 
 
 @attr_extensions.with_copy

--- a/tests/hikari/test_stickers.py
+++ b/tests/hikari/test_stickers.py
@@ -73,7 +73,7 @@ class TestPartialSticker:
         ) as route:
             assert model.image_url == "file"
 
-        route.compile_to_file.assert_called_once_with(urls.CDN_URL, hash=123, file_format="png")
+        route.compile_to_file.assert_called_once_with(urls.CDN_URL, sticker_id=123, file_format="png")
 
     def test_image_url_when_LOTTIE(self, model):
         model.format_type = stickers.StickerFormatType.LOTTIE
@@ -83,4 +83,4 @@ class TestPartialSticker:
         ) as route:
             assert model.image_url == "file"
 
-        route.compile_to_file.assert_called_once_with(urls.CDN_URL, hash=123, file_format="json")
+        route.compile_to_file.assert_called_once_with(urls.CDN_URL, sticker_id=123, file_format="json")


### PR DESCRIPTION
### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

