### PR TITLE
Disable ws autoclose

### DIFF
--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -279,6 +279,8 @@ class _GatewayTransport(aiohttp.ClientWebSocketResponse):
                     proxy=proxy_settings.url,
                     proxy_headers=proxy_settings.headers,
                     url=url,
+                    # We manage these ourselves
+                    autoclose=False,
                 )
             )
             assert isinstance(web_socket, cls)

--- a/tests/hikari/impl/test_shard.py
+++ b/tests/hikari/impl/test_shard.py
@@ -354,6 +354,7 @@ class TestGatewayTransport:
             proxy=proxy_settings.url,
             proxy_headers=proxy_settings.headers,
             url="https://some.url",
+            autoclose=False,
         )
         mock_client_session.assert_used_once()
         mock_websocket.assert_used_once()


### PR DESCRIPTION
### Summary
From testing, this doesnt seem to affect anything at all and just sends payloads that Discord will ignore as well as close unexpectedly on us. Further testing (running constantly for at least 48h) is needed, but I dont see why we should have these enabled.

Would greatly appreciate if someone could try out this PR in their bot and lmk how it goes

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
