### PR TITLE
docs: fix intellisense relation for `DeferredResponseTypesT`

### DIFF
--- a/hikari/interactions/base_interactions.py
+++ b/hikari/interactions/base_interactions.py
@@ -161,7 +161,6 @@ This includes the following:
 DeferredResponseTypesT = typing.Literal[
     ResponseType.DEFERRED_MESSAGE_CREATE, 5, ResponseType.DEFERRED_MESSAGE_UPDATE, 6
 ]
-
 """Type-hint of the response types which are valid for deferred messages responses.
 
 The following are valid for this:


### PR DESCRIPTION
### Summary
This is not allowing me to properly see the documentation in PyCharm for.. whatever reason. I believe Pylance for my env is not recognising it because of that one nutty space.

### Checklist
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues

