### PR TITLE
Correct seconds to minutes in docs for auto_archive_duration

### DIFF
--- a/changes/1530.doc.md
+++ b/changes/1530.doc.md
@@ -1,0 +1,1 @@
+Corrects seconds to minutes in docs for auto_archive_duration

--- a/changes/1530.doc.md
+++ b/changes/1530.doc.md
@@ -1,1 +1,0 @@
-Corrects seconds to minutes in docs for auto_archive_duration

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -265,7 +265,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If provided, the auto archive duration Discord's end user client
             should default to when creating threads in this channel.
 
-            This should be either 60, 1440, 4320 or 10080 seconds and, as of
+            This should be either 60, 1440, 4320 or 10080 minutes and, as of
             writing, ignores the parent channel's set default_auto_archive_duration
             when passed as `hikari.undefined.UNDEFINED`.
         default_thread_rate_limit_per_user : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
@@ -300,7 +300,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If provided, the new auto archive duration for this thread. This
             only applies to threads.
 
-            This should be either 60, 1440, 4320 or 10080 seconds, as of
+            This should be either 60, 1440, 4320 or 10080 minutes, as of
             writing.
         applied_tags : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.ForumTag]]
             If provided, the new tags to apply to the thread. This only applies
@@ -4056,7 +4056,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If provided, the auto archive duration Discord's end user client
             should default to when creating threads in this channel.
 
-            This should be either 60, 1440, 4320 or 10080 seconds and, as of
+            This should be either 60, 1440, 4320 or 10080 minutes and, as of
             writing, ignores the parent channel's set default_auto_archive_duration
             when passed as `hikari.undefined.UNDEFINED`.
         reason : hikari.undefined.UndefinedOr[str]
@@ -4134,7 +4134,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If provided, the auto archive duration Discord's end user client
             should default to when creating threads in this channel.
 
-            This should be either 60, 1440, 4320 or 10080 seconds and, as of
+            This should be either 60, 1440, 4320 or 10080 minutes and, as of
             writing, ignores the parent channel's set default_auto_archive_duration
             when passed as `hikari.undefined.UNDEFINED`.
         reason : hikari.undefined.UndefinedOr[str]
@@ -4220,7 +4220,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If provided, the auto archive duration Discord's end user client
             should default to when creating threads in this channel.
 
-            This should be either 60, 1440, 4320 or 10080 seconds and, as of
+            This should be either 60, 1440, 4320 or 10080 minutes and, as of
             writing, ignores the parent channel's set default_auto_archive_duration
             when passed as `hikari.undefined.UNDEFINED`.
         default_thread_rate_limit_per_user : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
@@ -4499,7 +4499,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         auto_archive_duration : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
             If provided, how long the thread should remain inactive until it's archived.
 
-            This should be either 60, 1440, 4320 or 10080 seconds and, as of
+            This should be either 60, 1440, 4320 or 10080 minutes and, as of
             writing, ignores the parent channel's set default_auto_archive_duration
             when passed as `hikari.undefined.UNDEFINED`.
         rate_limit_per_user : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
@@ -4566,7 +4566,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         auto_archive_duration : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
             If provided, how long the thread should remain inactive until it's archived.
 
-            This should be either 60, 1440, 4320 or 10080 seconds and, as of
+            This should be either 60, 1440, 4320 or 10080 minutes and, as of
             writing, ignores the parent channel's set default_auto_archive_duration
             when passed as `hikari.undefined.UNDEFINED`.
         invitable : undefined.UndefinedOr[bool]
@@ -4734,7 +4734,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         auto_archive_duration : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
             If provided, how long the post should remain inactive until it's archived.
 
-            This should be either 60, 1440, 4320 or 10080 seconds and, as of
+            This should be either 60, 1440, 4320 or 10080 minutes and, as of
             writing, ignores the parent channel's set default_auto_archive_duration
             when passed as `hikari.undefined.UNDEFINED`.
         rate_limit_per_user : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -1037,7 +1037,7 @@ class GuildChannel(PartialChannel):
             If provided, the auto archive duration Discord's end user client
             should default to when creating threads in this channel.
 
-            This should be either 60, 1440, 4320 or 10080 seconds, as of
+            This should be either 60, 1440, 4320 or 10080 minutes, as of
             writing.
         flags : hikari.undefined.UndefinedOr[ChannelFlag]
             If provided, the new channel flags to use for the channel. This can
@@ -1050,7 +1050,7 @@ class GuildChannel(PartialChannel):
             If provided, the new auto archive duration for this thread. This
             only applies to threads.
 
-            This should be either 60, 1440, 4320 or 10080 seconds, as of
+            This should be either 60, 1440, 4320 or 10080 minutes, as of
             writing.
         locked : hikari.undefined.UndefinedOr[bool]
             If provided, the new locked state for the thread. This only applies

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -2113,7 +2113,7 @@ class PartialGuild(snowflakes.Unique):
             If provided, the auto archive duration Discord's end user client
             should default to when creating threads in this channel.
 
-            This should be either 60, 1440, 4320 or 10080 seconds and, as of
+            This should be either 60, 1440, 4320 or 10080 minutes and, as of
             writing, ignores the parent channel's set default_auto_archive_duration
             when passed as `hikari.undefined.UNDEFINED`.
         default_thread_rate_limit_per_user : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]


### PR DESCRIPTION
### Summary
Minor correction to the documentation for the auto_archive_duration parameter, where it should be in minutes instead of seconds

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
N/A