### PR TITLE
Add get_guild() to hikari.GuildChannel

### DIFF
--- a/changes/1057.feature.md
+++ b/changes/1057.feature.md
@@ -1,0 +1,1 @@
+`get_guild()` is now available on `hikari.GuildChannel`.

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -974,6 +974,19 @@ class GuildChannel(PartialChannel):
 
         return None
 
+    def get_guild(self) -> typing.Optional[guilds.GatewayGuild]:
+        """Return the guild linked to this channel.
+
+        Returns
+        -------
+        typing.Optional[hikari.guilds.Guild]
+            `builtins.None` if the guild is not cached.
+        """
+        if not isinstance(self.app, traits.CacheAware):
+            return None
+
+        return self.app.cache.get_guild(self.guild_id)
+
     async def fetch_guild(self) -> guilds.PartialGuild:
         """Fetch the guild linked to this channel.
 

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -980,7 +980,7 @@ class GuildChannel(PartialChannel):
         Returns
         -------
         typing.Optional[hikari.guilds.Guild]
-            `builtins.None` if the guild is not cached.
+            The linked guild object or `builtins.None` if it's not cached.
         """
         if not isinstance(self.app, traits.CacheAware):
             return None

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -528,7 +528,7 @@ class Member(users.User):
         Returns
         -------
         typing.Optional[hikari.guilds.Guild]
-            `builtins.None` if the the guild is not cached.
+            The linked guild object or `builtins.None` if it's not cached.
         """
         if not isinstance(self.user.app, traits.CacheAware):
             return None

--- a/tests/hikari/test_channels.py
+++ b/tests/hikari/test_channels.py
@@ -388,6 +388,26 @@ class TestGuildChannel:
             333,
         )
 
+    def test_get_guild(self, model):
+        guild = mock.Mock(id=123456789)
+        model.app.cache.get_guild.side_effect = [guild]
+
+        assert model.get_guild() == guild
+
+        model.app.cache.get_guild.assert_called_once_with(123456789)
+
+    def test_get_guild_when_guild_not_in_cache(self, model):
+        model.app.cache.get_guild.side_effect = [None]
+
+        assert model.get_guild() is None
+
+        model.app.cache.get_guild.assert_called_once_with(123456789)
+
+    def test_get_guild_when_no_cache_trait(self, model):
+        model.app = object()
+
+        assert model.get_guild() is None
+
     @pytest.mark.asyncio()
     async def test_fetch_guild(self, model):
         model.app.rest.fetch_guild = mock.AsyncMock()


### PR DESCRIPTION
### Summary

This PR adds `get_guild()` to `hikari.GuildChannel`.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
