### PR TITLE
Implement member timeout

### DIFF
--- a/changes/940.feature.md
+++ b/changes/940.feature.md
@@ -1,4 +1,4 @@
 Implement member timeouts
- - Add `communication_disabled_until` and `is_timed_out` to `Member`
+ - Add `raw_communication_disabled_until` and `communication_disabled_until` to `Member`
  - Add `MODERATE_MEMBERS` to `Permission`
  - Add `communication_disabled_until` attribute to `edit_member`

--- a/changes/940.feature.md
+++ b/changes/940.feature.md
@@ -1,0 +1,4 @@
+Implement member timeouts
+ - Add `communication_disabled_until` and `is_timed_out` to `Member`
+ - Add `MODERATE_MEMBERS` to `Permission`
+ - Add `communication_disabled_until` attribute to `edit_member`

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -4953,6 +4953,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         voice_channel: undefined.UndefinedNoneOr[
             snowflakes.SnowflakeishOr[channels_.GuildVoiceChannel]
         ] = undefined.UNDEFINED,
+        communication_disabled_until: undefined.UndefinedNoneOr[datetime.datetime] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> guilds.Member:
         """Edit a guild member.
@@ -4997,6 +4998,12 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             !!! note
                 If the member is not in a voice channel, this will
                 take no effect.
+        communication_disabled_until : hikari.undefined.UndefinedNoneOr[datetime.datetime]
+            If provided, the datetime when the timeout (disable communication)
+            of the member expires, up to 28 days in the future, or `builtins.None`
+            to remove the timeout from the member.
+
+            Requires the `MODERATE_MEMBERS` permission.
         reason : hikari.undefined.UndefinedOr[builtins.str]
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -1176,6 +1176,11 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             time.iso8601_datetime_string_to_datetime(raw_premium_since) if raw_premium_since is not None else None
         )
 
+        if raw_communication_disabled_until := payload.get("communication_disabled_until"):
+            communication_disabled_until = time.iso8601_datetime_string_to_datetime(raw_communication_disabled_until)
+        else:
+            communication_disabled_until = None
+
         return guild_models.Member(
             user=user,
             guild_id=guild_id,
@@ -1187,6 +1192,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             is_deaf=payload.get("deaf", undefined.UNDEFINED),
             is_mute=payload.get("mute", undefined.UNDEFINED),
             is_pending=payload.get("pending", undefined.UNDEFINED),
+            raw_communication_disabled_until=communication_disabled_until,
         )
 
     def deserialize_role(
@@ -1789,6 +1795,11 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         if (raw_premium_since := payload.get("premium_since")) is not None:
             premium_since = time.iso8601_datetime_string_to_datetime(raw_premium_since)
 
+        if raw_disabled_until := payload.get("communication_disabled_until"):
+            disabled_until = time.iso8601_datetime_string_to_datetime(raw_disabled_until)
+        else:
+            disabled_until = None
+
         # TODO: deduplicate member unmarshalling logic
         return base_interactions.InteractionMember(
             user=user,
@@ -1802,6 +1813,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             is_mute=payload.get("mute", undefined.UNDEFINED),
             is_pending=payload.get("pending", undefined.UNDEFINED),
             permissions=permission_models.Permissions(int(payload["permissions"])),
+            raw_communication_disabled_until=disabled_until,
         )
 
     def deserialize_command_interaction(

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -2707,6 +2707,7 @@ class RESTClientImpl(rest_api.RESTClient):
         voice_channel: undefined.UndefinedNoneOr[
             snowflakes.SnowflakeishOr[channels_.GuildVoiceChannel]
         ] = undefined.UNDEFINED,
+        communication_disabled_until: undefined.UndefinedNoneOr[datetime.datetime] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> guilds.Member:
         route = routes.PATCH_GUILD_MEMBER.compile(guild=guild, user=user)
@@ -2718,8 +2719,13 @@ class RESTClientImpl(rest_api.RESTClient):
 
         if voice_channel is None:
             body.put("channel_id", None)
-        elif voice_channel is not undefined.UNDEFINED:
+        else:
             body.put_snowflake("channel_id", voice_channel)
+
+        if isinstance(communication_disabled_until, datetime.datetime):
+            body.put("communication_disabled_until", communication_disabled_until.isoformat())
+        else:
+            body.put("communication_disabled_until", communication_disabled_until)
 
         response = await self._request(route, json=body, reason=reason)
         assert isinstance(response, dict)

--- a/hikari/internal/cache.py
+++ b/hikari/internal/cache.py
@@ -412,6 +412,7 @@ class MemberData(BaseData[guilds.Member]):
     is_deaf: undefined.UndefinedOr[bool] = attr.field()
     is_mute: undefined.UndefinedOr[bool] = attr.field()
     is_pending: undefined.UndefinedOr[bool] = attr.field()
+    raw_communication_disabled_until: typing.Optional[datetime.datetime] = attr.field()
     # meta-attribute
     has_been_deleted: bool = attr.field(default=False)
 
@@ -429,6 +430,7 @@ class MemberData(BaseData[guilds.Member]):
             is_mute=member.is_mute,
             is_pending=member.is_pending,
             user=user or RefCell(copy.copy(member.user)),
+            raw_communication_disabled_until=member.raw_communication_disabled_until,
             # role_ids is a special case as it may be mutable so we want to ensure it's immutable when cached.
             role_ids=tuple(member.role_ids),
         )
@@ -444,6 +446,7 @@ class MemberData(BaseData[guilds.Member]):
             is_deaf=self.is_deaf,
             is_mute=self.is_mute,
             is_pending=self.is_pending,
+            raw_communication_disabled_until=self.raw_communication_disabled_until,
             user=self.user.copy(),
         )
 

--- a/hikari/permissions.py
+++ b/hikari/permissions.py
@@ -277,7 +277,10 @@ class Permissions(enums.Flag):
     """Allows for sending messages in threads."""
 
     START_EMBEDDED_ACTIVITIES = 1 << 39
-    """Allows for launching activities (applications with the `EMBEDDED` flag) in a voice channel"""
+    """Allows for launching activities (applications with the `EMBEDDED` flag) in a voice channel."""
+
+    MODERATE_MEMBERS = 1 << 40
+    """Allows for timing out members."""
 
     @classmethod
     def all_permissions(cls) -> Permissions:

--- a/tests/hikari/impl/test_cache.py
+++ b/tests/hikari/impl/test_cache.py
@@ -1502,6 +1502,9 @@ class TestCacheImpl:
             is_deaf=False,
             is_mute=True,
             is_pending=False,
+            raw_communication_disabled_until=datetime.datetime(
+                2021, 10, 18, 13, 11, 18, 384554, tzinfo=datetime.timezone.utc
+            ),
         )
 
         member = cache_impl._build_member(cache_utilities.RefCell(member_data))
@@ -1517,6 +1520,9 @@ class TestCacheImpl:
         assert member.is_deaf is False
         assert member.is_mute is True
         assert member.is_pending is False
+        assert member.raw_communication_disabled_until == datetime.datetime(
+            2021, 10, 18, 13, 11, 18, 384554, tzinfo=datetime.timezone.utc
+        )
 
     def test_clear_members(self, cache_impl):
         mock_user_1 = cache_utilities.RefCell(mock.Mock(id=snowflakes.Snowflake(2123123)))
@@ -1850,6 +1856,9 @@ class TestCacheImpl:
             guild_avatar_hash="gay",
             is_mute=False,
             is_pending=True,
+            raw_communication_disabled_until=datetime.datetime(
+                2021, 10, 18, 13, 11, 18, 384554, tzinfo=datetime.timezone.utc
+            ),
         )
         cache_impl._set_user = mock.Mock(return_value=mock_user_ref)
         cache_impl._increment_ref_count = mock.Mock()
@@ -1879,6 +1888,9 @@ class TestCacheImpl:
         assert member_entry.object.is_deaf is True
         assert member_entry.object.is_mute is False
         assert member_entry.object.is_pending is True
+        assert member_entry.object.raw_communication_disabled_until == datetime.datetime(
+            2021, 10, 18, 13, 11, 18, 384554, tzinfo=datetime.timezone.utc
+        )
 
     def test_set_member_doesnt_increment_user_ref_count_for_pre_cached_member(self, cache_impl):
         mock_user = mock.Mock(users.User, id=snowflakes.Snowflake(645234123))

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -1882,6 +1882,7 @@ class TestEntityFactoryImpl:
             "mute": True,
             "pending": False,
             "user": user_payload,
+            "communication_disabled_until": "2021-10-18T06:26:56.936000+00:00",
         }
 
     def test_deserialize_member(self, entity_factory_impl, mock_app, member_payload, user_payload):
@@ -1895,6 +1896,9 @@ class TestEntityFactoryImpl:
         assert member.role_ids == [11111, 22222, 33333, 44444, 76543325]
         assert member.joined_at == datetime.datetime(2015, 4, 26, 6, 26, 56, 936000, tzinfo=datetime.timezone.utc)
         assert member.premium_since == datetime.datetime(2019, 5, 17, 6, 26, 56, 936000, tzinfo=datetime.timezone.utc)
+        assert member.raw_communication_disabled_until == datetime.datetime(
+            2021, 10, 18, 6, 26, 56, 936000, tzinfo=datetime.timezone.utc
+        )
         assert member.is_deaf is False
         assert member.is_mute is True
         assert member.is_pending is False
@@ -1932,6 +1936,7 @@ class TestEntityFactoryImpl:
                 "pending": False,
                 "user": user_payload,
                 "guild_id": "123123453234",
+                "communication_disabled_until": None,
             }
         )
         assert member.nickname is None
@@ -2879,6 +2884,7 @@ class TestEntityFactoryImpl:
             "avatar": "oestrogen",
             "permissions": "17179869183",
             "premium_since": "2020-10-01T23:06:10.431000+00:00",
+            "communication_disabled_until": "2021-10-18T23:06:10.431000+00:00",
             "roles": [
                 "582345963851743243",
                 "582689893965365248",
@@ -2898,6 +2904,9 @@ class TestEntityFactoryImpl:
         assert member.is_mute is undefined.UNDEFINED
         assert member.is_pending is False
         assert member.premium_since == datetime.datetime(2020, 10, 1, 23, 6, 10, 431000, tzinfo=datetime.timezone.utc)
+        assert member.raw_communication_disabled_until == datetime.datetime(
+            2021, 10, 18, 23, 6, 10, 431000, tzinfo=datetime.timezone.utc
+        )
         assert member.role_ids == [
             582345963851743243,
             582689893965365248,
@@ -2934,11 +2943,13 @@ class TestEntityFactoryImpl:
     ):
         del interaction_member_payload["premium_since"]
         del interaction_member_payload["avatar"]
+        del interaction_member_payload["communication_disabled_until"]
 
         member = entity_factory_impl._deserialize_interaction_member(interaction_member_payload, guild_id=43123123)
 
         assert member.guild_avatar_hash is None
         assert member.premium_since is None
+        assert member.raw_communication_disabled_until is None
 
     def test__deserialize_interaction_member_with_passed_user(
         self, entity_factory_impl, interaction_member_payload, user_payload

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -3434,8 +3434,16 @@ class TestRESTClientImplAsync:
 
     async def test_edit_member(self, rest_client):
         expected_route = routes.PATCH_GUILD_MEMBER.compile(guild=123, user=456)
-        expected_json = {"nick": "test", "roles": ["654", "321"], "mute": True, "deaf": False, "channel_id": "987"}
+        expected_json = {
+            "nick": "test",
+            "roles": ["654", "321"],
+            "mute": True,
+            "deaf": False,
+            "channel_id": "987",
+            "communication_disabled_until": "2021-10-18T07:18:11.554023+00:00",
+        }
         rest_client._request = mock.AsyncMock(return_value={"id": "789"})
+        mock_timestamp = datetime.datetime(2021, 10, 18, 7, 18, 11, 554023, tzinfo=datetime.timezone.utc)
 
         result = await rest_client.edit_member(
             StubModel(123),
@@ -3445,6 +3453,7 @@ class TestRESTClientImplAsync:
             mute=True,
             deaf=False,
             voice_channel=StubModel(987),
+            communication_disabled_until=mock_timestamp,
             reason="because i can",
         )
         assert result is rest_client._entity_factory.deserialize_member.return_value
@@ -3474,11 +3483,25 @@ class TestRESTClientImplAsync:
         rest_client._entity_factory.deserialize_member.assert_called_once_with(
             rest_client._request.return_value, guild_id=123
         )
-        rest_client._request.assert_awaited_once_with(
-            expected_route,
-            json=expected_json,
+        rest_client._request.assert_awaited_once_with(expected_route, json=expected_json, reason="because i can")
+
+    async def test_edit_member_when_communication_disabled_until_is_None(self, rest_client):
+        expected_route = routes.PATCH_GUILD_MEMBER.compile(guild=123, user=456)
+        expected_json = {"communication_disabled_until": None}
+        rest_client._request = mock.AsyncMock(return_value={"id": "789"})
+
+        result = await rest_client.edit_member(
+            StubModel(123),
+            StubModel(456),
+            communication_disabled_until=None,
             reason="because i can",
         )
+        assert result is rest_client._entity_factory.deserialize_member.return_value
+
+        rest_client._entity_factory.deserialize_member.assert_called_once_with(
+            rest_client._request.return_value, guild_id=123
+        )
+        rest_client._request.assert_awaited_once_with(expected_route, json=expected_json, reason="because i can")
 
     async def test_edit_member_without_optionals(self, rest_client):
         expected_route = routes.PATCH_GUILD_MEMBER.compile(guild=123, user=456)

--- a/tests/hikari/integration/test_users_comparison.py
+++ b/tests/hikari/integration/test_users_comparison.py
@@ -81,6 +81,7 @@ def make_guild_member(user_id, username):
         is_deaf=False,
         is_mute=False,
         is_pending=False,
+        raw_communication_disabled_until=None,
     )
 
 

--- a/tests/hikari/test_permissions.py
+++ b/tests/hikari/test_permissions.py
@@ -27,4 +27,4 @@ class TestPermissions:
         all_perms = permissions.Permissions.all_permissions()
 
         assert isinstance(all_perms, permissions.Permissions)
-        assert all_perms == 1090921693183
+        assert all_perms == 2190433320959


### PR DESCRIPTION
### Summary
Implements member `communication_disabled_until` and the new `MODERATE_MEMBERS` permission.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] Dav has made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
