### PR TITLE
Fix incorrect type for ATTACHMENT option values

### DIFF
--- a/changes/1066.bugfix.md
+++ b/changes/1066.bugfix.md
@@ -1,0 +1,1 @@
+Fix incorrect type for ATTACHMENT option values.

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -72,6 +72,7 @@ _interaction_option_type_mapping: typing.Dict[int, typing.Callable[[typing.Any],
     commands.OptionType.CHANNEL: snowflakes.Snowflake,
     commands.OptionType.ROLE: snowflakes.Snowflake,
     commands.OptionType.MENTIONABLE: snowflakes.Snowflake,
+    commands.OptionType.ATTACHMENT: snowflakes.Snowflake,
 }
 
 


### PR DESCRIPTION
- Fixes the value for options with ATTACHMENT type being of `str` instead of `Snowflake`

### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
