### PR TITLE
Add speedups with orjson

### DIFF
--- a/hikari/errors.py
+++ b/hikari/errors.py
@@ -317,7 +317,7 @@ class BadRequestError(ClientHTTPResponseError):
             try:
                 value += _dump_errors(self.errors).strip("\n")
             except KeyError:
-                value += data_binding.dump_json(self.errors, indent=2)
+                value += data_binding.dump_json(self.errors, indent=2).decode()
 
         self._cached_str = value
         return value

--- a/hikari/impl/interaction_server.py
+++ b/hikari/impl/interaction_server.py
@@ -142,7 +142,7 @@ class _Response:
 
 # Constant response
 _PONG_RESPONSE: typing.Final[_Response] = _Response(
-    _OK_STATUS, data_binding.dump_json({"type": _PONG_RESPONSE_TYPE}).encode(), content_type=_JSON_CONTENT_TYPE
+    _OK_STATUS, data_binding.dump_json({"type": _PONG_RESPONSE_TYPE}), content_type=_JSON_CONTENT_TYPE
 )
 
 
@@ -194,9 +194,11 @@ class InteractionServer(interaction_server.InteractionServer):
     Other Parameters
     ----------------
     dumps : aiohttp.typedefs.JSONEncoder
-        The JSON encoder this server should use. Defaults to `json.dumps`.
+        The JSON encoder this server should use. Defaults to `json.dumps`. If speedups are
+        installed, default to `orjson.dumps`.
     loads : aiohttp.typedefs.JSONDecoder
-        The JSON decoder this server should use. Defaults to `json.loads`.
+        The JSON decoder this server should use. Defaults to `json.loads`. If speedups are
+        installed, default to `orjson.loads`.
     public_key : bytes
         The public key this server should use for verifying request payloads from
         Discord. If left as `None` then the client will try to work this
@@ -224,7 +226,7 @@ class InteractionServer(interaction_server.InteractionServer):
     def __init__(
         self,
         *,
-        dumps: aiohttp.typedefs.JSONEncoder = data_binding.dump_json,
+        dumps: aiohttp.typedefs.JSONEncoder = lambda obj: data_binding.dump_json(obj).decode(),
         entity_factory: entity_factory_api.EntityFactory,
         executor: typing.Optional[concurrent.futures.Executor] = None,
         loads: aiohttp.typedefs.JSONDecoder = data_binding.load_json,

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -1457,7 +1457,9 @@ class RESTClientImpl(rest_api.RESTClient):
         body.put("message_reference", reply, conversion=lambda m: {"message_id": str(int(m))})
 
         if form_builder is not None:
-            form_builder.add_field("payload_json", data_binding.dump_json(body), content_type=_APPLICATION_JSON)
+            form_builder.add_field(
+                "payload_json", data_binding.dump_json(body).decode(), content_type=_APPLICATION_JSON
+            )
             response = await self._request(route, form_builder=form_builder)
         else:
             response = await self._request(route, json=body)
@@ -1523,7 +1525,9 @@ class RESTClientImpl(rest_api.RESTClient):
         )
 
         if form_builder is not None:
-            form_builder.add_field("payload_json", data_binding.dump_json(body), content_type=_APPLICATION_JSON)
+            form_builder.add_field(
+                "payload_json", data_binding.dump_json(body).decode(), content_type=_APPLICATION_JSON
+            )
             response = await self._request(route, form_builder=form_builder)
         else:
             response = await self._request(route, json=body)
@@ -1838,7 +1842,9 @@ class RESTClientImpl(rest_api.RESTClient):
         body.put("avatar_url", avatar_url, conversion=str)
 
         if form_builder is not None:
-            form_builder.add_field("payload_json", data_binding.dump_json(body), content_type=_APPLICATION_JSON)
+            form_builder.add_field(
+                "payload_json", data_binding.dump_json(body).decode(), content_type=_APPLICATION_JSON
+            )
             response = await self._request(route, form_builder=form_builder, query=query, auth=None)
         else:
             response = await self._request(route, json=body, query=query, auth=None)
@@ -1916,7 +1922,9 @@ class RESTClientImpl(rest_api.RESTClient):
         )
 
         if form_builder is not None:
-            form_builder.add_field("payload_json", data_binding.dump_json(body), content_type=_APPLICATION_JSON)
+            form_builder.add_field(
+                "payload_json", data_binding.dump_json(body).decode(), content_type=_APPLICATION_JSON
+            )
             response = await self._request(route, form_builder=form_builder, query=query, auth=None)
         else:
             response = await self._request(route, json=body, query=query, auth=None)
@@ -2855,7 +2863,9 @@ class RESTClientImpl(rest_api.RESTClient):
         body.put("message", message_body)
 
         if form_builder is not None:
-            form_builder.add_field("payload_json", data_binding.dump_json(body), content_type=_APPLICATION_JSON)
+            form_builder.add_field(
+                "payload_json", data_binding.dump_json(body).decode(), content_type=_APPLICATION_JSON
+            )
             response = await self._request(route, form_builder=form_builder, reason=reason)
         else:
             response = await self._request(route, json=body, reason=reason)
@@ -3930,7 +3940,7 @@ class RESTClientImpl(rest_api.RESTClient):
         body.put("data", data)
 
         if form is not None:
-            form.add_field("payload_json", data_binding.dump_json(body), content_type=_APPLICATION_JSON)
+            form.add_field("payload_json", data_binding.dump_json(body).decode(), content_type=_APPLICATION_JSON)
             await self._request(route, form_builder=form, auth=None)
         else:
             await self._request(route, json=body, auth=None)
@@ -3978,7 +3988,9 @@ class RESTClientImpl(rest_api.RESTClient):
         )
 
         if form_builder is not None:
-            form_builder.add_field("payload_json", data_binding.dump_json(body), content_type=_APPLICATION_JSON)
+            form_builder.add_field(
+                "payload_json", data_binding.dump_json(body).decode(), content_type=_APPLICATION_JSON
+            )
             response = await self._request(route, form_builder=form_builder, auth=None)
         else:
             response = await self._request(route, json=body, auth=None)

--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -195,10 +195,10 @@ class _GatewayTransport:
     async def send_json(self, data: data_binding.JSONObject) -> None:
         pl = data_binding.dump_json(data)
         if self._logger.isEnabledFor(ux.TRACE):
-            filtered = self._log_filterer(pl)
+            filtered = self._log_filterer(pl.decode())
             self._logger.log(ux.TRACE, "sending payload with size %s\n    %s", len(pl), filtered)
 
-        await self._ws.send_str(pl)
+        await self._ws.send_bytes(pl)
 
     def _handle_other_message(self, message: aiohttp.WSMessage, /) -> typing.NoReturn:
         if message.type == aiohttp.WSMsgType.TEXT:

--- a/hikari/internal/data_binding.py
+++ b/hikari/internal/data_binding.py
@@ -109,7 +109,8 @@ else:
 
         JSONDecodeError = json.JSONDecodeError
 
-        def dump_json(obj: typing.Union[JSONArray, JSONObject], **kwargs: typing.Any) -> bytes:
+        def dump_json(obj: typing.Union[JSONArray, JSONObject], **kwargs: typing.Any) -> bytes:  # noqa: D103
+            # First definition already has docstring.
             return json.dumps(obj, **kwargs).encode("UTF-8")
 
         load_json = json.loads

--- a/speedup-requirements.txt
+++ b/speedup-requirements.txt
@@ -1,2 +1,3 @@
 aiohttp[speedups]~=3.8
 ciso8601~=2.3
+orjson~=3.8.4

--- a/tests/hikari/impl/test_shard.py
+++ b/tests/hikari/impl/test_shard.py
@@ -177,13 +177,13 @@ class TestGatewayTransport:
     @pytest.mark.asyncio()
     @pytest.mark.parametrize("trace", [True, False])
     async def test_send_json(self, transport_impl, trace):
-        transport_impl._ws.send_str = mock.AsyncMock()
+        transport_impl._ws.send_bytes = mock.AsyncMock()
         transport_impl._logger = mock.Mock(enabled_for=mock.Mock(return_value=trace))
 
         with mock.patch.object(data_binding, "dump_json") as dump_json:
             await transport_impl.send_json({"json_send": None})
 
-        transport_impl._ws.send_str.assert_awaited_once_with(dump_json.return_value)
+        transport_impl._ws.send_bytes.assert_awaited_once_with(dump_json.return_value)
         dump_json.assert_called_once_with({"json_send": None})
 
     @pytest.mark.asyncio()


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

This is a draft of adding speedups with orjson. This PR changes `data_binding.dump_json` to return a bytes object because I thought that was a good idea because it fits with orjson better. Casting the result of `orjson.dumps` to a string takes extremely long.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
