### PR TITLE
Add flag to skip generation of reference docs when running sphinx

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ py -3 -m pip install -U hikari
 ## Bots
 
 Hikari provides two different default bot implementations to suit your needs:
-- [GatewayBot](#GatewayBot)
-- [RESTBot](#RESTBot)
+- [GatewayBot](#gatewaybot)
+- [RESTBot](#restbot)
 
 ### GatewayBot
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,15 +57,21 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
     "sphinx.ext.mathjax",
-    # Docs generation
-    "autoapi.extension",
-    "numpydoc",
+    # Our extensions
     "myst_parser",
-    # Misc
     "sphinxext.opengraph",
     "sphinx_copybutton",
     "sphinxcontrib.towncrier.ext",
 ]
+
+if os.getenv("SKIP_REFERENCE_DOCS") is None:
+    extensions.extend(
+        (
+            "autoapi.extension",
+            "numpydoc",
+        )
+    )
+
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -2738,6 +2738,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             Depending on the time of the previously created application role
             records through `set_application_role_connection_metadata_records`,
             this mapping should contain those keys to the valid type of the record:
+
                 - `INTEGER_X`: An `int`.
                 - `DATETIME_X`: A `datetime.datetime` object.
                 - `BOOLEAN_X`: A `bool`.

--- a/pipelines/sphinx.nox.py
+++ b/pipelines/sphinx.nox.py
@@ -36,6 +36,9 @@ from pipelines import nox
 @nox.session(reuse_venv=True)
 def sphinx(session: nox.Session):
     """Generate docs using sphinx."""
+    if "--no-refs" in session.posargs:
+        session.env["SKIP_REFERENCE_DOCS"] = "1"
+
     if not os.path.exists(config.ARTIFACT_DIRECTORY):
         os.mkdir(config.ARTIFACT_DIRECTORY)
 


### PR DESCRIPTION
### Summary
This is to aid when it comes to developing the documentations static pages.

Can be done like this:
```
nox -s sphinx -- --no-refs
# or
SKIP_REFERENCE_DOCS=1 nox -s sphinx
```

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
