### PR TITLE
Use abstractmethods for protocols 

### DIFF
--- a/changes/1516.feature.md
+++ b/changes/1516.feature.md
@@ -1,0 +1,1 @@
+Traits now use `abc.abstractmethod`. This gives better type errors.

--- a/hikari/traits.py
+++ b/hikari/traits.py
@@ -40,6 +40,7 @@ __all__: typing.Sequence[str] = (
     "VoiceAware",
 )
 
+import abc
 import typing
 
 from hikari import presences
@@ -75,11 +76,13 @@ class NetworkSettingsAware(fast_protocol.FastProtocolChecking, typing.Protocol):
     __slots__: typing.Sequence[str] = ()
 
     @property
+    @abc.abstractmethod
     def http_settings(self) -> config.HTTPSettings:
         """HTTP settings in use by this component."""
         raise NotImplementedError
 
     @property
+    @abc.abstractmethod
     def proxy_settings(self) -> config.ProxySettings:
         """Proxy settings in use by this component."""
         raise NotImplementedError
@@ -95,6 +98,7 @@ class EventManagerAware(fast_protocol.FastProtocolChecking, typing.Protocol):
     __slots__: typing.Sequence[str] = ()
 
     @property
+    @abc.abstractmethod
     def event_manager(self) -> event_manager_.EventManager:
         """Event manager for this object."""
         raise NotImplementedError
@@ -110,6 +114,7 @@ class EntityFactoryAware(fast_protocol.FastProtocolChecking, typing.Protocol):
     __slots__: typing.Sequence[str] = ()
 
     @property
+    @abc.abstractmethod
     def entity_factory(self) -> entity_factory_.EntityFactory:
         """Entity factory implementation for this object."""
         raise NotImplementedError
@@ -127,6 +132,7 @@ class ExecutorAware(fast_protocol.FastProtocolChecking, typing.Protocol):
     __slots__: typing.Sequence[str] = ()
 
     @property
+    @abc.abstractmethod
     def executor(self) -> typing.Optional[futures.Executor]:
         """Executor to use for blocking operations.
 
@@ -146,6 +152,7 @@ class EventFactoryAware(fast_protocol.FastProtocolChecking, typing.Protocol):
     __slots__: typing.Sequence[str] = ()
 
     @property
+    @abc.abstractmethod
     def event_factory(self) -> event_factory_.EventFactory:
         """Event factory component."""
         raise NotImplementedError
@@ -158,6 +165,7 @@ class IntentsAware(fast_protocol.FastProtocolChecking, typing.Protocol):
     __slots__: typing.Sequence[str] = ()
 
     @property
+    @abc.abstractmethod
     def intents(self) -> intents_.Intents:
         """Intents registered for the application."""
         raise NotImplementedError
@@ -175,6 +183,7 @@ class RESTAware(
     __slots__: typing.Sequence[str] = ()
 
     @property
+    @abc.abstractmethod
     def rest(self) -> rest_.RESTClient:
         """REST client to use for HTTP requests."""
         raise NotImplementedError
@@ -191,6 +200,7 @@ class VoiceAware(fast_protocol.FastProtocolChecking, typing.Protocol):
     __slots__: typing.Sequence[str] = ()
 
     @property
+    @abc.abstractmethod
     def voice(self) -> voice_.VoiceComponent:
         """Voice connection manager component for this application."""
         raise NotImplementedError
@@ -214,6 +224,7 @@ class ShardAware(
     __slots__: typing.Sequence[str] = ()
 
     @property
+    @abc.abstractmethod
     def heartbeat_latencies(self) -> typing.Mapping[int, float]:
         """Mapping of shard ID to heartbeat latency.
 
@@ -222,6 +233,7 @@ class ShardAware(
         raise NotImplementedError
 
     @property
+    @abc.abstractmethod
     def heartbeat_latency(self) -> float:
         """Average heartbeat latency of all started shards.
 
@@ -230,6 +242,7 @@ class ShardAware(
         raise NotImplementedError
 
     @property
+    @abc.abstractmethod
     def shards(self) -> typing.Mapping[int, gateway_shard.GatewayShard]:
         """Mapping of shards in this application instance.
 
@@ -241,6 +254,7 @@ class ShardAware(
         raise NotImplementedError
 
     @property
+    @abc.abstractmethod
     def shard_count(self) -> int:
         """Number of shards in the total application.
 
@@ -249,6 +263,7 @@ class ShardAware(
         """
         raise NotImplementedError
 
+    @abc.abstractmethod
     def get_me(self) -> typing.Optional[users_.OwnUser]:
         """Return the bot user, if known.
 
@@ -264,6 +279,7 @@ class ShardAware(
         """
         raise NotImplementedError
 
+    @abc.abstractmethod
     async def update_presence(
         self,
         *,
@@ -308,6 +324,7 @@ class ShardAware(
         """
         raise NotImplementedError
 
+    @abc.abstractmethod
     async def update_voice_state(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
@@ -340,6 +357,7 @@ class ShardAware(
             client.
         """
 
+    @abc.abstractmethod
     async def request_guild_members(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
@@ -395,6 +413,7 @@ class InteractionServerAware(RESTAware, EntityFactoryAware, fast_protocol.FastPr
     __slots__: typing.Sequence[str] = ()
 
     @property
+    @abc.abstractmethod
     def interaction_server(self) -> interaction_server_.InteractionServer:
         """Interaction server this app is bound to."""
         raise NotImplementedError
@@ -410,6 +429,7 @@ class CacheAware(fast_protocol.FastProtocolChecking, typing.Protocol):
     __slots__: typing.Sequence[str] = ()
 
     @property
+    @abc.abstractmethod
     def cache(self) -> cache_.Cache:
         """Immutable cache implementation for this object."""
         raise NotImplementedError
@@ -422,6 +442,7 @@ class Runnable(fast_protocol.FastProtocolChecking, typing.Protocol):
     __slots__: typing.Sequence[str] = ()
 
     @property
+    @abc.abstractmethod
     def is_alive(self) -> bool:
         """Whether the application is running or not.
 
@@ -431,9 +452,11 @@ class Runnable(fast_protocol.FastProtocolChecking, typing.Protocol):
         """
         raise NotImplementedError
 
+    @abc.abstractmethod
     async def close(self) -> None:
         """Kill the application by shutting all components down."""
 
+    @abc.abstractmethod
     async def join(self) -> None:
         """Wait indefinitely until the application closes.
 
@@ -443,10 +466,12 @@ class Runnable(fast_protocol.FastProtocolChecking, typing.Protocol):
         """
         raise NotImplementedError
 
+    @abc.abstractmethod
     def run(self) -> None:
         """Start the application and block until it's finished running."""
         raise NotImplementedError
 
+    @abc.abstractmethod
     async def start(self) -> None:
         """Start the application and then return."""
         raise NotImplementedError
@@ -475,6 +500,7 @@ class RESTBotAware(InteractionServerAware, Runnable, fast_protocol.FastProtocolC
     __slots__: typing.Sequence[str] = ()
 
     @property
+    @abc.abstractmethod
     def on_shutdown(
         self,
     ) -> typing.Sequence[typing.Callable[[Self], typing.Coroutine[typing.Any, typing.Any, None]]]:
@@ -482,12 +508,14 @@ class RESTBotAware(InteractionServerAware, Runnable, fast_protocol.FastProtocolC
         raise NotImplementedError
 
     @property
+    @abc.abstractmethod
     def on_startup(
         self,
     ) -> typing.Sequence[typing.Callable[[Self], typing.Coroutine[typing.Any, typing.Any, None]]]:
         """Sequence of the bot's asynchronous startup callbacks."""
         raise NotImplementedError
 
+    @abc.abstractmethod
     def add_shutdown_callback(
         self, callback: typing.Callable[[RESTBotAware], typing.Coroutine[typing.Any, typing.Any, None]], /
     ) -> None:
@@ -500,6 +528,7 @@ class RESTBotAware(InteractionServerAware, Runnable, fast_protocol.FastProtocolC
         """
         raise NotImplementedError
 
+    @abc.abstractmethod
     def remove_shutdown_callback(
         self, callback: typing.Callable[[RESTBotAware], typing.Coroutine[typing.Any, typing.Any, None]], /
     ) -> None:
@@ -517,6 +546,7 @@ class RESTBotAware(InteractionServerAware, Runnable, fast_protocol.FastProtocolC
         """
         raise NotImplementedError
 
+    @abc.abstractmethod
     def add_startup_callback(
         self, callback: typing.Callable[[RESTBotAware], typing.Coroutine[typing.Any, typing.Any, None]], /
     ) -> None:
@@ -529,6 +559,7 @@ class RESTBotAware(InteractionServerAware, Runnable, fast_protocol.FastProtocolC
         """
         raise NotImplementedError
 
+    @abc.abstractmethod
     def remove_startup_callback(
         self, callback: typing.Callable[[RESTBotAware], typing.Coroutine[typing.Any, typing.Any, None]], /
     ) -> None:


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

Methods in protocols can be annotated with `abc.abstractmethod` to give better type errors. [PEP 544](https://peps.python.org/pep-0544/#explicitly-declaring-implementation)

In practice (tested with Mypy)
```python
import abc
import typing


class Proto(typing.Protocol):
    def function(self) -> None:
        raise NotImplementedError


class ProtoAbstract(typing.Protocol):
    @abc.abstractmethod
    def function(self) -> None:
        raise NotImplementedError


class Cls(Proto):
    ...

Cls()  # this does not give a type error


class Cls2(ProtoAbstract):
    ...

Cls2()  # this does
```

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
