### PR TITLE
Make sure build methods are typed consistently

### DIFF
--- a/changes/1164.breaking.md
+++ b/changes/1164.breaking.md
@@ -1,0 +1,1 @@
+`build` methods are now typed as returning `MutableMapping[str, typing.Any]`.

--- a/hikari/api/special_endpoints.py
+++ b/hikari/api/special_endpoints.py
@@ -65,7 +65,6 @@ if typing.TYPE_CHECKING:
     from hikari.api import entity_factory as entity_factory_
     from hikari.api import rest as rest_api
     from hikari.interactions import base_interactions
-    from hikari.internal import data_binding
     from hikari.internal import time
 
     _T = typing.TypeVar("_T")

--- a/hikari/api/special_endpoints.py
+++ b/hikari/api/special_endpoints.py
@@ -569,7 +569,7 @@ class InteractionResponseBuilder(abc.ABC):
     @abc.abstractmethod
     def build(
         self, entity_factory: entity_factory_.EntityFactory, /
-    ) -> typing.Tuple[data_binding.JSONObject, typing.Sequence[files.Resource[files.AsyncReader]]]:
+    ) -> typing.Tuple[typing.MutableMapping[str, typing.Any], typing.Sequence[files.Resource[files.AsyncReader]]]:
         """Build a JSON object from this builder.
 
         Parameters
@@ -579,7 +579,7 @@ class InteractionResponseBuilder(abc.ABC):
 
         Returns
         -------
-        typing.Tuple[hikari.internal.data_binding.JSONObject, typing.Sequence[files.Resource[Files.AsyncReader]]
+        typing.Tuple[typing.MutableMapping[str, typing.Any], typing.Sequence[files.Resource[Files.AsyncReader]]
             A tuple of the built json object representation of this builder and
             a sequence of up to 10 files to send with the response.
         """
@@ -1020,7 +1020,7 @@ class CommandBuilder(abc.ABC):
         """
 
     @abc.abstractmethod
-    def build(self, entity_factory: entity_factory_.EntityFactory, /) -> data_binding.JSONObject:
+    def build(self, entity_factory: entity_factory_.EntityFactory, /) -> typing.MutableMapping[str, typing.Any]:
         """Build a JSON object from this builder.
 
         Parameters
@@ -1030,7 +1030,7 @@ class CommandBuilder(abc.ABC):
 
         Returns
         -------
-        hikari.internal.data_binding.JSONObject
+        typing.MutableMapping[str, typing.Any]
             The built json object representation of this builder.
         """
 
@@ -1196,12 +1196,12 @@ class ComponentBuilder(abc.ABC):
     __slots__: typing.Sequence[str] = ()
 
     @abc.abstractmethod
-    def build(self) -> data_binding.JSONObject:
+    def build(self) -> typing.MutableMapping[str, typing.Any]:
         """Build a JSON object from this builder.
 
         Returns
         -------
-        hikari.internal.data_binding.JSONObject
+        typing.MutableMapping[str, typing.Any]
             The built json object representation of this builder.
         """
 

--- a/hikari/errors.py
+++ b/hikari/errors.py
@@ -292,7 +292,7 @@ class BadRequestError(ClientHTTPResponseError):
     status: http.HTTPStatus = attr.field(default=http.HTTPStatus.BAD_REQUEST, init=False)
     """The HTTP status code for the response."""
 
-    errors: typing.Optional[typing.Dict[str, data_binding.JSONObject]] = attr.field(default=None, kw_only=True)
+    errors: typing.Optional[typing.Mapping[str, data_binding.JSONObject]] = attr.field(default=None, kw_only=True)
     """Dict of top level field names to field specific error paths.
 
     For more information, this error format is loosely defined at

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -1208,7 +1208,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             payload["author"] = author_payload
 
         if embed.fields:
-            field_payloads: list[data_binding.JSONObject] = []
+            field_payloads: typing.List[data_binding.JSONObject] = []
             for i, field in enumerate(embed.fields):
 
                 # Yep, these are technically two unreachable branches. However, this is an incredibly

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -1138,11 +1138,10 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         )
 
     def serialize_embed(  # noqa: C901 - Function too complex
-        self,
-        embed: embed_models.Embed,
+        self, embed: embed_models.Embed
     ) -> typing.Tuple[data_binding.JSONObject, typing.List[files.Resource[files.AsyncReader]]]:
 
-        payload: data_binding.JSONObject = {}
+        payload: typing.Dict[str, typing.Any] = {}
         uploads: typing.List[files.Resource[files.AsyncReader]] = []
 
         if embed.title is not None:
@@ -1161,7 +1160,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             payload["color"] = int(embed.color)
 
         if embed.footer is not None:
-            footer_payload: data_binding.JSONObject = {}
+            footer_payload: typing.MutableMapping[str, typing.Any] = {}
 
             if embed.footer.text is not None:
                 footer_payload["text"] = embed.footer.text
@@ -1175,7 +1174,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             payload["footer"] = footer_payload
 
         if embed.image is not None:
-            image_payload: data_binding.JSONObject = {}
+            image_payload: typing.MutableMapping[str, typing.Any] = {}
 
             if not isinstance(embed.image.resource, files.WebResource):
                 uploads.append(embed.image.resource)
@@ -1184,7 +1183,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             payload["image"] = image_payload
 
         if embed.thumbnail is not None:
-            thumbnail_payload: data_binding.JSONObject = {}
+            thumbnail_payload: typing.MutableMapping[str, typing.Any] = {}
 
             if not isinstance(embed.thumbnail.resource, files.WebResource):
                 uploads.append(embed.thumbnail.resource)
@@ -1193,7 +1192,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             payload["thumbnail"] = thumbnail_payload
 
         if embed.author is not None:
-            author_payload: data_binding.JSONObject = {}
+            author_payload: typing.MutableMapping[str, typing.Any] = {}
 
             if embed.author.name is not None:
                 author_payload["name"] = embed.author.name
@@ -1209,7 +1208,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             payload["author"] = author_payload
 
         if embed.fields:
-            field_payloads: data_binding.JSONArray = []
+            field_payloads: list[data_binding.JSONObject] = []
             for i, field in enumerate(embed.fields):
 
                 # Yep, these are technically two unreachable branches. However, this is an incredibly
@@ -1339,7 +1338,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         return guild_models.WelcomeScreen(description=payload["description"], channels=channels)
 
     def serialize_welcome_channel(self, welcome_channel: guild_models.WelcomeChannel) -> data_binding.JSONObject:
-        payload: data_binding.JSONObject = {
+        payload: typing.Dict[str, typing.Any] = {
             "channel_id": str(welcome_channel.channel_id),
             "description": welcome_channel.description,
         }
@@ -2102,7 +2101,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         raise errors.UnrecognisedEntityError(f"Unrecognised interaction type {interaction_type}")
 
     def serialize_command_option(self, option: commands.CommandOption) -> data_binding.JSONObject:
-        payload: data_binding.JSONObject = {
+        payload: typing.MutableMapping[str, typing.Any] = {
             "type": option.type,
             "name": option.name,
             "description": option.description,

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -1265,7 +1265,7 @@ class RESTClientImpl(rest_api.RESTClient):
         elif attachments is not undefined.UNDEFINED:
             final_attachments.extend([files.ensure_resource(a) for a in attachments])
 
-        serialized_components: undefined.UndefinedOr[typing.List[data_binding.JSONObject]] = undefined.UNDEFINED
+        serialized_components: undefined.UndefinedOr[typing.List[typing.Mapping[str, typing.Any]]] = undefined.UNDEFINED
         if component is not undefined.UNDEFINED:
             if component is not None:
                 serialized_components = [component.build()]

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -1265,7 +1265,7 @@ class RESTClientImpl(rest_api.RESTClient):
         elif attachments is not undefined.UNDEFINED:
             final_attachments.extend([files.ensure_resource(a) for a in attachments])
 
-        serialized_components: undefined.UndefinedOr[typing.List[typing.Mapping[str, typing.Any]]] = undefined.UNDEFINED
+        serialized_components: undefined.UndefinedOr[typing.List[data_binding.JSONObject]] = undefined.UNDEFINED
         if component is not undefined.UNDEFINED:
             if component is not None:
                 serialized_components = [component.build()]

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -1113,7 +1113,7 @@ class CommandBuilder(special_endpoints.CommandBuilder):
         self._default_permission = state
         return self
 
-    def build(self, _: entity_factory_.EntityFactory, /) -> data_binding.JSONObject:
+    def build(self, _: entity_factory_.EntityFactory, /) -> typing.MutableMapping[str, typing.Any]:
         data = data_binding.JSONObjectBuilder()
         data["name"] = self._name
         data["type"] = self.type
@@ -1146,7 +1146,7 @@ class SlashCommandBuilder(CommandBuilder, special_endpoints.SlashCommandBuilder)
     def options(self) -> typing.Sequence[commands.CommandOption]:
         return self._options.copy()
 
-    def build(self, entity_factory: entity_factory_.EntityFactory, /) -> data_binding.JSONObject:
+    def build(self, entity_factory: entity_factory_.EntityFactory, /) -> typing.MutableMapping[str, typing.Any]:
         data = super().build(entity_factory)
         # Under this context we know this'll always be a JSONObjectBuilder but
         # the return types need to be kept as JSONObject to avoid exposing an
@@ -1278,7 +1278,7 @@ class _ButtonBuilder(special_endpoints.ButtonBuilder[_ContainerProtoT]):
         self._container.add_component(self)
         return self._container
 
-    def build(self) -> data_binding.JSONObject:
+    def build(self) -> typing.MutableMapping[str, typing.Any]:
         data = data_binding.JSONObjectBuilder()
 
         data["type"] = messages.ComponentType.BUTTON
@@ -1379,7 +1379,7 @@ class _SelectOptionBuilder(special_endpoints.SelectOptionBuilder["_SelectMenuBui
         self._menu.add_raw_option(self)
         return self._menu
 
-    def build(self) -> data_binding.JSONObject:
+    def build(self) -> typing.MutableMapping[str, typing.Any]:
         data = data_binding.JSONObjectBuilder()
 
         data["label"] = self._label
@@ -1467,7 +1467,7 @@ class SelectMenuBuilder(special_endpoints.SelectMenuBuilder[_ContainerProtoT]):
         self._container.add_component(self)
         return self._container
 
-    def build(self) -> data_binding.JSONObject:
+    def build(self) -> typing.MutableMapping[str, typing.Any]:
         data = data_binding.JSONObjectBuilder()
 
         data["type"] = messages.ComponentType.SELECT_MENU
@@ -1545,7 +1545,7 @@ class ActionRowBuilder(special_endpoints.ActionRowBuilder):
         self._assert_can_add_type(messages.ComponentType.SELECT_MENU)
         return SelectMenuBuilder(container=self, custom_id=custom_id)
 
-    def build(self) -> data_binding.JSONObject:
+    def build(self) -> typing.MutableMapping[str, typing.Any]:
         return {
             "type": messages.ComponentType.ACTION_ROW,
             "components": [component.build() for component in self._components],

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -843,7 +843,7 @@ class InteractionAutocompleteBuilder(special_endpoints.InteractionAutocompleteBu
 
     def build(
         self, _: entity_factory_.EntityFactory, /
-    ) -> typing.Tuple[data_binding.JSONObject, typing.Sequence[files.Resource[files.AsyncReader]]]:
+    ) -> typing.Tuple[typing.MutableMapping[str, typing.Any], typing.Sequence[files.Resource[files.AsyncReader]]]:
         data = {"choices": [{"name": choice.name, "value": choice.value} for choice in self._choices]}
         return {"type": self.type, "data": data}, ()
 
@@ -885,7 +885,7 @@ class InteractionDeferredBuilder(special_endpoints.InteractionDeferredBuilder):
 
     def build(
         self, _: entity_factory_.EntityFactory, /
-    ) -> typing.Tuple[data_binding.JSONObject, typing.Sequence[files.Resource[files.AsyncReader]]]:
+    ) -> typing.Tuple[typing.MutableMapping[str, typing.Any], typing.Sequence[files.Resource[files.AsyncReader]]]:
         if self._flags is not undefined.UNDEFINED:
             return {"type": self._type, "data": {"flags": self._flags}}, ()
 
@@ -1051,7 +1051,7 @@ class InteractionMessageBuilder(special_endpoints.InteractionMessageBuilder):
 
     def build(
         self, entity_factory: entity_factory_.EntityFactory, /
-    ) -> typing.Tuple[data_binding.JSONObject, typing.Sequence[files.Resource[files.AsyncReader]]]:
+    ) -> typing.Tuple[typing.MutableMapping[str, typing.Any], typing.Sequence[files.Resource[files.AsyncReader]]]:
         data = data_binding.JSONObjectBuilder()
         data.put("content", self.content)
 

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -1149,7 +1149,7 @@ class SlashCommandBuilder(CommandBuilder, special_endpoints.SlashCommandBuilder)
     def build(self, entity_factory: entity_factory_.EntityFactory, /) -> typing.MutableMapping[str, typing.Any]:
         data = super().build(entity_factory)
         # Under this context we know this'll always be a JSONObjectBuilder but
-        # the return types need to be kept as JSONObject to avoid exposing an
+        # the return types need to be kept as MutableMapping to avoid exposing an
         # internal type on the public API.
         assert isinstance(data, data_binding.JSONObjectBuilder)
         data.put("description", self._description)

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -1113,7 +1113,7 @@ class CommandBuilder(special_endpoints.CommandBuilder):
         self._default_permission = state
         return self
 
-    def build(self, entity_factory: entity_factory_.EntityFactory, /) -> data_binding.JSONObjectBuilder:
+    def build(self, _: entity_factory_.EntityFactory, /) -> data_binding.JSONObject:
         data = data_binding.JSONObjectBuilder()
         data["name"] = self._name
         data["type"] = self.type
@@ -1146,8 +1146,12 @@ class SlashCommandBuilder(CommandBuilder, special_endpoints.SlashCommandBuilder)
     def options(self) -> typing.Sequence[commands.CommandOption]:
         return self._options.copy()
 
-    def build(self, entity_factory: entity_factory_.EntityFactory, /) -> data_binding.JSONObjectBuilder:
+    def build(self, entity_factory: entity_factory_.EntityFactory, /) -> data_binding.JSONObject:
         data = super().build(entity_factory)
+        # Under this context we know this'll always be a JSONObjectBuilder but
+        # the return types need to be kept as JSONObject to avoid exposing an
+        # internal type on the public API.
+        assert isinstance(data, data_binding.JSONObjectBuilder)
         data.put("description", self._description)
         data.put_array("options", self._options, conversion=entity_factory.serialize_command_option)
         return data

--- a/hikari/internal/data_binding.py
+++ b/hikari/internal/data_binding.py
@@ -60,10 +60,10 @@ Query = typing.Union[typing.Dict[str, str], multidict.MultiDict[str]]
 # MyPy does not support recursive types yet. This has been ongoing for a long time, unfortunately.
 # See https://github.com/python/typing/issues/182
 
-JSONObject = typing.Dict[str, typing.Any]
+JSONObject = typing.Mapping[str, typing.Any]
 """Type hint for a JSON-decoded object representation as a mapping."""
 
-JSONArray = typing.List[typing.Any]
+JSONArray = typing.Sequence[typing.Any]
 """Type hint for a JSON-decoded array representation as a sequence."""
 
 JSONish = typing.Union[str, int, float, bool, None, JSONArray, JSONObject]
@@ -73,10 +73,7 @@ Stringish = typing.Union[str, int, bool, undefined.UndefinedType, None, snowflak
 """Type hint for any valid that can be put in a StringMapBuilder"""
 
 _StringMapBuilderArg = typing.Union[
-    typing.Mapping[str, str],
-    typing.Dict[str, str],
-    multidict.MultiMapping[str],
-    typing.Iterable[typing.Tuple[str, str]],
+    typing.Mapping[str, str], multidict.MultiMapping[str], typing.Iterable[typing.Tuple[str, str]]
 ]
 
 _APPLICATION_OCTET_STREAM: typing.Final[str] = "application/octet-stream"


### PR DESCRIPTION
### Summary
Returning JSONObjectBuilder introduces issues for anybody who's overriding these methods as they'd have to type their return methods as JSONObjectBuilder which is an internal type.

And  MutableMapping is preferred over JSONObject for a return type

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
