### PR TITLE
Fix incorrect deprecation version for `RESTClientImpl.edit_permission_overwrites`

### DIFF
--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -1078,7 +1078,7 @@ class RESTClientImpl(rest_api.RESTClient):
         body.put("deny", deny)
         await self._request(route, json=body, reason=reason)
 
-    @deprecation.deprecated("2.0.0.dev110", "edit_permission_overwrite")
+    @deprecation.deprecated("2.0.0.dev113", "edit_permission_overwrite")
     async def edit_permission_overwrites(
         self,
         channel: snowflakes.SnowflakeishOr[channels_.GuildChannel],
@@ -1093,7 +1093,7 @@ class RESTClientImpl(rest_api.RESTClient):
     ) -> None:
         """Edit permissions for a specific entity in the given guild channel.
 
-        .. deprecated:: 2.0.0.dev110
+        .. deprecated:: 2.0.0.dev113
             Use `RESTClient.edit_permission_overwrite` instead.
         """
         await self.edit_permission_overwrite(

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -1093,7 +1093,7 @@ class RESTClientImpl(rest_api.RESTClient):
     ) -> None:
         """Edit permissions for a specific entity in the given guild channel.
 
-        .. deprecated:: 2.0.0.dev113
+        .. deprecated:: 2.0.0.dev110
             Use `RESTClient.edit_permission_overwrite` instead.
         """
         await self.edit_permission_overwrite(


### PR DESCRIPTION
### Summary
Wrong version was used in error.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
