### PR TITLE
Remove field validation from `serialize_embed`

### DIFF
--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -1215,35 +1215,9 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             payload["author"] = author_payload
 
         if embed.fields:
-            field_payloads: typing.List[data_binding.JSONObject] = []
-            for i, field in enumerate(embed.fields):
-
-                # Yep, these are technically two unreachable branches. However, this is an incredibly
-                # common mistake to make when working with embeds and not using a static type
-                # checker, so I have added these as additional safeguards for UX and ease
-                # of debugging. The case that there are `None` should be detected immediately by
-                # static type checkers, regardless.
-                name = str(field.name) if field.name is not None else None
-                value = str(field.value) if field.value is not None else None
-
-                if name is None:
-                    raise TypeError(f"in embed.fields[{i}].name - cannot have `None`")
-                if not name:
-                    raise TypeError(f"in embed.fields[{i}].name - cannot have empty string")
-                if not name.strip():
-                    raise TypeError(f"in embed.fields[{i}].name - cannot have only whitespace")
-
-                if value is None:
-                    raise TypeError(f"in embed.fields[{i}].value - cannot have `None`")
-                if not value:
-                    raise TypeError(f"in embed.fields[{i}].value - cannot have empty string")
-                if not value.strip():
-                    raise TypeError(f"in embed.fields[{i}].value - cannot have only whitespace")
-
-                # Name and value always have to be specified; we can always
-                # send a default `inline` value also just to keep this simpler.
-                field_payloads.append({"name": name, "value": value, "inline": field.is_inline})
-            payload["fields"] = field_payloads
+            payload["fields"] = [
+                {"name": field.name, "value": field.value, "inline": field.is_inline} for field in embed.fields
+            ]
 
         return payload, uploads
 

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -2136,23 +2136,6 @@ class TestEntityFactoryImpl:
     def test_serialize_embed_with_null_attributes(self, entity_factory_impl):
         assert entity_factory_impl.serialize_embed(embed_models.Embed()) == ({}, [])
 
-    @pytest.mark.parametrize(
-        "field_kwargs",
-        [
-            {"name": None, "value": "correct value"},
-            {"name": "", "value": "correct value"},
-            {"name": "    ", "value": "correct value"},
-            {"name": "correct value", "value": None},
-            {"name": "correct value", "value": ""},
-            {"name": "correct value", "value": "    "},
-        ],
-    )
-    def test_serialize_embed_validators(self, entity_factory_impl, field_kwargs):
-        embed_obj = embed_models.Embed()
-        embed_obj.add_field(**field_kwargs)
-        with pytest.raises(TypeError):
-            entity_factory_impl.serialize_embed(embed_obj)
-
     ################
     # EMOJI MODELS #
     ################


### PR DESCRIPTION
This validation only checks fields and not all the other possibilities that Discord will complain about. It is best to just leave it to Discord to decide whether to error or not.