### PR TITLE
Switch to using tuples for `__all__`

### DIFF
--- a/.idea/fileTemplates/Python Module.py
+++ b/.idea/fileTemplates/Python Module.py
@@ -24,6 +24,6 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = []
+__all__: typing.Sequence[str] = ()
 
 import typing

--- a/hikari/api/cache.py
+++ b/hikari/api/cache.py
@@ -23,7 +23,7 @@
 """Core interface for a cache implementation."""
 from __future__ import annotations
 
-__all__: typing.List[str] = ["CacheView", "Cache", "MutableCache"]
+__all__: typing.Sequence[str] = ("CacheView", "Cache", "MutableCache")
 
 import abc
 import typing

--- a/hikari/api/config.py
+++ b/hikari/api/config.py
@@ -23,7 +23,7 @@
 """Core interface for Hikari's configuration dataclasses."""
 from __future__ import annotations
 
-__all__: typing.List[str] = ["CacheComponents"]
+__all__: typing.Sequence[str] = ("CacheComponents",)
 
 import abc
 import typing

--- a/hikari/api/entity_factory.py
+++ b/hikari/api/entity_factory.py
@@ -23,7 +23,7 @@
 """Core interface for an object that serializes/deserializes API objects."""
 from __future__ import annotations
 
-__all__: typing.List[str] = ["EntityFactory", "GatewayGuildDefinition"]
+__all__: typing.Sequence[str] = ("EntityFactory", "GatewayGuildDefinition")
 
 import abc
 import typing

--- a/hikari/api/event_factory.py
+++ b/hikari/api/event_factory.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["EventFactory"]
+__all__: typing.Sequence[str] = ("EventFactory",)
 
 import abc
 import typing

--- a/hikari/api/event_manager.py
+++ b/hikari/api/event_manager.py
@@ -23,7 +23,7 @@
 """Core interface for components that manage events in the library."""
 from __future__ import annotations
 
-__all__: typing.List[str] = ["EventManager", "EventStream"]
+__all__: typing.Sequence[str] = ("EventManager", "EventStream")
 
 import abc
 import asyncio

--- a/hikari/api/interaction_server.py
+++ b/hikari/api/interaction_server.py
@@ -23,7 +23,7 @@
 """Provides an interface for Interaction REST server API implementations to follow."""
 from __future__ import annotations
 
-__all__: typing.List[str] = ["ListenerT", "Response", "InteractionServer"]
+__all__: typing.Sequence[str] = ("ListenerT", "Response", "InteractionServer")
 
 import abc
 import typing

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -23,7 +23,7 @@
 """Provides an interface for REST API implementations to follow."""
 from __future__ import annotations
 
-__all__: typing.List[str] = ["RESTClient", "TokenStrategy"]
+__all__: typing.Sequence[str] = ("RESTClient", "TokenStrategy")
 
 import abc
 import typing

--- a/hikari/api/shard.py
+++ b/hikari/api/shard.py
@@ -23,7 +23,7 @@
 """Provides an interface for gateway shard implementations to conform to."""
 from __future__ import annotations
 
-__all__: typing.List[str] = ["GatewayDataFormat", "GatewayCompression", "GatewayShard"]
+__all__: typing.Sequence[str] = ("GatewayDataFormat", "GatewayCompression", "GatewayShard")
 
 import abc
 import typing

--- a/hikari/api/special_endpoints.py
+++ b/hikari/api/special_endpoints.py
@@ -23,7 +23,7 @@
 """Special additional endpoints used by the REST API."""
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "ActionRowBuilder",
     "ButtonBuilder",
     "CommandBuilder",
@@ -40,7 +40,7 @@ __all__: typing.List[str] = [
     "LinkButtonBuilder",
     "SelectMenuBuilder",
     "SelectOptionBuilder",
-]
+)
 
 import abc
 import typing

--- a/hikari/api/voice.py
+++ b/hikari/api/voice.py
@@ -23,7 +23,7 @@
 """Interfaces used to describe voice client implementations."""
 from __future__ import annotations
 
-__all__: typing.List[str] = ["VoiceComponent", "VoiceConnection"]
+__all__: typing.Sequence[str] = ("VoiceComponent", "VoiceConnection")
 
 import abc
 import typing

--- a/hikari/applications.py
+++ b/hikari/applications.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "InviteApplication",
     "Application",
     "ApplicationFlags",
@@ -42,7 +42,7 @@ __all__: typing.List[str] = [
     "TeamMembershipState",
     "TokenType",
     "get_token_id",
-]
+)
 
 import base64
 import typing

--- a/hikari/audit_logs.py
+++ b/hikari/audit_logs.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "AuditLog",
     "AuditLogChange",
     "AuditLogChangeKey",
@@ -38,7 +38,7 @@ __all__: typing.List[str] = [
     "MessageBulkDeleteEntryInfo",
     "MessageDeleteEntryInfo",
     "MessagePinEntryInfo",
-]
+)
 
 import abc
 import typing

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "ChannelType",
     "VideoQualityMode",
     "ChannelFollow",
@@ -44,7 +44,7 @@ __all__: typing.List[str] = [
     "GuildStageChannel",
     "WebhookChannelT",
     "WebhookChannelTypes",
-]
+)
 
 import typing
 

--- a/hikari/colors.py
+++ b/hikari/colors.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["Color", "Colorish"]
+__all__: typing.Sequence[str] = ("Color", "Colorish")
 
 import re
 import string

--- a/hikari/colours.py
+++ b/hikari/colours.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["Colour", "Colourish"]
+__all__: typing.Sequence[str] = ("Colour", "Colourish")
 
 import typing
 

--- a/hikari/commands.py
+++ b/hikari/commands.py
@@ -23,7 +23,7 @@
 """Models and enums used for application commands on Discord."""
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "PartialCommand",
     "ContextMenuCommand",
     "SlashCommand",
@@ -34,7 +34,7 @@ __all__: typing.List[str] = [
     "CommandType",
     "GuildCommandPermissions",
     "OptionType",
-]
+)
 
 import typing
 

--- a/hikari/embeds.py
+++ b/hikari/embeds.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "Embed",
     "EmbedResource",
     "EmbedResourceWithProxy",
@@ -34,7 +34,7 @@ __all__: typing.List[str] = [
     "EmbedAuthor",
     "EmbedFooter",
     "EmbedField",
-]
+)
 
 import textwrap
 import typing

--- a/hikari/emojis.py
+++ b/hikari/emojis.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["Emoji", "UnicodeEmoji", "CustomEmoji", "KnownCustomEmoji"]
+__all__: typing.Sequence[str] = ("Emoji", "UnicodeEmoji", "CustomEmoji", "KnownCustomEmoji")
 
 import abc
 import re

--- a/hikari/errors.py
+++ b/hikari/errors.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "HikariError",
     "HikariWarning",
     "HikariInterrupt",
@@ -48,7 +48,7 @@ __all__: typing.List[str] = [
     "MissingIntentError",
     "BulkDeleteError",
     "VoiceError",
-]
+)
 
 import http
 import typing

--- a/hikari/events/base_events.py
+++ b/hikari/events/base_events.py
@@ -23,14 +23,14 @@
 """Base types and functions for events in Hikari."""
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "Event",
     "ExceptionEvent",
     "is_no_recursive_throw_event",
     "no_recursive_throw",
     "get_required_intents_for",
     "requires_intents",
-]
+)
 
 import abc
 import inspect

--- a/hikari/events/channel_events.py
+++ b/hikari/events/channel_events.py
@@ -27,7 +27,7 @@ This does not include message events, nor reaction events.
 
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "ChannelEvent",
     "GuildChannelEvent",
     "DMChannelEvent",
@@ -41,7 +41,7 @@ __all__: typing.List[str] = [
     "InviteCreateEvent",
     "InviteDeleteEvent",
     "WebhookUpdateEvent",
-]
+)
 
 import abc
 import typing

--- a/hikari/events/guild_events.py
+++ b/hikari/events/guild_events.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "GuildEvent",
     "GuildVisibilityEvent",
     "GuildAvailableEvent",
@@ -41,7 +41,7 @@ __all__: typing.List[str] = [
     "IntegrationDeleteEvent",
     "IntegrationUpdateEvent",
     "PresenceUpdateEvent",
-]
+)
 
 import abc
 import typing

--- a/hikari/events/interaction_events.py
+++ b/hikari/events/interaction_events.py
@@ -23,7 +23,7 @@
 """Events fired for interaction related changes."""
 from __future__ import annotations
 
-__all__: typing.List[str] = ["InteractionCreateEvent"]
+__all__: typing.Sequence[str] = ("InteractionCreateEvent",)
 
 import typing
 

--- a/hikari/events/lifetime_events.py
+++ b/hikari/events/lifetime_events.py
@@ -28,7 +28,7 @@ be used to initialize other resources, fetch information, and perform checks.
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["StartingEvent", "StartedEvent", "StoppingEvent", "StoppedEvent"]
+__all__: typing.Sequence[str] = ("StartingEvent", "StartedEvent", "StoppingEvent", "StoppedEvent")
 
 import typing
 

--- a/hikari/events/member_events.py
+++ b/hikari/events/member_events.py
@@ -23,7 +23,7 @@
 """Events concerning manipulation of members within guilds."""
 from __future__ import annotations
 
-__all__: typing.List[str] = ["MemberEvent", "MemberCreateEvent", "MemberUpdateEvent", "MemberDeleteEvent"]
+__all__: typing.Sequence[str] = ("MemberEvent", "MemberCreateEvent", "MemberUpdateEvent", "MemberDeleteEvent")
 
 import abc
 import typing

--- a/hikari/events/message_events.py
+++ b/hikari/events/message_events.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "MessageEvent",
     "MessageCreateEvent",
     "MessageUpdateEvent",
@@ -36,7 +36,7 @@ __all__: typing.List[str] = [
     "DMMessageCreateEvent",
     "DMMessageUpdateEvent",
     "DMMessageDeleteEvent",
-]
+)
 
 import abc
 import typing

--- a/hikari/events/reaction_events.py
+++ b/hikari/events/reaction_events.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "ReactionEvent",
     "GuildReactionEvent",
     "DMReactionEvent",
@@ -40,7 +40,7 @@ __all__: typing.List[str] = [
     "DMReactionDeleteEvent",
     "DMReactionDeleteEmojiEvent",
     "DMReactionDeleteAllEvent",
-]
+)
 
 import abc
 import typing

--- a/hikari/events/role_events.py
+++ b/hikari/events/role_events.py
@@ -23,7 +23,7 @@
 """Events pertaining to manipulation of roles within guilds."""
 from __future__ import annotations
 
-__all__: typing.List[str] = ["RoleEvent", "RoleCreateEvent", "RoleUpdateEvent", "RoleDeleteEvent"]
+__all__: typing.Sequence[str] = ("RoleEvent", "RoleCreateEvent", "RoleUpdateEvent", "RoleDeleteEvent")
 
 import abc
 import typing

--- a/hikari/events/scheduled_events.py
+++ b/hikari/events/scheduled_events.py
@@ -23,14 +23,14 @@
 """Events fired for guild scheduled event related changes."""
 from __future__ import annotations
 
-__all__: typing.Sequence[str] = [
+__all__: typing.Sequence[str] = (
     "ScheduledEventEvent",
     "ScheduledEventCreateEvent",
     "ScheduledEventDeleteEvent",
     "ScheduledEventUpdateEvent",
     "ScheduledEventUserAddEvent",
     "ScheduledEventUserRemoveEvent",
-]
+)
 
 import abc
 import typing

--- a/hikari/events/shard_events.py
+++ b/hikari/events/shard_events.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "ShardEvent",
     "ShardPayloadEvent",
     "ShardStateEvent",
@@ -33,7 +33,7 @@ __all__: typing.List[str] = [
     "ShardReadyEvent",
     "ShardResumedEvent",
     "MemberChunkEvent",
-]
+)
 
 import abc
 import typing

--- a/hikari/events/typing_events.py
+++ b/hikari/events/typing_events.py
@@ -23,7 +23,7 @@
 """Events fired when users begin typing in channels."""
 from __future__ import annotations
 
-__all__: typing.List[str] = ["TypingEvent", "GuildTypingEvent", "DMTypingEvent"]
+__all__: typing.Sequence[str] = ("TypingEvent", "GuildTypingEvent", "DMTypingEvent")
 
 import abc
 import typing

--- a/hikari/events/user_events.py
+++ b/hikari/events/user_events.py
@@ -23,7 +23,7 @@
 """Events fired when the account user is updated."""
 from __future__ import annotations
 
-__all__: typing.List[str] = ["OwnUserUpdateEvent"]
+__all__: typing.Sequence[str] = ("OwnUserUpdateEvent",)
 
 import typing
 

--- a/hikari/events/voice_events.py
+++ b/hikari/events/voice_events.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["VoiceEvent", "VoiceStateUpdateEvent", "VoiceServerUpdateEvent"]
+__all__: typing.Sequence[str] = ("VoiceEvent", "VoiceStateUpdateEvent", "VoiceServerUpdateEvent")
 
 import abc
 import typing

--- a/hikari/files.py
+++ b/hikari/files.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "ensure_path",
     "ensure_resource",
     "unwrap_bytes",
@@ -42,7 +42,7 @@ __all__: typing.List[str] = [
     "WebReader",
     "Bytes",
     "IteratorReader",
-]
+)
 
 import abc
 import asyncio

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "Guild",
     "RESTGuild",
     "GatewayGuild",
@@ -52,7 +52,7 @@ __all__: typing.List[str] = [
     "PartialRole",
     "WelcomeScreen",
     "WelcomeChannel",
-]
+)
 
 import typing
 

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["GatewayBot"]
+__all__: typing.Sequence[str] = ("GatewayBot",)
 
 import asyncio
 import datetime

--- a/hikari/impl/buckets.py
+++ b/hikari/impl/buckets.py
@@ -184,7 +184,7 @@ released or documented...
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["UNKNOWN_HASH", "RESTBucket", "RESTBucketManager"]
+__all__: typing.Sequence[str] = ("UNKNOWN_HASH", "RESTBucket", "RESTBucketManager")
 
 import asyncio
 import logging

--- a/hikari/impl/cache.py
+++ b/hikari/impl/cache.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["CacheImpl"]
+__all__: typing.Sequence[str] = ("CacheImpl",)
 
 import copy
 import logging

--- a/hikari/impl/config.py
+++ b/hikari/impl/config.py
@@ -24,7 +24,13 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["BasicAuthHeader", "ProxySettings", "HTTPTimeoutSettings", "HTTPSettings", "CacheSettings"]
+__all__: typing.Sequence[str] = (
+    "BasicAuthHeader",
+    "ProxySettings",
+    "HTTPTimeoutSettings",
+    "HTTPSettings",
+    "CacheSettings",
+)
 
 import base64
 import ssl as ssl_

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["EntityFactoryImpl"]
+__all__: typing.Sequence[str] = ("EntityFactoryImpl",)
 
 import datetime
 import logging

--- a/hikari/impl/event_factory.py
+++ b/hikari/impl/event_factory.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["EventFactoryImpl"]
+__all__: typing.Sequence[str] = ("EventFactoryImpl",)
 
 import datetime
 import types

--- a/hikari/impl/event_manager.py
+++ b/hikari/impl/event_manager.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["EventManagerImpl"]
+__all__: typing.Sequence[str] = ("EventManagerImpl",)
 
 import asyncio
 import base64

--- a/hikari/impl/event_manager_base.py
+++ b/hikari/impl/event_manager_base.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["filtered", "EventManagerBase", "EventStream"]
+__all__: typing.Sequence[str] = ("filtered", "EventManagerBase", "EventStream")
 
 import asyncio
 import inspect

--- a/hikari/impl/interaction_server.py
+++ b/hikari/impl/interaction_server.py
@@ -23,7 +23,7 @@
 """Standard implementation of a REST based interactions server."""
 from __future__ import annotations
 
-__all__: typing.List[str] = ["InteractionServer"]
+__all__: typing.Sequence[str] = ("InteractionServer",)
 
 import asyncio
 import logging

--- a/hikari/impl/rate_limits.py
+++ b/hikari/impl/rate_limits.py
@@ -27,13 +27,13 @@ See `hikari.impl.buckets` for HTTP-specific rate-limiting logic.
 
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "BaseRateLimiter",
     "BurstRateLimiter",
     "ManualRateLimiter",
     "WindowedBurstRateLimiter",
     "ExponentialBackOff",
-]
+)
 
 import abc
 import asyncio

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -28,7 +28,7 @@ RESTful functionality.
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["ClientCredentialsStrategy", "RESTApp", "RESTClientImpl"]
+__all__: typing.Sequence[str] = ("ClientCredentialsStrategy", "RESTApp", "RESTClientImpl")
 
 import asyncio
 import base64

--- a/hikari/impl/rest_bot.py
+++ b/hikari/impl/rest_bot.py
@@ -23,7 +23,7 @@
 """Standard implementations of a Interaction based REST-only bot."""
 from __future__ import annotations
 
-__all__: typing.List[str] = ["RESTBot"]
+__all__: typing.Sequence[str] = ("RESTBot",)
 
 import asyncio
 import logging

--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["GatewayShardImpl"]
+__all__: typing.Sequence[str] = ("GatewayShardImpl",)
 
 import asyncio
 import contextlib

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -26,7 +26,7 @@ You should never need to make any of these objects manually.
 """
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "ActionRowBuilder",
     "CommandBuilder",
     "SlashCommandBuilder",
@@ -39,7 +39,7 @@ __all__: typing.List[str] = [
     "InteractiveButtonBuilder",
     "LinkButtonBuilder",
     "SelectMenuBuilder",
-]
+)
 
 import asyncio
 import typing

--- a/hikari/impl/voice.py
+++ b/hikari/impl/voice.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["VoiceComponentImpl"]
+__all__: typing.Sequence[str] = ("VoiceComponentImpl",)
 
 import asyncio
 import logging

--- a/hikari/intents.py
+++ b/hikari/intents.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["Intents"]
+__all__: typing.Sequence[str] = ("Intents",)
 
 import typing
 

--- a/hikari/interactions/base_interactions.py
+++ b/hikari/interactions/base_interactions.py
@@ -23,7 +23,7 @@
 """Base classes and enums inherited and used throughout the interactions flow."""
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "DEFERRED_RESPONSE_TYPES",
     "DeferredResponseTypesT",
     "InteractionMember",
@@ -33,7 +33,7 @@ __all__: typing.List[str] = [
     "MessageResponseTypesT",
     "PartialInteraction",
     "ResponseType",
-]
+)
 
 import typing
 

--- a/hikari/interactions/command_interactions.py
+++ b/hikari/interactions/command_interactions.py
@@ -23,7 +23,7 @@
 """Models and enums used for Discord's Slash Commands interaction flow."""
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "AutocompleteInteraction",
     "BaseCommandInteraction",
     "CommandInteractionOption",
@@ -33,7 +33,7 @@ __all__: typing.List[str] = [
     "CommandResponseTypesT",
     "InteractionChannel",
     "ResolvedOptionData",
-]
+)
 
 import typing
 

--- a/hikari/interactions/component_interactions.py
+++ b/hikari/interactions/component_interactions.py
@@ -23,7 +23,7 @@
 """Models and enums used for Discord's Components interaction flow."""
 from __future__ import annotations
 
-__all__: typing.List[str] = ["ComponentInteraction", "COMPONENT_RESPONSE_TYPES", "ComponentResponseTypesT"]
+__all__: typing.Sequence[str] = ("ComponentInteraction", "COMPONENT_RESPONSE_TYPES", "ComponentResponseTypesT")
 
 import typing
 

--- a/hikari/internal/aio.py
+++ b/hikari/internal/aio.py
@@ -24,14 +24,14 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "completed_future",
     "get_or_make_loop",
     "is_async_iterator",
     "is_async_iterable",
     "first_completed",
     "all_of",
-]
+)
 
 import asyncio
 import inspect

--- a/hikari/internal/attr_extensions.py
+++ b/hikari/internal/attr_extensions.py
@@ -23,13 +23,13 @@
 """Utility for extending and optimising the usage of `attr` models."""
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "with_copy",
     "copy_attrs",
     "deep_copy_attrs",
     "invalidate_deep_copy_cache",
     "invalidate_shallow_copy_cache",
-]
+)
 
 import copy as std_copy
 import logging

--- a/hikari/internal/cache.py
+++ b/hikari/internal/cache.py
@@ -23,7 +23,7 @@
 """Various utilities that may be used in a cache-impl."""
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "CacheMappingView",
     "EmptyCacheView",
     "GuildRecord",
@@ -44,7 +44,7 @@ __all__: typing.List[str] = [
     "DataT",
     "KeyT",
     "ValueT",
-]
+)
 
 import abc
 import copy

--- a/hikari/internal/collections.py
+++ b/hikari/internal/collections.py
@@ -23,7 +23,7 @@
 """Custom data structures used within Hikari's core implementation."""
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "ExtendedMapT",
     "KeyT",
     "ValueT",
@@ -32,7 +32,7 @@ __all__: typing.List[str] = [
     "FreezableDict",
     "LimitedCapacityCacheMap",
     "get_index_or_slice",
-]
+)
 
 import abc
 import array

--- a/hikari/internal/data_binding.py
+++ b/hikari/internal/data_binding.py
@@ -23,7 +23,7 @@
 """Data binding utilities."""
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "Headers",
     "Query",
     "JSONObject",
@@ -34,7 +34,7 @@ __all__: typing.List[str] = [
     "JSONDecodeError",
     "JSONObjectBuilder",
     "URLEncodedFormBuilder",
-]
+)
 
 import typing
 

--- a/hikari/internal/deprecation.py
+++ b/hikari/internal/deprecation.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["deprecated", "warn_deprecated"]
+__all__: typing.Sequence[str] = ("deprecated", "warn_deprecated")
 
 import functools
 import inspect

--- a/hikari/internal/enums.py
+++ b/hikari/internal/enums.py
@@ -23,7 +23,7 @@
 """Implementation of parts of Python's `enum` protocol to be more performant."""
 from __future__ import annotations
 
-__all__: typing.List[str] = ["Enum", "Flag"]
+__all__: typing.Sequence[str] = ("Enum", "Flag")
 
 import functools
 import operator

--- a/hikari/internal/fast_protocol.py
+++ b/hikari/internal/fast_protocol.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["FastProtocolChecking"]
+__all__: typing.Sequence[str] = ("FastProtocolChecking",)
 
 import typing
 

--- a/hikari/internal/mentions.py
+++ b/hikari/internal/mentions.py
@@ -23,7 +23,7 @@
 """Utility functions used for managing mentions on Discord."""
 from __future__ import annotations
 
-__all__: typing.List[str] = ["generate_allowed_mentions"]
+__all__: typing.Sequence[str] = ("generate_allowed_mentions",)
 
 import typing
 

--- a/hikari/internal/net.py
+++ b/hikari/internal/net.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["generate_error_response", "create_client_session"]
+__all__: typing.Sequence[str] = ("generate_error_response", "create_client_session")
 
 import http
 import typing

--- a/hikari/internal/reflect.py
+++ b/hikari/internal/reflect.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["resolve_signature"]
+__all__: typing.Sequence[str] = ("resolve_signature",)
 
 import functools
 import inspect

--- a/hikari/internal/routes.py
+++ b/hikari/internal/routes.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["CompiledRoute", "Route", "CDNRoute"]
+__all__: typing.Sequence[str] = ("CompiledRoute", "Route", "CDNRoute")
 
 import math
 import re

--- a/hikari/internal/spel.py
+++ b/hikari/internal/spel.py
@@ -52,7 +52,7 @@ prior notice for the time being.
 """
 from __future__ import annotations
 
-__all__: typing.List[str] = ["AttrGetter"]
+__all__: typing.Sequence[str] = ("AttrGetter",)
 
 import operator
 import typing

--- a/hikari/internal/time.py
+++ b/hikari/internal/time.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "DISCORD_EPOCH",
     "datetime_to_discord_epoch",
     "discord_epoch_to_datetime",
@@ -36,7 +36,7 @@ __all__: typing.List[str] = [
     "monotonic",
     "monotonic_ns",
     "uuid",
-]
+)
 
 import datetime
 import time

--- a/hikari/internal/ux.py
+++ b/hikari/internal/ux.py
@@ -23,7 +23,7 @@
 """User-experience extensions and utilities."""
 from __future__ import annotations
 
-__all__: typing.List[str] = ["init_logging", "print_banner", "supports_color", "HikariVersion", "check_for_updates"]
+__all__: typing.Sequence[str] = ("init_logging", "print_banner", "supports_color", "HikariVersion", "check_for_updates")
 
 import importlib.resources
 import logging

--- a/hikari/invites.py
+++ b/hikari/invites.py
@@ -24,14 +24,14 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "TargetType",
     "VanityURL",
     "InviteGuild",
     "InviteCode",
     "Invite",
     "InviteWithMetadata",
-]
+)
 
 import abc
 import typing

--- a/hikari/iterators.py
+++ b/hikari/iterators.py
@@ -28,7 +28,7 @@ wish to extend this API further!
 """
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "LazyIterator",
     "FlatLazyIterator",
     "All",
@@ -36,7 +36,7 @@ __all__: typing.List[str] = [
     "BufferedLazyIterator",
     "ValueT",
     "AnotherValueT",
-]
+)
 
 import abc
 import asyncio

--- a/hikari/messages.py
+++ b/hikari/messages.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "MessageType",
     "MessageFlag",
     "MessageActivityType",
@@ -45,7 +45,7 @@ __all__: typing.List[str] = [
     "InteractiveButtonTypesT",
     "ComponentType",
     "PartialComponent",
-]
+)
 
 import typing
 

--- a/hikari/permissions.py
+++ b/hikari/permissions.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["Permissions"]
+__all__: typing.Sequence[str] = ("Permissions",)
 
 import functools
 import operator

--- a/hikari/presences.py
+++ b/hikari/presences.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "Activity",
     "ActivityAssets",
     "ActivityFlag",
@@ -36,7 +36,7 @@ __all__: typing.List[str] = [
     "MemberPresence",
     "RichActivity",
     "Status",
-]
+)
 
 import typing
 

--- a/hikari/scheduled_events.py
+++ b/hikari/scheduled_events.py
@@ -23,7 +23,7 @@
 """Application and entities that are used to describe guild scheduled events on Discord."""
 from __future__ import annotations
 
-__all__: typing.Sequence[str] = [
+__all__: typing.Sequence[str] = (
     "EventPrivacyLevel",
     "ScheduledEventType",
     "ScheduledEventStatus",
@@ -32,7 +32,7 @@ __all__: typing.Sequence[str] = [
     "ScheduledStageEvent",
     "ScheduledVoiceEvent",
     "ScheduledEventUser",
-]
+)
 
 import typing
 

--- a/hikari/sessions.py
+++ b/hikari/sessions.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["GatewayBotInfo", "SessionStartLimit"]
+__all__: typing.Sequence[str] = ("GatewayBotInfo", "SessionStartLimit")
 
 import typing
 

--- a/hikari/snowflakes.py
+++ b/hikari/snowflakes.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "Snowflake",
     "Unique",
     "calculate_shard_id",
@@ -34,7 +34,7 @@ __all__: typing.List[str] = [
     "SearchableSnowflakeishOr",
     "SnowflakeishIterable",
     "SnowflakeishSequence",
-]
+)
 
 import abc
 import typing

--- a/hikari/stickers.py
+++ b/hikari/stickers.py
@@ -24,14 +24,14 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "StickerType",
     "StickerFormatType",
     "PartialSticker",
     "GuildSticker",
     "StandardSticker",
     "StickerPack",
-]
+)
 
 import typing
 

--- a/hikari/templates.py
+++ b/hikari/templates.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["Template", "TemplateGuild", "TemplateRole"]
+__all__: typing.Sequence[str] = ("Template", "TemplateGuild", "TemplateRole")
 
 import typing
 

--- a/hikari/traits.py
+++ b/hikari/traits.py
@@ -23,7 +23,7 @@
 """Core app interface for application implementations."""
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "CacheAware",
     "EventManagerAware",
     "EntityFactoryAware",
@@ -38,7 +38,7 @@ __all__: typing.List[str] = [
     "InteractionServerAware",
     "ShardAware",
     "VoiceAware",
-]
+)
 
 import typing
 

--- a/hikari/undefined.py
+++ b/hikari/undefined.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "UNDEFINED",
     "UndefinedNoneOr",
     "UndefinedOr",
@@ -32,7 +32,7 @@ __all__: typing.List[str] = [
     "all_undefined",
     "any_undefined",
     "count",
-]
+)
 
 import typing
 

--- a/hikari/urls.py
+++ b/hikari/urls.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["BASE_URL", "REST_API_URL", "OAUTH2_API_URL", "CDN_URL"]
+__all__: typing.Sequence[str] = ("BASE_URL", "REST_API_URL", "OAUTH2_API_URL", "CDN_URL")
 
 import typing
 

--- a/hikari/users.py
+++ b/hikari/users.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["PartialUser", "User", "OwnUser", "UserFlag", "PremiumType"]
+__all__: typing.Sequence[str] = ("PartialUser", "User", "OwnUser", "UserFlag", "PremiumType")
 
 import abc
 import typing

--- a/hikari/voices.py
+++ b/hikari/voices.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = ["VoiceRegion", "VoiceState"]
+__all__: typing.Sequence[str] = ("VoiceRegion", "VoiceState")
 
 import typing
 

--- a/hikari/webhooks.py
+++ b/hikari/webhooks.py
@@ -24,14 +24,14 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = [
+__all__: typing.Sequence[str] = (
     "ApplicationWebhook",
     "ChannelFollowerWebhook",
     "ExecutableWebhook",
     "PartialWebhook",
     "WebhookType",
     "IncomingWebhook",
-]
+)
 
 import abc
 import typing


### PR DESCRIPTION
### Summary
No real change here, just less memory wasted, since there is no need for them to be lists instead of tuples

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
