### PR TITLE
fix GuildFeature.MORE_STICKERS

### DIFF
--- a/changes/1989.bugfix.md
+++ b/changes/1989.bugfix.md
@@ -1,0 +1,1 @@
+Fix incorrect value for `GuildFeature.MORE_STICKERS`.

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -167,7 +167,7 @@ class GuildFeature(str, enums.Enum):
     MONETIZATION_ENABLED = "MONETIZATION_ENABLED"
     """Guild has enabled monetization."""
 
-    MORE_STICKERS = "MONETIZATION_ENABLED"
+    MORE_STICKERS = "MORE_STICKERS"
     """Guild has an increased custom stickers slots."""
 
 


### PR DESCRIPTION
### Summary

`GuildFeature.MORE_STICKERS` has the wrong value.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

