### PR TITLE
move mention property from `GuildChannel` to `PartialChannel`

### DIFF
--- a/changes/1221.feature.md
+++ b/changes/1221.feature.md
@@ -1,0 +1,1 @@
+Add `mention` property to `PartialChannel`.

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -333,7 +333,9 @@ class PartialChannel(snowflakes.Unique):
 
         !!! note
             As of writing, GuildCategory, GroupDMChannel, and DMChannel channels are
-            a special case for this and mentions of them will not resolve as clickable.
+            a special case for this. Mentions of them will not resolve as clickable
+            on all platforms, a "#" followed by the channel's name is rendered on the 
+            client instead.
 
         Returns
         -------

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -327,6 +327,21 @@ class PartialChannel(snowflakes.Unique):
     type: typing.Union[ChannelType, int] = attr.field(eq=False, hash=False, repr=True)
     """The channel's type."""
 
+    @property
+    def mention(self) -> str:
+        """Return a raw mention string for the channel.
+
+        !!! note
+            As of writing, GuildCategory, GroupDMChannel, and DMChannel channels are
+            a special case for this and mentions of them will not resolve as clickable.
+
+        Returns
+        -------
+        builtins.str
+            The mention string to use.
+        """
+        return f"<#{self.id}>"
+
     def __str__(self) -> str:
         return self.name if self.name is not None else f"Unnamed {self.__class__.__name__} ID {self.id}"
 
@@ -938,21 +953,6 @@ class GuildChannel(PartialChannel):
 
     If no parent category is set for the channel, this will be `builtins.None`.
     """
-
-    @property
-    def mention(self) -> str:
-        """Return a raw mention string for the guild channel.
-
-        !!! note
-            As of writing, GuildCategory channels are a special case
-            for this and mentions of them will not resolve as clickable.
-
-        Returns
-        -------
-        builtins.str
-            The mention string to use.
-        """
-        return f"<#{self.id}>"
 
     @property
     def shard_id(self) -> typing.Optional[int]:

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -332,10 +332,9 @@ class PartialChannel(snowflakes.Unique):
         """Return a raw mention string for the channel.
 
         !!! note
-            As of writing, GuildCategory, GroupDMChannel, and DMChannel channels are
-            a special case for this. Mentions of them will not resolve as clickable
-            on all platforms, a "#" followed by the channel's name is rendered on the 
-            client instead.
+            There are platform specific inconsistencies with mentions of
+            GuildCategories, GroupDMChannels and DMChannels showing
+            the correct name but not being interactable.
 
         Returns
         -------

--- a/tests/hikari/test_channels.py
+++ b/tests/hikari/test_channels.py
@@ -113,7 +113,7 @@ class TestPartialChannel:
         assert str(model) == "Unnamed PartialChannel ID 1234567"
 
     def test_mention_property(self, model):
-        assert model.mention == "<#69420>"
+        assert model.mention == "<#1234567>"
 
     @pytest.mark.asyncio()
     async def test_delete(self, model):

--- a/tests/hikari/test_channels.py
+++ b/tests/hikari/test_channels.py
@@ -112,6 +112,9 @@ class TestPartialChannel:
         model.name = None
         assert str(model) == "Unnamed PartialChannel ID 1234567"
 
+    def test_mention_property(self, model):
+        assert model.mention == "<#69420>"
+
     @pytest.mark.asyncio()
     async def test_delete(self, model):
         model.app.rest.delete_channel = mock.AsyncMock()
@@ -334,9 +337,6 @@ class TestGuildChannel:
     def test_shard_id_property_when_guild_id_is_not_None(self, model):
         model.app.shard_count = 3
         assert model.shard_id == 2
-
-    def test_mention_property(self, model):
-        assert model.mention == "<#69420>"
 
     @pytest.mark.asyncio()
     async def test_edit_overwrite(self, model):


### PR DESCRIPTION
### Summary
Discord allows mentioning of all channels through the `<#id>` syntax, so it makes sense to move the mention property to the base class.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
