### PR TITLE
Remove pages and safety from the default nox sessions

### DIFF
--- a/pipelines/nox.py
+++ b/pipelines/nox.py
@@ -32,7 +32,7 @@ from nox.sessions import Session
 from pipelines import config
 
 # Default sessions should be defined here
-_options.sessions = ["reformat-code", "pytest", "flake8", "mypy", "verify-types", "safety"]
+_options.sessions = ["reformat-code", "pytest", "flake8", "mypy", "verify-types"]
 
 _NoxCallbackSig = typing.Callable[[Session], None]
 

--- a/pipelines/nox.py
+++ b/pipelines/nox.py
@@ -32,7 +32,7 @@ from nox.sessions import Session
 from pipelines import config
 
 # Default sessions should be defined here
-_options.sessions = ["reformat-code", "pytest", "flake8", "mypy", "verify-types", "safety", "pages"]
+_options.sessions = ["reformat-code", "pytest", "flake8", "mypy", "verify-types", "safety"]
 
 _NoxCallbackSig = typing.Callable[[Session], None]
 


### PR DESCRIPTION
### Summary
Mostly just a suggestion since this doesn't seem helpful to most ppl running it locally and under the rare case that their changes break doc gen this'll still be flagged up by pipelines when they open a PR

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
