### PR TITLE
Properly close when not fully started

### DIFF
--- a/changes/1023.bugfix.md
+++ b/changes/1023.bugfix.md
@@ -1,0 +1,1 @@
+Properly close `GatewayBot` when not fully started.

--- a/hikari/api/shard.py
+++ b/hikari/api/shard.py
@@ -141,11 +141,11 @@ class GatewayShard(abc.ABC):
 
     @abc.abstractmethod
     async def close(self) -> None:
-        """Close the websocket if it is connected, otherwise do nothing."""
+        """Close the websocket if it is connected."""
 
     @abc.abstractmethod
     async def join(self) -> None:
-        """Wait indefinitely until the websocket closes permanently.
+        """Wait indefinitely until the websocket closes.
 
         This can be placed in a task and cancelled without affecting the
         websocket runtime itself.

--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -509,6 +509,7 @@ class GatewayShardImpl(shard.GatewayShard):
         return self._shard_count
 
     async def close(self) -> None:
+        self._check_if_alive()
         if not self._closing_event.is_set():
             try:
                 if self._ws is not None:
@@ -538,7 +539,7 @@ class GatewayShardImpl(shard.GatewayShard):
         return self._ws
 
     async def join(self) -> None:
-        """Wait for this shard to close, if running."""
+        self._check_if_alive()
         await self._closed_event.wait()
 
     async def _send_json(

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -3334,8 +3334,7 @@ class TestRESTClientImplAsync:
         rest_client._request.assert_awaited_once_with(expected_route)
         assert rest_client._entity_factory.deserialize_voice_region.call_count == 2
         rest_client._entity_factory.deserialize_voice_region.assert_has_calls(
-            [mock.call({"id": "123"}), mock.call({"id": "456"})],
-            any_order=False,
+            [mock.call({"id": "123"}), mock.call({"id": "456"})]
         )
 
     async def test_fetch_user(self, rest_client):

--- a/tests/hikari/impl/test_shard.py
+++ b/tests/hikari/impl/test_shard.py
@@ -789,6 +789,7 @@ class TestGatewayShardImpl:
 @pytest.mark.asyncio()
 class TestGatewayShardImplAsync:
     async def test_close_when_closing_event_set(self, client):
+        client._check_if_alive = mock.Mock()
         client._closing_event = mock.Mock(is_set=mock.Mock(return_value=True))
         client._closed_event = mock.Mock(wait=mock.AsyncMock())
         client._send_close = mock.Mock()
@@ -804,6 +805,7 @@ class TestGatewayShardImplAsync:
         client._closed_event.wait.assert_awaited_once_with()
 
     async def test_close_when_closing_event_not_set(self, client):
+        client._check_if_alive = mock.Mock()
         client._closing_event = mock.Mock(is_set=mock.Mock(return_value=False))
         client._closed_event = mock.Mock(wait=mock.AsyncMock())
         client._ws = mock.Mock(send_close=mock.AsyncMock())
@@ -821,6 +823,7 @@ class TestGatewayShardImplAsync:
         client._closed_event.wait.assert_awaited_once_with()
 
     async def test_close_when_closing_event_not_set_and_ws_is_None(self, client):
+        client._check_if_alive = mock.Mock()
         client._closing_event = mock.Mock(is_set=mock.Mock(return_value=False))
         client._closed_event = mock.Mock(wait=mock.AsyncMock())
         client._ws = None
@@ -846,6 +849,7 @@ class TestGatewayShardImplAsync:
         assert await client.get_user_id() == 123
 
     async def test_join(self, client):
+        client._check_if_alive = mock.Mock()
         client._closed_event = mock.Mock(wait=mock.AsyncMock())
 
         await client.join()

--- a/tests/hikari/impl/test_voice.py
+++ b/tests/hikari/impl/test_voice.py
@@ -297,7 +297,6 @@ class TestVoiceComponentImpl:
                     predicate=voice_client._init_server_update_predicate.return_value,
                 ),
             ],
-            any_order=False,
         )
         mock_app.cache.get_me.assert_called_once_with()
         voice_client._init_state_update_predicate.assert_called_once_with(123, mock_app.cache.get_me.return_value.id)


### PR DESCRIPTION
### Summary
Properly close when not started correctly.

Cleans up errors with "Unclosed client session" and anything else the event loop might want to throw
![image](https://user-images.githubusercontent.com/29100934/154519962-4d08d797-e1b9-42e8-8e2c-370dc6de9e09.png)


### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
