### PR TITLE
Add display_avatar_url property for Member & User

### DIFF
--- a/changes/975.feature.md
+++ b/changes/975.feature.md
@@ -1,0 +1,1 @@
+Add display_avatar_url property to hikari.Member and hikari.User

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -424,7 +424,7 @@ class Member(users.User):
     @property
     def default_avatar_url(self) -> files.URL:
         return self.user.default_avatar_url
-    
+
     @property
     def display_avatar_url(self) -> files.URL:
         return self.guild_avatar_url or super().display_avatar_url

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -427,7 +427,7 @@ class Member(users.User):
 
     @property
     def display_avatar_url(self) -> files.URL:
-        return self.guild_avatar_url or super().display_avatar_url
+        return self.make_guild_avatar_url() or super().display_avatar_url
 
     @property
     def banner_hash(self) -> typing.Optional[str]:

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -427,7 +427,7 @@ class Member(users.User):
     
     @property
     def display_avatar_url(self) -> files.URL:
-        return self.guild_avatar_url or self.avatar_url or self.default_avatar_url
+        return self.guild_avatar_url or super().display_avatar_url
 
     @property
     def banner_hash(self) -> typing.Optional[str]:

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -424,6 +424,10 @@ class Member(users.User):
     @property
     def default_avatar_url(self) -> files.URL:
         return self.user.default_avatar_url
+    
+    @property
+    def display_avatar_url(self) -> files.URL:
+        return self.guild_avatar_url or self.avatar_url or self.default_avatar_url
 
     @property
     def banner_hash(self) -> typing.Optional[str]:

--- a/hikari/users.py
+++ b/hikari/users.py
@@ -515,7 +515,7 @@ class User(PartialUser, abc.ABC):
     @property
     def display_avatar_url(self) -> files.URL:
         """Display avatar URL for this user."""
-        return self.avatar_url or self.default_avatar_url
+        return self.make_avatar_url() or self.default_avatar_url
 
     @property
     @abc.abstractmethod

--- a/hikari/users.py
+++ b/hikari/users.py
@@ -515,7 +515,7 @@ class User(PartialUser, abc.ABC):
     @property
     def display_avatar_url(self) -> files.URL:
         """Display avatar URL for this user."""
-        return self.avatar_url or self.display_avatar_url
+        return self.avatar_url or self.default_avatar_url
 
     @property
     @abc.abstractmethod

--- a/hikari/users.py
+++ b/hikari/users.py
@@ -511,6 +511,11 @@ class User(PartialUser, abc.ABC):
             discriminator=int(self.discriminator) % 5,
             file_format="png",
         )
+    
+    @property
+    def display_avatar_url(self) -> files.URL:
+        """Display avatar URL for this user."""
+        return self.avatar_url or self.display_avatar_url
 
     @property
     @abc.abstractmethod

--- a/hikari/users.py
+++ b/hikari/users.py
@@ -511,7 +511,7 @@ class User(PartialUser, abc.ABC):
             discriminator=int(self.discriminator) % 5,
             file_format="png",
         )
-    
+
     @property
     def display_avatar_url(self) -> files.URL:
         """Display avatar URL for this user."""

--- a/tests/hikari/test_guilds.py
+++ b/tests/hikari/test_guilds.py
@@ -260,6 +260,14 @@ class TestMember:
 
     def test_avatar_url_property(self, model, mock_user):
         assert model.avatar_url is mock_user.avatar_url
+    
+    def test_display_avatar_url_when_guild_hash_is_None(self, model, mock_user):
+        model.guild_avatar_url = None
+        assert model.display_avatar_url is mock_user.display_avatar_url
+    
+    def test_display_guild_avatar_url_when_guild_hash_is_not_None(self, model, mock_user):
+        model.guild_avatar_url = object()
+        assert model.display_avatar_url is model.guild_avatar_url
 
     def test_banner_hash_property(self, model, mock_user):
         assert model.banner_hash is mock_user.banner_hash

--- a/tests/hikari/test_guilds.py
+++ b/tests/hikari/test_guilds.py
@@ -263,11 +263,11 @@ class TestMember:
         assert model.avatar_url is mock_user.avatar_url
 
     def test_display_avatar_url_when_guild_hash_is_None(self, model, mock_user):
-        with mock.patch.object(guilds.Member, "guild_avatar_url") as mock_guild_avatar_url:
-            assert model.display_avatar_url is mock_guild_avatar_url
+        with mock.patch.object(guilds.Member, "make_guild_avatar_url") as mock_make_guild_avatar_url:
+            assert model.display_avatar_url is mock_make_guild_avatar_url.return_value
 
     def test_display_guild_avatar_url_when_guild_hash_is_not_None(self, model, mock_user):
-        with mock.patch.object(guilds.Member, "guild_avatar_url", new=None):
+        with mock.patch.object(guilds.Member, "make_guild_avatar_url", return_value=None):
             with mock.patch.object(users.User, "display_avatar_url") as mock_display_avatar_url:
                 assert model.display_avatar_url is mock_display_avatar_url
 

--- a/tests/hikari/test_guilds.py
+++ b/tests/hikari/test_guilds.py
@@ -31,6 +31,7 @@ from hikari import permissions
 from hikari import snowflakes
 from hikari import undefined
 from hikari import urls
+from hikari import users
 from hikari.impl import bot
 from hikari.internal import routes
 from hikari.internal import time
@@ -262,12 +263,13 @@ class TestMember:
         assert model.avatar_url is mock_user.avatar_url
 
     def test_display_avatar_url_when_guild_hash_is_None(self, model, mock_user):
-        model.guild_avatar_url = None
-        assert model.display_avatar_url is mock_user.display_avatar_url
+        with mock.patch.object(guilds.Member, "guild_avatar_url") as mock_guild_avatar_url:
+            assert model.display_avatar_url is mock_guild_avatar_url
 
     def test_display_guild_avatar_url_when_guild_hash_is_not_None(self, model, mock_user):
-        model.guild_avatar_url = object()
-        assert model.display_avatar_url is model.guild_avatar_url
+        with mock.patch.object(guilds.Member, "guild_avatar_url", new=None):
+            with mock.patch.object(users.User, "display_avatar_url") as mock_display_avatar_url:
+                assert model.display_avatar_url is mock_display_avatar_url
 
     def test_banner_hash_property(self, model, mock_user):
         assert model.banner_hash is mock_user.banner_hash

--- a/tests/hikari/test_guilds.py
+++ b/tests/hikari/test_guilds.py
@@ -260,11 +260,11 @@ class TestMember:
 
     def test_avatar_url_property(self, model, mock_user):
         assert model.avatar_url is mock_user.avatar_url
-    
+
     def test_display_avatar_url_when_guild_hash_is_None(self, model, mock_user):
         model.guild_avatar_url = None
         assert model.display_avatar_url is mock_user.display_avatar_url
-    
+
     def test_display_guild_avatar_url_when_guild_hash_is_not_None(self, model, mock_user):
         model.guild_avatar_url = object()
         assert model.display_avatar_url is model.guild_avatar_url

--- a/tests/hikari/test_users.py
+++ b/tests/hikari/test_users.py
@@ -245,11 +245,11 @@ class TestUser:
         )
 
     def test_display_avatar_url_when_avatar_url(self, obj):
-        with mock.patch.object(users.User, "avatar_url") as mock_avatar_url:
-            assert obj.display_avatar_url is mock_avatar_url
+        with mock.patch.object(users.User, "make_avatar_url") as mock_make_avatar_url:
+            assert obj.display_avatar_url is mock_make_avatar_url.return_value
 
     def test_display_avatar_url_when_no_avatar_url(self, obj):
-        with mock.patch.object(users.User, "avatar_url", new=None):
+        with mock.patch.object(users.User, "make_avatar_url", return_value=None):
             with mock.patch.object(users.User, "default_avatar_url") as mock_default_avatar_url:
                 assert obj.display_avatar_url is mock_default_avatar_url
 

--- a/tests/hikari/test_users.py
+++ b/tests/hikari/test_users.py
@@ -244,6 +244,15 @@ class TestUser:
             file_format="url",
         )
 
+    def test_display_avatar_url_when_avatar_url(self, obj):
+        with mock.patch.object(users.User, "avatar_url") as mock_avatar_url:
+            assert obj.display_avatar_url is mock_avatar_url
+
+    def test_display_avatar_url_when_no_avatar_url(self, obj):
+        with mock.patch.object(users.User, "avatar_url", new=None):
+            with mock.patch.object(users.User, "default_avatar_url") as mock_default_avatar_url:
+                assert obj.display_avatar_url is mock_default_avatar_url
+
     def test_default_avatar(self, obj):
         obj.avatar_hash = "18dnf8dfbakfdh"
         obj.discriminator = "1234"


### PR DESCRIPTION
### Summary
It is somewhat tedious to get an `avatar_url` that is guaranteed to always exist, this property aims to rectify this issue, and simplify getting avatars somewhat.

### Checklist
- [x] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.
