### PR TITLE
Optimize tests and fix flaky tests to reduce race conditions

### DIFF
--- a/hikari/internal/collections.py
+++ b/hikari/internal/collections.py
@@ -30,7 +30,6 @@ __all__: typing.List[str] = [
     "SnowflakeSet",
     "ExtendedMutableMapping",
     "FreezableDict",
-    "TimedCacheMap",
     "LimitedCapacityCacheMap",
     "get_index_or_slice",
 ]
@@ -38,10 +37,8 @@ __all__: typing.List[str] = [
 import abc
 import array
 import bisect
-import datetime
 import itertools
 import sys
-import time
 import typing
 
 from hikari import snowflakes
@@ -157,92 +154,6 @@ class _FrozenDict(typing.MutableMapping[KeyT, ValueT]):
 
     def __setitem__(self, key: KeyT, value: ValueT) -> None:
         self._source[key] = (0.0, value)
-
-
-class TimedCacheMap(ExtendedMutableMapping[KeyT, ValueT]):
-    """A most-recently-inserted limited mutable mapping implementation.
-
-    This will remove entries on modification as as they pass the expiry limit.
-
-    Parameters
-    ----------
-    expiry : datetime.timedelta
-        The timedelta of how long entries should be stored for before removal.
-
-    Other Parameters
-    ----------------
-    source : typing.Optional[typing.Dict[KeyT, typing.Tuple[builtins.float, ValueT]]
-        A source dictionary of keys to tuples of float timestamps and values to
-        create this from.
-    on_expire : typing.Optional[typing.Callable[[ValueT], None]]
-        A function to call each time an item is garbage collected from this
-        map. This should take one positional argument of the same type stored
-        in this mapping as the value and should return `builtins.None`.
-
-        This will always be called after the entry has been removed.
-    """
-
-    __slots__: typing.Sequence[str] = ("_data", "_expiry", "_on_expire")
-
-    def __init__(
-        self,
-        source: typing.Optional[typing.Dict[KeyT, typing.Tuple[float, ValueT]]] = None,
-        /,
-        *,
-        expiry: datetime.timedelta,
-        on_expire: typing.Optional[typing.Callable[[ValueT], None]] = None,
-    ) -> None:
-        if expiry <= datetime.timedelta():
-            raise ValueError("expiry time must be greater than 0 microseconds.")
-
-        self._expiry: float = expiry.total_seconds()
-        self._data = source or {}
-        self._on_expire = on_expire
-        self._garbage_collect()
-
-    def clear(self) -> None:
-        self._data.clear()
-
-    def copy(self) -> TimedCacheMap[KeyT, ValueT]:
-        return TimedCacheMap(
-            self._data.copy(), expiry=datetime.timedelta(seconds=self._expiry), on_expire=self._on_expire
-        )
-
-    def freeze(self) -> typing.MutableMapping[KeyT, ValueT]:
-        return _FrozenDict(self._data.copy())
-
-    def _garbage_collect(self) -> None:
-        current_time = time.perf_counter()
-        for key, value in tuple(self._data.items()):
-            if current_time - value[0] < self._expiry:
-                break
-
-            del self._data[key]
-
-            if self._on_expire:
-                self._on_expire(value[1])
-
-    def __delitem__(self, key: KeyT) -> None:
-        del self._data[key]
-        self._garbage_collect()
-
-    def __getitem__(self, key: KeyT) -> ValueT:
-        return self._data[key][1]
-
-    def __iter__(self) -> typing.Iterator[KeyT]:
-        return iter(self._data)
-
-    def __len__(self) -> int:
-        return len(self._data)
-
-    def __setitem__(self, key: KeyT, value: ValueT) -> None:
-        #  Seeing as we rely on insertion order in _garbage_collect, we have to make sure that each item is added to
-        #  the end of the dict.
-        if key in self:
-            del self[key]
-
-        self._data[key] = (time.perf_counter(), value)
-        self._garbage_collect()
 
 
 class LimitedCapacityCacheMap(ExtendedMutableMapping[KeyT, ValueT]):

--- a/tests/hikari/hikari_test_helpers.py
+++ b/tests/hikari/hikari_test_helpers.py
@@ -150,10 +150,6 @@ def skip_on_system(os_name: str):
     return decorator
 
 
-async def idle(for_=REASONABLE_SLEEP_TIME, /):
-    await asyncio.sleep(for_)
-
-
 @contextlib.contextmanager
 def ensure_occurs_quickly():
     with async_timeout.timeout(REASONABLE_QUICK_RESPONSE_TIME):

--- a/tests/hikari/internal/test_aio.py
+++ b/tests/hikari/internal/test_aio.py
@@ -365,7 +365,7 @@ class TestAllOf:
         f2 = event_loop.create_future()
         f3 = event_loop.create_future()
 
-        waiter = event_loop.create_task(aio.all_of(f1, f2, f3, timeout=0.01))
+        waiter = event_loop.create_task(aio.all_of(f1, f2, f3, timeout=0.001))
         with pytest.raises(asyncio.TimeoutError):
             await waiter
         assert not waiter.cancelled(), "future was forcefully cancelled?"


### PR DESCRIPTION
### Summary
Some people were complaining that the tests where taking too long to run, so this goes out for them :P

#### Local machine (no coverage) [`nox -s pytest -- --skip-coverage`]
```
Before: 11s 264ms
After: 996ms
```
#### CI (https://github.com/hikari-py/hikari/runs/5074464193 vs https://github.com/hikari-py/hikari/runs/5067388127) [ubuntu-latest 3.8 - "Run tests" step]
```
Before: 2min 14s
After: 1min 49s
```


#
This pr also removes `TimedCacheMap`, as while optimizing the tests for it I noticed that it wasnt being used anywhere. This removal can be moved to a separate pr if needed. Since its considered internal detail, I dont think there is a need for deprecation or breaking changelog

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Closes #1010