### PR TITLE
Add UserCredentialsStrategy

### DIFF
--- a/changes/unknown.feature.md
+++ b/changes/unknown.feature.md
@@ -1,0 +1,2 @@
+Add `UserCredentialsStrategy` to `hikari\impl\rest.py` similar to `ClientCredentialsStrategy` to allow simple OAuth2
+token generation and refreshing


### PR DESCRIPTION
### Summary
Add `UserCredentialsStrategy` to `hikari\impl\rest.py` similar to `ClientCredentialsStrategy` to allow simple OAuth2 token generation and refreshing.

I do not know how to make the tests for this except by copying from the ones for `ClientCredentialsStrategy` and I tried but I do not know how to use the mock stuff.  I am also not sure which tests I will need.  Don't be afraid to be harsh giving feedback on what to do or I did.

### Checklist
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
- None
