### PR TITLE
Fix logic to ensure no CHANGELOG files exist

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,7 +21,7 @@
 # SOFTWARE.
 set -e
 
-if [ $(ls -1 changes/*.*.md 2>/dev/null | wc -l) = 0]; then
+if [ $(ls -1 changes/*.*.md 2>/dev/null | wc -l) != 0 ]; then
     echo "Cannot create release if CHANGELOG fragment files exist under 'changes/'!"
     exit 1
 fi


### PR DESCRIPTION
### Summary
Thanks to @Jonxslays for pointing this out to me. Looks like this line was never running due to a missing space

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
