### PR TITLE
Require pytest-asyncio to run pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ norecursedirs = [
     "ci",
 ]
 filterwarnings = ["ignore:.*assertions not in test modules or plugins will be ignored because assert statements are not executed by the underlying Python interpreter.*:pytest.PytestConfigWarning"]
+required_plugins = ["pytest-asyncio"]
 
 [tool.towncrier]
 package = "hikari"


### PR DESCRIPTION
This replaces the current behaviour (where async tests will just be ignored if pytest-asyncio isn't installed) with getting a loud error if pytest-asyncio isn't installed.

### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
