### PR TITLE
Fix raise_interrupt test failing on some platforms

### DIFF
--- a/tests/hikari/internal/test_signals.py
+++ b/tests/hikari/internal/test_signals.py
@@ -28,9 +28,10 @@ import pytest
 from hikari import errors
 from hikari.internal import signals
 
-with mock.patch.object(signal, "strsignal"):  # signals are not always implemented
-    with pytest.raises(errors.HikariInterrupt):
-        signals._raise_interrupt(1)
+def test__raise_interrupt():
+    with mock.patch.object(signal, "strsignal"):  # signals are not always implemented
+        with pytest.raises(errors.HikariInterrupt):
+            signals._raise_interrupt(1)
 
 
 @pytest.mark.parametrize("trace", [True, False])

--- a/tests/hikari/internal/test_signals.py
+++ b/tests/hikari/internal/test_signals.py
@@ -28,8 +28,7 @@ import pytest
 from hikari import errors
 from hikari.internal import signals
 
-
-def test__raise_interrupt():
+with mock.patch.object(signal, "strsignal"):  # signals are not always implemented
     with pytest.raises(errors.HikariInterrupt):
         signals._raise_interrupt(1)
 

--- a/tests/hikari/internal/test_signals.py
+++ b/tests/hikari/internal/test_signals.py
@@ -28,6 +28,7 @@ import pytest
 from hikari import errors
 from hikari.internal import signals
 
+
 def test__raise_interrupt():
     with mock.patch.object(signal, "strsignal"):  # signals are not always implemented
         with pytest.raises(errors.HikariInterrupt):


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
