### PR TITLE
Run CI tests on `bash` to exit fast on error on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Test Installation
+        shell: bash
         run: |
           pip install -r dev-requirements/build.txt
 
@@ -39,6 +40,7 @@ jobs:
           pip uninstall -y hikari
 
       - name: Run tests
+        shell: bash
         run: |
           pip install -r dev-requirements/nox.txt
           nox -s pytest


### PR DESCRIPTION
Looks like windows is the odd-one-out again. https://github.com/actions/runner-images/issues/6668.

Been sitting on this for a while now so they would hopefully fix it, but it looks like its intended behavior. 