### PR TITLE
Add MESSAGE_CONTENT intent

### DIFF
--- a/changes/1021.feature.md
+++ b/changes/1021.feature.md
@@ -1,0 +1,1 @@
+Add MESSAGE_CONTENT intent

--- a/changes/1021.feature.md
+++ b/changes/1021.feature.md
@@ -1,1 +1,1 @@
-Add MESSAGE_CONTENT intent
+Add MESSAGE_CONTENT intent.

--- a/hikari/intents.py
+++ b/hikari/intents.py
@@ -355,7 +355,7 @@ class Intents(enums.Flag):
     ALL_UNPRIVILEGED = ALL_GUILDS_UNPRIVILEGED | ALL_DMS
     """All unprivileged intents."""
 
-    ALL_PRIVILEGED = ALL_GUILDS_PRIVILEGED
+    ALL_PRIVILEGED = ALL_GUILDS_PRIVILEGED | MESSAGE_CONTENT
     """All privileged intents.
 
     !!! warning

--- a/hikari/intents.py
+++ b/hikari/intents.py
@@ -296,8 +296,7 @@ class Intents(enums.Flag):
     MESSAGE_CONTENT = 1 << 15
     """Receive message content for all messages.
 
-    DM's to the bot and messages that mention it will still show the
-    content regardless of this intent.
+    DM's to the bot and messages that mention it are exempt from this.
 
     !!! warning
         This intent is privileged, and requires enabling/whitelisting to use.

--- a/hikari/intents.py
+++ b/hikari/intents.py
@@ -288,9 +288,18 @@ class Intents(enums.Flag):
     """
 
     DM_MESSAGE_TYPING = 1 << 14
-    """Subscribes to the following events
+    """Subscribes to the following events:
 
     * `TYPING_START` (in private message channels (non-guild bound) only)
+    """
+    MESSAGE_CONTENT = 1 << 15
+    """Receive message content for all messages.
+
+    DM's to the bot and messages that mention it will still show the
+    content regardless of this intent.
+
+    !!! warning
+        This intent is privileged, and requires enabling/whitelisting to use.
     """
 
     # Annoyingly, enums hide classmethods and staticmethods from __dir__ in

--- a/hikari/intents.py
+++ b/hikari/intents.py
@@ -292,6 +292,7 @@ class Intents(enums.Flag):
 
     * `TYPING_START` (in private message channels (non-guild bound) only)
     """
+
     MESSAGE_CONTENT = 1 << 15
     """Receive message content for all messages.
 

--- a/tests/hikari/impl/test_shard.py
+++ b/tests/hikari/impl/test_shard.py
@@ -1071,7 +1071,7 @@ class TestGatewayShardImplAsync:
                     "$device": "hikari v1.0.0",
                 },
                 "shard": [0, 1],
-                "intents": 32767,
+                "intents": 65535,
                 "presence": {"presence": "payload"},
             },
         }


### PR DESCRIPTION
### Summary
Message content intent will be required for verified applications starting April 30th 2022, this change adds them to hikari.
https://support-dev.discord.com/hc/en-us/articles/4404772028055
https://github.com/discord/discord-api-docs/discussions/4510

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.
