### PR TITLE
Temporarily disable testing in 3.11-dev due to CPython crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10", 3.11-dev]
+        # 3.11-dev temporarily disabled due to CPython crash
+        # https://github.com/python/cpython/issues/97002
+        python-version: [3.8, 3.9, "3.10"]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
### Summary
Ill keep everything else added by #847, as we do technically support 3.11 and everything works fine, the only issue is just a cpython bug when running pytest. Its what happens with dev versions :)

ref: https://github.com/python/cpython/issues/97002

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
