### PR TITLE
Remove `merge_group` trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   push:
   pull_request:
-  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,7 +5,6 @@ on:
     branches-ignore:
       - "dependabot/**"
   pull_request:
-  merge_group:
   schedule:
     - cron: "0 0 * * *" # Every day at 00:00
 


### PR DESCRIPTION
### Summary
For the looks of it, `push` will also be fired on merge groups, which will conflict and cancel the tasks