### PR TITLE
Fix `$browser` to use the correct format

### DIFF
--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -688,7 +688,7 @@ class GatewayShardImpl(shard.GatewayShard):
                 "large_threshold": self._large_threshold,
                 "properties": {
                     "$os": f"{platform.system()} {platform.architecture()[0]}",
-                    "$browser": f"aiohttp {aiohttp.__version__}",
+                    "$browser": f"hikari ({about.__version__}, aiohttp {aiohttp.__version__})",
                     "$device": f"hikari {about.__version__}",
                 },
                 "shard": [self._shard_id, self._shard_count],

--- a/tests/hikari/impl/test_shard.py
+++ b/tests/hikari/impl/test_shard.py
@@ -1012,7 +1012,7 @@ class TestGatewayShardImpl:
                 "large_threshold": 123,
                 "properties": {
                     "$os": "Potato PC ARM64",
-                    "$browser": "aiohttp v0.0.1",
+                    "$browser": "hikari (v1.0.0, aiohttp v0.0.1)",
                     "$device": "hikari v1.0.0",
                 },
                 "shard": [0, 1],


### PR DESCRIPTION
### Summary
![image](https://user-images.githubusercontent.com/29100934/152205357-34716113-ee2e-4edc-902d-509ebe600192.png)

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
