### PR TITLE
Add suppress_notifications bit flag to MessageFlag

### DIFF
--- a/changes/1504.feature.md
+++ b/changes/1504.feature.md
@@ -1,0 +1,1 @@
+Add and document the new `SUPPRESS_NOTIFICATIONS` message flag.

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -1116,7 +1116,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             `hikari.undefined.UNDEFINED`, then nothing is changed.
 
             Note that some flags may not be able to be set. Currently the only
-            flags that can be set are `NONE` and `SUPPRESS_EMBEDS`.
+            flags that can be set are `SUPPRESS_NOTIFICATIONS` and
+            `SUPPRESS_EMBEDS`.
 
         Returns
         -------
@@ -2023,8 +2024,12 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         """Execute a webhook.
 
         .. warning::
-            As of writing, `username` and `avatar_url` are ignored for
+            At the time of writing, `username` and `avatar_url` are ignored for
             interaction webhooks.
+
+            Additionally, flags this can only be set for interaction webhooks
+            and the only settable flag is `EPHEMERAL`; this field is just
+            ignored for non-interaction webhooks.
 
         Parameters
         ----------
@@ -2127,11 +2132,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             specific roles.
         flags : typing.Union[hikari.undefined.UndefinedType, int, hikari.messages.MessageFlag]
             The flags to set for this webhook message.
-
-            .. warning::
-                As of writing this can only be set for interaction webhooks
-                and the only settable flags are `EPHEMERAL` and `SUPPRESS_NOTIFICATIONS`;
-                this field is just ignored for non-interaction webhooks.
 
         Returns
         -------

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -2027,9 +2027,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             At the time of writing, `username` and `avatar_url` are ignored for
             interaction webhooks.
 
-            Additionally, flags this can only be set for interaction webhooks
-            and the only settable flag is `EPHEMERAL`; this field is just
-            ignored for non-interaction webhooks.
+            Additionally, only `SUPPRESS_EMBEDS`, `SUPPRESS_NOTIFICATIONS` and `EPHEMERAL`
+            are the only flags that can be set, with `EPHEMERAL` limited to
+            interaction webhooks.
 
         Parameters
         ----------
@@ -7437,8 +7437,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         flags : typing.Union[int, hikari.messages.MessageFlag, hikari.undefined.UndefinedType]
             If provided, the message flags this response should have.
 
-            As of writing the only message flags that can be set here is
-            `hikari.messages.MessageFlag.EPHEMERAL` and `hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`.
+            As of writing the only message flags that can be set here are
+            `hikari.messages.MessageFlag.EPHEMERAL`, `hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`
+            and `hikari.messages.MessageFlag.SUPPRESS_EMBEDS`.
         tts : hikari.undefined.UndefinedOr[bool]
             If provided, whether the message will be read out by a screen
             reader using Discord's TTS (text-to-speech) system.

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -2027,7 +2027,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             At the time of writing, `username` and `avatar_url` are ignored for
             interaction webhooks.
 
-            Additionally, only `SUPPRESS_EMBEDS`, `SUPPRESS_NOTIFICATIONS` and `EPHEMERAL`
+            Additionally, `SUPPRESS_EMBEDS`, `SUPPRESS_NOTIFICATIONS` and `EPHEMERAL`
             are the only flags that can be set, with `EPHEMERAL` limited to
             interaction webhooks.
 
@@ -7437,7 +7437,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         flags : typing.Union[int, hikari.messages.MessageFlag, hikari.undefined.UndefinedType]
             If provided, the message flags this response should have.
 
-            As of writing the only message flags that can be set here are
+            As of writing the only message flags which can be set here are
             `hikari.messages.MessageFlag.EPHEMERAL`, `hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`
             and `hikari.messages.MessageFlag.SUPPRESS_EMBEDS`.
         tts : hikari.undefined.UndefinedOr[bool]

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -2130,8 +2130,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
             .. warning::
                 As of writing this can only be set for interaction webhooks
-                and the only settable flag is `EPHEMERAL`; this field is just
-                ignored for non-interaction webhooks.
+                and the only settable flags are `EPHEMERAL` and `SUPPRESS_NOTIFICATIONS`;
+                this field is just ignored for non-interaction webhooks.
 
         Returns
         -------
@@ -7437,8 +7437,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         flags : typing.Union[int, hikari.messages.MessageFlag, hikari.undefined.UndefinedType]
             If provided, the message flags this response should have.
 
-            As of writing the only message flag which can be set here is
-            `hikari.messages.MessageFlag.EPHEMERAL`.
+            As of writing the only message flags that can be set here is
+            `hikari.messages.MessageFlag.EPHEMERAL` and `hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`.
         tts : hikari.undefined.UndefinedOr[bool]
             If provided, whether the message will be read out by a screen
             reader using Discord's TTS (text-to-speech) system.

--- a/hikari/api/special_endpoints.py
+++ b/hikari/api/special_endpoints.py
@@ -653,7 +653,7 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
         """Message flags this response should have.
 
         .. note::
-            As of writing the only message flag which can be set here are
+            As of writing the only message flags which can be set here are
             `hikari.messages.MessageFlag.EPHEMERAL`,
             `hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`
             and `hikari.messages.MessageFlag.SUPRESS_EMBEDS`.
@@ -771,7 +771,7 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
         """Set message flags for this response.
 
         .. note::
-            As of writing, the only message flag which can be set is
+            As of writing, the only message flags which can be set is
             `hikari.messages.MessageFlag.EPHEMERAL` and `hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`..
 
         Parameters

--- a/hikari/api/special_endpoints.py
+++ b/hikari/api/special_endpoints.py
@@ -559,8 +559,9 @@ class InteractionDeferredBuilder(InteractionResponseBuilder, abc.ABC):
         """Message flags this response should have.
 
         .. note::
-            As of writing the only message flags which can be set here is
-            `hikari.messages.MessageFlag.EPHEMERAL` and `hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`.
+            As of writing the only message flags which can be set here are
+            `hikari.messages.MessageFlag.EPHEMERAL`, `hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`
+            and `hikari.messages.MessageFlag.SUPRESS_EMBEDS`.
         """
 
     @abc.abstractmethod
@@ -568,8 +569,9 @@ class InteractionDeferredBuilder(InteractionResponseBuilder, abc.ABC):
         """Set message flags for this response.
 
         .. note::
-            As of writing, the only message flags which can be set is `hikari.messages.MessageFlag.EPHEMERAL`
-            and `hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`.
+            As of writing, the only message flags which can be set are `hikari.messages.MessageFlag.EPHEMERAL`
+            `hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS` and
+            `hikari.messages.MessageFlag.SUPRESS_EMBEDS`.
 
         Parameters
         ----------
@@ -651,8 +653,10 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
         """Message flags this response should have.
 
         .. note::
-            As of writing the only message flag which can be set here is
-            `hikari.messages.MessageFlag.EPHEMERAL` and `hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`.
+            As of writing the only message flag which can be set here are
+            `hikari.messages.MessageFlag.EPHEMERAL`,
+            `hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`
+            and `hikari.messages.MessageFlag.SUPRESS_EMBEDS`.
         """
 
     @property

--- a/hikari/api/special_endpoints.py
+++ b/hikari/api/special_endpoints.py
@@ -559,8 +559,8 @@ class InteractionDeferredBuilder(InteractionResponseBuilder, abc.ABC):
         """Message flags this response should have.
 
         .. note::
-            As of writing the only message flag which can be set here is
-            `hikari.messages.MessageFlag.EPHEMERAL`.
+            As of writing the only message flags which can be set here is
+            `hikari.messages.MessageFlag.EPHEMERAL` and `hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`.
         """
 
     @abc.abstractmethod
@@ -568,7 +568,8 @@ class InteractionDeferredBuilder(InteractionResponseBuilder, abc.ABC):
         """Set message flags for this response.
 
         .. note::
-            As of writing, the only message flag which can be set is `hikari.messages.MessageFlag.EPHEMERAL`.
+            As of writing, the only message flags which can be set is `hikari.messages.MessageFlag.EPHEMERAL`
+            and `hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`.
 
         Parameters
         ----------
@@ -651,7 +652,7 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
 
         .. note::
             As of writing the only message flag which can be set here is
-            `hikari.messages.MessageFlag.EPHEMERAL`.
+            `hikari.messages.MessageFlag.EPHEMERAL` and `hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`.
         """
 
     @property
@@ -767,7 +768,7 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
 
         .. note::
             As of writing, the only message flag which can be set is
-            `hikari.messages.MessageFlag.EPHEMERAL`..
+            `hikari.messages.MessageFlag.EPHEMERAL` and `hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`..
 
         Parameters
         ----------

--- a/hikari/interactions/base_interactions.py
+++ b/hikari/interactions/base_interactions.py
@@ -308,8 +308,8 @@ class MessageResponseMixin(PartialInteraction, typing.Generic[_CommandResponseTy
         flags : typing.Union[int, hikari.messages.MessageFlag, hikari.undefined.UndefinedType]
             If provided, the message flags this response should have.
 
-            As of writing the only message flag which can be set here is
-            `hikari.messages.MessageFlag.EPHEMERAL`.
+            As of writing the only message flags which can be set here is
+            `hikari.messages.MessageFlag.EPHEMERAL` and `hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`.
         tts : hikari.undefined.UndefinedOr[bool]
             If provided, whether the message will be read out by a screen
             reader using Discord's TTS (text-to-speech) system.

--- a/hikari/interactions/base_interactions.py
+++ b/hikari/interactions/base_interactions.py
@@ -308,8 +308,9 @@ class MessageResponseMixin(PartialInteraction, typing.Generic[_CommandResponseTy
         flags : typing.Union[int, hikari.messages.MessageFlag, hikari.undefined.UndefinedType]
             If provided, the message flags this response should have.
 
-            As of writing the only message flags which can be set here is
-            `hikari.messages.MessageFlag.EPHEMERAL` and `hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`.
+            As of writing the only message flags that can be set here are
+            `hikari.messages.MessageFlag.EPHEMERAL`, `hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`
+            and `hikari.messages.MessageFlag.SUPPRESS_EMBEDS`.
         tts : hikari.undefined.UndefinedOr[bool]
             If provided, whether the message will be read out by a screen
             reader using Discord's TTS (text-to-speech) system.

--- a/hikari/interactions/base_interactions.py
+++ b/hikari/interactions/base_interactions.py
@@ -308,7 +308,7 @@ class MessageResponseMixin(PartialInteraction, typing.Generic[_CommandResponseTy
         flags : typing.Union[int, hikari.messages.MessageFlag, hikari.undefined.UndefinedType]
             If provided, the message flags this response should have.
 
-            As of writing the only message flags that can be set here are
+            As of writing the only message flags which can be set here are
             `hikari.messages.MessageFlag.EPHEMERAL`, `hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`
             and `hikari.messages.MessageFlag.SUPPRESS_EMBEDS`.
         tts : hikari.undefined.UndefinedOr[bool]

--- a/hikari/messages.py
+++ b/hikari/messages.py
@@ -165,6 +165,9 @@ class MessageFlag(enums.Flag):
     FAILED_TO_MENTION_SOME_ROLES_IN_THREAD = 1 << 8
     """This message failed to mention some roles and add their mentions to the thread."""
 
+    SUPPRESS_NOTIFICATIONS = 1 << 12
+    """This message will not trigger push and desktop notifications."""
+
 
 @typing.final
 class MessageActivityType(int, enums.Enum):

--- a/hikari/webhooks.py
+++ b/hikari/webhooks.py
@@ -125,7 +125,7 @@ class ExecutableWebhook(abc.ABC):
             At the time of writing, `username` and `avatar_url` are ignored for
             interaction webhooks.
 
-            Additionally, only `SUPPRESS_EMBEDS`, `SUPPRESS_NOTIFICATIONS` and `EPHEMERAL`
+            Additionally, `SUPPRESS_EMBEDS`, `SUPPRESS_NOTIFICATIONS` and `EPHEMERAL`
             are the only flags that can be set, with `EPHEMERAL` limited to
             interaction webhooks.
 

--- a/hikari/webhooks.py
+++ b/hikari/webhooks.py
@@ -126,8 +126,8 @@ class ExecutableWebhook(abc.ABC):
             interaction webhooks.
 
             Additionally, flags this can only be set for interaction webhooks
-            and the only settable flag is EPHEMERAL and SUPPRESS_NOTIFICATIONS;
-            this field is just ignored for non-interaction webhooks.
+            and the only settable flag is `EPHEMERAL`; this field is just
+            ignored for non-interaction webhooks.
 
         Parameters
         ----------

--- a/hikari/webhooks.py
+++ b/hikari/webhooks.py
@@ -125,9 +125,9 @@ class ExecutableWebhook(abc.ABC):
             At the time of writing, `username` and `avatar_url` are ignored for
             interaction webhooks.
 
-            Additionally, flags this can only be set for interaction webhooks
-            and the only settable flag is `EPHEMERAL`; this field is just
-            ignored for non-interaction webhooks.
+            Additionally, only `SUPPRESS_EMBEDS`, `SUPPRESS_NOTIFICATIONS` and `EPHEMERAL`
+            are the only flags that can be set, with `EPHEMERAL` limited to
+            interaction webhooks.
 
         Parameters
         ----------

--- a/hikari/webhooks.py
+++ b/hikari/webhooks.py
@@ -126,8 +126,8 @@ class ExecutableWebhook(abc.ABC):
             interaction webhooks.
 
             Additionally, flags this can only be set for interaction webhooks
-            and the only settable flag is EPHEMERAL; this field is just
-            ignored for non-interaction webhooks.
+            and the only settable flag is EPHEMERAL and SUPPRESS_NOTIFICATIONS;
+            this field is just ignored for non-interaction webhooks.
 
         Parameters
         ----------


### PR DESCRIPTION
### Summary
This PR adds and documents the new [`SUPPRESS_NOTIFICATIONS`](https://github.com/discord/discord-api-docs/commit/dd3f05a1709add398bac3a68af3cc27287f67038) bitwise flag supported on various message response methods.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
  - Just want to note that flake8 failed due to docstrings (not mine) being written in a way flake8 doesn't like
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
