### PR TITLE
Remove `VoiceRegion.is_vip` due to Discord no longer sending it

### DIFF
--- a/changes/1086.breaking.md
+++ b/changes/1086.breaking.md
@@ -1,0 +1,1 @@
+Remove `VoiceRegion.is_vip` due to Discord no longer sending it.

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -3335,9 +3335,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     async def fetch_voice_regions(self) -> typing.Sequence[voices.VoiceRegion]:
         """Fetch available voice regions.
 
-        !!! note
-            This endpoint doesn't return VIP voice regions.
-
         Returns
         -------
         typing.Sequence[hikari.voices.VoiceRegion]
@@ -5954,10 +5951,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
     ) -> typing.Sequence[voices.VoiceRegion]:
         """Fetch the available voice regions for a guild.
-
-        !!! note
-            Unlike `RESTClient.fetch_voice_regions`, this will
-            return the VIP regions if the guild has access to them.
 
         Parameters
         ----------

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -2973,7 +2973,6 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         return voice_models.VoiceRegion(
             id=payload["id"],
             name=payload["name"],
-            is_vip=payload["vip"],
             is_optimal_location=payload["optimal"],
             is_deprecated=payload["deprecated"],
             is_custom=payload["custom"],

--- a/hikari/voices.py
+++ b/hikari/voices.py
@@ -116,9 +116,6 @@ class VoiceRegion:
     name: str = attr.field(eq=False, hash=False, repr=True)
     """The name of this region."""
 
-    is_vip: bool = attr.field(eq=False, hash=False, repr=False)
-    """Whether this region is vip-only."""
-
     is_optimal_location: bool = attr.field(eq=False, hash=False, repr=False)
     """Whether this region's server is closest to the current user's client."""
 

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -5465,13 +5465,12 @@ class TestEntityFactoryImpl:
 
     @pytest.fixture()
     def voice_region_payload(self):
-        return {"id": "london", "name": "LONDON", "vip": True, "optimal": False, "deprecated": True, "custom": False}
+        return {"id": "london", "name": "LONDON", "optimal": False, "deprecated": True, "custom": False}
 
     def test_deserialize_voice_region(self, entity_factory_impl, voice_region_payload):
         voice_region = entity_factory_impl.deserialize_voice_region(voice_region_payload)
         assert voice_region.id == "london"
         assert voice_region.name == "LONDON"
-        assert voice_region.is_vip is True
         assert voice_region.is_optimal_location is False
         assert voice_region.is_deprecated is True
         assert voice_region.is_custom is False


### PR DESCRIPTION
Documentation change PR: https://github.com/discord/discord-api-docs/pull/3908

---

Considering removing `fetch_guild_voice_regions` and keeping `fetch_voice_regions`, as there is no difference between them anymore

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
