### PR TITLE
Read the banner with `utf-8` encoding

### DIFF
--- a/changes/1545.bugfix.md
+++ b/changes/1545.bugfix.md
@@ -1,0 +1,1 @@
+Open `banner.txt`s with `utf-8` encoding explicitly.

--- a/hikari/internal/ux.py
+++ b/hikari/internal/ux.py
@@ -240,10 +240,10 @@ _UNCONDITIONAL_ANSI_FLAGS: typing.Final[typing.FrozenSet[str]] = frozenset(("PYC
 
 def _read_banner(package: str) -> str:
     if sys.version_info >= (3, 9):
-        with importlib.resources.files(package).joinpath("banner.txt").open("r") as fp:
+        with importlib.resources.files(package).joinpath("banner.txt").open("r", encoding="utf-8") as fp:
             return fp.read()
     else:
-        return importlib.resources.read_text(package, "banner.txt")
+        return importlib.resources.read_text(package, "banner.txt", encoding="utf-8")
 
 
 def print_banner(

--- a/tests/hikari/internal/test_ux.py
+++ b/tests/hikari/internal/test_ux.py
@@ -233,13 +233,15 @@ class TestRedBanner:
             joint_path = None
             open_mode = None
             mock_file = None
+            open_encoding = None
 
             def joinpath(self, path):
                 self.joint_path = path
                 return self
 
-            def open(self, mode):
+            def open(self, mode, encoding):
                 self.open_mode = mode
+                self.open_encoding = encoding
                 return self.mock_file
 
         traversable = MockTraversable()
@@ -253,6 +255,7 @@ class TestRedBanner:
         read_text.assert_called_once_with("hikaru")
         assert traversable.joint_path == "banner.txt"
         assert traversable.open_mode == "r"
+        assert traversable.open_encoding == "utf-8"
         assert traversable.mock_file.context_entered == 1
         assert traversable.mock_file.context_exited == 1
 
@@ -261,7 +264,7 @@ class TestRedBanner:
             with mock.patch.object(importlib.resources, "read_text") as read_text:
                 assert ux._read_banner("hikaru") is read_text.return_value
 
-        read_text.assert_called_once_with("hikaru", "banner.txt")
+        read_text.assert_called_once_with("hikaru", "banner.txt", encoding="utf-8")
 
 
 class TestPrintBanner:


### PR DESCRIPTION
### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.