### PR TITLE
Temporarily freeze jinja2 to 3.0.3

### DIFF
--- a/flake8-requirements.txt
+++ b/flake8-requirements.txt
@@ -14,6 +14,7 @@ flake8-docstrings==1.6.0                # pydocstyle support
 flake8-executable==2.1.1                # shebangs
 flake8-fixme==1.1.1                     # "fix me" counter
 flake8-functions==0.0.7                 # function linting
+jinja2==3.0.3                           # temporarily freeze jinja2 due to incompatibilities with flake8-html
 flake8-html==0.4.1                      # html output
 flake8-if-statements==0.1.0             # condition linting
 flake8-isort==4.1.1                     # runs isort


### PR DESCRIPTION
### Summary
Flake8-html already has a fix for this on master, so we just need to wait for a release (https://github.com/lordmauve/flake8-html/commit/edef580c6d5e0ccb3ab54aa31b42b4359f7b9235)

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
