### PR TITLE
Use right roles in `objects.inv` file

### DIFF
--- a/docs/documentation.mako
+++ b/docs/documentation.mako
@@ -550,7 +550,7 @@
             sphobjinv.DataObjStr(
                 name = name,
                 domain = "py",
-                role = "var",
+                role = "variable",
                 uri = v.url(),
                 priority = "1",
                 dispname = "-",
@@ -602,7 +602,7 @@
                 sphobjinv.DataObjStr(
                     name = f.obj.__module__ + "." + f.obj.__qualname__,
                     domain = "py",
-                    role = "func",
+                    role = "function",
                     uri = f.url(),
                     priority = "1",
                     dispname = "-",


### PR DESCRIPTION
### Summary
Use right roles in `objects.inv` file, in documentation, so `intersphinx` can normally access them.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
See https://github.com/hikari-py/hikari/pull/1118#discussion_r884153829 and https://sphobjinv.readthedocs.io/en/latest/syntax.html.
