### PR TITLE
Attempt to reconnect on a gateway TimeoutError

### DIFF
--- a/changes/1014.bugfix.md
+++ b/changes/1014.bugfix.md
@@ -1,0 +1,1 @@
+Attempt to reconnect on a gateway `TimeoutError`.


### PR DESCRIPTION
  - Improve `GatewayShard.is_alive` detection
  - Cleanup code for `GatewayTransport.send_close`

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Closes #1011