### PR TITLE
Improve deprecation notices for rest cmd methods

### DIFF
--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -6638,10 +6638,10 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     @abc.abstractmethod
     def command_builder(self, name: str, description: str) -> special_endpoints.SlashCommandBuilder:
-        r"""Create a command builder for use in `RESTClient.set_application_commands`.
+        r"""Create a slash command builder for use in `RESTClient.set_application_commands`.
 
         .. deprecated:: 2.0.0.dev106
-            Use `RESTClient.slash_command_builder` or `RESTClient.context_menu_command_builder` instead.
+            Use `RESTClient.slash_command_builder` instead.
 
         Parameters
         ----------
@@ -6815,10 +6815,10 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         options: undefined.UndefinedOr[typing.Sequence[commands.CommandOption]] = undefined.UNDEFINED,
         default_permission: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
     ) -> commands.SlashCommand:
-        r"""Create an application command.
+        r"""Create an application slash command.
 
         .. deprecated:: 2.0.0.dev106
-            Use `RESTClient.create_slash_command` or `RESTClient.create_context_menu_command` instead.
+            Use `RESTClient.create_slash_command` instead.
 
         Parameters
         ----------

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -3116,7 +3116,7 @@ class RESTClientImpl(rest_api.RESTClient):
         assert isinstance(response, dict)
         return self._entity_factory.deserialize_template(response)
 
-    @deprecation.deprecated("2.0.0.dev106", "slash_command_builder or context_menu_builder")
+    @deprecation.deprecated("2.0.0.dev106", "slash_command_builder")
     def command_builder(self, name: str, description: str) -> special_endpoints.SlashCommandBuilder:
         return self.slash_command_builder(name, description)
 
@@ -3194,7 +3194,7 @@ class RESTClientImpl(rest_api.RESTClient):
             response, guild_id=snowflakes.Snowflake(guild) if guild is not undefined.UNDEFINED else None
         )
 
-    @deprecation.deprecated("2.0.0.dev106", "create_slash_command or create_context_menu_command")
+    @deprecation.deprecated("2.0.0.dev106", "create_slash_command")
     async def create_application_command(
         self,
         application: snowflakes.SnowflakeishOr[guilds.PartialApplication],


### PR DESCRIPTION
### Summary
This should better clarify that the deprecated methods still only create slash command (builders) and only point towards the relevant new slash command method.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
