### PR TITLE
Remove case of bang (`!`) from `Member.mention` property

### DIFF
--- a/changes/1207.breaking.md
+++ b/changes/1207.breaking.md
@@ -1,2 +1,1 @@
-`Member.mention` now returns a mention string without the `!` bang regardless of nickname setting.
- - Example: `<@1234567890>` instead of `<@!1234567890>`
+Removed case of `Member.mention` returning bang (!) mention, as it is deprecated by Discord.

--- a/changes/1207.breaking.md
+++ b/changes/1207.breaking.md
@@ -1,1 +1,1 @@
-Removed case of `Member.mention` returning bang (!) mention, as it is deprecated by Discord.
+Removed case of `Member.mention` returning bang (`!`) mention, as it is deprecated by Discord.

--- a/changes/1207.breaking.md
+++ b/changes/1207.breaking.md
@@ -1,0 +1,2 @@
+`Member.mention` now returns a mention string without the `!` bang regardless of nickname setting.
+ - Example: `<@1234567890>` instead of `<@!1234567890>`

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -486,18 +486,12 @@ class Member(users.User):
     def mention(self) -> str:
         """Return a raw mention string for the given member.
 
-        If the member has a known nickname, we always return
-        a bang ("`!`") before the ID part of the mention string. This
-        mimics the behaviour Discord clients tend to provide.
-
         Example
         -------
 
         ```py
-        >>> some_member_without_nickname.mention
+        >>> some_member.mention
         '<@123456789123456789>'
-        >>> some_member_with_nickname.mention
-        '<@!123456789123456789>'
         ```
 
         Returns
@@ -505,7 +499,7 @@ class Member(users.User):
         builtins.str
             The mention string to use.
         """
-        return f"<@!{self.id}>" if self.nickname is not None else self.user.mention
+        return self.user.mention
 
     def communication_disabled_until(self) -> typing.Optional[datetime.datetime]:
         """Return when the timeout for this member ends.

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -484,21 +484,6 @@ class Member(users.User):
 
     @property
     def mention(self) -> str:
-        """Return a raw mention string for the given member.
-
-        Example
-        -------
-
-        ```py
-        >>> some_member.mention
-        '<@123456789123456789>'
-        ```
-
-        Returns
-        -------
-        builtins.str
-            The mention string to use.
-        """
         return self.user.mention
 
     def communication_disabled_until(self) -> typing.Optional[datetime.datetime]:

--- a/tests/hikari/test_guilds.py
+++ b/tests/hikari/test_guilds.py
@@ -485,11 +485,7 @@ class TestMember:
         model.nickname = None
         assert model.display_name is mock_user.username
 
-    def test_mention_property_when_nickname(self, model):
-        assert model.mention == "<@!123>"
-
-    def test_mention_property_when_no_nickname(self, model, mock_user):
-        model.nickname = None
+    def test_mention_property(self, model, mock_user):
         assert model.mention == mock_user.mention
 
     def test_get_guild(self, model):


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->
Discord mentions should not have the `!` bang anymore per deprecation by Discord.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
