### PR TITLE
Remove unnecessary pyright version lock

### DIFF
--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -1080,9 +1080,7 @@ class GuildChannel(PartialChannel):
 
     async def remove_overwrite(
         self,
-        target: snowflakes.SnowflakeishOr[
-            typing.Union[PermissionOverwrite, guilds.PartialRole, users.PartialUser, snowflakes.Snowflakeish]
-        ],
+        target: typing.Union[PermissionOverwrite, guilds.PartialRole, users.PartialUser, snowflakes.Snowflakeish],
     ) -> None:
         """Delete a custom permission for an entity in a given guild channel.
 

--- a/pipelines/config.py
+++ b/pipelines/config.py
@@ -37,7 +37,6 @@ LOGO_SOURCE = "logo.png"
 FLAKE8_REPORT = "public/flake8"
 PYPROJECT_TOML = "pyproject.toml"
 COVERAGE_HTML_PATH = _os.path.join(ARTIFACT_DIRECTORY, "coverage", "html")
-PYRIGHT_VERSION = "1.1.190"  # 2021-11-25 (UTC+0)
 
 # Reformatting paths
 

--- a/pipelines/pyright.nox.py
+++ b/pipelines/pyright.nox.py
@@ -31,6 +31,5 @@ def verify_types(session: nox.Session) -> None:
     session.install("-r", "dev-requirements.txt")
     session.install(".")
     # session.env["PYRIGHT_PYTHON_GLOBAL_NODE"] = "off"
-    session.env["PYRIGHT_PYTHON_FORCE_VERSION"] = config.PYRIGHT_VERSION
     session.run("python", "-m", "pyright", "--version")
     session.run("python", "-m", "pyright", "--verifytypes", config.MAIN_PACKAGE, "--ignoreexternal")


### PR DESCRIPTION
### Summary
This is unnecessary now that the pypi wrapper for pyright locks the default pyright version it uses

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
