### PR TITLE
added sync_id to the hikari.presences.RichActivity

### DIFF
--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -2694,6 +2694,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
                 is_instance=activity_payload.get("instance"),  # TODO: can we safely default this to False?
                 flags=presence_models.ActivityFlag(activity_payload["flags"]) if "flags" in activity_payload else None,
                 buttons=activity_payload.get("buttons") or [],
+                sync_id=activity_payload.get("sync_id"),
             )
             activities.append(activity)
 

--- a/hikari/internal/cache.py
+++ b/hikari/internal/cache.py
@@ -525,6 +525,7 @@ class RichActivityData(BaseData[presences.RichActivity]):
     is_instance: typing.Optional[bool] = attr.field()
     flags: typing.Optional[presences.ActivityFlag] = attr.field()
     buttons: typing.Tuple[str, ...] = attr.field()
+    sync_id: typing.Optional[str] = attr.field()
 
     @classmethod
     def build_from_entity(
@@ -563,6 +564,7 @@ class RichActivityData(BaseData[presences.RichActivity]):
             assets=assets,
             secrets=secrets,
             buttons=tuple(activity.buttons),
+            sync_id=activity.sync_id,
         )
 
     def build_entity(self, _: traits.RESTAware, /) -> presences.RichActivity:
@@ -589,6 +591,7 @@ class RichActivityData(BaseData[presences.RichActivity]):
             secrets=copy.copy(self.secrets) if self.secrets is not None else None,
             emoji=emoji,
             buttons=self.buttons,
+            sync_id=self.sync_id,
         )
 
 

--- a/hikari/presences.py
+++ b/hikari/presences.py
@@ -362,6 +362,9 @@ class RichActivity(Activity):
     buttons: typing.Sequence[str] = attr.field(repr=False)
     """A sequence of up to 2 of the button labels shown in this rich presence."""
 
+    sync_id: typing.Optional[str] = attr.field(repr=False)
+    """The sync ID for this activity, if applicable."""
+
 
 @typing.final
 class Status(str, enums.Enum):

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -192,6 +192,7 @@ def presence_activity_payload(custom_emoji_payload):
         "instance": True,
         "flags": 3,
         "buttons": ["owo", "no"],
+        "sync_id": "4cOdK2wGLETKBW3PvgPWqT",
     }
 
 
@@ -4965,6 +4966,7 @@ class TestEntityFactoryImpl:
         assert activity.type == presence_models.ActivityType.STREAMING
         assert activity.url == "https://69.420.owouwunyaa"
         assert activity.created_at == datetime.datetime(2020, 3, 23, 20, 53, 12, 798000, tzinfo=datetime.timezone.utc)
+        assert activity.sync_id == "4cOdK2wGLETKBW3PvgPWqT"
         # ActivityTimestamps
         assert activity.timestamps.start == datetime.datetime(
             2020, 3, 23, 20, 53, 12, 798000, tzinfo=datetime.timezone.utc
@@ -5060,6 +5062,7 @@ class TestEntityFactoryImpl:
         assert activity.is_instance is None
         assert activity.flags is None
         assert activity.buttons == []
+        assert activity.sync_id is None
 
     def test_deserialize_member_presence_with_null_activity_fields(self, entity_factory_impl, user_payload):
         presence = entity_factory_impl.deserialize_member_presence(
@@ -5092,6 +5095,7 @@ class TestEntityFactoryImpl:
                         "secrets": {"join": "who's a good secret?", "spectate": "I'm a good secret", "match": "No."},
                         "instance": True,
                         "flags": 3,
+                        "sync_id": None,
                     }
                 ],
                 "client_status": {},
@@ -5103,6 +5107,7 @@ class TestEntityFactoryImpl:
         assert activity.details is None
         assert activity.state is None
         assert activity.emoji is None
+        assert activity.sync_id is None
 
     def test_deserialize_member_presence_with_unset_activity_sub_fields(self, entity_factory_impl, user_payload):
         presence = entity_factory_impl.deserialize_member_presence(
@@ -5127,6 +5132,7 @@ class TestEntityFactoryImpl:
                         "secrets": {},
                         "instance": True,
                         "flags": 3,
+                        "sync_id": "4cOdK2wGLETKBW3PvgPWqT",
                     }
                 ],
                 "client_status": {},


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->
Hikari's hikari.presences.RichActivity Class doesn't include the sync_id property, that sometimes gets included with presence updates.
The most notable example is Spotify where the sync_id is equal to the id of the song.
It doesn't seem to be documented anywhere.
https://open.spotify.com/track/2ROoHzuEZV64bi3TCHEvzZ
example without: 
`{'type': 4, 'state': '🏳️‍⚧️🏳️‍⚧️🏳️‍⚧️🏳️‍⚧️', 'name': 'Custom Status', 'id': 'custom', 'created_at': 1652908335972}`
example with: 
`{'type': 2, 'timestamps': {'start': 1652910953459, 'end': 1652911137709}, 'sync_id': '2ROoHzuEZV64bi3TCHEvzZ', 'state': 'Cavetown', 'session_id': 'there_was_something_here', 'party': {'id': 'spotify:there_was_something_here''}, 'name': 'Spotify', 'id': 'spotify:1', 'flags': 48, 'details': 'Everything Is Temporary (Sticks and Stones)', 'created_at': 1652910953626, 'assets': {'large_text': 'Cavetown', 'large_image': 'spotify:ab67616d0000b2739ed6b04a8fe894a9204630f6'}}`

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
