### PR TITLE
Bump multidict to ~=6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp~=3.8
 attrs~=21.4
 colorlog~=6.6
-multidict~=5.2
+multidict~=6.0
 pure25519==0.0.1


### PR DESCRIPTION
### Summary
Looks like the issue was fixed with the release of 6.0.2, but dependabot catch it an open the pr, so I will beat it to it :)

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Followup for #979
