### PR TITLE
Remove incorrect `is_nsfw` from threads

### DIFF
--- a/changes/1386.bugfix.md
+++ b/changes/1386.bugfix.md
@@ -1,2 +1,2 @@
 Remove incorrect `is_nsfw` field from threads.
-- The "NSFW" status is inherited from the parent object and sent in threads.
+- The "NSFW" status is inherited from the parent object and not sent for threads.

--- a/changes/1386.bugfix.md
+++ b/changes/1386.bugfix.md
@@ -1,0 +1,2 @@
+Remove incorrect `is_nsfw` field from threads.
+- The "NSFW" status is inherited from the parent object and sent in threads.

--- a/changes/1386.bugfix.md
+++ b/changes/1386.bugfix.md
@@ -1,2 +1,3 @@
 Remove incorrect `is_nsfw` field from threads.
 - The "NSFW" status is inherited from the parent object and not sent for threads.
+- This also involved moving the base attribute from `GuildChannel` to `PermissibleGuildChannel`.

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -956,14 +956,6 @@ class GuildChannel(PartialChannel):
     guild_id: snowflakes.Snowflake = attr.field(eq=False, hash=False, repr=True)
     """The ID of the guild the channel belongs to."""
 
-    is_nsfw: typing.Optional[bool] = attr.field(eq=False, hash=False, repr=False)
-    """Whether the channel is marked as NSFW.
-
-    !!! warning
-        This will be `builtins.None` when received over the gateway in certain events
-        (e.g Guild Create).
-    """
-
     parent_id: typing.Optional[snowflakes.Snowflake] = attr.field(eq=False, hash=False, repr=True)
     """The ID of the parent channel the channel belongs to.
 
@@ -1146,6 +1138,9 @@ class PermissibleGuildChannel(GuildChannel):
 
     Higher numbers appear further down the channel list.
     """
+
+    is_nsfw: bool = attr.field(eq=False, hash=False, repr=False)
+    """Whether the channel is marked as NSFW."""
 
     permission_overwrites: typing.Mapping[snowflakes.Snowflake, PermissionOverwrite] = attr.field(
         eq=False, hash=False, repr=False

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -110,7 +110,6 @@ class _GuildChannelFields:
     name: typing.Optional[str] = attr.field()
     type: typing.Union[channel_models.ChannelType, int] = attr.field()
     guild_id: snowflakes.Snowflake = attr.field()
-    is_nsfw: typing.Optional[bool] = attr.field()
     parent_id: typing.Optional[snowflakes.Snowflake] = attr.field()
 
 
@@ -930,7 +929,6 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             name=payload.get("name"),
             type=channel_models.ChannelType(payload["type"]),
             guild_id=guild_id,
-            is_nsfw=payload.get("nsfw"),
             parent_id=parent_id,
         )
 
@@ -952,7 +950,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             type=channel_fields.type,
             guild_id=channel_fields.guild_id,
             permission_overwrites=permission_overwrites,
-            is_nsfw=channel_fields.is_nsfw,
+            is_nsfw=payload.get("nsfw", False),
             parent_id=None,
             position=int(payload["position"]),
         )
@@ -987,7 +985,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             type=channel_fields.type,
             guild_id=channel_fields.guild_id,
             permission_overwrites=permission_overwrites,
-            is_nsfw=channel_fields.is_nsfw,
+            is_nsfw=payload.get("nsfw", False),
             parent_id=channel_fields.parent_id,
             topic=payload["topic"],
             last_message_id=last_message_id,
@@ -1030,7 +1028,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             type=channel_fields.type,
             guild_id=channel_fields.guild_id,
             permission_overwrites=permission_overwrites,
-            is_nsfw=channel_fields.is_nsfw,
+            is_nsfw=payload.get("nsfw", False),
             parent_id=channel_fields.parent_id,
             topic=payload["topic"],
             last_message_id=last_message_id,
@@ -1064,7 +1062,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             type=channel_fields.type,
             guild_id=channel_fields.guild_id,
             permission_overwrites=permission_overwrites,
-            is_nsfw=channel_fields.is_nsfw,
+            is_nsfw=payload.get("nsfw", False),
             parent_id=channel_fields.parent_id,
             # There seems to be an edge case where rtc_region won't be included in gateway events (e.g. GUILD_CREATE)
             # for a voice channel that just hasn't been touched since this was introduced (e.g. has been archived).
@@ -1094,7 +1092,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             type=channel_fields.type,
             guild_id=channel_fields.guild_id,
             permission_overwrites=permission_overwrites,
-            is_nsfw=channel_fields.is_nsfw,
+            is_nsfw=payload.get("nsfw", False),
             parent_id=channel_fields.parent_id,
             region=payload["rtc_region"],
             bitrate=int(payload["bitrate"]),
@@ -1164,7 +1162,6 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             name=channel_fields.name,
             type=channel_fields.type,
             guild_id=channel_fields.guild_id,
-            is_nsfw=channel_fields.is_nsfw,
             parent_id=channel_fields.parent_id,
             last_message_id=last_message_id,
             last_pin_timestamp=last_pin_timestamp,
@@ -1213,7 +1210,6 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             name=channel_fields.name,
             type=channel_fields.type,
             guild_id=channel_fields.guild_id,
-            is_nsfw=channel_fields.is_nsfw,
             parent_id=channel_fields.parent_id,
             last_message_id=last_message_id,
             last_pin_timestamp=last_pin_timestamp,
@@ -1262,7 +1258,6 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             name=channel_fields.name,
             type=channel_fields.type,
             guild_id=channel_fields.guild_id,
-            is_nsfw=channel_fields.is_nsfw,
             parent_id=channel_fields.parent_id,
             last_message_id=last_message_id,
             last_pin_timestamp=last_pin_timestamp,

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -1670,7 +1670,7 @@ class TestEntityFactoryImpl:
             }
         )
         assert guild_category.parent_id is None
-        assert guild_category.is_nsfw is None
+        assert guild_category.is_nsfw is False
 
     def test_deserialize_guild_category_with_null_fields(self, entity_factory_impl, permission_overwrite_payload):
         guild_category = entity_factory_impl.deserialize_guild_category(
@@ -1723,7 +1723,7 @@ class TestEntityFactoryImpl:
                 "guild_id": "123123123",
             }
         )
-        assert guild_text_channel.is_nsfw is None
+        assert guild_text_channel.is_nsfw is False
         assert guild_text_channel.rate_limit_per_user.total_seconds() == 0
         assert guild_text_channel.last_pin_timestamp is None
         assert guild_text_channel.parent_id is None
@@ -1787,7 +1787,7 @@ class TestEntityFactoryImpl:
                 "guild_id": "4123",
             }
         )
-        assert news_channel.is_nsfw is None
+        assert news_channel.is_nsfw is False
         assert news_channel.parent_id is None
         assert news_channel.last_pin_timestamp is None
         assert news_channel.last_message_id is None
@@ -1869,7 +1869,7 @@ class TestEntityFactoryImpl:
         )
         assert voice_channel.video_quality_mode is channel_models.VideoQualityMode.AUTO
         assert voice_channel.parent_id is None
-        assert voice_channel.is_nsfw is None
+        assert voice_channel.is_nsfw is False
         assert voice_channel.region is None
 
     @pytest.fixture()
@@ -1941,7 +1941,7 @@ class TestEntityFactoryImpl:
             }
         )
         assert voice_channel.parent_id is None
-        assert voice_channel.is_nsfw is None
+        assert voice_channel.is_nsfw is False
 
     def test_deserialize_thread_member(
         self, entity_factory_impl: entity_factory.EntityFactoryImpl, thread_member_payload: typing.Dict[str, typing.Any]

--- a/tests/hikari/test_channels.py
+++ b/tests/hikari/test_channels.py
@@ -324,7 +324,6 @@ class TestGuildChannel:
             name="foo1",
             type=channels.ChannelType.GUILD_VOICE,
             guild_id=snowflakes.Snowflake(123456789),
-            is_nsfw=True,
             parent_id=None,
         )
 


### PR DESCRIPTION
### Summary
`is_nsfw` now also defaults to `False` when excluded from the payload. It seems like Discord will always send the nsfw field when it is set to `True`, but randomly exclude it when its `False`.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Closes #1328
