### PR TITLE
Allow passing multiple events to the @listen decorator

### DIFF
--- a/changes/1103.feature.md
+++ b/changes/1103.feature.md
@@ -1,0 +1,2 @@
+Allow passing multiple event types to the listen decorator.
+Parse union type hints for events if listen decorator is empty.

--- a/hikari/api/event_manager.py
+++ b/hikari/api/event_manager.py
@@ -408,7 +408,6 @@ class EventManager(abc.ABC):
             instead from the type hints on the function signature.
 
             `T` must be a subclass of `hikari.events.base_events.Event`.
-
         *event_types : typing.Type[T]
             The additional event types to subscribe to.
 

--- a/hikari/api/event_manager.py
+++ b/hikari/api/event_manager.py
@@ -393,7 +393,6 @@ class EventManager(abc.ABC):
     @abc.abstractmethod
     def listen(
         self,
-        event_type: typing.Optional[typing.Type[EventT_co]] = None,
         *event_types: typing.Type[EventT_co],
     ) -> typing.Callable[[CallbackT[EventT_co]], CallbackT[EventT_co]]:
         """Generate a decorator to subscribe a callback to an event type.
@@ -402,14 +401,12 @@ class EventManager(abc.ABC):
 
         Parameters
         ----------
-        event_type : typing.Optional[typing.Type[T]]
-            The event type to subscribe to. The implementation may allow this
+        *event_types : typing.Optional[typing.Type[T]]
+            The event types to subscribe to. The implementation may allow this
             to be undefined. If this is the case, the event type will be inferred
             instead from the type hints on the function signature.
 
             `T` must be a subclass of `hikari.events.base_events.Event`.
-        *event_types : typing.Type[T]
-            The additional event types to subscribe to.
 
         Returns
         -------

--- a/hikari/api/event_manager.py
+++ b/hikari/api/event_manager.py
@@ -394,6 +394,7 @@ class EventManager(abc.ABC):
     def listen(
         self,
         event_type: typing.Optional[typing.Type[EventT_co]] = None,
+        *event_types: typing.Type[EventT_co],
     ) -> typing.Callable[[CallbackT[EventT_co]], CallbackT[EventT_co]]:
         """Generate a decorator to subscribe a callback to an event type.
 
@@ -407,6 +408,9 @@ class EventManager(abc.ABC):
             instead from the type hints on the function signature.
 
             `T` must be a subclass of `hikari.events.base_events.Event`.
+
+        *event_types : typing.Type[T]
+            The additional event types to subscribe to.
 
         Returns
         -------

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -619,7 +619,6 @@ class GatewayBot(traits.GatewayBotAware):
 
     def listen(
         self,
-        event_type: typing.Optional[typing.Type[event_manager_.EventT_co]] = None,
         *event_types: typing.Type[event_manager_.EventT_co],
     ) -> typing.Callable[
         [event_manager_.CallbackT[event_manager_.EventT_co]],
@@ -631,8 +630,8 @@ class GatewayBot(traits.GatewayBotAware):
 
         Parameters
         ----------
-        event_type : typing.Optional[typing.Type[T]]
-            The event type to subscribe to. The implementation may allow this
+        *event_types : typing.Optional[typing.Type[T]]
+            The event types to subscribe to. The implementation may allow this
             to be undefined. If this is the case, the event type will be inferred
             instead from the type hints on the function signature.
 
@@ -653,7 +652,7 @@ class GatewayBot(traits.GatewayBotAware):
         Unsubscribe: `hikari.impl.bot.GatewayBot.unsubscribe`
         Wait_for: `hikari.impl.bot.GatewayBot.wait_for`
         """
-        return self._event_manager.listen(event_type, *event_types)
+        return self._event_manager.listen(*event_types)
 
     @staticmethod
     def print_banner(

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -618,7 +618,9 @@ class GatewayBot(traits.GatewayBotAware):
         await aio.first_completed(*awaitables)
 
     def listen(
-        self, event_type: typing.Optional[typing.Type[event_manager_.EventT_co]] = None
+        self,
+        event_type: typing.Optional[typing.Type[event_manager_.EventT_co]] = None,
+        *event_types: typing.Type[event_manager_.EventT_co],
     ) -> typing.Callable[
         [event_manager_.CallbackT[event_manager_.EventT_co]],
         event_manager_.CallbackT[event_manager_.EventT_co],
@@ -651,7 +653,7 @@ class GatewayBot(traits.GatewayBotAware):
         Unsubscribe: `hikari.impl.bot.GatewayBot.unsubscribe`
         Wait_for: `hikari.impl.bot.GatewayBot.wait_for`
         """
-        return self._event_manager.listen(event_type)
+        return self._event_manager.listen(event_type, *event_types)
 
     @staticmethod
     def print_banner(

--- a/hikari/impl/event_manager_base.py
+++ b/hikari/impl/event_manager_base.py
@@ -50,8 +50,6 @@ from hikari.internal import reflect
 from hikari.internal import ux
 
 if typing.TYPE_CHECKING:
-    import types
-
     from hikari import intents as intents_
     from hikari.api import event_factory as event_factory_
     from hikari.api import shard as gateway_shard
@@ -77,6 +75,12 @@ if typing.TYPE_CHECKING:
     _EventStreamT = typing.TypeVar("_EventStreamT", bound="EventStream[typing.Any]")
 
 _LOGGER: typing.Final[logging.Logger] = logging.getLogger("hikari.event_manager")
+
+if sys.version_info >= (3, 10):
+    # We can use types.UnionType on 3.10+
+    UNIONS = frozenset((typing.Union, types.UnionType))
+else:
+    UNIONS = frozenset((typing.Union,))
 
 
 @typing.runtime_checkable
@@ -528,12 +532,6 @@ class EventManagerBase(event_manager_.EventManager):
 
                 if annotation is event_param.empty:
                     raise TypeError("Must provide the event type in the @listen decorator or as a type hint!")
-
-                if sys.version_info >= (3, 10):
-                    # We can use types.UnionType on 3.10+
-                    UNIONS = {typing.Union, types.UnionType}
-                else:
-                    UNIONS = {typing.Union}
 
                 if typing.get_origin(annotation) in UNIONS:
                     # Resolve the types inside the union

--- a/tests/hikari/impl/test_event_manager_base.py
+++ b/tests/hikari/impl/test_event_manager_base.py
@@ -865,8 +865,10 @@ class TestEventManagerBase:
         assert subscribe.call_count == 2
         resolve_signature.assert_not_called()
         subscribe.assert_has_calls(
-            subscribe(member_events.MemberCreateEvent, test, _nested=1),
-            subscribe(member_events.MemberDeleteEvent, test, _nested=1),
+            [
+                mock.call(member_events.MemberCreateEvent, test, _nested=1),
+                mock.call(member_events.MemberDeleteEvent, test, _nested=1),
+            ]
         )
 
     def test_listen_when_param_provided_in_typehint(self, event_manager):

--- a/tests/hikari/impl/test_event_manager_base.py
+++ b/tests/hikari/impl/test_event_manager_base.py
@@ -19,9 +19,12 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import logging
+import sys
 import typing
 import unittest
 import warnings
@@ -880,7 +883,7 @@ class TestEventManagerBase:
 
         subscribe.assert_called_once_with(member_events.MemberCreateEvent, test, _nested=1)
 
-    def test_listen_when_multiple_params_provided_as_union_in_typehint(self, event_manager):
+    def test_listen_when_multiple_params_provided_as_typing_union_in_typehint(self, event_manager):
         with mock.patch.object(event_manager_base.EventManagerBase, "subscribe") as subscribe:
 
             @event_manager.listen()
@@ -894,3 +897,26 @@ class TestEventManagerBase:
                 mock.call(member_events.MemberDeleteEvent, test, _nested=1),
             ]
         )
+
+    @pytest.mark.skipif(sys.version_info < (3, 10), reason="Bitwise union only available on 3.10+")
+    def test_listen_when_multiple_params_provided_as_bitwise_union_in_typehint(self, event_manager):
+        with mock.patch.object(event_manager_base.EventManagerBase, "subscribe") as subscribe:
+
+            @event_manager.listen()
+            async def test(event: member_events.MemberCreateEvent | member_events.MemberDeleteEvent):
+                ...
+
+        assert subscribe.call_count == 2
+        subscribe.assert_has_calls(
+            [
+                mock.call(member_events.MemberCreateEvent, test, _nested=1),
+                mock.call(member_events.MemberDeleteEvent, test, _nested=1),
+            ]
+        )
+
+    def test_listen_when_incorrect_type_in_typehint(self, event_manager):
+        with pytest.raises(TypeError):
+
+            @event_manager.listen()
+            async def test(event: list[member_events.MemberUpdateEvent]):
+                ...


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->
This pull requests allows passing multiple events to the listen decorator.
Alternatively, a Union can be used in the type hint to achieve the same thing.

```py
@bot.listen(hikari.GuildAvailableEvent, hikari.GuildJoinEvent)
async def on_guild_available(event: ...) -> None:
    ...

@bot.listen()
async def on_start(event: hikari.StartingEvent | hikari.StartedEvent) -> None:
    ...
```

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

Flake8 session is failing - but it was on master before I touched anything.
