### PR TITLE
Bundle requirement files with source distribution 

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,8 @@ graft hikari
 include LICENSE
 include setup.py
 include README.md
+include requirements.txt
+include server-requirements.txt
+inlcude speedup-requirements.txt
 include pyproject.toml
 global-exclude *.py[cod]


### PR DESCRIPTION
### Summary
Sdist should be freestanding bootstrapable distributions of the python package. In #1000 requirement files were removed from the MANIFEST.in making sdists no longer freestanding. I discovered this when I attempted to use nix-community/poetry2nix in a project which prefer's building from sdists.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.


Closes #1323