### PR TITLE
Pass strings instead of bytes to add_field for payload_json

### DIFF
--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -1505,7 +1505,7 @@ class RESTClientImpl(rest_api.RESTClient):
             body.put("message_reference", message_reference)
 
         if form_builder is not None:
-            form_builder.add_field("payload_json", self._dumps(body), content_type=_APPLICATION_JSON)
+            form_builder.add_field("payload_json", self._dumps(body).decode(), content_type=_APPLICATION_JSON)
             response = await self._request(route, form_builder=form_builder)
         else:
             response = await self._request(route, json=body)
@@ -1571,7 +1571,7 @@ class RESTClientImpl(rest_api.RESTClient):
         )
 
         if form_builder is not None:
-            form_builder.add_field("payload_json", self._dumps(body), content_type=_APPLICATION_JSON)
+            form_builder.add_field("payload_json", self._dumps(body).decode(), content_type=_APPLICATION_JSON)
             response = await self._request(route, form_builder=form_builder)
         else:
             response = await self._request(route, json=body)
@@ -1886,7 +1886,7 @@ class RESTClientImpl(rest_api.RESTClient):
         body.put("avatar_url", avatar_url, conversion=str)
 
         if form_builder is not None:
-            form_builder.add_field("payload_json", self._dumps(body), content_type=_APPLICATION_JSON)
+            form_builder.add_field("payload_json", self._dumps(body).decode(), content_type=_APPLICATION_JSON)
             response = await self._request(route, form_builder=form_builder, query=query, auth=None)
         else:
             response = await self._request(route, json=body, query=query, auth=None)
@@ -1964,7 +1964,7 @@ class RESTClientImpl(rest_api.RESTClient):
         )
 
         if form_builder is not None:
-            form_builder.add_field("payload_json", self._dumps(body), content_type=_APPLICATION_JSON)
+            form_builder.add_field("payload_json", self._dumps(body).decode(), content_type=_APPLICATION_JSON)
             response = await self._request(route, form_builder=form_builder, query=query, auth=None)
         else:
             response = await self._request(route, json=body, query=query, auth=None)
@@ -2903,7 +2903,7 @@ class RESTClientImpl(rest_api.RESTClient):
         body.put("message", message_body)
 
         if form_builder is not None:
-            form_builder.add_field("payload_json", self._dumps(body), content_type=_APPLICATION_JSON)
+            form_builder.add_field("payload_json", self._dumps(body).decode(), content_type=_APPLICATION_JSON)
             response = await self._request(route, form_builder=form_builder, reason=reason)
         else:
             response = await self._request(route, json=body, reason=reason)
@@ -3978,7 +3978,7 @@ class RESTClientImpl(rest_api.RESTClient):
         body.put("data", data)
 
         if form is not None:
-            form.add_field("payload_json", self._dumps(body), content_type=_APPLICATION_JSON)
+            form.add_field("payload_json", self._dumps(body).decode(), content_type=_APPLICATION_JSON)
             await self._request(route, form_builder=form, auth=None)
         else:
             await self._request(route, json=body, auth=None)
@@ -4026,7 +4026,7 @@ class RESTClientImpl(rest_api.RESTClient):
         )
 
         if form_builder is not None:
-            form_builder.add_field("payload_json", self._dumps(body), content_type=_APPLICATION_JSON)
+            form_builder.add_field("payload_json", self._dumps(body).decode(), content_type=_APPLICATION_JSON)
             response = await self._request(route, form_builder=form_builder, auth=None)
         else:
             response = await self._request(route, json=body, auth=None)

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -2573,7 +2573,7 @@ class TestRESTClientImplAsync:
         )
         mock_form.add_field.assert_called_once_with(
             "payload_json",
-            b'{"testing":"ensure_in_test","message_reference":{"message_id":"987654321","fail_if_not_exists":false}}',
+            '{"testing":"ensure_in_test","message_reference":{"message_id":"987654321","fail_if_not_exists":false}}',
             content_type="application/json",
         )
         rest_client._request.assert_awaited_once_with(expected_route, form_builder=mock_form)
@@ -2696,7 +2696,7 @@ class TestRESTClientImplAsync:
             edit=True,
         )
         mock_form.add_field.assert_called_once_with(
-            "payload_json", b'{"testing":"ensure_in_test"}', content_type="application/json"
+            "payload_json", '{"testing":"ensure_in_test"}', content_type="application/json"
         )
         rest_client._request.assert_awaited_once_with(expected_route, form_builder=mock_form)
         rest_client._entity_factory.deserialize_message.assert_called_once_with({"message_id": 123})
@@ -3172,7 +3172,7 @@ class TestRESTClientImplAsync:
         )
         mock_form.add_field.assert_called_once_with(
             "payload_json",
-            b'{"testing":"ensure_in_test","username":"davfsa","avatar_url":"https://website.com/davfsa_logo"}',
+            '{"testing":"ensure_in_test","username":"davfsa","avatar_url":"https://website.com/davfsa_logo"}',
             content_type="application/json",
         )
         rest_client._request.assert_awaited_once_with(
@@ -3211,7 +3211,7 @@ class TestRESTClientImplAsync:
             role_mentions=undefined.UNDEFINED,
         )
         mock_form.add_field.assert_called_once_with(
-            "payload_json", b'{"testing":"ensure_in_test"}', content_type="application/json"
+            "payload_json", '{"testing":"ensure_in_test"}', content_type="application/json"
         )
         rest_client._request.assert_awaited_once_with(
             expected_route,
@@ -3382,7 +3382,7 @@ class TestRESTClientImplAsync:
             edit=True,
         )
         mock_form.add_field.assert_called_once_with(
-            "payload_json", b'{"testing":"ensure_in_test"}', content_type="application/json"
+            "payload_json", '{"testing":"ensure_in_test"}', content_type="application/json"
         )
         rest_client._request.assert_awaited_once_with(expected_route, form_builder=mock_form, query={}, auth=None)
         rest_client._entity_factory.deserialize_message.assert_called_once_with({"message_id": 123})
@@ -3414,7 +3414,7 @@ class TestRESTClientImplAsync:
             edit=True,
         )
         mock_form.add_field.assert_called_once_with(
-            "payload_json", b'{"testing":"ensure_in_test"}', content_type="application/json"
+            "payload_json", '{"testing":"ensure_in_test"}', content_type="application/json"
         )
         rest_client._request.assert_awaited_once_with(
             expected_route, form_builder=mock_form, query={"thread_id": "123543123"}, auth=None
@@ -4786,8 +4786,8 @@ class TestRESTClientImplAsync:
 
         mock_form.add_field.assert_called_once_with(
             "payload_json",
-            b'{"name":"Post with secret content!","auto_archive_duration":54123,"rate_limit_per_user":101,'
-            b'"applied_tags":["12220","12201"],"message":{"mock":"message body"}}',
+            '{"name":"Post with secret content!","auto_archive_duration":54123,"rate_limit_per_user":101,'
+            '"applied_tags":["12220","12201"],"message":{"mock":"message body"}}',
             content_type="application/json",
         )
 
@@ -5983,7 +5983,7 @@ class TestRESTClientImplAsync:
             role_mentions=[1234],
         )
         mock_form.add_field.assert_called_once_with(
-            "payload_json", b'{"type":1,"data":{"testing":"ensure_in_test"}}', content_type="application/json"
+            "payload_json", '{"type":1,"data":{"testing":"ensure_in_test"}}', content_type="application/json"
         )
         rest_client._request.assert_awaited_once_with(expected_route, form_builder=mock_form, auth=None)
 
@@ -6080,7 +6080,7 @@ class TestRESTClientImplAsync:
             edit=True,
         )
         mock_form.add_field.assert_called_once_with(
-            "payload_json", b'{"testing":"ensure_in_test"}', content_type="application/json"
+            "payload_json", '{"testing":"ensure_in_test"}', content_type="application/json"
         )
         rest_client._request.assert_awaited_once_with(expected_route, form_builder=mock_form, auth=None)
         rest_client._entity_factory.deserialize_message.assert_called_once_with({"message_id": 123})


### PR DESCRIPTION
### Summary
Passing bytes here leads to add_field treating the field as files and setting the filename to payload_json Discord will then treat this as an attachment/file rather than as the actual json payload.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
