### PR TITLE
Change SelectMenuBuilder min_value to 1 by default

### DIFF
--- a/changes/1187.bugfix.md
+++ b/changes/1187.bugfix.md
@@ -1,0 +1,1 @@
+Changed the default `min_value` in `SelectMenuBuilder` from 0 to 1.

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -1406,7 +1406,7 @@ class SelectMenuBuilder(special_endpoints.SelectMenuBuilder[_ContainerProtoT]):
     # Any has to be used here as we can't access Self type in this context
     _options: typing.List[special_endpoints.SelectOptionBuilder[typing.Any]] = attr.field(factory=list)
     _placeholder: undefined.UndefinedOr[str] = attr.field(default=undefined.UNDEFINED)
-    _min_values: int = attr.field(default=0)
+    _min_values: int = attr.field(default=1)
     _max_values: int = attr.field(default=1)
     _is_disabled: bool = attr.field(default=False)
 

--- a/tests/hikari/impl/test_special_endpoints.py
+++ b/tests/hikari/impl/test_special_endpoints.py
@@ -1097,7 +1097,7 @@ class TestSelectMenuBuilder:
             "custom_id": "o2o2o2",
             "options": [],
             "disabled": False,
-            "min_values": 0,
+            "min_values": 1,
             "max_values": 1,
         }
 


### PR DESCRIPTION
### Summary
Changed the default min_value in SelectMenuBuilder from 0 to 1.

As per Discord API docs, the default value of min_value is 1 while the least it can go to is 0. (Also, when using select menu on phone, before this PR, the select options would appear with a checkbox near it if set_min_value() isn't used although the max_value is 1.)

### Checklist
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Found no issue related to this.
