### PR TITLE
Revert changing the default nox -s ordering

### DIFF
--- a/pipelines/codespell.nox.py
+++ b/pipelines/codespell.nox.py
@@ -29,7 +29,7 @@ IGNORED_WORDS = [
 ]
 
 
-@nox.session(default_session=True)
+@nox.session()
 def codespell(session: nox.Session) -> None:
     """Run codespell to check for spelling mistakes."""
     session.install(*nox.dev_requirements("codespell"))

--- a/pipelines/flake8.nox.py
+++ b/pipelines/flake8.nox.py
@@ -25,7 +25,7 @@ from pipelines import config
 from pipelines import nox
 
 
-@nox.session(default_session=True)
+@nox.session()
 def flake8(session: nox.Session) -> None:
     """Run code linting, SAST, and analysis."""
     _flake8(session)

--- a/pipelines/format.nox.py
+++ b/pipelines/format.nox.py
@@ -32,7 +32,7 @@ from pipelines import nox
 GIT = shutil.which("git")
 
 
-@nox.session(default_session=True)
+@nox.session()
 def reformat_code(session: nox.Session) -> None:
     """Remove trailing whitespace in source, run isort, codespell and then run black code formatter."""
     session.install(*nox.dev_requirements("formatting"))
@@ -43,7 +43,7 @@ def reformat_code(session: nox.Session) -> None:
     session.run("black", *config.PYTHON_REFORMATTING_PATHS)
 
 
-@nox.session(default_session=True, venv_backend="none")
+@nox.session(venv_backend="none")
 def check_trailing_whitespaces(session: nox.Session) -> None:
     """Check for trailing whitespaces in the project."""
     remove_trailing_whitespaces(session, check_only=True)

--- a/pipelines/mypy.nox.py
+++ b/pipelines/mypy.nox.py
@@ -32,7 +32,7 @@ STUBGEN_GENERATE = [
 ]
 
 
-@nox.session(default_session=True)
+@nox.session()
 def mypy(session: nox.Session) -> None:
     """Perform static type analysis on Python source code using mypy."""
     session.install(

--- a/pipelines/nox.py
+++ b/pipelines/nox.py
@@ -39,10 +39,6 @@ def session(**kwargs: _typing.Any) -> _typing.Callable[[_NoxCallbackSig], _NoxCa
     def decorator(func: _NoxCallbackSig) -> _NoxCallbackSig:
         name = func.__name__.replace("_", "-")
         reuse_venv = kwargs.pop("reuse_venv", True)
-
-        if kwargs.pop("default_session", False):
-            _options.sessions.append(name)
-
         return _session(name=name, reuse_venv=reuse_venv, **kwargs)(func)
 
     return decorator

--- a/pipelines/nox.py
+++ b/pipelines/nox.py
@@ -30,7 +30,7 @@ from nox.sessions import Session
 from pipelines import config as _pipelines_config
 
 # Default sessions should be defined here
-_options.sessions = []
+_options.sessions = ["reformat-code", "pytest-all-features", "flake8", "slotscheck", "mypy", "verify-types"]
 
 _NoxCallbackSig = _typing.Callable[[Session], None]
 

--- a/pipelines/pyright.nox.py
+++ b/pipelines/pyright.nox.py
@@ -45,7 +45,7 @@ def pyright(session: nox.Session) -> None:
     session.run("pyright")
 
 
-@nox.session(default_session=True)
+@nox.session()
 def verify_types(session: nox.Session) -> None:
     """Verify the "type completeness" of types exported by the library using Pyright."""
     session.install(".", *nox.dev_requirements("pyright"))

--- a/pipelines/pytest.nox.py
+++ b/pipelines/pytest.nox.py
@@ -44,7 +44,7 @@ COVERAGE_FLAGS = [
 ]
 
 
-@nox.session(default_session=True)
+@nox.session()
 def pytest(session: nox.Session) -> None:
     """Run unit tests and measure code coverage.
 

--- a/pipelines/safety.nox.py
+++ b/pipelines/safety.nox.py
@@ -24,7 +24,7 @@
 from pipelines import nox
 
 
-@nox.session(default_session=True)
+@nox.session()
 def safety(session: nox.Session) -> None:
     """Perform dependency scanning."""
     session.install("-r", "requirements.txt", *nox.dev_requirements("safety"))

--- a/pipelines/slotscheck.nox.py
+++ b/pipelines/slotscheck.nox.py
@@ -25,7 +25,7 @@ from pipelines import config
 from pipelines import nox
 
 
-@nox.session(default_session=True)
+@nox.session()
 def slotscheck(session: nox.Session) -> None:
     """Check for common slotting mistakes."""
     session.install(".", *nox.dev_requirements("slotscheck"))


### PR DESCRIPTION
### Summary
Without this running `nox -s` will lead to flake8 running before reformatting, potentially giving unnecessary black would reformat this errors.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
