### PR TITLE
Fix endpoint used in reposition_channels

### DIFF
--- a/changes/1259.bugfix.md
+++ b/changes/1259.bugfix.md
@@ -1,0 +1,1 @@
+Fix `reposition_channels` to use the correct route.

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -2585,7 +2585,7 @@ class RESTClientImpl(rest_api.RESTClient):
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
         positions: typing.Mapping[int, snowflakes.SnowflakeishOr[channels_.GuildChannel]],
     ) -> None:
-        route = routes.POST_GUILD_CHANNELS.compile(guild=guild)
+        route = routes.PATCH_GUILD_CHANNELS.compile(guild=guild)
         body = [{"id": str(int(channel)), "position": pos} for pos, channel in positions.items()]
         await self._request(route, json=body)
 

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -4031,7 +4031,7 @@ class TestRESTClientImplAsync:
         )
 
     async def test_reposition_channels(self, rest_client):
-        expected_route = routes.POST_GUILD_CHANNELS.compile(guild=123)
+        expected_route = routes.PATCH_GUILD_CHANNELS.compile(guild=123)
         expected_json = [{"id": "456", "position": 1}, {"id": "789", "position": 2}]
         rest_client._request = mock.AsyncMock()
 


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->
`reposition_channels` currently doesn't work, as it uses the `POST_GUILD_CHANNELS` route instead
 of the `PATCH_GUILD_CHANNELS` route.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
