### PR TITLE
Add new ACTIVE_DEVELOPER flag to UserFlags

### DIFF
--- a/changes/1355.feature.md
+++ b/changes/1355.feature.md
@@ -1,2 +1,1 @@
-Add the new [Active Developer](https://support-dev.discord.com/hc/en-us/articles/10113997751447) flag to the 
-available UserFlags that can be present on a user account.
+Add new `UserFlag.ACTIVE_DEVELOPER`.

--- a/changes/1355.feature.md
+++ b/changes/1355.feature.md
@@ -1,0 +1,2 @@
+Add the new [Active Developer](https://support-dev.discord.com/hc/en-us/articles/10113997751447) flag to the 
+available UserFlags that can be present on a user account.

--- a/hikari/users.py
+++ b/hikari/users.py
@@ -102,6 +102,9 @@ class UserFlag(enums.Flag):
     BOT_HTTP_INTERACTIONS = 1 << 19
     """Bot uses only HTTP interactions and is shown in the active member list."""
 
+    ACTIVE_DEVELOPER = 1 << 22
+    """User is an active bot developer."""
+
 
 @typing.final
 class PremiumType(int, enums.Enum):

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -216,7 +216,7 @@ def user_payload():
         "discriminator": "6127",
         "bot": True,
         "system": True,
-        "public_flags": int(user_models.UserFlag.EARLY_VERIFIED_DEVELOPER),
+        "public_flags": int(user_models.UserFlag.EARLY_VERIFIED_DEVELOPER | user_models.UserFlag.ACTIVE_DEVELOPER),
     }
 
 
@@ -6322,7 +6322,7 @@ class TestEntityFactoryImpl:
         assert user.discriminator == "6127"
         assert user.is_bot is True
         assert user.is_system is True
-        assert user.flags == user_models.UserFlag.EARLY_VERIFIED_DEVELOPER
+        assert user.flags == user_models.UserFlag.EARLY_VERIFIED_DEVELOPER | user_models.UserFlag.ACTIVE_DEVELOPER
         assert isinstance(user, user_models.UserImpl)
 
     def test_deserialize_user_with_unset_fields(self, entity_factory_impl, mock_app, user_payload):


### PR DESCRIPTION
### Summary
Adds the new [Active Developer](https://support-dev.discord.com/hc/en-us/articles/10113997751447) badge to the list of available user flags.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

<!--
### Related issues
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
