### PR TITLE
Fix forum applied tags

### DIFF
--- a/changes/1564.bugfix.md
+++ b/changes/1564.bugfix.md
@@ -1,0 +1,1 @@
+Fixed forum channel applied tags not being a sequence of snowflakes.

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -302,7 +302,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
             This should be either 60, 1440, 4320 or 10080 minutes, as of
             writing.
-        applied_tags : hikari.undefined.UndefinedOr[hikari.SnowflakeishSequence[hikari.channels.ForumTag]]
+        applied_tags : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishSequence[hikari.channels.ForumTag]]
             If provided, the new tags to apply to the thread. This only applies
             to threads in a forum channel.
         reason : hikari.undefined.UndefinedOr[str]

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -219,7 +219,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         locked: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         invitable: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         auto_archive_duration: undefined.UndefinedOr[time.Intervalish] = undefined.UNDEFINED,
-        applied_tags: undefined.UndefinedOr[typing.Sequence[channels_.ForumTag]] = undefined.UNDEFINED,
+        applied_tags: undefined.UndefinedOr[snowflakes.SnowflakeishSequence[channels_.ForumTag]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> channels_.PartialChannel:
         """Edit a channel.
@@ -302,7 +302,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
             This should be either 60, 1440, 4320 or 10080 minutes, as of
             writing.
-        applied_tags : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.ForumTag]]
+        applied_tags : hikari.undefined.UndefinedOr[hikari.SnowflakeishSequence[hikari.channels.ForumTag]]
             If provided, the new tags to apply to the thread. This only applies
             to threads in a forum channel.
         reason : hikari.undefined.UndefinedOr[str]

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -1001,7 +1001,7 @@ class GuildChannel(PartialChannel):
         auto_archive_duration: undefined.UndefinedOr[time.Intervalish] = undefined.UNDEFINED,
         locked: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         invitable: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-        applied_tags: undefined.UndefinedOr[typing.Sequence[ForumTag]] = undefined.UNDEFINED,
+        applied_tags: undefined.UndefinedOr[snowflakes.SnowflakeishSequence[ForumTag]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> PartialChannel:
         """Edit the text channel.
@@ -1060,7 +1060,7 @@ class GuildChannel(PartialChannel):
         invitable : hikari.undefined.UndefinedOr[bool]
             If provided, the new setting for whether non-moderators can invite
             new members to a private thread. This only applies to threads.
-        applied_tags : hikari.undefined.UndefinedOr[typing.Sequence[ForumTag]]
+        applied_tags : hikari.undefined.UndefinedOr[hikari.SnowflakeishSequence[hikari.channels.ForumTag]]
             If provided, the new tags to apply to the thread. This only applies
             to threads in a forum channel.
         reason : hikari.undefined.UndefinedOr[str]

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -1060,7 +1060,7 @@ class GuildChannel(PartialChannel):
         invitable : hikari.undefined.UndefinedOr[bool]
             If provided, the new setting for whether non-moderators can invite
             new members to a private thread. This only applies to threads.
-        applied_tags : hikari.undefined.UndefinedOr[hikari.SnowflakeishSequence[hikari.channels.ForumTag]]
+        applied_tags : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishSequence[hikari.channels.ForumTag]]
             If provided, the new tags to apply to the thread. This only applies
             to threads in a forum channel.
         reason : hikari.undefined.UndefinedOr[str]

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -1043,7 +1043,7 @@ class RESTClientImpl(rest_api.RESTClient):
         locked: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         invitable: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         auto_archive_duration: undefined.UndefinedOr[time.Intervalish] = undefined.UNDEFINED,
-        applied_tags: undefined.UndefinedOr[typing.Sequence[channels_.ForumTag]] = undefined.UNDEFINED,
+        applied_tags: undefined.UndefinedOr[snowflakes.SnowflakeishSequence[channels_.ForumTag]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> channels_.PartialChannel:
         if isinstance(auto_archive_duration, datetime.timedelta):
@@ -1095,7 +1095,7 @@ class RESTClientImpl(rest_api.RESTClient):
         body.put("auto_archive_duration", auto_archive_duration, conversion=time.timespan_to_int)
         body.put("locked", locked)
         body.put("invitable", invitable)
-        body.put_array("applied_tags", applied_tags, conversion=self._entity_factory.serialize_forum_tag)
+        body.put_snowflake_array("applied_tags", applied_tags)
 
         response = await self._request(route, json=body, reason=reason)
         assert isinstance(response, dict)

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -2216,7 +2216,7 @@ class TestRESTClientImplAsync:
             "invitable": True,
             "auto_archive_duration": 12322,
             "flags": 12,
-            "applied_tags": [{"id": 0, "name": "testing", "moderated": True, "emoji_id": None, "emoji_name": None}],
+            "applied_tags": ["0"],
         }
 
         result = await rest_client.edit_channel(
@@ -2251,7 +2251,7 @@ class TestRESTClientImplAsync:
             invitable=True,
             auto_archive_duration=auto_archive_duration,
             flags=12,
-            applied_tags=[channels.ForumTag(name="testing", moderated=True)],
+            applied_tags=[0],
         )
 
         assert result == mock_object

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -2251,7 +2251,7 @@ class TestRESTClientImplAsync:
             invitable=True,
             auto_archive_duration=auto_archive_duration,
             flags=12,
-            applied_tags=[0],
+            applied_tags=[StubModel(0)],
         )
 
         assert result == mock_object


### PR DESCRIPTION
### Summary
Fixed applied forum tags not being a sequence of snowflakes.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

