### PR TITLE
Add ability to send attachments in an interaction initial response

### DIFF
--- a/changes/971.feature.md
+++ b/changes/971.feature.md
@@ -1,0 +1,1 @@
+Add ability to send attachments in an interaction initial response

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -7277,6 +7277,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         *,
         flags: typing.Union[int, messages_.MessageFlag, undefined.UndefinedType] = undefined.UNDEFINED,
         tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
+        attachment: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
+        attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
         component: undefined.UndefinedOr[special_endpoints.ComponentBuilder] = undefined.UNDEFINED,
         components: undefined.UndefinedOr[typing.Sequence[special_endpoints.ComponentBuilder]] = undefined.UNDEFINED,
         embed: undefined.UndefinedOr[embeds_.Embed] = undefined.UNDEFINED,
@@ -7318,6 +7320,12 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             no `embeds` kwarg is provided, then this will instead
             update the embed. This allows for simpler syntax when
             sending an embed alone.
+        attachment : hikari.undefined.UndefinedOr[hikari.files.Resourceish],
+            If provided, the message attachment. This can be a resource,
+            or string of a path on your computer or a URL.
+        attachments : hikari.undefined.UndefinedOr[typing.Sequence[hikari.files.Resourceish]],
+            If provided, the message attachments. These can be resources, or
+            strings consisting of paths on your computer or URLs.
         component : hikari.undefined.UndefinedOr[hikari.api.special_endpoints.ComponentBuilder]
             If provided, builder object of the component to include in this message.
         components : hikari.undefined.UndefinedOr[typing.Sequence[hikari.api.special_endpoints.ComponentBuilder]]

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -1218,7 +1218,7 @@ class RESTClientImpl(rest_api.RESTClient):
         embed: undefined.UndefinedNoneOr[embeds_.Embed] = undefined.UNDEFINED,
         embeds: undefined.UndefinedNoneOr[typing.Sequence[embeds_.Embed]] = undefined.UNDEFINED,
         replace_attachments: bool = False,
-        flags: undefined.UndefinedOr[messages_.MessageFlag] = undefined.UNDEFINED,
+        flags: typing.Union[undefined.UndefinedType, int, messages_.MessageFlag] = undefined.UNDEFINED,
         tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
@@ -1420,7 +1420,7 @@ class RESTClientImpl(rest_api.RESTClient):
         role_mentions: undefined.UndefinedOr[
             typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
         ] = undefined.UNDEFINED,
-        flags: undefined.UndefinedOr[messages_.MessageFlag] = undefined.UNDEFINED,
+        flags: typing.Union[undefined.UndefinedType, int, messages_.MessageFlag] = undefined.UNDEFINED,
     ) -> messages_.Message:
         route = routes.PATCH_CHANNEL_MESSAGE.compile(channel=channel, message=message)
         body, form = self._build_message_payload(

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -1320,7 +1320,7 @@ class RESTClientImpl(rest_api.RESTClient):
         else:
             body.put("content", None)
 
-        if edit and replace_attachments:
+        if replace_attachments:
             body.put("attachments", None)
 
         body.put("tts", tts)

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -1309,12 +1309,7 @@ class RESTClientImpl(rest_api.RESTClient):
                     final_attachments.extend(embed_attachments)
                     serialized_embeds.append(embed_payload)
 
-        if edit and not undefined.all_undefined(mentions_everyone, mentions_reply, user_mentions, role_mentions):
-            body.put(
-                "allowed_mentions",
-                mentions.generate_allowed_mentions(mentions_everyone, mentions_reply, user_mentions, role_mentions),
-            )
-        else:
+        if not edit or not undefined.all_undefined(mentions_everyone, mentions_reply, user_mentions, role_mentions):
             body.put(
                 "allowed_mentions",
                 mentions.generate_allowed_mentions(mentions_everyone, mentions_reply, user_mentions, role_mentions),

--- a/hikari/interactions/base_interactions.py
+++ b/hikari/interactions/base_interactions.py
@@ -233,6 +233,8 @@ class MessageResponseMixin(PartialInteraction, typing.Generic[_CommandResponseTy
         *,
         flags: typing.Union[int, messages.MessageFlag, undefined.UndefinedType] = undefined.UNDEFINED,
         tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
+        attachment: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
+        attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
         component: undefined.UndefinedOr[special_endpoints.ComponentBuilder] = undefined.UNDEFINED,
         components: undefined.UndefinedOr[typing.Sequence[special_endpoints.ComponentBuilder]] = undefined.UNDEFINED,
         embed: undefined.UndefinedOr[embeds_.Embed] = undefined.UNDEFINED,
@@ -269,6 +271,12 @@ class MessageResponseMixin(PartialInteraction, typing.Generic[_CommandResponseTy
             If this is a `hikari.embeds.Embed` and no `embed` nor `embeds` kwarg
             is provided, then this will instead update the embed. This allows
             for simpler syntax when sending an embed alone.
+        attachment : hikari.undefined.UndefinedOr[hikari.files.Resourceish],
+            If provided, the message attachment. This can be a resource,
+            or string of a path on your computer or a URL.
+        attachments : hikari.undefined.UndefinedOr[typing.Sequence[hikari.files.Resourceish]],
+            If provided, the message attachments. These can be resources, or
+            strings consisting of paths on your computer or URLs.
         component : hikari.undefined.UndefinedOr[hikari.api.special_endpoints.ComponentBuilder]
             If provided, builder object of the component to include in this message.
         components : hikari.undefined.UndefinedOr[typing.Sequence[hikari.api.special_endpoints.ComponentBuilder]]
@@ -343,6 +351,8 @@ class MessageResponseMixin(PartialInteraction, typing.Generic[_CommandResponseTy
             response_type,
             content,
             tts=tts,
+            attachment=attachment,
+            attachments=attachments,
             component=component,
             components=components,
             embed=embed,

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -1926,7 +1926,6 @@ class TestRESTClientImplAsync:
 
     def test__build_message_payload_embed_content_syntactic_sugar(self, rest_client):
         embed = mock.Mock(embeds.Embed)
-        embed_attachment = object()
 
         stack = contextlib.ExitStack()
         generate_allowed_mentions = stack.enter_context(

--- a/tests/hikari/interactions/test_base_interactions.py
+++ b/tests/hikari/interactions/test_base_interactions.py
@@ -74,6 +74,8 @@ class TestMessageResponseMixin:
         mock_embed_2 = object()
         mock_component = object()
         mock_components = object(), object()
+        mock_attachment = object()
+        mock_attachments = object(), object()
         await mock_message_response_mixin.create_initial_response(
             base_interactions.ResponseType.MESSAGE_CREATE,
             "content",
@@ -83,6 +85,8 @@ class TestMessageResponseMixin:
             embeds=[mock_embed_2],
             component=mock_component,
             components=mock_components,
+            attachment=mock_attachment,
+            attachments=mock_attachments,
             mentions_everyone=False,
             user_mentions=[123432],
             role_mentions=[6324523],
@@ -99,6 +103,8 @@ class TestMessageResponseMixin:
             embeds=[mock_embed_2],
             component=mock_component,
             components=mock_components,
+            attachment=mock_attachment,
+            attachments=mock_attachments,
             mentions_everyone=False,
             user_mentions=[123432],
             role_mentions=[6324523],
@@ -121,6 +127,8 @@ class TestMessageResponseMixin:
             embeds=undefined.UNDEFINED,
             component=undefined.UNDEFINED,
             components=undefined.UNDEFINED,
+            attachment=undefined.UNDEFINED,
+            attachments=undefined.UNDEFINED,
             mentions_everyone=undefined.UNDEFINED,
             user_mentions=undefined.UNDEFINED,
             role_mentions=undefined.UNDEFINED,


### PR DESCRIPTION
### Summary
Adds the ability to pass attachments with `create_initial_response`

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
