### PR TITLE
Deprecate CacheView.iterator in favour of using itertools

### DIFF
--- a/changes/1289.deprecation.md
+++ b/changes/1289.deprecation.md
@@ -1,0 +1,1 @@
+Deprecate `CacheView.iterator` in favour of using the `itertools` module.

--- a/hikari/api/cache.py
+++ b/hikari/api/cache.py
@@ -28,8 +28,6 @@ __all__: typing.Sequence[str] = ("CacheView", "Cache", "MutableCache")
 import abc
 import typing
 
-from hikari import iterators
-
 if typing.TYPE_CHECKING:
     from hikari import channels
     from hikari import emojis
@@ -68,10 +66,6 @@ class CacheView(typing.Mapping[_KeyT, _ValueT], abc.ABC):
     @abc.abstractmethod
     def get_item_at(self, index: typing.Union[slice, int], /) -> typing.Union[_ValueT, typing.Sequence[_ValueT]]:
         ...
-
-    @abc.abstractmethod
-    def iterator(self) -> iterators.LazyIterator[_ValueT]:
-        """Get a lazy iterator of the entities in the view."""
 
 
 class Cache(abc.ABC):

--- a/hikari/internal/cache.py
+++ b/hikari/internal/cache.py
@@ -66,6 +66,7 @@ from hikari import voices
 from hikari.api import cache
 from hikari.internal import attr_extensions
 from hikari.internal import collections
+from hikari.internal import deprecation
 
 if typing.TYPE_CHECKING:
     from hikari import applications
@@ -156,6 +157,11 @@ class CacheMappingView(cache.CacheView[KeyT, ValueT]):
         return collections.get_index_or_slice(self, index)
 
     def iterator(self) -> iterators.LazyIterator[ValueT]:
+        deprecation.warn_deprecated(
+            "iterator",
+            removal_version="2.0.0.dev113",
+            additional_info="Use the 'itertools' module instead",
+        )
         return iterators.FlatLazyIterator(self.values())
 
 
@@ -180,6 +186,11 @@ class EmptyCacheView(cache.CacheView[typing.Any, typing.Any]):
         raise IndexError(index)
 
     def iterator(self) -> iterators.LazyIterator[ValueT]:
+        deprecation.warn_deprecated(
+            "iterator",
+            removal_version="2.0.0.dev113",
+            additional_info="Use the 'itertools' module instead",
+        )
         return iterators.FlatLazyIterator(())
 
 

--- a/tests/hikari/internal/test_cache.py
+++ b/tests/hikari/internal/test_cache.py
@@ -22,7 +22,9 @@
 import copy
 
 import mock
+import pytest
 
+from hikari import iterators
 from hikari import snowflakes
 from hikari import stickers
 from hikari.internal import cache
@@ -73,3 +75,28 @@ class TestStickerData:
         assert data.user is refcell.return_value
         mock_copy.assert_called_once_with(mock_user)
         refcell.assert_called_once_with(mock_copy.return_value)
+
+
+class TestCacheMappingView:
+    @pytest.fixture()
+    def cache_view(self):
+        return cache.CacheMappingView({"some": "data"})
+
+    def test_iterator(self, cache_view):
+        with mock.patch.object(iterators, "FlatLazyIterator") as flat_lazy_iterator:
+            with mock.patch.object(cache.CacheMappingView, "values") as values:
+                assert cache_view.iterator() is flat_lazy_iterator.return_value
+
+        flat_lazy_iterator.assert_called_once_with(values.return_value)
+
+
+class TestEmptyCacheView:
+    @pytest.fixture()
+    def cache_view(self):
+        return cache.EmptyCacheView()
+
+    def test_iterator(self, cache_view):
+        with mock.patch.object(iterators, "FlatLazyIterator") as flat_lazy_iterator:
+            assert cache_view.iterator() is flat_lazy_iterator.return_value
+
+        flat_lazy_iterator.assert_called_once_with(())


### PR DESCRIPTION
### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.