### PR TITLE
Remove codespell from reformat-code

### DIFF
--- a/pipelines/format.nox.py
+++ b/pipelines/format.nox.py
@@ -35,13 +35,12 @@ GIT = shutil.which("git")
 @nox.session(reuse_venv=True)
 def reformat_code(session: nox.Session) -> None:
     """Remove trailing whitespace in source, run isort, codespell and then run black code formatter."""
-    session.install(*nox.dev_requirements("formatting", "codespell"))
+    session.install(*nox.dev_requirements("formatting"))
 
     remove_trailing_whitespaces(session)
 
     session.run("isort", *config.PYTHON_REFORMATTING_PATHS)
     session.run("black", *config.PYTHON_REFORMATTING_PATHS)
-    session.run("codespell", "-w", *config.FULL_REFORMATTING_PATHS)
 
 
 @nox.session(reuse_venv=True)


### PR DESCRIPTION
### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

