### PR TITLE
Fix ROLE_ICON cdn route

### DIFF
--- a/changes/931.bugfix.md
+++ b/changes/931.bugfix.md
@@ -1,0 +1,1 @@
+Fixed the url being generated for role icons to not erroneously insert ".png" before the file extension

--- a/changes/idk.bugfix.md
+++ b/changes/idk.bugfix.md
@@ -1,1 +1,0 @@
-Fixed the url being generated for role icons to not erronously insert ".png" before the file extension

--- a/changes/idk.bugfix.md
+++ b/changes/idk.bugfix.md
@@ -1,0 +1,1 @@
+Fixed the url being generated for role icons to not erronously insert ".png" before the file extension

--- a/hikari/internal/routes.py
+++ b/hikari/internal/routes.py
@@ -543,7 +543,7 @@ CDN_USER_BANNER: typing.Final[CDNRoute] = CDNRoute("/banners/{user_id}/{hash}", 
 CDN_MEMBER_AVATAR: typing.Final[CDNRoute] = CDNRoute(
     "/guilds/{guild_id}/users/{user_id}/avatars/{hash}", {PNG, *JPEG_JPG, WEBP, GIF}
 )
-CDN_ROLE_ICON: typing.Final[CDNRoute] = CDNRoute("/role-icons/{role_id}/{hash}.png", {PNG, *JPEG_JPG, WEBP})
+CDN_ROLE_ICON: typing.Final[CDNRoute] = CDNRoute("/role-icons/{role_id}/{hash}", {PNG, *JPEG_JPG, WEBP})
 
 CDN_APPLICATION_ICON: typing.Final[CDNRoute] = CDNRoute("/app-icons/{application_id}/{hash}", {PNG, *JPEG_JPG, WEBP})
 CDN_APPLICATION_COVER: typing.Final[CDNRoute] = CDNRoute("/app-assets/{application_id}/{hash}", {PNG, *JPEG_JPG, WEBP})


### PR DESCRIPTION
### Summary
Fix ROLE_ICON cdn route as to not always include ".png" before the file type extension

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
