### PR TITLE
add retry on timeout

### DIFF
--- a/changes/1132.feature.md
+++ b/changes/1132.feature.md
@@ -1,1 +1,1 @@
-Retry on request timeout.
+Retry on request timeout or connection error.

--- a/changes/1132.feature.md
+++ b/changes/1132.feature.md
@@ -1,0 +1,1 @@
+Retry on request timeout.

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -715,7 +715,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
         url = compiled_route.create_url(self._rest_url)
 
-        # This is initiated the first time we hit a 5xx error to save a little memory when nothing goes wrong
+        # This is initiated the first time we time our or hit a 5xx error to save a little memory when nothing goes wrong
         backoff: typing.Optional[rate_limits.ExponentialBackOff] = None
         retry_count = 0
 

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -680,7 +680,7 @@ class RESTClientImpl(rest_api.RESTClient):
             return None
 
     @typing.final
-    async def _request(
+    async def _request(  # noqa: C901 CFQ001
         self,
         compiled_route: routes.CompiledRoute,
         *,

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -758,7 +758,10 @@ class RESTClientImpl(rest_api.RESTClient):
                             proxy=self._proxy_settings.url,
                             proxy_headers=self._proxy_settings.all_headers,
                         )
-                    except asyncio.TimeoutError:  # Request timed out
+                    except (
+                        asyncio.TimeoutError,
+                        aiohttp.ClientOSError,
+                    ):  # Request timed out or failed due to connection issues
                         if retry_count >= self._max_retries:
                             raise
 

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -715,7 +715,7 @@ class RESTClientImpl(rest_api.RESTClient):
 
         url = compiled_route.create_url(self._rest_url)
 
-        # This is initiated the first time we time our or hit a 5xx error to save a little memory when nothing goes wrong
+        # This is initiated the first time we time out or hit a 5xx error to save a little memory when nothing goes wrong
         backoff: typing.Optional[rate_limits.ExponentialBackOff] = None
         retry_count = 0
 


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->
Retry on `asyncio.TimeoutError` that aiohttp raises when a request times out.

Currently testing this in production, hence draft, no changelog fragment and a lack of formatting/tests.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
