### PR TITLE
Fix docstrings for CommandOption.min|max_value

### DIFF
--- a/hikari/commands.py
+++ b/hikari/commands.py
@@ -150,14 +150,14 @@ class CommandOption:
     """The minimum value permitted (inclusive).
 
     This will be `builtins.int` if the type of the option is `hikari.commands.OptionType.INTEGER`
-    and `builtins.float` if the type is `hikari.commands.OptionType.NUMBER`.
+    and `builtins.float` if the type is `hikari.commands.OptionType.FLOAT`.
     """
 
     max_value: typing.Union[int, float, None] = attr.field(default=None, repr=False)
     """The maximum value permitted (inclusive).
 
     This will be `builtins.int` if the type of the option is `hikari.commands.OptionType.INTEGER`
-    and `builtins.float` if the type is `hikari.commands.OptionType.NUMBER`.
+    and `builtins.float` if the type is `hikari.commands.OptionType.FLOAT`.
     """
 
 


### PR DESCRIPTION
### Summary
Fixes incorrect docstrings for CommandOption.min_value and CommandOption.max_value

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
