### PR TITLE
Fix handling of when the first zlib message is complete

### DIFF
--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -101,7 +101,7 @@ _VERSION: int = 8
 # Used to identify the end of a ZLIB payload
 _ZLIB_SUFFIX: typing.Final[bytes] = b"\x00\x00\xff\xff"
 # Close codes which don't invalidate the current session.
-_RECONNECTABLE_CLOSE_CODES: typing.Final[frozenset[errors.ShardCloseCode]] = frozenset(
+_RECONNECTABLE_CLOSE_CODES: typing.Final[typing.Frozenset[errors.ShardCloseCode]] = frozenset(
     (
         errors.ShardCloseCode.UNKNOWN_ERROR,
         errors.ShardCloseCode.DECODE_ERROR,

--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -101,7 +101,7 @@ _VERSION: int = 8
 # Used to identify the end of a ZLIB payload
 _ZLIB_SUFFIX: typing.Final[bytes] = b"\x00\x00\xff\xff"
 # Close codes which don't invalidate the current session.
-_RECONNECTABLE_CLOSE_CODES: typing.Final[typing.Frozenset[errors.ShardCloseCode]] = frozenset(
+_RECONNECTABLE_CLOSE_CODES: typing.Frozenset[errors.ShardCloseCode] = frozenset(
     (
         errors.ShardCloseCode.UNKNOWN_ERROR,
         errors.ShardCloseCode.DECODE_ERROR,

--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -101,7 +101,7 @@ _VERSION: int = 8
 # Used to identify the end of a ZLIB payload
 _ZLIB_SUFFIX: typing.Final[bytes] = b"\x00\x00\xff\xff"
 # Close codes which don't invalidate the current session.
-_RECONNECTABLE_CLOSE_CODES = frozenset(
+_RECONNECTABLE_CLOSE_CODES: typing.Final[frozenset[errors.ShardCloseCode]] = frozenset(
     (
         errors.ShardCloseCode.UNKNOWN_ERROR,
         errors.ShardCloseCode.DECODE_ERROR,

--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -101,7 +101,7 @@ _VERSION: int = 8
 # Used to identify the end of a ZLIB payload
 _ZLIB_SUFFIX: typing.Final[bytes] = b"\x00\x00\xff\xff"
 # Close codes which don't invalidate the current session.
-_RECONNECTABLE_CLOSE_CODES: typing.Frozenset[errors.ShardCloseCode] = frozenset(
+_RECONNECTABLE_CLOSE_CODES: typing.FrozenSet[errors.ShardCloseCode] = frozenset(
     (
         errors.ShardCloseCode.UNKNOWN_ERROR,
         errors.ShardCloseCode.DECODE_ERROR,

--- a/tests/hikari/impl/test_shard.py
+++ b/tests/hikari/impl/test_shard.py
@@ -222,13 +222,11 @@ class TestGatewayTransport:
     async def test__receive_and_check_when_message_type_is_BINARY_and_the_full_payload(self, transport_impl):
         response = StubResponse(type=aiohttp.WSMsgType.BINARY, data=b"some initial data\x00\x00\xff\xff")
         transport_impl.receive = mock.AsyncMock(return_value=response)
-        transport_impl._receive_and_check_complete_zlib_package = mock.AsyncMock()
         transport_impl.zlib = mock.Mock(decompress=mock.Mock(return_value=b"aaaaaaaaaaaaaaaaaa"))
 
         assert await transport_impl._receive_and_check(10) == "aaaaaaaaaaaaaaaaaa"
 
         transport_impl.receive.assert_awaited_once_with(10)
-        transport_impl._receive_and_check_complete_zlib_package.assert_not_called()
         transport_impl.zlib.decompress.assert_called_once_with(response.data)
 
     @pytest.mark.asyncio()

--- a/tests/hikari/impl/test_shard.py
+++ b/tests/hikari/impl/test_shard.py
@@ -242,6 +242,7 @@ class TestGatewayTransport:
     async def test__receive_and_check_complete_zlib_package_when_not_BINARY(self, transport_impl):
         response = StubResponse(type=aiohttp.WSMsgType.TEXT, data="not binary")
         transport_impl.receive = mock.AsyncMock(return_value=response)
+        transport_impl._exception = None
 
         with pytest.raises(errors.GatewayError, match="Unexpected message type received TEXT, expected BINARY"):
             await transport_impl._receive_and_check_complete_zlib_package(b"some", 10)


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
