### PR TITLE
Bring back more concise typing for set_listener

### DIFF
--- a/hikari/api/interaction_server.py
+++ b/hikari/api/interaction_server.py
@@ -195,18 +195,6 @@ class InteractionServer(abc.ABC):
     ) -> None:
         ...
 
-    @typing.overload
-    @abc.abstractmethod
-    def set_listener(
-        self,
-        interaction_type: typing.Type[_InteractionT_co],
-        listener: typing.Optional[ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder]],
-        /,
-        *,
-        replace: bool = False,
-    ) -> None:
-        ...
-
     @abc.abstractmethod
     def set_listener(
         self,

--- a/hikari/impl/interaction_server.py
+++ b/hikari/impl/interaction_server.py
@@ -538,19 +538,6 @@ class InteractionServer(interaction_server.InteractionServer):
     ) -> None:
         ...
 
-    @typing.overload
-    def set_listener(
-        self,
-        interaction_type: typing.Type[_InteractionT_co],
-        listener: typing.Optional[
-            interaction_server.ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder]
-        ],
-        /,
-        *,
-        replace: bool = False,
-    ) -> None:
-        ...
-
     def set_listener(
         self,
         interaction_type: typing.Type[_InteractionT_co],

--- a/hikari/impl/rest_bot.py
+++ b/hikari/impl/rest_bot.py
@@ -624,7 +624,6 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
     ) -> None:
         ...
 
-    @typing.overload
     def set_listener(
         self,
         interaction_type: typing.Type[_InteractionT_co],
@@ -635,16 +634,4 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
         *,
         replace: bool = False,
     ) -> None:
-        ...
-
-    def set_listener(
-        self,
-        interaction_type: typing.Type[_InteractionT_co],
-        listener: typing.Optional[
-            interaction_server_.ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder]
-        ],
-        /,
-        *,
-        replace: bool = False,
-    ) -> None:
-        self._server.set_listener(interaction_type, listener, replace=replace)
+        self._server.set_listener(interaction_type, listener, replace=replace)  # type: ignore


### PR DESCRIPTION
### Summary
This union fallback was erroneously added in while adding in fallback types for getting methods which had overloaded behaviour based on unions and adding this here has a different unwanted effect (removing the Interaction type to response builder type(s) restriction).

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
