### PR TITLE
Don't close low-level stdout stream when printing banner

### DIFF
--- a/hikari/internal/ux.py
+++ b/hikari/internal/ux.py
@@ -222,8 +222,7 @@ def print_banner(
         for code in colorlog.escape_codes.escape_codes:
             args[code] = ""
 
-    # 1 maps to stdout
-    with open(1, "w", encoding="utf-8") as stdout:
+    with open(sys.stdout.fileno(), "w", encoding="utf-8", closefd=False) as stdout:
         stdout.write(string.Template(raw_banner).safe_substitute(args))
 
 

--- a/tests/hikari/internal/test_ux.py
+++ b/tests/hikari/internal/test_ux.py
@@ -184,6 +184,7 @@ class TestPrintBanner:
         builtins_open = stack.enter_context(mock.patch.object(builtins, "open"))
         abspath = stack.enter_context(mock.patch.object(os.path, "abspath", return_value="some path"))
         dirname = stack.enter_context(mock.patch.object(os.path, "dirname"))
+        fileno = stack.enter_context(mock.patch.object(sys.stdout, "fileno"))
 
         with stack:
             ux.print_banner("hikari", True, False)
@@ -208,7 +209,7 @@ class TestPrintBanner:
 
         template.assert_called_once_with(read_text())
         template().safe_substitute.assert_called_once_with(args)
-        builtins_open.assert_called_once_with(1, "w", encoding="utf-8")
+        builtins_open.assert_called_once_with(fileno.return_value, "w", encoding="utf-8", closefd=False)
         builtins_open.return_value.__enter__.return_value.write.assert_called_once_with(template().safe_substitute())
         dirname.assert_called_once_with("~/hikari")
         abspath.assert_called_once_with(dirname())
@@ -226,6 +227,7 @@ class TestPrintBanner:
         abspath = stack.enter_context(mock.patch.object(os.path, "abspath", return_value="some path"))
         dirname = stack.enter_context(mock.patch.object(os.path, "dirname"))
         builtins_open = stack.enter_context(mock.patch.object(builtins, "open"))
+        fileno = stack.enter_context(mock.patch.object(sys.stdout, "fileno"))
 
         with stack:
             ux.print_banner("hikari", True, False)
@@ -253,7 +255,7 @@ class TestPrintBanner:
         dirname.assert_called_once_with("~/hikari")
         abspath.assert_called_once_with(dirname())
         supports_color.assert_called_once_with(True, False)
-        builtins_open.assert_called_once_with(1, "w", encoding="utf-8")
+        builtins_open.assert_called_once_with(fileno.return_value, "w", encoding="utf-8", closefd=False)
         builtins_open.return_value.__enter__.return_value.write.assert_called_once_with(template().safe_substitute())
 
     def test_use_extra_args(self, mock_args):
@@ -264,6 +266,7 @@ class TestPrintBanner:
         template = stack.enter_context(mock.patch.object(string, "Template"))
         builtins_open = stack.enter_context(mock.patch.object(builtins, "open"))
         stack.enter_context(mock.patch.object(os.path, "abspath", return_value="some path"))
+        fileno = stack.enter_context(mock.patch.object(sys.stdout, "fileno"))
 
         extra_args = {
             "extra_argument_1": "one",
@@ -292,7 +295,7 @@ class TestPrintBanner:
 
         template.assert_called_once_with(read_text())
         template().safe_substitute.assert_called_once_with(args)
-        builtins_open.assert_called_once_with(1, "w", encoding="utf-8")
+        builtins_open.assert_called_once_with(fileno.return_value, "w", encoding="utf-8", closefd=False)
         builtins_open.return_value.__enter__.return_value.write.assert_called_once_with(template().safe_substitute())
 
     def test_overwrite_args_raises_error(self, mock_args):


### PR DESCRIPTION
### Summary
Fix a bug introduced by #1120

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
