### PR TITLE
Use right roles in `objects.inv` file

### DIFF
--- a/docs/patched_pdoc.py
+++ b/docs/patched_pdoc.py
@@ -55,13 +55,6 @@ if generate_inventory:
     project_inventory.project = "hikari"
     project_inventory.version = hikari.__version__
 
-    type_to_role = {
-        "module": "module",
-        "class": "class",
-        "function": "func",
-        "variable": "var",
-    }
-
     def _add_to_inventory(dobj: pdoc_doc.Doc):
         if dobj.name.startswith("_"):
             # These won't be documented anyway, so we can ignore them
@@ -76,7 +69,7 @@ if generate_inventory:
             sphobjinv.DataObjStr(
                 name=dobj.fullname,
                 domain="py",
-                role=type_to_role[dobj.type],
+                role=dobj.type,
                 uri=uri,
                 priority="1",
                 dispname="-",


### PR DESCRIPTION
### Summary
Use right roles in `objects.inv` file, in documentation, so `intersphinx` can normally access them.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
See #1173, https://github.com/hikari-py/hikari/pull/1118#discussion_r884153829 and https://sphobjinv.readthedocs.io/en/latest/syntax.html.