### PR TITLE
Add multipart responses to the interaction server

### DIFF
--- a/changes/1048.feature.md
+++ b/changes/1048.feature.md
@@ -1,0 +1,1 @@
+Support for attachments in REST-based interaction responses.

--- a/hikari/api/interaction_server.py
+++ b/hikari/api/interaction_server.py
@@ -29,6 +29,7 @@ import abc
 import typing
 
 if typing.TYPE_CHECKING:
+    from hikari import files as files_
     from hikari.api import special_endpoints
     from hikari.interactions import base_interactions
     from hikari.interactions import command_interactions
@@ -68,24 +69,23 @@ class Response(typing.Protocol):
     __slots__: typing.Sequence[str] = ()
 
     @property
-    def headers(self) -> typing.Optional[typing.Mapping[str, str]]:
-        """Headers that should be added to the response if applicable.
+    def content_type(self) -> typing.Optional[str]:
+        """Content type of the response's payload, if applicable."""
+        raise NotImplementedError
 
-        Returns
-        -------
-        typing.Optional[typing.Mapping[builtins.str, builtins.str]]
-            A mapping of string header names to string header values that should
-            be included in the response if applicable else `builtins.None`.
-        """
+    @property
+    def files(self) -> typing.Sequence[files_.Resource[files_.AsyncReader]]:
+        """Up to 10 files that should be included alongside a JSON response."""
+        raise NotImplementedError
+
+    @property
+    def headers(self) -> typing.Optional[typing.MutableMapping[str, str]]:
+        """Headers that should be added to the response if applicable."""
         raise NotImplementedError
 
     @property
     def payload(self) -> typing.Optional[bytes]:
         """Payload to provide in the response.
-
-        !!! note
-            If this is not `builtins.None` then an appropriate `"Content-Type"`
-            header should be declared in `Response.headers`
 
         Returns
         -------

--- a/hikari/api/special_endpoints.py
+++ b/hikari/api/special_endpoints.py
@@ -683,24 +683,18 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
 
     @property
     @abc.abstractmethod
-    def attachments(self) -> typing.Sequence[files.Resourceish]:
+    def attachments(self) -> undefined.UndefinedOr[typing.Sequence[files.Resourceish]]:
         """Sequence of up to 10 attachments to send with the message."""
 
     @property
     @abc.abstractmethod
-    def components(self) -> typing.Sequence[ComponentBuilder]:
+    def components(self) -> undefined.UndefinedOr[typing.Sequence[ComponentBuilder]]:
         """Sequence of up to 5 component builders to send in this response."""
 
     @property
     @abc.abstractmethod
-    def embeds(self) -> typing.Sequence[embeds_.Embed]:
-        """Sequence of up to 10 of the embeds included in this response.
-
-        Returns
-        -------
-        typing.Sequence[hikari.embeds.Embed]
-            A sequence of up to 10 of the embeds included in this response.
-        """
+    def embeds(self) -> undefined.UndefinedOr[typing.Sequence[embeds_.Embed]]:
+        """Sequence of up to 10 of the embeds included in this response."""
 
     # Settable fields
 
@@ -784,6 +778,21 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
             `builtins.False` or `hikari.undefined.UNDEFINED` to disallow any user
             mentions or `True` to allow all user mentions.
         """  # noqa: E501 - Line too long
+
+    @abc.abstractmethod
+    def add_attachment(self: _T, attachment: files.Resourceish, /) -> _T:
+        """Add an attachment to this response.
+
+        Parameters
+        ----------
+        attachment : hikari.files.Resourceish
+            The attachment to add.
+
+        Returns
+        -------
+        InteractionMessageBuilder
+            Object of this builder.
+        """
 
     @abc.abstractmethod
     def add_component(self: _T, component: ComponentBuilder, /) -> _T:

--- a/hikari/api/special_endpoints.py
+++ b/hikari/api/special_endpoints.py
@@ -566,7 +566,9 @@ class InteractionResponseBuilder(abc.ABC):
         """
 
     @abc.abstractmethod
-    def build(self, entity_factory: entity_factory_.EntityFactory, /) -> data_binding.JSONObject:
+    def build(
+        self, entity_factory: entity_factory_.EntityFactory, /
+    ) -> typing.Tuple[data_binding.JSONObject, typing.Sequence[files.Resource[files.AsyncReader]]]:
         """Build a JSON object from this builder.
 
         Parameters
@@ -576,8 +578,9 @@ class InteractionResponseBuilder(abc.ABC):
 
         Returns
         -------
-        hikari.internal.data_binding.JSONObject
-            The built json object representation of this builder.
+        typing.Tuple[hikari.internal.data_binding.JSONObject, typing.Sequence[files.Resource[Files.AsyncReader]]
+            A tuple of the built json object representation of this builder and
+            a sequence of up to 10 files to send with the response.
         """
 
 
@@ -677,6 +680,11 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
         """
 
     # Extendable fields
+
+    @property
+    @abc.abstractmethod
+    def attachments(self) -> typing.Sequence[files.Resourceish]:
+        """Sequence of up to 10 attachments to send with the message."""
 
     @property
     @abc.abstractmethod

--- a/hikari/impl/interaction_server.py
+++ b/hikari/impl/interaction_server.py
@@ -93,7 +93,7 @@ _TEXT_TYPE_WITH_CHARSET: typing.Final[str] = f"{_TEXT_CONTENT_TYPE}; charset={_U
 
 
 class _Response:
-    __slots__: typing.Sequence[str] = ("_content_type", "_files", "_headers", "_payload", "_status_code")
+    __slots__: typing.Sequence[str] = ("_content_type", "_files", "_payload", "_status_code")
 
     def __init__(
         self,
@@ -108,7 +108,6 @@ class _Response:
 
         self._content_type = content_type
         self._files = files
-        self._headers = None
         self._payload = payload
         self._status_code = status_code
 
@@ -122,7 +121,7 @@ class _Response:
 
     @property
     def headers(self) -> typing.Optional[typing.MutableMapping[str, str]]:
-        return self._headers
+        return None
 
     @property
     def payload(self) -> typing.Optional[bytes]:

--- a/hikari/impl/interaction_server.py
+++ b/hikari/impl/interaction_server.py
@@ -138,7 +138,7 @@ _PONG_RESPONSE: typing.Final[_Response] = _Response(
 )
 
 
-class _Payload(aiohttp.Payload):
+class _FilePayload(aiohttp.Payload):
     _value: files_.Resource[files_.AsyncReader]
 
     def __init__(
@@ -335,7 +335,7 @@ class InteractionServer(interaction_server.InteractionServer):
                 async with file_.stream(head_only=True) as stream:
                     mimetype = stream.mimetype or _APPLICATION_OCTET_STREAM
 
-                payload = _Payload(file_, mimetype, executor=self._executor)
+                payload = _FilePayload(file_, mimetype, executor=self._executor)
                 payload.set_content_disposition("form-data", name=f"files[{index}]", filename=file_.filename)
                 multipart.append_payload(payload)
 

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -1011,9 +1011,7 @@ class InteractionMessageBuilder(special_endpoints.InteractionMessageBuilder):
         if self._embeds is not undefined.UNDEFINED:
             embeds: typing.List[data_binding.JSONObject] = []
             for embed, attachments in map(entity_factory.serialize_embed, self._embeds):
-                if attachments:
-                    final_attachments.extend(attachments)
-
+                final_attachments.extend(attachments)
                 embeds.append(embed)
 
             data["embeds"] = embeds

--- a/hikari/internal/data_binding.py
+++ b/hikari/internal/data_binding.py
@@ -46,7 +46,7 @@ from hikari import snowflakes
 from hikari import undefined
 
 if typing.TYPE_CHECKING:
-    import concurrent
+    import concurrent.futures
     import contextlib
 
     T_co = typing.TypeVar("T_co", covariant=True)
@@ -87,9 +87,11 @@ if typing.TYPE_CHECKING:
 
     def dump_json(_: typing.Union[JSONArray, JSONObject], /, *, indent: int = ...) -> str:
         """Convert a Python type to a JSON string."""
+        raise NotImplementedError
 
     def load_json(_: typing.AnyStr, /) -> typing.Union[JSONArray, JSONObject]:
         """Convert a JSON string to a Python type."""
+        raise NotImplementedError
 
 else:
     import json

--- a/tests/hikari/impl/test_interaction_server.py
+++ b/tests/hikari/impl/test_interaction_server.py
@@ -140,7 +140,8 @@ class Test_Response:
     def test_defaults_to_text_content_type(self):
         response = interaction_server_impl._Response(status_code=200, payload=b"hi there")
 
-        assert response.headers == {"Content-Type": "text/plain; charset=UTF-8"}
+        assert response.content_type == "text/plain; charset=UTF-8"
+        assert response.headers is None
         assert response.payload == b"hi there"
         assert response.status_code == 200
 
@@ -149,7 +150,8 @@ class Test_Response:
             status_code=201, payload=b'{"ok": "no"}', content_type="application/json"
         )
 
-        assert response.headers == {"Content-Type": "application/json"}
+        assert response.content_type == "application/json"
+        assert response.headers is None
         assert response.payload == b'{"ok": "no"}'
         assert response.status_code == 201
 

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -1365,7 +1365,8 @@ class TestRESTClientImpl:
         assert isinstance(result, special_endpoints.InteractionAutocompleteBuilder)
         assert len(result.choices) == 2
 
-        raw = result.build(mock.Mock())
+        raw, files = result.build(mock.Mock())
+        assert files == ()
         assert raw["data"] == {"choices": [{"name": "name", "value": "value"}, {"name": "a", "value": "b"}]}
 
     def test_interaction_autocomplete_builder_with_set_choices(self, rest_client):


### PR DESCRIPTION
### Summary
Opening this as a draft just to keep track of it somewhere since this responses over 150 KiB seem to be automatically failed/rejected so...

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
