### PR TITLE
fixed typo in `fetch_message` docstring

### DIFF
--- a/changes/1222.doc.md
+++ b/changes/1222.doc.md
@@ -1,1 +1,0 @@
-Small fix in `hikari/api/rest.py` in `fetch_message` docstring. `channel` was mistaken with `message` and the other way around.

--- a/changes/1222.doc.md
+++ b/changes/1222.doc.md
@@ -1,0 +1,1 @@
+Small fix in `hikari/api/rest.py` in `fetch_message` docstring. `channel` was mistaken with `message` and the other way around.

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -1036,10 +1036,10 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------
         channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
             The channel to fetch messages in. This may be the object or
-            the ID of an existing message.
+            the ID of an existing channel.
         message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
             The message to fetch. This may be the object or the ID of an
-            existing channel.
+            existing message.
 
         Returns
         -------


### PR DESCRIPTION
### Summary
fixed `fetch_message` docstring

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
