### PR TITLE
Fix deprecation warning raised by out of loop asyncio.gather calls

### DIFF
--- a/changes/954.bugfix.md
+++ b/changes/954.bugfix.md
@@ -1,0 +1,1 @@
+Fix deprecation warnings raised by usage of asyncio.gather outside of an active event loop in GatewayBot.run

--- a/changes/idk.bugfix.md
+++ b/changes/idk.bugfix.md
@@ -1,0 +1,1 @@
+Fix deprecation warnings raised by usage of asyncio.gather outside of an active event loop in GatewayBot.run

--- a/changes/idk.bugfix.md
+++ b/changes/idk.bugfix.md
@@ -1,1 +1,0 @@
-Fix deprecation warnings raised by usage of asyncio.gather outside of an active event loop in GatewayBot.run

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -75,9 +75,9 @@ _LOGGER: typing.Final[logging.Logger] = logging.getLogger("hikari.bot")
 
 
 async def _gather(coros: typing.Iterator[typing.Awaitable[typing.Any]]) -> None:
-    # Calling asyncio outside of a running event loop isn't safe and will lead
-    # to RuntimeErrors in later versions of python, so this call is kept within
-    # a coroutine function.
+    # Calling asyncio.gather outside of a running event loop isn't safe and
+    # will lead to RuntimeErrors in later versions of python, so this call is
+    # kept within a coroutine function.
     await asyncio.gather(*coros)
 
 

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -75,6 +75,9 @@ _LOGGER: typing.Final[logging.Logger] = logging.getLogger("hikari.bot")
 
 
 async def _gather(coros: typing.Iterator[typing.Awaitable[typing.Any]]) -> None:
+    # Calling asyncio outside of a running event loop isn't safe and will lead
+    # to RuntimeErrors in later versions of python, so this call is kept within
+    # a coroutine function.
     await asyncio.gather(*coros)
 
 

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -81,6 +81,50 @@ async def _gather(coros: typing.Iterator[typing.Awaitable[typing.Any]]) -> None:
     await asyncio.gather(*coros)
 
 
+def _destroy_loop(loop: asyncio.AbstractEventLoop) -> None:
+    async def murder(future: asyncio.Future[typing.Any]) -> None:
+        # These include _GatheringFuture which must be awaited if the children
+        # throw an asyncio.CancelledError, otherwise it will spam logs with warnings
+        # about exceptions not being retrieved before GC.
+        try:
+            _LOGGER.log(ux.TRACE, "killing %s", future)
+            future.cancel()
+            await future
+        except asyncio.CancelledError:
+            pass
+        except Exception as ex:
+            loop.call_exception_handler(
+                {
+                    "message": "Future raised unexpected exception after requesting cancellation",
+                    "exception": ex,
+                    "future": future,
+                }
+            )
+
+    remaining_tasks = [t for t in asyncio.all_tasks(loop) if not t.done()]
+
+    if remaining_tasks:
+        _LOGGER.debug("terminating %s remaining tasks forcefully", len(remaining_tasks))
+        loop.run_until_complete(_gather((murder(task) for task in remaining_tasks)))
+    else:
+        _LOGGER.debug("No remaining tasks exist, good job!")
+
+    if sys.version_info >= (3, 9):
+        _LOGGER.debug("shutting down default executor")
+        try:
+            # This seems to raise a NotImplementedError when running with uvloop.
+            loop.run_until_complete(loop.shutdown_default_executor())
+        except NotImplementedError:
+            pass
+
+    _LOGGER.debug("shutting down asyncgens")
+    loop.run_until_complete(loop.shutdown_asyncgens())
+
+    _LOGGER.debug("closing event loop")
+    loop.close()
+    # Closed loops cannot be re-used so it should also be un-set.
+    asyncio.set_event_loop(None)
+
 class GatewayBot(traits.GatewayBotAware):
     """Basic auto-sharding bot implementation.
 
@@ -818,7 +862,7 @@ class GatewayBot(traits.GatewayBotAware):
                             pass
 
                 if close_loop:
-                    self._destroy_loop(loop)
+                    _destroy_loop(loop)
 
                 _LOGGER.info("successfully terminated")
 
@@ -1297,51 +1341,6 @@ class GatewayBot(traits.GatewayBotAware):
             return new_shard
 
         raise errors.GatewayError(f"shard {shard_id} shut down immediately when starting")
-
-    @staticmethod
-    def _destroy_loop(loop: asyncio.AbstractEventLoop) -> None:
-        async def murder(future: asyncio.Future[typing.Any]) -> None:
-            # These include _GatheringFuture which must be awaited if the children
-            # throw an asyncio.CancelledError, otherwise it will spam logs with warnings
-            # about exceptions not being retrieved before GC.
-            try:
-                _LOGGER.log(ux.TRACE, "killing %s", future)
-                future.cancel()
-                await future
-            except asyncio.CancelledError:
-                pass
-            except Exception as ex:
-                loop.call_exception_handler(
-                    {
-                        "message": "Future raised unexpected exception after requesting cancellation",
-                        "exception": ex,
-                        "future": future,
-                    }
-                )
-
-        remaining_tasks = [t for t in asyncio.all_tasks(loop) if not t.done()]
-
-        if remaining_tasks:
-            _LOGGER.debug("terminating %s remaining tasks forcefully", len(remaining_tasks))
-            loop.run_until_complete(_gather((murder(task) for task in remaining_tasks)))
-        else:
-            _LOGGER.debug("No remaining tasks exist, good job!")
-
-        if sys.version_info >= (3, 9):
-            _LOGGER.debug("shutting down default executor")
-            try:
-                # This seems to raise a NotImplementedError when running with uvloop.
-                loop.run_until_complete(loop.shutdown_default_executor())
-            except NotImplementedError:
-                pass
-
-        _LOGGER.debug("shutting down asyncgens")
-        loop.run_until_complete(loop.shutdown_asyncgens())
-
-        _LOGGER.debug("closing event loop")
-        loop.close()
-        # Closed loops cannot be re-used so it should also be un-set.
-        asyncio.set_event_loop(None)
 
     @staticmethod
     def _validate_activity(activity: undefined.UndefinedNoneOr[presences.Activity]) -> None:

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -74,6 +74,10 @@ if typing.TYPE_CHECKING:
 _LOGGER: typing.Final[logging.Logger] = logging.getLogger("hikari.bot")
 
 
+async def _gather(coros: typing.Iterator[typing.Awaitable[typing.Any]]) -> None:
+    await asyncio.gather(*coros)
+
+
 class GatewayBot(traits.GatewayBotAware):
     """Basic auto-sharding bot implementation.
 
@@ -1316,7 +1320,7 @@ class GatewayBot(traits.GatewayBotAware):
 
         if remaining_tasks:
             _LOGGER.debug("terminating %s remaining tasks forcefully", len(remaining_tasks))
-            loop.run_until_complete(asyncio.gather(*(murder(task) for task in remaining_tasks)))
+            loop.run_until_complete(_gather((murder(task) for task in remaining_tasks)))
         else:
             _LOGGER.debug("No remaining tasks exist, good job!")
 

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -126,7 +126,6 @@ def _destroy_loop(loop: asyncio.AbstractEventLoop) -> None:
     asyncio.set_event_loop(None)
 
 
-@staticmethod
 def _validate_activity(activity: undefined.UndefinedNoneOr[presences.Activity]) -> None:
     # This seems to cause confusion for a lot of people, so lets add some warnings into the mix.
 

--- a/tests/hikari/impl/test_bot.py
+++ b/tests/hikari/impl/test_bot.py
@@ -47,14 +47,14 @@ from hikari.internal import ux
 
 
 @pytest.mark.parametrize("activity", [undefined.UNDEFINED, None])
-def test_validate_activity_when_no_activity(self, activity):
+def test_validate_activity_when_no_activity(activity):
     with mock.patch.object(warnings, "warn") as warn:
         bot_impl._validate_activity(activity)
 
     warn.assert_not_called()
 
 
-def test_validate_activity_when_type_is_custom(self):
+def test_validate_activity_when_type_is_custom():
     activity = presences.Activity(name="test", type=presences.ActivityType.CUSTOM)
 
     with mock.patch.object(warnings, "warn") as warn:
@@ -68,7 +68,7 @@ def test_validate_activity_when_type_is_custom(self):
     )
 
 
-def test_validate_activity_when_type_is_streaming_but_no_url(self):
+def test_validate_activity_when_type_is_streaming_but_no_url():
     activity = presences.Activity(name="test", url=None, type=presences.ActivityType.STREAMING)
 
     with mock.patch.object(warnings, "warn") as warn:
@@ -82,7 +82,7 @@ def test_validate_activity_when_type_is_streaming_but_no_url(self):
     )
 
 
-def test_validate_activity_when_no_warning(self):
+def test_validate_activity_when_no_warning():
     activity = presences.Activity(name="test", type=presences.ActivityType.PLAYING)
 
     with mock.patch.object(warnings, "warn") as warn:


### PR DESCRIPTION
### Summary
Fix deprecation warning raised by out of loop asyncio.gather calls

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
