### PR TITLE
Configure black to skip magic trailing commas

### DIFF
--- a/examples/slash.py
+++ b/examples/slash.py
@@ -35,11 +35,7 @@ async def register_commands(event: hikari.StartingEvent) -> None:
         bot.rest.slash_command_builder("ephemeral", "Send a very secret message."),
     ]
 
-    await bot.rest.set_application_commands(
-        application=application.id,
-        commands=commands,
-        guild=COMMAND_GUILD_ID,
-    )
+    await bot.rest.set_application_commands(application=application.id, commands=commands, guild=COMMAND_GUILD_ID)
 
 
 @bot.listen()
@@ -51,14 +47,12 @@ async def handle_interactions(event: hikari.InteractionCreateEvent) -> None:
 
     if event.interaction.command_name == "ping":
         await event.interaction.create_initial_response(
-            hikari.ResponseType.MESSAGE_CREATE,
-            f"Pong! {bot.heartbeat_latency * 1_000:.0f}ms",
+            hikari.ResponseType.MESSAGE_CREATE, f"Pong! {bot.heartbeat_latency * 1_000:.0f}ms"
         )
 
     elif event.interaction.command_name == "info":
         await event.interaction.create_initial_response(
-            hikari.ResponseType.MESSAGE_CREATE,
-            "Hello, this is an example bot written in hikari!",
+            hikari.ResponseType.MESSAGE_CREATE, "Hello, this is an example bot written in hikari!"
         )
 
     elif event.interaction.command_name == "ephemeral":

--- a/hikari/__init__.pyi
+++ b/hikari/__init__.pyi
@@ -24,9 +24,7 @@ from hikari._about import __url__ as __url__
 from hikari._about import __version__ as __version__
 from hikari.applications import Application as Application
 from hikari.applications import ApplicationFlags as ApplicationFlags
-from hikari.applications import (
-    ApplicationRoleConnectionMetadataRecord as ApplicationRoleConnectionMetadataRecord,
-)
+from hikari.applications import ApplicationRoleConnectionMetadataRecord as ApplicationRoleConnectionMetadataRecord
 from hikari.applications import (
     ApplicationRoleConnectionMetadataRecordType as ApplicationRoleConnectionMetadataRecordType,
 )
@@ -36,9 +34,7 @@ from hikari.applications import ConnectionVisibility as ConnectionVisibility
 from hikari.applications import OAuth2AuthorizationToken as OAuth2AuthorizationToken
 from hikari.applications import OAuth2ImplicitToken as OAuth2ImplicitToken
 from hikari.applications import OAuth2Scope as OAuth2Scope
-from hikari.applications import (
-    OwnApplicationRoleConnection as OwnApplicationRoleConnection,
-)
+from hikari.applications import OwnApplicationRoleConnection as OwnApplicationRoleConnection
 from hikari.applications import OwnConnection as OwnConnection
 from hikari.applications import OwnGuild as OwnGuild
 from hikari.applications import PartialOAuth2Token as PartialOAuth2Token

--- a/hikari/api/entity_factory.py
+++ b/hikari/api/entity_factory.py
@@ -1114,10 +1114,7 @@ class EntityFactory(abc.ABC):
 
     @abc.abstractmethod
     def deserialize_role(
-        self,
-        payload: data_binding.JSONObject,
-        *,
-        guild_id: snowflakes.Snowflake,
+        self, payload: data_binding.JSONObject, *, guild_id: snowflakes.Snowflake
     ) -> guild_models.Role:
         """Parse a raw payload from Discord into a role object.
 

--- a/hikari/api/event_factory.py
+++ b/hikari/api/event_factory.py
@@ -676,9 +676,7 @@ class EventFactory(abc.ABC):
 
     @abc.abstractmethod
     def deserialize_audit_log_entry_create_event(
-        self,
-        shard: gateway_shard.GatewayShard,
-        payload: data_binding.JSONObject,
+        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> guild_events.AuditLogEntryCreateEvent:
         """Parse a raw payload from Discord into a audit log entry create event object.
 
@@ -701,9 +699,7 @@ class EventFactory(abc.ABC):
 
     @abc.abstractmethod
     def deserialize_interaction_create_event(
-        self,
-        shard: gateway_shard.GatewayShard,
-        payload: data_binding.JSONObject,
+        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> interaction_events.InteractionCreateEvent:
         """Parse a raw payload from Discord into a interaction create event object.
 
@@ -884,9 +880,7 @@ class EventFactory(abc.ABC):
 
     @abc.abstractmethod
     def deserialize_scheduled_event_create_event(
-        self,
-        shard: gateway_shard.GatewayShard,
-        payload: data_binding.JSONObject,
+        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> scheduled_events.ScheduledEventCreateEvent:
         """Parse a raw payload from Discord into a scheduled event create event object.
 
@@ -905,9 +899,7 @@ class EventFactory(abc.ABC):
 
     @abc.abstractmethod
     def deserialize_scheduled_event_update_event(
-        self,
-        shard: gateway_shard.GatewayShard,
-        payload: data_binding.JSONObject,
+        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> scheduled_events.ScheduledEventUpdateEvent:
         """Parse a raw payload from Discord into a scheduled event update event object.
 
@@ -926,9 +918,7 @@ class EventFactory(abc.ABC):
 
     @abc.abstractmethod
     def deserialize_scheduled_event_delete_event(
-        self,
-        shard: gateway_shard.GatewayShard,
-        payload: data_binding.JSONObject,
+        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> scheduled_events.ScheduledEventDeleteEvent:
         """Parse a raw payload from Discord into a scheduled event delete event object.
 
@@ -947,9 +937,7 @@ class EventFactory(abc.ABC):
 
     @abc.abstractmethod
     def deserialize_scheduled_event_user_add_event(
-        self,
-        shard: gateway_shard.GatewayShard,
-        payload: data_binding.JSONObject,
+        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> scheduled_events.ScheduledEventUserAddEvent:
         """Parse a raw payload from Discord into a scheduled event user add event object.
 
@@ -968,9 +956,7 @@ class EventFactory(abc.ABC):
 
     @abc.abstractmethod
     def deserialize_scheduled_event_user_remove_event(
-        self,
-        shard: gateway_shard.GatewayShard,
-        payload: data_binding.JSONObject,
+        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> scheduled_events.ScheduledEventUserRemoveEvent:
         """Parse a raw payload from Discord into a scheduled event user remove event object.
 
@@ -1245,9 +1231,7 @@ class EventFactory(abc.ABC):
 
     @abc.abstractmethod
     def deserialize_ready_event(
-        self,
-        shard: gateway_shard.GatewayShard,
-        payload: data_binding.JSONObject,
+        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> shard_events.ShardReadyEvent:
         """Parse a raw payload from Discord into a ready event object.
 

--- a/hikari/api/event_manager.py
+++ b/hikari/api/event_manager.py
@@ -355,11 +355,7 @@ class EventManager(abc.ABC):
 
     @abc.abstractmethod
     def get_listeners(
-        self,
-        event_type: typing.Type[base_events.EventT],
-        /,
-        *,
-        polymorphic: bool = True,
+        self, event_type: typing.Type[base_events.EventT], /, *, polymorphic: bool = True
     ) -> typing.Collection[CallbackT[base_events.EventT]]:
         """Get the listeners for a given event type, if there are any.
 
@@ -383,8 +379,7 @@ class EventManager(abc.ABC):
 
     @abc.abstractmethod
     def listen(
-        self,
-        *event_types: typing.Type[base_events.EventT],
+        self, *event_types: typing.Type[base_events.EventT]
     ) -> typing.Callable[[CallbackT[base_events.EventT]], CallbackT[base_events.EventT]]:
         """Generate a decorator to subscribe a callback to an event type.
 

--- a/hikari/api/interaction_server.py
+++ b/hikari/api/interaction_server.py
@@ -39,13 +39,9 @@ if typing.TYPE_CHECKING:
     _InteractionT_co = typing.TypeVar("_InteractionT_co", bound=base_interactions.PartialInteraction, covariant=True)
     _ResponseT_co = typing.TypeVar("_ResponseT_co", bound=special_endpoints.InteractionResponseBuilder, covariant=True)
     _MessageResponseBuilderT = typing.Union[
-        special_endpoints.InteractionDeferredBuilder,
-        special_endpoints.InteractionMessageBuilder,
+        special_endpoints.InteractionDeferredBuilder, special_endpoints.InteractionMessageBuilder
     ]
-    _ModalOrMessageResponseBuilder = typing.Union[
-        _MessageResponseBuilderT,
-        special_endpoints.InteractionModalBuilder,
-    ]
+    _ModalOrMessageResponseBuilder = typing.Union[_MessageResponseBuilderT, special_endpoints.InteractionModalBuilder]
 
 
 ListenerT = typing.Union[

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -1847,8 +1847,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     @abc.abstractmethod
     async def fetch_channel_webhooks(
-        self,
-        channel: snowflakes.SnowflakeishOr[channels_.WebhookChannelT],
+        self, channel: snowflakes.SnowflakeishOr[channels_.WebhookChannelT]
     ) -> typing.Sequence[webhooks.PartialWebhook]:
         """Fetch all channel webhooks.
 
@@ -1881,8 +1880,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     @abc.abstractmethod
     async def fetch_guild_webhooks(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild]
     ) -> typing.Sequence[webhooks.PartialWebhook]:
         """Fetch all guild webhooks.
 
@@ -3501,8 +3499,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     @abc.abstractmethod
     async def fetch_sticker(
-        self,
-        sticker: snowflakes.SnowflakeishOr[stickers_.PartialSticker],
+        self, sticker: snowflakes.SnowflakeishOr[stickers_.PartialSticker]
     ) -> typing.Union[stickers_.GuildSticker, stickers_.StandardSticker]:
         """Fetch a sticker.
 
@@ -5205,9 +5202,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     @abc.abstractmethod
     async def fetch_member(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        user: snowflakes.SnowflakeishOr[users.PartialUser],
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], user: snowflakes.SnowflakeishOr[users.PartialUser]
     ) -> guilds.Member:
         """Fetch a guild member.
 
@@ -5309,9 +5304,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     @abc.abstractmethod
     async def search_members(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        name: str,
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], name: str
     ) -> typing.Sequence[guilds.Member]:
         """Search the members in a guild by nickname and username.
 
@@ -5734,9 +5727,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     @abc.abstractmethod
     async def fetch_ban(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        user: snowflakes.SnowflakeishOr[users.PartialUser],
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], user: snowflakes.SnowflakeishOr[users.PartialUser]
     ) -> guilds.GuildBan:
         """Fetch the guild's ban info for a user.
 
@@ -5825,10 +5816,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         """
 
     @abc.abstractmethod
-    async def fetch_roles(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-    ) -> typing.Sequence[guilds.Role]:
+    async def fetch_roles(self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild]) -> typing.Sequence[guilds.Role]:
         """Fetch the roles of a guild.
 
         Parameters
@@ -6036,9 +6024,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     @abc.abstractmethod
     async def delete_role(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        role: snowflakes.SnowflakeishOr[guilds.PartialRole],
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], role: snowflakes.SnowflakeishOr[guilds.PartialRole]
     ) -> None:
         """Delete a role.
 
@@ -6173,8 +6159,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     @abc.abstractmethod
     async def fetch_guild_voice_regions(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild]
     ) -> typing.Sequence[voices.VoiceRegion]:
         """Fetch the available voice regions for a guild.
 
@@ -6204,8 +6189,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     @abc.abstractmethod
     async def fetch_guild_invites(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild]
     ) -> typing.Sequence[invites.InviteWithMetadata]:
         """Fetch the guild's invites.
 
@@ -6237,8 +6221,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     @abc.abstractmethod
     async def fetch_integrations(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild]
     ) -> typing.Sequence[guilds.Integration]:
         """Fetch the guild's integrations.
 
@@ -6554,9 +6537,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     @abc.abstractmethod
     async def delete_template(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        template: typing.Union[str, templates.Template],
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], template: typing.Union[str, templates.Template]
     ) -> templates.Template:
         """Delete a guild template.
 
@@ -6695,9 +6676,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     @abc.abstractmethod
     async def sync_guild_template(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        template: typing.Union[str, templates.Template],
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], template: typing.Union[str, templates.Template]
     ) -> templates.Template:
         """Create a guild template.
 
@@ -6730,11 +6709,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         """
 
     @abc.abstractmethod
-    def slash_command_builder(
-        self,
-        name: str,
-        description: str,
-    ) -> special_endpoints.SlashCommandBuilder:
+    def slash_command_builder(self, name: str, description: str) -> special_endpoints.SlashCommandBuilder:
         r"""Create a command builder to use in `RESTClient.set_application_commands`.
 
         Parameters
@@ -6754,9 +6729,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     @abc.abstractmethod
     def context_menu_command_builder(
-        self,
-        type: typing.Union[commands.CommandType, int],
-        name: str,
+        self, type: typing.Union[commands.CommandType, int], name: str
     ) -> special_endpoints.ContextMenuCommandBuilder:
         r"""Create a command builder to use in `RESTClient.set_application_commands`.
 

--- a/hikari/api/special_endpoints.py
+++ b/hikari/api/special_endpoints.py
@@ -1174,16 +1174,12 @@ class SlashCommandBuilder(CommandBuilder):
 
     @property
     @abc.abstractmethod
-    def description_localizations(
-        self,
-    ) -> typing.Mapping[typing.Union[locales.Locale, str], str]:
+    def description_localizations(self) -> typing.Mapping[typing.Union[locales.Locale, str], str]:
         """Command's localised descriptions."""
 
     @abc.abstractmethod
     def set_description_localizations(
-        self,
-        description_localizations: typing.Mapping[typing.Union[locales.Locale, str], str],
-        /,
+        self, description_localizations: typing.Mapping[typing.Union[locales.Locale, str], str], /
     ) -> Self:
         """Set the localised descriptions for this command.
 
@@ -2137,11 +2133,7 @@ class ModalActionRowBuilder(ComponentBuilder, abc.ABC):
         """Sequence of the component builders registered within this action row."""
 
     @abc.abstractmethod
-    def add_component(
-        self,
-        component: ComponentBuilder,
-        /,
-    ) -> Self:
+    def add_component(self, component: ComponentBuilder, /) -> Self:
         """Add a component to this action row builder.
 
         .. warning::

--- a/hikari/applications.py
+++ b/hikari/applications.py
@@ -499,11 +499,7 @@ class Team(snowflakes.Unique):
             return None
 
         return routes.CDN_TEAM_ICON.compile_to_file(
-            urls.CDN_URL,
-            team_id=self.id,
-            hash=self.icon_hash,
-            size=size,
-            file_format=ext,
+            urls.CDN_URL, team_id=self.id, hash=self.icon_hash, size=size, file_format=ext
         )
 
 
@@ -555,11 +551,7 @@ class InviteApplication(guilds.PartialApplication):
             return None
 
         return routes.CDN_APPLICATION_COVER.compile_to_file(
-            urls.CDN_URL,
-            application_id=self.id,
-            hash=self.cover_image_hash,
-            size=size,
-            file_format=ext,
+            urls.CDN_URL, application_id=self.id, hash=self.cover_image_hash, size=size, file_format=ext
         )
 
 
@@ -662,11 +654,7 @@ class Application(guilds.PartialApplication):
             return None
 
         return routes.CDN_APPLICATION_COVER.compile_to_file(
-            urls.CDN_URL,
-            application_id=self.id,
-            hash=self.cover_image_hash,
-            size=size,
-            file_format=ext,
+            urls.CDN_URL, application_id=self.id, hash=self.cover_image_hash, size=size, file_format=ext
         )
 
 
@@ -832,18 +820,12 @@ class ApplicationRoleConnectionMetadataRecord:
     """The metadata's field description."""
 
     name_localizations: typing.Mapping[typing.Union[locales.Locale, str], str] = attrs.field(
-        eq=False,
-        hash=False,
-        repr=False,
-        factory=dict,
+        eq=False, hash=False, repr=False, factory=dict
     )
     """A mapping of name localizations for this metadata field."""
 
     description_localizations: typing.Mapping[typing.Union[locales.Locale, str], str] = attrs.field(
-        eq=False,
-        hash=False,
-        repr=False,
-        factory=dict,
+        eq=False, hash=False, repr=False, factory=dict
     )
     """A mapping of description localizations for this metadata field."""
 

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -778,8 +778,7 @@ class TextableChannel(PartialChannel):
     async def delete_messages(
         self,
         messages: typing.Union[
-            snowflakes.SnowflakeishOr[messages.PartialMessage],
-            snowflakes.SnowflakeishIterable[messages.PartialMessage],
+            snowflakes.SnowflakeishOr[messages.PartialMessage], snowflakes.SnowflakeishIterable[messages.PartialMessage]
         ],
         /,
         *other_messages: snowflakes.SnowflakeishOr[messages.PartialMessage],
@@ -923,11 +922,7 @@ class GroupDMChannel(PrivateChannel):
             return None
 
         return routes.CDN_CHANNEL_ICON.compile_to_file(
-            urls.CDN_URL,
-            channel_id=self.id,
-            hash=self.icon_hash,
-            size=size,
-            file_format=ext,
+            urls.CDN_URL, channel_id=self.id, hash=self.icon_hash, size=size, file_format=ext
         )
 
 
@@ -1217,8 +1212,7 @@ class PermissibleGuildChannel(GuildChannel):
         )
 
     async def remove_overwrite(
-        self,
-        target: typing.Union[PermissionOverwrite, guilds.PartialRole, users.PartialUser, snowflakes.Snowflakeish],
+        self, target: typing.Union[PermissionOverwrite, guilds.PartialRole, users.PartialUser, snowflakes.Snowflakeish]
     ) -> None:
         """Delete a custom permission for an entity in a given guild channel.
 

--- a/hikari/colors.py
+++ b/hikari/colors.py
@@ -508,11 +508,7 @@ class Color(int):
         raise ValueError(f"Could not transform {value!r} into a {cls.__qualname__} object")
 
     def to_bytes(
-        self,
-        length: typing.SupportsIndex,
-        byteorder: typing.Literal["little", "big"],
-        *,
-        signed: bool = True,
+        self, length: typing.SupportsIndex, byteorder: typing.Literal["little", "big"], *, signed: bool = True
     ) -> bytes:
         """Convert the color code to bytes.
 

--- a/hikari/embeds.py
+++ b/hikari/embeds.py
@@ -76,10 +76,7 @@ class EmbedResource(files.Resource[files.AsyncReader]):
         return self.resource.filename
 
     def stream(
-        self,
-        *,
-        executor: typing.Optional[concurrent.futures.Executor] = None,
-        head_only: bool = False,
+        self, *, executor: typing.Optional[concurrent.futures.Executor] = None, head_only: bool = False
     ) -> files.AsyncReaderContextManager[files.AsyncReader]:
         """Produce a stream of data for the resource.
 

--- a/hikari/files.py
+++ b/hikari/files.py
@@ -451,11 +451,7 @@ class Resource(typing.Generic[ReaderImplT], abc.ABC):
         _, _, ext = self.filename.rpartition(".")
         return ext if ext != self.filename else None
 
-    async def read(
-        self,
-        *,
-        executor: typing.Optional[concurrent.futures.Executor] = None,
-    ) -> bytes:
+    async def read(self, *, executor: typing.Optional[concurrent.futures.Executor] = None) -> bytes:
         """Read the entire resource at once into memory.
 
         .. code-block:: python
@@ -488,11 +484,7 @@ class Resource(typing.Generic[ReaderImplT], abc.ABC):
             return await reader.read()
 
     async def save(
-        self,
-        path: Pathish,
-        *,
-        executor: typing.Optional[concurrent.futures.Executor] = None,
-        force: bool = False,
+        self, path: Pathish, *, executor: typing.Optional[concurrent.futures.Executor] = None, force: bool = False
     ) -> None:
         """Save this resource to disk.
 
@@ -523,10 +515,7 @@ class Resource(typing.Generic[ReaderImplT], abc.ABC):
 
     @abc.abstractmethod
     def stream(
-        self,
-        *,
-        executor: typing.Optional[concurrent.futures.Executor] = None,
-        head_only: bool = False,
+        self, *, executor: typing.Optional[concurrent.futures.Executor] = None, head_only: bool = False
     ) -> AsyncReaderContextManager[ReaderImplT]:
         """Produce a stream of data for the resource.
 
@@ -692,10 +681,7 @@ class WebResource(Resource[WebReader], abc.ABC):
     __slots__: typing.Sequence[str] = ()
 
     def stream(
-        self,
-        *,
-        executor: typing.Optional[concurrent.futures.Executor] = None,
-        head_only: bool = False,
+        self, *, executor: typing.Optional[concurrent.futures.Executor] = None, head_only: bool = False
     ) -> AsyncReaderContextManager[WebReader]:
         """Start streaming the content into memory by downloading it.
 
@@ -926,10 +912,7 @@ class File(Resource[ThreadedFileReader]):
         return filename
 
     def stream(
-        self,
-        *,
-        executor: typing.Optional[concurrent.futures.Executor] = None,
-        head_only: bool = False,
+        self, *, executor: typing.Optional[concurrent.futures.Executor] = None, head_only: bool = False
     ) -> AsyncReaderContextManager[ThreadedFileReader]:
         """Start streaming the resource using a thread pool executor.
 
@@ -965,11 +948,7 @@ class File(Resource[ThreadedFileReader]):
         raise TypeError("The executor must be a ThreadPoolExecutor or None")
 
     async def save(
-        self,
-        path: Pathish,
-        *,
-        executor: typing.Optional[concurrent.futures.Executor] = None,
-        force: bool = False,
+        self, path: Pathish, *, executor: typing.Optional[concurrent.futures.Executor] = None, force: bool = False
     ) -> None:
         # An optimization can be done here to avoid a lot of thread calls and streaming
         # by just copying the file
@@ -1122,10 +1101,7 @@ class Bytes(Resource[IteratorReader]):
         return self._filename
 
     def stream(
-        self,
-        *,
-        executor: typing.Optional[concurrent.futures.Executor] = None,
-        head_only: bool = False,
+        self, *, executor: typing.Optional[concurrent.futures.Executor] = None, head_only: bool = False
     ) -> AsyncReaderContextManager[IteratorReader]:
         """Start streaming the content in chunks.
 
@@ -1145,11 +1121,7 @@ class Bytes(Resource[IteratorReader]):
         return _NoOpAsyncReaderContextManagerImpl(IteratorReader(self.filename, self.mimetype, self.data))
 
     async def save(
-        self,
-        path: Pathish,
-        *,
-        executor: typing.Optional[concurrent.futures.Executor] = None,
-        force: bool = False,
+        self, path: Pathish, *, executor: typing.Optional[concurrent.futures.Executor] = None, force: bool = False
     ) -> None:
         if not isinstance(self.data, (bytes, bytearray, memoryview)):
             await super().save(path, executor=executor, force=force)

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -713,11 +713,7 @@ class Member(users.User):
             self.guild_id, self.user.id, delete_message_seconds=delete_message_seconds, reason=reason
         )
 
-    async def unban(
-        self,
-        *,
-        reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-    ) -> None:
+    async def unban(self, *, reason: undefined.UndefinedOr[str] = undefined.UNDEFINED) -> None:
         """Unban this member from the guild.
 
         Other Parameters
@@ -744,11 +740,7 @@ class Member(users.User):
         """
         await self.user.app.rest.unban_user(self.guild_id, self.user.id, reason=reason)
 
-    async def kick(
-        self,
-        *,
-        reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-    ) -> None:
+    async def kick(self, *, reason: undefined.UndefinedOr[str] = undefined.UNDEFINED) -> None:
         """Kick this member from this guild.
 
         Other Parameters
@@ -1086,11 +1078,7 @@ class Role(PartialRole):
             return None
 
         return routes.CDN_ROLE_ICON.compile_to_file(
-            urls.CDN_URL,
-            role_id=self.id,
-            hash=self.icon_hash,
-            size=size,
-            file_format=ext,
+            urls.CDN_URL, role_id=self.id, hash=self.icon_hash, size=size, file_format=ext
         )
 
 
@@ -1190,11 +1178,7 @@ class PartialApplication(snowflakes.Unique):
             return None
 
         return routes.CDN_APPLICATION_ICON.compile_to_file(
-            urls.CDN_URL,
-            application_id=self.id,
-            hash=self.icon_hash,
-            size=size,
-            file_format=ext,
+            urls.CDN_URL, application_id=self.id, hash=self.icon_hash, size=size, file_format=ext
         )
 
 
@@ -1410,11 +1394,7 @@ class PartialGuild(snowflakes.Unique):
                 ext = "png"
 
         return routes.CDN_GUILD_ICON.compile_to_file(
-            urls.CDN_URL,
-            guild_id=self.id,
-            hash=self.icon_hash,
-            size=size,
-            file_format=ext,
+            urls.CDN_URL, guild_id=self.id, hash=self.icon_hash, size=size, file_format=ext
         )
 
     async def ban(
@@ -2525,11 +2505,7 @@ class GuildPreview(PartialGuild):
             return None
 
         return routes.CDN_GUILD_DISCOVERY_SPLASH.compile_to_file(
-            urls.CDN_URL,
-            guild_id=self.id,
-            hash=self.discovery_splash_hash,
-            size=size,
-            file_format=ext,
+            urls.CDN_URL, guild_id=self.id, hash=self.discovery_splash_hash, size=size, file_format=ext
         )
 
     def make_splash_url(self, *, ext: str = "png", size: int = 4096) -> typing.Optional[files.URL]:
@@ -2558,11 +2534,7 @@ class GuildPreview(PartialGuild):
             return None
 
         return routes.CDN_GUILD_SPLASH.compile_to_file(
-            urls.CDN_URL,
-            guild_id=self.id,
-            hash=self.splash_hash,
-            size=size,
-            file_format=ext,
+            urls.CDN_URL, guild_id=self.id, hash=self.splash_hash, size=size, file_format=ext
         )
 
 
@@ -2847,11 +2819,7 @@ class Guild(PartialGuild):
                 ext = "png"
 
         return routes.CDN_GUILD_BANNER.compile_to_file(
-            urls.CDN_URL,
-            guild_id=self.id,
-            hash=self.banner_hash,
-            size=size,
-            file_format=ext,
+            urls.CDN_URL, guild_id=self.id, hash=self.banner_hash, size=size, file_format=ext
         )
 
     def make_discovery_splash_url(self, *, ext: str = "png", size: int = 4096) -> typing.Optional[files.URL]:
@@ -2880,11 +2848,7 @@ class Guild(PartialGuild):
             return None
 
         return routes.CDN_GUILD_DISCOVERY_SPLASH.compile_to_file(
-            urls.CDN_URL,
-            guild_id=self.id,
-            hash=self.discovery_splash_hash,
-            size=size,
-            file_format=ext,
+            urls.CDN_URL, guild_id=self.id, hash=self.discovery_splash_hash, size=size, file_format=ext
         )
 
     def make_splash_url(self, *, ext: str = "png", size: int = 4096) -> typing.Optional[files.URL]:
@@ -2913,16 +2877,11 @@ class Guild(PartialGuild):
             return None
 
         return routes.CDN_GUILD_SPLASH.compile_to_file(
-            urls.CDN_URL,
-            guild_id=self.id,
-            hash=self.splash_hash,
-            size=size,
-            file_format=ext,
+            urls.CDN_URL, guild_id=self.id, hash=self.splash_hash, size=size, file_format=ext
         )
 
     def get_channel(
-        self,
-        channel: snowflakes.SnowflakeishOr[channels_.PartialChannel],
+        self, channel: snowflakes.SnowflakeishOr[channels_.PartialChannel]
     ) -> typing.Optional[channels_.PermissibleGuildChannel]:
         """Get a cached channel that belongs to the guild by it's ID or object.
 

--- a/hikari/impl/bot.py
+++ b/hikari/impl/bot.py
@@ -106,11 +106,7 @@ async def _close_resource(name: str, awaitable: typing.Awaitable[typing.Any]) ->
         await future
     except Exception as ex:
         asyncio.get_running_loop().call_exception_handler(
-            {
-                "message": f"{name} raised an exception during shut down",
-                "future": future,
-                "exception": ex,
-            }
+            {"message": f"{name} raised an exception during shut down", "future": future, "exception": ex}
         )
 
 
@@ -606,8 +602,7 @@ class GatewayBot(traits.GatewayBotAware):
         await aio.first_completed(self._closed_event.wait(), *(s.join() for s in self._shards.values()))
 
     def listen(
-        self,
-        *event_types: typing.Type[base_events.EventT],
+        self, *event_types: typing.Type[base_events.EventT]
     ) -> typing.Callable[[event_manager_.CallbackT[base_events.EventT]], event_manager_.CallbackT[base_events.EventT]]:
         """Generate a decorator to subscribe a callback to an event type.
 
@@ -812,9 +807,7 @@ class GatewayBot(traits.GatewayBotAware):
 
         try:
             with signals.handle_interrupts(
-                enabled=enable_signal_handlers,
-                loop=loop,
-                propagate_interrupts=propagate_interrupts,
+                enabled=enable_signal_handlers, loop=loop, propagate_interrupts=propagate_interrupts
             ):
                 loop.run_until_complete(
                     self.start(
@@ -924,8 +917,7 @@ class GatewayBot(traits.GatewayBotAware):
 
         if check_for_updates:
             asyncio.create_task(
-                ux.check_for_updates(self._http_settings, self._proxy_settings),
-                name="check for package updates",
+                ux.check_for_updates(self._http_settings, self._proxy_settings), name="check for package updates"
             )
 
         self._rest.start()

--- a/hikari/impl/buckets.py
+++ b/hikari/impl/buckets.py
@@ -227,12 +227,7 @@ class RESTBucket(rate_limits.WindowedBurstRateLimiter):
     which allows dynamically changing the enforced rate limits at any time.
     """
 
-    __slots__: typing.Sequence[str] = (
-        "_compiled_route",
-        "_max_rate_limit",
-        "_global_ratelimit",
-        "_lock",
-    )
+    __slots__: typing.Sequence[str] = ("_compiled_route", "_max_rate_limit", "_global_ratelimit", "_lock")
 
     def __init__(
         self,
@@ -534,12 +529,7 @@ class RESTBucketManager:
             _LOGGER.debug("%s is being mapped to existing bucket %s", compiled_route, real_bucket_hash)
         else:
             _LOGGER.debug("%s is being mapped to new bucket %s", compiled_route, real_bucket_hash)
-            bucket = RESTBucket(
-                real_bucket_hash,
-                compiled_route,
-                self._global_ratelimit,
-                self._max_rate_limit,
-            )
+            bucket = RESTBucket(real_bucket_hash, compiled_route, self._global_ratelimit, self._max_rate_limit)
             self._real_hashes_to_buckets[real_bucket_hash] = bucket
 
         return bucket
@@ -609,12 +599,7 @@ class RESTBucketManager:
                     remaining_header,
                 )
 
-                bucket = RESTBucket(
-                    real_bucket_hash,
-                    compiled_route,
-                    self._global_ratelimit,
-                    self._max_rate_limit,
-                )
+                bucket = RESTBucket(real_bucket_hash, compiled_route, self._global_ratelimit, self._max_rate_limit)
 
             self._real_hashes_to_buckets[real_bucket_hash] = bucket
 

--- a/hikari/impl/cache.py
+++ b/hikari/impl/cache.py
@@ -95,8 +95,7 @@ class CacheImpl(cache.MutableCache):
     _role_entries: collections.ExtendedMutableMapping[snowflakes.Snowflake, guilds.Role]
     _sticker_entries: collections.ExtendedMutableMapping[snowflakes.Snowflake, cache_utility.GuildStickerData]
     _unknown_custom_emoji_entries: collections.ExtendedMutableMapping[
-        snowflakes.Snowflake,
-        cache_utility.RefCell[emojis.CustomEmoji],
+        snowflakes.Snowflake, cache_utility.RefCell[emojis.CustomEmoji]
     ]
     _user_entries: collections.ExtendedMutableMapping[snowflakes.Snowflake, cache_utility.RefCell[users.User]]
     _message_entries: collections.ExtendedMutableMapping[
@@ -188,10 +187,7 @@ class CacheImpl(cache.MutableCache):
 
         self._dm_channel_entries[snowflakes.Snowflake(user)] = snowflakes.Snowflake(channel)
 
-    def _build_emoji(
-        self,
-        emoji_data: cache_utility.KnownCustomEmojiData,
-    ) -> emojis.KnownCustomEmoji:
+    def _build_emoji(self, emoji_data: cache_utility.KnownCustomEmojiData) -> emojis.KnownCustomEmoji:
         return emoji_data.build_entity(self._app)
 
     def clear_emojis(self) -> cache.CacheView[snowflakes.Snowflake, emojis.KnownCustomEmoji]:
@@ -313,10 +309,7 @@ class CacheImpl(cache.MutableCache):
         self.set_emoji(emoji)
         return cached_emoji, self.get_emoji(emoji.id)
 
-    def _build_sticker(
-        self,
-        sticker_data: cache_utility.GuildStickerData,
-    ) -> stickers.GuildSticker:
+    def _build_sticker(self, sticker_data: cache_utility.GuildStickerData) -> stickers.GuildSticker:
         return sticker_data.build_entity(self._app)
 
     def clear_stickers(self) -> cache.CacheView[snowflakes.Snowflake, stickers.GuildSticker]:
@@ -671,9 +664,7 @@ class CacheImpl(cache.MutableCache):
         if not guild_record or not guild_record.threads:
             return cache_utility.EmptyCacheView()
 
-        return cache_utility.CacheMappingView(
-            {sf: self._guild_thread_entries[sf] for sf in guild_record.threads},
-        )
+        return cache_utility.CacheMappingView({sf: self._guild_thread_entries[sf] for sf in guild_record.threads})
 
     def get_threads_view_for_channel(
         self,
@@ -837,10 +828,7 @@ class CacheImpl(cache.MutableCache):
         self.set_guild_channel(channel)
         return cached_channel, self.get_guild_channel(channel.id)
 
-    def _build_invite(
-        self,
-        invite_data: cache_utility.InviteData,
-    ) -> invites.InviteWithMetadata:
+    def _build_invite(self, invite_data: cache_utility.InviteData) -> invites.InviteWithMetadata:
         return invite_data.build_entity(self._app)
 
     def _remove_invite_users(self, invite: cache_utility.InviteData) -> None:
@@ -1055,16 +1043,11 @@ class CacheImpl(cache.MutableCache):
         self.set_me(user)
         return cached_user, self.get_me()
 
-    def _build_member(
-        self,
-        member_data: cache_utility.RefCell[cache_utility.MemberData],
-    ) -> guilds.Member:
+    def _build_member(self, member_data: cache_utility.RefCell[cache_utility.MemberData]) -> guilds.Member:
         return member_data.object.build_entity(self._app)
 
     @staticmethod
-    def _can_remove_member(
-        member: cache_utility.RefCell[cache_utility.MemberData],
-    ) -> bool:
+    def _can_remove_member(member: cache_utility.RefCell[cache_utility.MemberData]) -> bool:
         return member.ref_count < 1 and member.object.has_been_deleted
 
     def _garbage_collect_member(
@@ -1241,10 +1224,7 @@ class CacheImpl(cache.MutableCache):
         self.set_member(member)
         return cached_member, self.get_member(member.guild_id, member.user.id)
 
-    def _build_presence(
-        self,
-        presence_data: cache_utility.MemberPresenceData,
-    ) -> presences.MemberPresence:
+    def _build_presence(self, presence_data: cache_utility.MemberPresenceData) -> presences.MemberPresence:
         return presence_data.build_entity(self._app)
 
     def _garbage_collect_unknown_custom_emoji(
@@ -1256,10 +1236,7 @@ class CacheImpl(cache.MutableCache):
         if emoji.ref_count < 1 and emoji.object.id in self._unknown_custom_emoji_entries:
             del self._unknown_custom_emoji_entries[emoji.object.id]
 
-    def _remove_presence_assets(
-        self,
-        presence_data: cache_utility.MemberPresenceData,
-    ) -> None:
+    def _remove_presence_assets(self, presence_data: cache_utility.MemberPresenceData) -> None:
         for activity_data in presence_data.activities:
             if isinstance(activity_data.emoji, cache_utility.RefCell):
                 self._garbage_collect_unknown_custom_emoji(activity_data.emoji, decrement=1)
@@ -1538,10 +1515,7 @@ class CacheImpl(cache.MutableCache):
 
         return cell
 
-    def _build_voice_state(
-        self,
-        voice_data: cache_utility.VoiceStateData,
-    ) -> voices.VoiceState:
+    def _build_voice_state(self, voice_data: cache_utility.VoiceStateData) -> voices.VoiceState:
         return voice_data.build_entity(self._app)
 
     def clear_voice_states(

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -515,9 +515,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         }
         self._modal_component_type_mapping: typing.Dict[
             int, typing.Callable[[data_binding.JSONObject], component_models.ModalComponentTypesT]
-        ] = {
-            component_models.ComponentType.TEXT_INPUT: self._deserialize_text_input,
-        }
+        ] = {component_models.ComponentType.TEXT_INPUT: self._deserialize_text_input}
         self._dm_channel_type_mapping = {
             channel_models.ChannelType.DM: self.deserialize_dm,
             channel_models.ChannelType.GROUP_DM: self.deserialize_group_dm,
@@ -1004,10 +1002,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         )
 
     def _set_guild_channel_attrsibutes(
-        self,
-        payload: data_binding.JSONObject,
-        *,
-        guild_id: undefined.UndefinedOr[snowflakes.Snowflake],
+        self, payload: data_binding.JSONObject, *, guild_id: undefined.UndefinedOr[snowflakes.Snowflake]
     ) -> _GuildChannelFields:
         if guild_id is undefined.UNDEFINED:
             guild_id = snowflakes.Snowflake(payload["guild_id"])
@@ -1539,11 +1534,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
                     proxy_resource=files.ensure_resource(raw_proxy_url) if raw_proxy_url else None,
                 )
 
-            author = embed_models.EmbedAuthor(
-                name=author_payload.get("name"),
-                url=author_payload.get("url"),
-                icon=icon,
-            )
+            author = embed_models.EmbedAuthor(name=author_payload.get("name"), url=author_payload.get("url"), icon=icon)
 
         footer: typing.Optional[embed_models.EmbedFooter] = None
         if footer_payload := payload.get("footer"):
@@ -1561,9 +1552,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             fields = []
             for field_payload in fields_array:
                 field = embed_models.EmbedField(
-                    name=field_payload["name"],
-                    value=field_payload["value"],
-                    inline=field_payload.get("inline", False),
+                    name=field_payload["name"], value=field_payload["value"], inline=field_payload.get("inline", False)
                 )
                 fields.append(field)
 
@@ -1692,9 +1681,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
 
     def deserialize_custom_emoji(self, payload: data_binding.JSONObject) -> emoji_models.CustomEmoji:
         return emoji_models.CustomEmoji(
-            id=snowflakes.Snowflake(payload["id"]),
-            name=payload["name"],
-            is_animated=payload.get("animated", False),
+            id=snowflakes.Snowflake(payload["id"]), name=payload["name"], is_animated=payload.get("animated", False)
         )
 
     def deserialize_known_custom_emoji(
@@ -1742,9 +1729,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             max_concurrency=max(session_start_limit_payload.get("max_concurrency", 0), 1),
         )
         return gateway_models.GatewayBotInfo(
-            url=payload["url"],
-            shard_count=int(payload["shards"]),
-            session_start_limit=session_start_limit,
+            url=payload["url"], shard_count=int(payload["shards"]), session_start_limit=session_start_limit
         )
 
     ################
@@ -1838,10 +1823,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         )
 
     def deserialize_role(
-        self,
-        payload: data_binding.JSONObject,
-        *,
-        guild_id: snowflakes.Snowflake,
+        self, payload: data_binding.JSONObject, *, guild_id: snowflakes.Snowflake
     ) -> guild_models.Role:
         bot_id: typing.Optional[snowflakes.Snowflake] = None
         integration_id: typing.Optional[snowflakes.Snowflake] = None
@@ -2404,8 +2386,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         )
 
     def _deserialize_autocomplete_interaction_option(
-        self,
-        payload: data_binding.JSONObject,
+        self, payload: data_binding.JSONObject
     ) -> command_interactions.AutocompleteInteractionOption:
         suboptions: typing.Optional[typing.Sequence[command_interactions.AutocompleteInteractionOption]] = None
         if raw_suboptions := payload.get("options"):
@@ -2467,10 +2448,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         )
 
     def _deserialize_resolved_option_data(
-        self,
-        payload: data_binding.JSONObject,
-        *,
-        guild_id: typing.Optional[snowflakes.Snowflake] = None,
+        self, payload: data_binding.JSONObject, *, guild_id: typing.Optional[snowflakes.Snowflake] = None
     ) -> base_interactions.ResolvedOptionData:
         channels: typing.Dict[snowflakes.Snowflake, base_interactions.InteractionChannel] = {}
         if raw_channels := payload.get("channels"):
@@ -2520,12 +2498,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             attachments = {}
 
         return base_interactions.ResolvedOptionData(
-            attachments=attachments,
-            channels=channels,
-            members=members,
-            messages=messages,
-            roles=roles,
-            users=users,
+            attachments=attachments, channels=channels, members=members, messages=messages, roles=roles, users=users
         )
 
     def deserialize_command_interaction(
@@ -2941,9 +2914,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
 
     def _deserialize_text_input(self, payload: data_binding.JSONObject) -> component_models.TextInputComponent:
         return component_models.TextInputComponent(
-            type=component_models.ComponentType(payload["type"]),
-            custom_id=payload["custom_id"],
-            value=payload["value"],
+            type=component_models.ComponentType(payload["type"]), custom_id=payload["custom_id"], value=payload["value"]
         )
 
     ##################
@@ -3454,9 +3425,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             member = self.deserialize_member(raw_member, user=user, guild_id=guild_id)
 
         return scheduled_events_models.ScheduledEventUser(
-            event_id=snowflakes.Snowflake(payload["guild_scheduled_event_id"]),
-            user=user,
-            member=member,
+            event_id=snowflakes.Snowflake(payload["guild_scheduled_event_id"]), user=user, member=member
         )
 
     ###################

--- a/hikari/impl/event_factory.py
+++ b/hikari/impl/event_factory.py
@@ -242,12 +242,7 @@ class EventFactoryImpl(event_factory.EventFactory):
     ) -> channel_events.WebhookUpdateEvent:
         guild_id = snowflakes.Snowflake(payload["guild_id"])
         channel_id = snowflakes.Snowflake(payload["channel_id"])
-        return channel_events.WebhookUpdateEvent(
-            app=self._app,
-            shard=shard,
-            channel_id=channel_id,
-            guild_id=guild_id,
-        )
+        return channel_events.WebhookUpdateEvent(app=self._app, shard=shard, channel_id=channel_id, guild_id=guild_id)
 
     def deserialize_invite_create_event(
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
@@ -286,11 +281,7 @@ class EventFactoryImpl(event_factory.EventFactory):
             guild_id = snowflakes.Snowflake(payload["guild_id"])
             member = self._app.entity_factory.deserialize_member(payload["member"], guild_id=guild_id)
             return typing_events.GuildTypingEvent(
-                shard=shard,
-                channel_id=channel_id,
-                guild_id=guild_id,
-                timestamp=timestamp,
-                member=member,
+                shard=shard, channel_id=channel_id, guild_id=guild_id, timestamp=timestamp, member=member
             )
 
         user_id = snowflakes.Snowflake(payload["user_id"])
@@ -487,9 +478,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         return guild_events.PresenceUpdateEvent(shard=shard, presence=presence, user=user, old_presence=old_presence)
 
     def deserialize_audit_log_entry_create_event(
-        self,
-        shard: gateway_shard.GatewayShard,
-        payload: data_binding.JSONObject,
+        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> guild_events.AuditLogEntryCreateEvent:
         return guild_events.AuditLogEntryCreateEvent(
             shard=shard, entry=self._app.entity_factory.deserialize_audit_log_entry(payload)
@@ -500,13 +489,10 @@ class EventFactoryImpl(event_factory.EventFactory):
     ######################
 
     def deserialize_interaction_create_event(
-        self,
-        shard: gateway_shard.GatewayShard,
-        payload: data_binding.JSONObject,
+        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> interaction_events.InteractionCreateEvent:
         return interaction_events.InteractionCreateEvent(
-            shard=shard,
-            interaction=self._app.entity_factory.deserialize_interaction(payload),
+            shard=shard, interaction=self._app.entity_factory.deserialize_interaction(payload)
         )
 
     #################
@@ -548,8 +534,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> role_events.RoleCreateEvent:
         role = self._app.entity_factory.deserialize_role(
-            payload["role"],
-            guild_id=snowflakes.Snowflake(payload["guild_id"]),
+            payload["role"], guild_id=snowflakes.Snowflake(payload["guild_id"])
         )
         return role_events.RoleCreateEvent(shard=shard, role=role)
 
@@ -561,8 +546,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         old_role: typing.Optional[guild_models.Role] = None,
     ) -> role_events.RoleUpdateEvent:
         role = self._app.entity_factory.deserialize_role(
-            payload["role"],
-            guild_id=snowflakes.Snowflake(payload["guild_id"]),
+            payload["role"], guild_id=snowflakes.Snowflake(payload["guild_id"])
         )
         return role_events.RoleUpdateEvent(shard=shard, role=role, old_role=old_role)
 
@@ -586,39 +570,28 @@ class EventFactoryImpl(event_factory.EventFactory):
     ##########################
 
     def deserialize_scheduled_event_create_event(
-        self,
-        shard: gateway_shard.GatewayShard,
-        payload: data_binding.JSONObject,
+        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> scheduled_events.ScheduledEventCreateEvent:
         return scheduled_events.ScheduledEventCreateEvent(
-            shard=shard,
-            event=self._app.entity_factory.deserialize_scheduled_event(payload),
+            shard=shard, event=self._app.entity_factory.deserialize_scheduled_event(payload)
         )
 
     def deserialize_scheduled_event_update_event(
-        self,
-        shard: gateway_shard.GatewayShard,
-        payload: data_binding.JSONObject,
+        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> scheduled_events.ScheduledEventUpdateEvent:
         return scheduled_events.ScheduledEventUpdateEvent(
-            shard=shard,
-            event=self._app.entity_factory.deserialize_scheduled_event(payload),
+            shard=shard, event=self._app.entity_factory.deserialize_scheduled_event(payload)
         )
 
     def deserialize_scheduled_event_delete_event(
-        self,
-        shard: gateway_shard.GatewayShard,
-        payload: data_binding.JSONObject,
+        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> scheduled_events.ScheduledEventDeleteEvent:
         return scheduled_events.ScheduledEventDeleteEvent(
-            shard=shard,
-            event=self._app.entity_factory.deserialize_scheduled_event(payload),
+            shard=shard, event=self._app.entity_factory.deserialize_scheduled_event(payload)
         )
 
     def deserialize_scheduled_event_user_add_event(
-        self,
-        shard: gateway_shard.GatewayShard,
-        payload: data_binding.JSONObject,
+        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> scheduled_events.ScheduledEventUserAddEvent:
         return scheduled_events.ScheduledEventUserAddEvent(
             app=self._app,
@@ -629,9 +602,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         )
 
     def deserialize_scheduled_event_user_remove_event(
-        self,
-        shard: gateway_shard.GatewayShard,
-        payload: data_binding.JSONObject,
+        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> scheduled_events.ScheduledEventUserRemoveEvent:
         return scheduled_events.ScheduledEventUserRemoveEvent(
             app=self._app,
@@ -706,11 +677,7 @@ class EventFactoryImpl(event_factory.EventFactory):
             )
 
         return message_events.DMMessageDeleteEvent(
-            app=self._app,
-            shard=shard,
-            channel_id=channel_id,
-            message_id=message_id,
-            old_message=old_message,
+            app=self._app, shard=shard, channel_id=channel_id, message_id=message_id, old_message=old_message
         )
 
     def deserialize_guild_message_delete_bulk_event(
@@ -824,10 +791,7 @@ class EventFactoryImpl(event_factory.EventFactory):
             )
 
         return reaction_events.DMReactionDeleteAllEvent(
-            app=self._app,
-            shard=shard,
-            channel_id=channel_id,
-            message_id=message_id,
+            app=self._app, shard=shard, channel_id=channel_id, message_id=message_id
         )
 
     def deserialize_message_reaction_remove_emoji_event(

--- a/hikari/impl/event_manager_base.py
+++ b/hikari/impl/event_manager_base.py
@@ -61,8 +61,7 @@ if typing.TYPE_CHECKING:
         [gateway_shard.GatewayShard, data_binding.JSONObject], typing.Coroutine[typing.Any, typing.Any, None]
     ]
     _ListenerMapT = typing.Dict[
-        typing.Type[base_events.EventT],
-        typing.List[event_manager_.CallbackT[base_events.EventT]],
+        typing.Type[base_events.EventT], typing.List[event_manager_.CallbackT[base_events.EventT]]
     ]
     _WaiterT = typing.Tuple[
         typing.Optional[event_manager_.PredicateT[base_events.EventT]], "asyncio.Future[base_events.EventT]"
@@ -420,11 +419,7 @@ class EventManagerBase(event_manager_.EventManager):
     # For the sake of UX, I will check this at runtime instead and let the
     # user use a static type checker.
     def subscribe(
-        self,
-        event_type: typing.Type[typing.Any],
-        callback: event_manager_.CallbackT[typing.Any],
-        *,
-        _nested: int = 0,
+        self, event_type: typing.Type[typing.Any], callback: event_manager_.CallbackT[typing.Any], *, _nested: int = 0
     ) -> None:
         if not inspect.iscoroutinefunction(callback):
             raise TypeError("Cannot subscribe a non-coroutine function callback")
@@ -448,11 +443,7 @@ class EventManagerBase(event_manager_.EventManager):
             self._increment_listener_group_count(event_type, 1)
 
     def get_listeners(
-        self,
-        event_type: typing.Type[base_events.EventT],
-        /,
-        *,
-        polymorphic: bool = True,
+        self, event_type: typing.Type[base_events.EventT], /, *, polymorphic: bool = True
     ) -> typing.Collection[event_manager_.CallbackT[base_events.EventT]]:
         if polymorphic:
             listeners: typing.List[event_manager_.CallbackT[base_events.EventT]] = []
@@ -471,11 +462,7 @@ class EventManagerBase(event_manager_.EventManager):
     # using ABCs that are not concrete in generic types passed to functions.
     # For the sake of UX, I will check this at runtime instead and let the
     # user use a static type checker.
-    def unsubscribe(
-        self,
-        event_type: typing.Type[typing.Any],
-        callback: event_manager_.CallbackT[typing.Any],
-    ) -> None:
+    def unsubscribe(self, event_type: typing.Type[typing.Any], callback: event_manager_.CallbackT[typing.Any]) -> None:
         if listeners := self._listeners.get(event_type):
             _LOGGER.debug(
                 "unsubscribing callback %s%s from event-type %s.%s",
@@ -490,8 +477,7 @@ class EventManagerBase(event_manager_.EventManager):
                 self._increment_listener_group_count(event_type, -1)
 
     def listen(
-        self,
-        *event_types: typing.Type[base_events.EventT],
+        self, *event_types: typing.Type[base_events.EventT]
     ) -> typing.Callable[[event_manager_.CallbackT[base_events.EventT]], event_manager_.CallbackT[base_events.EventT]]:
         def decorator(
             callback: event_manager_.CallbackT[base_events.EventT],
@@ -603,10 +589,7 @@ class EventManagerBase(event_manager_.EventManager):
             raise
 
     async def _handle_dispatch(
-        self,
-        consumer: _Consumer,
-        shard: gateway_shard.GatewayShard,
-        payload: data_binding.JSONObject,
+        self, consumer: _Consumer, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> None:
         if not consumer.is_enabled:
             name = consumer.callback.__name__
@@ -647,11 +630,7 @@ class EventManagerBase(event_manager_.EventManager):
                     exc_info=trio,
                 )
             else:
-                exception_event = base_events.ExceptionEvent(
-                    exception=ex,
-                    failed_event=event,
-                    failed_callback=callback,
-                )
+                exception_event = base_events.ExceptionEvent(exception=ex, failed_event=event, failed_callback=callback)
 
                 log = _LOGGER.debug if self.get_listeners(type(exception_event), polymorphic=True) else _LOGGER.error
                 log("an exception occurred handling an event (%s)", type(event).__name__, exc_info=trio)

--- a/hikari/impl/interaction_server.py
+++ b/hikari/impl/interaction_server.py
@@ -61,13 +61,9 @@ if typing.TYPE_CHECKING:
 
     _InteractionT_co = typing.TypeVar("_InteractionT_co", bound=base_interactions.PartialInteraction, covariant=True)
     _MessageResponseBuilderT = typing.Union[
-        special_endpoints.InteractionDeferredBuilder,
-        special_endpoints.InteractionMessageBuilder,
+        special_endpoints.InteractionDeferredBuilder, special_endpoints.InteractionMessageBuilder
     ]
-    _ModalOrMessageResponseBuilderT = typing.Union[
-        _MessageResponseBuilderT,
-        special_endpoints.InteractionModalBuilder,
-    ]
+    _ModalOrMessageResponseBuilderT = typing.Union[_MessageResponseBuilderT, special_endpoints.InteractionModalBuilder]
 
 _LOGGER: typing.Final[logging.Logger] = logging.getLogger("hikari.interaction_server")
 

--- a/hikari/impl/rate_limits.py
+++ b/hikari/impl/rate_limits.py
@@ -483,11 +483,7 @@ class ExponentialBackOff:
     """
 
     def __init__(
-        self,
-        base: float = 2.0,
-        maximum: float = 64.0,
-        jitter_multiplier: float = 1.0,
-        initial_increment: int = 0,
+        self, base: float = 2.0, maximum: float = 64.0, jitter_multiplier: float = 1.0, initial_increment: int = 0
     ) -> None:
         # https://mypy.readthedocs.io/en/stable/duck_type_compatibility.html
         # Mypy makes the assumption that ints will always be compatible with floats, this isn't the case and could lead

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -361,9 +361,7 @@ class RESTApp(traits.ExecutorAware):
 
     @typing.overload
     def acquire(
-        self,
-        token: str,
-        token_type: typing.Union[str, applications.TokenType] = applications.TokenType.BEARER,
+        self, token: str, token_type: typing.Union[str, applications.TokenType] = applications.TokenType.BEARER
     ) -> RESTClientImpl:
         ...
 
@@ -1673,9 +1671,7 @@ class RESTClientImpl(rest_api.RESTClient):
         emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.CustomEmoji]] = undefined.UNDEFINED,
     ) -> None:
         route = routes.PUT_MY_REACTION.compile(
-            emoji=_transform_emoji_to_url_format(emoji, emoji_id),
-            channel=channel,
-            message=message,
+            emoji=_transform_emoji_to_url_format(emoji, emoji_id), channel=channel, message=message
         )
         await self._request(route)
 
@@ -1687,9 +1683,7 @@ class RESTClientImpl(rest_api.RESTClient):
         emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.CustomEmoji]] = undefined.UNDEFINED,
     ) -> None:
         route = routes.DELETE_MY_REACTION.compile(
-            emoji=_transform_emoji_to_url_format(emoji, emoji_id),
-            channel=channel,
-            message=message,
+            emoji=_transform_emoji_to_url_format(emoji, emoji_id), channel=channel, message=message
         )
         await self._request(route)
 
@@ -1701,9 +1695,7 @@ class RESTClientImpl(rest_api.RESTClient):
         emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.CustomEmoji]] = undefined.UNDEFINED,
     ) -> None:
         route = routes.DELETE_REACTION_EMOJI.compile(
-            emoji=_transform_emoji_to_url_format(emoji, emoji_id),
-            channel=channel,
-            message=message,
+            emoji=_transform_emoji_to_url_format(emoji, emoji_id), channel=channel, message=message
         )
         await self._request(route)
 
@@ -1716,10 +1708,7 @@ class RESTClientImpl(rest_api.RESTClient):
         emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.CustomEmoji]] = undefined.UNDEFINED,
     ) -> None:
         route = routes.DELETE_REACTION_USER.compile(
-            emoji=_transform_emoji_to_url_format(emoji, emoji_id),
-            channel=channel,
-            message=message,
-            user=user,
+            emoji=_transform_emoji_to_url_format(emoji, emoji_id), channel=channel, message=message, user=user
         )
         await self._request(route)
 
@@ -1785,8 +1774,7 @@ class RESTClientImpl(rest_api.RESTClient):
         return self._entity_factory.deserialize_webhook(response)
 
     async def fetch_channel_webhooks(
-        self,
-        channel: snowflakes.SnowflakeishOr[channels_.WebhookChannelT],
+        self, channel: snowflakes.SnowflakeishOr[channels_.WebhookChannelT]
     ) -> typing.Sequence[webhooks.PartialWebhook]:
         route = routes.GET_CHANNEL_WEBHOOKS.compile(channel=channel)
         response = await self._request(route)
@@ -1794,8 +1782,7 @@ class RESTClientImpl(rest_api.RESTClient):
         return data_binding.cast_variants_array(self._entity_factory.deserialize_webhook, response)
 
     async def fetch_guild_webhooks(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild]
     ) -> typing.Sequence[webhooks.PartialWebhook]:
         route = routes.GET_GUILD_WEBHOOKS.compile(guild=guild)
         response = await self._request(route)
@@ -2404,8 +2391,7 @@ class RESTClientImpl(rest_api.RESTClient):
         ]
 
     async def fetch_sticker(
-        self,
-        sticker: snowflakes.SnowflakeishOr[stickers_.PartialSticker],
+        self, sticker: snowflakes.SnowflakeishOr[stickers_.PartialSticker]
     ) -> typing.Union[stickers_.StandardSticker, stickers_.GuildSticker]:
         route = routes.GET_STICKER.compile(sticker=sticker)
         response = await self._request(route)
@@ -3136,9 +3122,7 @@ class RESTClientImpl(rest_api.RESTClient):
         await self._request(route, json=body)
 
     async def fetch_member(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        user: snowflakes.SnowflakeishOr[users.PartialUser],
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], user: snowflakes.SnowflakeishOr[users.PartialUser]
     ) -> guilds.Member:
         route = routes.GET_GUILD_MEMBER.compile(guild=guild, user=user)
         response = await self._request(route)
@@ -3159,9 +3143,7 @@ class RESTClientImpl(rest_api.RESTClient):
         return self._entity_factory.deserialize_member(response, guild_id=snowflakes.Snowflake(guild))
 
     async def search_members(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        name: str,
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], name: str
     ) -> typing.Sequence[guilds.Member]:
         route = routes.GET_GUILD_MEMBERS_SEARCH.compile(guild=guild)
         query = data_binding.StringMapBuilder()
@@ -3313,9 +3295,7 @@ class RESTClientImpl(rest_api.RESTClient):
         return self.unban_user(guild, user, reason=reason)
 
     async def fetch_ban(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        user: snowflakes.SnowflakeishOr[users.PartialUser],
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], user: snowflakes.SnowflakeishOr[users.PartialUser]
     ) -> guilds.GuildBan:
         route = routes.GET_GUILD_BAN.compile(guild=guild, user=user)
         response = await self._request(route)
@@ -3341,10 +3321,7 @@ class RESTClientImpl(rest_api.RESTClient):
             self._entity_factory, self._request, guild, newest_first, str(start_at)
         )
 
-    async def fetch_roles(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-    ) -> typing.Sequence[guilds.Role]:
+    async def fetch_roles(self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild]) -> typing.Sequence[guilds.Role]:
         route = routes.GET_GUILD_ROLES.compile(guild=guild)
         response = await self._request(route)
         assert isinstance(response, list)
@@ -3443,9 +3420,7 @@ class RESTClientImpl(rest_api.RESTClient):
         return self._entity_factory.deserialize_role(response, guild_id=snowflakes.Snowflake(guild))
 
     async def delete_role(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        role: snowflakes.SnowflakeishOr[guilds.PartialRole],
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], role: snowflakes.SnowflakeishOr[guilds.PartialRole]
     ) -> None:
         route = routes.DELETE_GUILD_ROLE.compile(guild=guild, role=role)
         await self._request(route)
@@ -3487,8 +3462,7 @@ class RESTClientImpl(rest_api.RESTClient):
         return int(pruned) if pruned is not None else None
 
     async def fetch_guild_voice_regions(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild]
     ) -> typing.Sequence[voices.VoiceRegion]:
         route = routes.GET_GUILD_VOICE_REGIONS.compile(guild=guild)
         response = await self._request(route)
@@ -3498,8 +3472,7 @@ class RESTClientImpl(rest_api.RESTClient):
         ]
 
     async def fetch_guild_invites(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild]
     ) -> typing.Sequence[invites.InviteWithMetadata]:
         route = routes.GET_GUILD_INVITES.compile(guild=guild)
         response = await self._request(route)
@@ -3507,8 +3480,7 @@ class RESTClientImpl(rest_api.RESTClient):
         return [self._entity_factory.deserialize_invite_with_metadata(invite_payload) for invite_payload in response]
 
     async def fetch_integrations(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild]
     ) -> typing.Sequence[guilds.Integration]:
         route = routes.GET_GUILD_INTEGRATIONS.compile(guild=guild)
         response = await self._request(route)
@@ -3599,9 +3571,7 @@ class RESTClientImpl(rest_api.RESTClient):
         return [self._entity_factory.deserialize_template(template_payload) for template_payload in response]
 
     async def sync_guild_template(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        template: typing.Union[templates.Template, str],
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], template: typing.Union[templates.Template, str]
     ) -> templates.Template:
         template = template if isinstance(template, str) else template.code
         route = routes.PUT_GUILD_TEMPLATE.compile(guild=guild, template=template)
@@ -3664,9 +3634,7 @@ class RESTClientImpl(rest_api.RESTClient):
         return self._entity_factory.deserialize_template(response)
 
     async def delete_template(
-        self,
-        guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        template: typing.Union[str, templates.Template],
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], template: typing.Union[str, templates.Template]
     ) -> templates.Template:
         template = template if isinstance(template, str) else template.code
         route = routes.DELETE_GUILD_TEMPLATE.compile(guild=guild, template=template)
@@ -3678,9 +3646,7 @@ class RESTClientImpl(rest_api.RESTClient):
         return special_endpoints_impl.SlashCommandBuilder(name, description)
 
     def context_menu_command_builder(
-        self,
-        type: typing.Union[commands.CommandType, int],
-        name: str,
+        self, type: typing.Union[commands.CommandType, int], name: str
     ) -> special_endpoints.ContextMenuCommandBuilder:
         return special_endpoints_impl.ContextMenuCommandBuilder(commands.CommandType(type), name)
 

--- a/hikari/impl/rest_bot.py
+++ b/hikari/impl/rest_bot.py
@@ -58,13 +58,9 @@ if typing.TYPE_CHECKING:
 
     _InteractionT_co = typing.TypeVar("_InteractionT_co", bound=base_interactions.PartialInteraction, covariant=True)
     _MessageResponseBuilderT = typing.Union[
-        special_endpoints.InteractionDeferredBuilder,
-        special_endpoints.InteractionMessageBuilder,
+        special_endpoints.InteractionDeferredBuilder, special_endpoints.InteractionMessageBuilder
     ]
-    _ModalOrMessageResponseBuilderT = typing.Union[
-        _MessageResponseBuilderT,
-        special_endpoints.InteractionModalBuilder,
-    ]
+    _ModalOrMessageResponseBuilderT = typing.Union[_MessageResponseBuilderT, special_endpoints.InteractionModalBuilder]
 
 _LOGGER: typing.Final[logging.Logger] = logging.getLogger("hikari.rest_bot")
 
@@ -337,9 +333,7 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
 
         # InteractionServer
         self._server = interaction_server_impl.InteractionServer(
-            entity_factory=self._entity_factory,
-            public_key=public_key,
-            rest_client=self._rest,
+            entity_factory=self._entity_factory, public_key=public_key, rest_client=self._rest
         )
 
     @property
@@ -576,9 +570,7 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
 
         try:
             with signals.handle_interrupts(
-                enabled=enable_signal_handlers,
-                loop=loop,
-                propagate_interrupts=propagate_interrupts,
+                enabled=enable_signal_handlers, loop=loop, propagate_interrupts=propagate_interrupts
             ):
                 loop.run_until_complete(
                     self.start(
@@ -668,8 +660,7 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
 
         if check_for_updates:
             asyncio.create_task(
-                ux.check_for_updates(self._http_settings, self._proxy_settings),
-                name="check for package updates",
+                ux.check_for_updates(self._http_settings, self._proxy_settings), name="check for package updates"
             )
 
         self._rest.start()

--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -634,10 +634,7 @@ class GatewayShardImpl(shard.GatewayShard):
             raise errors.ComponentStateConflictError("Cannot run more than one instance of one shard concurrently")
 
         self._handshake_event = asyncio.Event()
-        keep_alive_task = asyncio.create_task(
-            self._keep_alive(),
-            name=f"keep alive (shard {self._shard_id})",
-        )
+        keep_alive_task = asyncio.create_task(self._keep_alive(), name=f"keep alive (shard {self._shard_id})")
 
         await aio.first_completed(self._handshake_event.wait(), asyncio.shield(keep_alive_task))
 
@@ -660,10 +657,7 @@ class GatewayShardImpl(shard.GatewayShard):
     ) -> None:
         self._check_if_connected()
         presence_payload = self._serialize_and_store_presence_payload(
-            idle_since=idle_since,
-            afk=afk,
-            activity=activity,
-            status=status,
+            idle_since=idle_since, afk=afk, activity=activity, status=status
         )
         await self._send_json({_OP: _PRESENCE_UPDATE, _D: presence_payload})
 
@@ -785,10 +779,7 @@ class GatewayShardImpl(shard.GatewayShard):
 
         assert self._handshake_event is not None
 
-        url_parts = urllib.parse.urlparse(
-            self._resume_gateway_url or self._gateway_url,
-            allow_fragments=True,
-        )
+        url_parts = urllib.parse.urlparse(self._resume_gateway_url or self._gateway_url, allow_fragments=True)
 
         query = dict(urllib.parse.parse_qsl(url_parts.query))
         query["v"] = str(urls.VERSION)
@@ -798,14 +789,7 @@ class GatewayShardImpl(shard.GatewayShard):
             query["compress"] = "zlib-stream"
 
         url = urllib.parse.urlunparse(
-            (
-                url_parts.scheme,
-                url_parts.netloc,
-                url_parts.path,
-                url_parts.params,
-                urllib.parse.urlencode(query),
-                "",
-            )
+            (url_parts.scheme, url_parts.netloc, url_parts.path, url_parts.params, urllib.parse.urlencode(query), "")
         )
 
         self._ws = await _GatewayTransport.connect(
@@ -862,10 +846,7 @@ class GatewayShardImpl(shard.GatewayShard):
         else:
             self._logger.debug("resuming session %s", self._session_id)
             await self._send_json(
-                {
-                    _OP: _RESUME,
-                    _D: {"token": self._token, "seq": self._seq, "session_id": self._session_id},
-                }
+                {_OP: _RESUME, _D: {"token": self._token, "seq": self._seq, "session_id": self._session_id}}
             )
 
         lifetime_tasks = (heartbeat_task, poll_events_task)
@@ -907,9 +888,7 @@ class GatewayShardImpl(shard.GatewayShard):
             except errors.GatewayServerClosedConnectionError as ex:
                 if not ex.can_reconnect:
                     self._logger.info(
-                        "server has closed the connection permanently [code:%s, reason:%s]",
-                        ex.code,
-                        ex.reason,
+                        "server has closed the connection permanently [code:%s, reason:%s]", ex.code, ex.reason
                     )
                     raise
 

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -1340,9 +1340,7 @@ class CommandBuilder(special_endpoints.CommandBuilder):
         return self
 
     def set_default_member_permissions(
-        self,
-        default_member_permissions: typing.Union[undefined.UndefinedType, int, permissions_.Permissions],
-        /,
+        self, default_member_permissions: typing.Union[undefined.UndefinedType, int, permissions_.Permissions], /
     ) -> Self:
         self._default_member_permissions = default_member_permissions
         return self
@@ -1360,9 +1358,7 @@ class CommandBuilder(special_endpoints.CommandBuilder):
         return self._name_localizations
 
     def set_name_localizations(
-        self,
-        name_localizations: typing.Mapping[typing.Union[locales.Locale, str], str],
-        /,
+        self, name_localizations: typing.Mapping[typing.Union[locales.Locale, str], str], /
     ) -> Self:
         self._name_localizations = name_localizations
         return self
@@ -1412,15 +1408,11 @@ class SlashCommandBuilder(CommandBuilder, special_endpoints.SlashCommandBuilder)
         return self._options.copy()
 
     @property
-    def description_localizations(
-        self,
-    ) -> typing.Mapping[typing.Union[locales.Locale, str], str]:
+    def description_localizations(self) -> typing.Mapping[typing.Union[locales.Locale, str], str]:
         return self._description_localizations
 
     def set_description_localizations(
-        self,
-        description_localizations: typing.Mapping[typing.Union[locales.Locale, str], str],
-        /,
+        self, description_localizations: typing.Mapping[typing.Union[locales.Locale, str], str], /
     ) -> Self:
         self._description_localizations = description_localizations
         return self
@@ -1555,9 +1547,7 @@ class _ButtonBuilder(special_endpoints.ButtonBuilder):
         return self._is_disabled
 
     def set_emoji(
-        self,
-        emoji: typing.Union[snowflakes.Snowflakeish, emojis.Emoji, str, undefined.UndefinedType],
-        /,
+        self, emoji: typing.Union[snowflakes.Snowflakeish, emojis.Emoji, str, undefined.UndefinedType], /
     ) -> Self:
         self._emoji_id, self._emoji_name = _build_emoji(emoji)
         self._emoji = emoji
@@ -1663,9 +1653,7 @@ class SelectOptionBuilder(special_endpoints.SelectOptionBuilder):
         return self
 
     def set_emoji(
-        self,
-        emoji: typing.Union[snowflakes.Snowflakeish, emojis.Emoji, str, undefined.UndefinedType],
-        /,
+        self, emoji: typing.Union[snowflakes.Snowflakeish, emojis.Emoji, str, undefined.UndefinedType], /
     ) -> Self:
         self._emoji_id, self._emoji_name = _build_emoji(emoji)
         self._emoji = emoji
@@ -1826,9 +1814,7 @@ class TextSelectMenuBuilder(SelectMenuBuilder, special_endpoints.TextSelectMenuB
         return self._parent
 
     @property
-    def options(
-        self,
-    ) -> typing.Sequence[special_endpoints.SelectOptionBuilder]:
+    def options(self) -> typing.Sequence[special_endpoints.SelectOptionBuilder]:
         return self._options.copy()
 
     def add_option(

--- a/hikari/impl/voice.py
+++ b/hikari/impl/voice.py
@@ -188,9 +188,7 @@ class VoiceComponentImpl(voice.VoiceComponent):
                 ),
             )
         except asyncio.TimeoutError as e:
-            raise errors.VoiceError(
-                f"Could not connect to voice channel {channel} in guild {guild}.",
-            ) from e
+            raise errors.VoiceError(f"Could not connect to voice channel {channel} in guild {guild}.") from e
 
         # We will never receive the first endpoint as `None`
         assert server_event.endpoint is not None
@@ -236,8 +234,7 @@ class VoiceComponentImpl(voice.VoiceComponent):
 
     @staticmethod
     def _init_state_update_predicate(
-        guild_id: snowflakes.Snowflake,
-        user_id: snowflakes.Snowflake,
+        guild_id: snowflakes.Snowflake, user_id: snowflakes.Snowflake
     ) -> typing.Callable[[voice_events.VoiceStateUpdateEvent], bool]:
         def predicate(event: voice_events.VoiceStateUpdateEvent) -> bool:
             return event.state.guild_id == guild_id and event.state.user_id == user_id
@@ -263,10 +260,7 @@ class VoiceComponentImpl(voice.VoiceComponent):
 
             # Leave the voice channel explicitly, otherwise we will just appear to
             # not leave properly.
-            await self._app.shards[connection.shard_id].update_voice_state(
-                guild=connection.guild_id,
-                channel=None,
-            )
+            await self._app.shards[connection.shard_id].update_voice_state(guild=connection.guild_id, channel=None)
 
             _LOGGER.debug(
                 "successfully unregistered voice connection %s to guild %s and left voice channel %s",

--- a/hikari/interactions/base_interactions.py
+++ b/hikari/interactions/base_interactions.py
@@ -582,12 +582,7 @@ class ModalResponseMixin(PartialInteraction):
             If both `component` and `components` are specified or if none are specified.
         """
         await self.app.rest.create_modal_response(
-            self.id,
-            self.token,
-            title=title,
-            custom_id=custom_id,
-            component=component,
-            components=components,
+            self.id, self.token, title=title, custom_id=custom_id, component=component, components=components
         )
 
     def build_modal_response(self, title: str, custom_id: str) -> special_endpoints.InteractionModalBuilder:

--- a/hikari/interactions/component_interactions.py
+++ b/hikari/interactions/component_interactions.py
@@ -85,8 +85,7 @@ The following types are valid for this:
 
 @attrs.define(hash=True, weakref_slot=False)
 class ComponentInteraction(
-    base_interactions.MessageResponseMixin[ComponentResponseTypesT],
-    base_interactions.ModalResponseMixin,
+    base_interactions.MessageResponseMixin[ComponentResponseTypesT], base_interactions.ModalResponseMixin
 ):
     """Represents a component interaction on Discord."""
 

--- a/hikari/interactions/modal_interactions.py
+++ b/hikari/interactions/modal_interactions.py
@@ -24,11 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.List[str] = [
-    "ModalResponseTypesT",
-    "ModalInteraction",
-    "ModalInteraction",
-]
+__all__: typing.List[str] = ["ModalResponseTypesT", "ModalInteraction", "ModalInteraction"]
 
 import typing
 

--- a/hikari/internal/aio.py
+++ b/hikari/internal/aio.py
@@ -104,10 +104,7 @@ def is_async_iterable(obj: typing.Any) -> typing_extensions.TypeGuard[typing.Asy
     return inspect.isfunction(attrs) or inspect.ismethod(attrs)
 
 
-async def first_completed(
-    *aws: typing.Awaitable[typing.Any],
-    timeout: typing.Optional[float] = None,
-) -> None:
+async def first_completed(*aws: typing.Awaitable[typing.Any], timeout: typing.Optional[float] = None) -> None:
     """Wait for the first awaitable to complete.
 
     The awaitables that don't complete first will be cancelled.
@@ -151,10 +148,7 @@ async def first_completed(
                     pass
 
 
-async def all_of(
-    *aws: typing.Awaitable[T_co],
-    timeout: typing.Optional[float] = None,
-) -> typing.Sequence[T_co]:
+async def all_of(*aws: typing.Awaitable[T_co], timeout: typing.Optional[float] = None) -> typing.Sequence[T_co]:
     """Await the completion of all the given awaitable items.
 
     If any fail or time out, then they are all cancelled.

--- a/hikari/internal/cache.py
+++ b/hikari/internal/cache.py
@@ -101,19 +101,11 @@ class CacheMappingView(cache.CacheView[KeyT, ValueT]):
     __slots__: typing.Sequence[str] = ("_data", "_builder")
 
     @typing.overload
-    def __init__(
-        self,
-        items: typing.Mapping[KeyT, ValueT],
-    ) -> None:
+    def __init__(self, items: typing.Mapping[KeyT, ValueT]) -> None:
         ...
 
     @typing.overload
-    def __init__(
-        self,
-        items: typing.Mapping[KeyT, DataT],
-        *,
-        builder: typing.Callable[[DataT], ValueT],
-    ) -> None:
+    def __init__(self, items: typing.Mapping[KeyT, DataT], *, builder: typing.Callable[[DataT], ValueT]) -> None:
         ...
 
     def __init__(
@@ -479,11 +471,7 @@ class KnownCustomEmojiData(BaseData[emojis.KnownCustomEmoji]):
 
     @classmethod
     def build_from_entity(
-        cls,
-        emoji: emojis.KnownCustomEmoji,
-        /,
-        *,
-        user: typing.Optional[RefCell[users_.User]] = None,
+        cls, emoji: emojis.KnownCustomEmoji, /, *, user: typing.Optional[RefCell[users_.User]] = None
     ) -> KnownCustomEmojiData:
         if not user and emoji.user:
             user = RefCell(copy.copy(emoji.user))
@@ -532,11 +520,7 @@ class GuildStickerData(BaseData[stickers_.GuildSticker]):
 
     @classmethod
     def build_from_entity(
-        cls,
-        sticker: stickers_.GuildSticker,
-        /,
-        *,
-        user: typing.Optional[RefCell[users_.User]] = None,
+        cls, sticker: stickers_.GuildSticker, /, *, user: typing.Optional[RefCell[users_.User]] = None
     ) -> GuildStickerData:
         if not user and sticker.user:
             user = RefCell(copy.copy(sticker.user))
@@ -588,11 +572,7 @@ class RichActivityData(BaseData[presences.RichActivity]):
 
     @classmethod
     def build_from_entity(
-        cls,
-        activity: presences.RichActivity,
-        /,
-        *,
-        emoji: typing.Union[RefCell[emojis.CustomEmoji], str, None] = None,
+        cls, activity: presences.RichActivity, /, *, emoji: typing.Union[RefCell[emojis.CustomEmoji], str, None] = None
     ) -> RichActivityData:
         if emoji:
             pass
@@ -698,11 +678,7 @@ class MessageInteractionData(BaseData[messages.MessageInteraction]):
 
     @classmethod
     def build_from_entity(
-        cls,
-        interaction: messages.MessageInteraction,
-        /,
-        *,
-        user: typing.Optional[RefCell[users_.User]] = None,
+        cls, interaction: messages.MessageInteraction, /, *, user: typing.Optional[RefCell[users_.User]] = None
     ) -> MessageInteractionData:
         if user is None:
             user = RefCell(interaction.user)
@@ -964,11 +940,7 @@ class VoiceStateData(BaseData[voices.VoiceState]):
 
     @classmethod
     def build_from_entity(
-        cls,
-        voice_state: voices.VoiceState,
-        /,
-        *,
-        member: typing.Optional[RefCell[MemberData]] = None,
+        cls, voice_state: voices.VoiceState, /, *, member: typing.Optional[RefCell[MemberData]] = None
     ) -> VoiceStateData:
         return cls(
             channel_id=voice_state.channel_id,

--- a/hikari/internal/data_binding.py
+++ b/hikari/internal/data_binding.py
@@ -186,22 +186,12 @@ class StringMapBuilder(multidict.MultiDict[str]):
         super().__init__(arg, **kwargs)
 
     @typing.overload
-    def put(
-        self,
-        key: str,
-        value: Stringish,
-        /,
-    ) -> None:
+    def put(self, key: str, value: Stringish, /) -> None:
         ...
 
     @typing.overload
     def put(
-        self,
-        key: str,
-        value: undefined.UndefinedOr[T_co],
-        /,
-        *,
-        conversion: typing.Callable[[T_co], Stringish],
+        self, key: str, value: undefined.UndefinedOr[T_co], /, *, conversion: typing.Callable[[T_co], Stringish]
     ) -> None:
         ...
 
@@ -280,12 +270,7 @@ class JSONObjectBuilder(typing.Dict[str, JSONish]):
 
     @typing.overload
     def put(
-        self,
-        key: str,
-        value: undefined.UndefinedNoneOr[T_co],
-        /,
-        *,
-        conversion: typing.Callable[[T_co], JSONish],
+        self, key: str, value: undefined.UndefinedNoneOr[T_co], /, *, conversion: typing.Callable[[T_co], JSONish]
     ) -> None:
         ...
 
@@ -324,12 +309,7 @@ class JSONObjectBuilder(typing.Dict[str, JSONish]):
             self[key] = conversion(value)
 
     @typing.overload
-    def put_array(
-        self,
-        key: str,
-        values: undefined.UndefinedOr[typing.Iterable[JSONish]],
-        /,
-    ) -> None:
+    def put_array(self, key: str, values: undefined.UndefinedOr[typing.Iterable[JSONish]], /) -> None:
         ...
 
     @typing.overload
@@ -399,10 +379,7 @@ class JSONObjectBuilder(typing.Dict[str, JSONish]):
             self[key] = value
 
     def put_snowflake_array(
-        self,
-        key: str,
-        values: undefined.UndefinedOr[typing.Iterable[snowflakes.SnowflakeishOr[snowflakes.Unique]]],
-        /,
+        self, key: str, values: undefined.UndefinedOr[typing.Iterable[snowflakes.SnowflakeishOr[snowflakes.Unique]]], /
     ) -> None:
         """Put an array of snowflakes with the given key into this builder.
 

--- a/hikari/internal/deprecation.py
+++ b/hikari/internal/deprecation.py
@@ -56,13 +56,7 @@ def check_if_past_removal(what: str, /, *, removal_version: str) -> None:
 
 
 def warn_deprecated(
-    what: str,
-    /,
-    *,
-    removal_version: str,
-    additional_info: str,
-    stack_level: int = 3,
-    quote: bool = True,
+    what: str, /, *, removal_version: str, additional_info: str, stack_level: int = 3, quote: bool = True
 ) -> None:
     """Issue a deprecation warning.
 

--- a/hikari/internal/enums.py
+++ b/hikari/internal/enums.py
@@ -56,9 +56,7 @@ class _DeprecatedAlias(typing.Generic[_T]):
         from hikari.internal import deprecation
 
         deprecation.warn_deprecated(
-            self._name,
-            removal_version=self._removal_version,
-            additional_info=f"Use '{self._alias}' instead.",
+            self._name, removal_version=self._removal_version, additional_info=f"Use '{self._alias}' instead."
         )
 
         return owner_enum[self._alias]

--- a/hikari/internal/fast_protocol.py
+++ b/hikari/internal/fast_protocol.py
@@ -45,10 +45,7 @@ class _FastProtocolChecking(type(typing.Protocol)):
     _attributes_: typing.Tuple[str, ...]
 
     def __new__(
-        cls,
-        cls_name: str,
-        bases: typing.Tuple[typing.Type[typing.Any], ...],
-        namespace: typing.Dict[str, typing.Any],
+        cls, cls_name: str, bases: typing.Tuple[typing.Type[typing.Any], ...], namespace: typing.Dict[str, typing.Any]
     ) -> Self:
         global _Protocol
 

--- a/hikari/internal/net.py
+++ b/hikari/internal/net.py
@@ -77,10 +77,7 @@ async def generate_error_response(response: aiohttp.ClientResponse) -> errors.HT
 
 
 def create_tcp_connector(
-    http_settings: config.HTTPSettings,
-    *,
-    dns_cache: typing.Union[bool, int] = True,
-    limit: int = 100,
+    http_settings: config.HTTPSettings, *, dns_cache: typing.Union[bool, int] = True, limit: int = 100
 ) -> aiohttp.TCPConnector:
     """Create a TCP connector and return it.
 

--- a/hikari/internal/reflect.py
+++ b/hikari/internal/reflect.py
@@ -97,13 +97,7 @@ def profiled(call: typing.Callable[..., _T]) -> typing.Callable[..., _T]:  # pra
     @functools.wraps(call)
     def wrapped(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
         print("Profiling", call.__module__ + "." + call.__qualname__)  # noqa: T201 print disallowed.
-        cProfile.runctx(
-            "result = call(*args, **kwargs)",
-            globals=globals(),
-            locals=locals(),
-            filename=None,
-            sort=1,
-        )
+        cProfile.runctx("result = call(*args, **kwargs)", globals=globals(), locals=locals(), filename=None, sort=1)
         return locals()["result"]
 
     return wrapped

--- a/hikari/internal/routes.py
+++ b/hikari/internal/routes.py
@@ -216,12 +216,7 @@ class CDNRoute:
     """Whether a `size` param can be specified."""
 
     def compile(
-        self,
-        base_url: str,
-        *,
-        file_format: str,
-        size: typing.Optional[int] = None,
-        **kwargs: typing.Any,
+        self, base_url: str, *, file_format: str, size: typing.Optional[int] = None, **kwargs: typing.Any
     ) -> str:
         """Generate a full CDN url from this endpoint.
 
@@ -285,12 +280,7 @@ class CDNRoute:
         return url
 
     def compile_to_file(
-        self,
-        base_url: str,
-        *,
-        file_format: str,
-        size: typing.Optional[int] = None,
-        **kwargs: typing.Any,
+        self, base_url: str, *, file_format: str, size: typing.Optional[int] = None, **kwargs: typing.Any
     ) -> files.URL:
         """Perform the same as `compile`, but return the URL as a `files.URL`."""
         return files.URL(self.compile(base_url, file_format=file_format, size=size, **kwargs))

--- a/hikari/internal/signals.py
+++ b/hikari/internal/signals.py
@@ -77,9 +77,7 @@ def _interrupt_handler(
 
 @contextlib.contextmanager
 def handle_interrupts(
-    enabled: typing.Optional[bool],
-    loop: asyncio.AbstractEventLoop,
-    propagate_interrupts: bool,
+    enabled: typing.Optional[bool], loop: asyncio.AbstractEventLoop, propagate_interrupts: bool
 ) -> typing.Generator[None, None, None]:
     """Context manager which cleanly exits on signal interrupts.
 

--- a/hikari/invites.py
+++ b/hikari/invites.py
@@ -24,14 +24,7 @@
 
 from __future__ import annotations
 
-__all__: typing.Sequence[str] = (
-    "TargetType",
-    "VanityURL",
-    "InviteGuild",
-    "InviteCode",
-    "Invite",
-    "InviteWithMetadata",
-)
+__all__: typing.Sequence[str] = ("TargetType", "VanityURL", "InviteGuild", "InviteCode", "Invite", "InviteWithMetadata")
 
 import abc
 import typing
@@ -168,11 +161,7 @@ class InviteGuild(guilds.PartialGuild):
             return None
 
         return routes.CDN_GUILD_SPLASH.compile_to_file(
-            urls.CDN_URL,
-            guild_id=self.id,
-            hash=self.splash_hash,
-            size=size,
-            file_format=ext,
+            urls.CDN_URL, guild_id=self.id, hash=self.splash_hash, size=size, file_format=ext
         )
 
     @property
@@ -217,11 +206,7 @@ class InviteGuild(guilds.PartialGuild):
                 ext = "png"
 
         return routes.CDN_GUILD_BANNER.compile_to_file(
-            urls.CDN_URL,
-            guild_id=self.id,
-            hash=self.banner_hash,
-            size=size,
-            file_format=ext,
+            urls.CDN_URL, guild_id=self.id, hash=self.banner_hash, size=size, file_format=ext
         )
 
 

--- a/hikari/iterators.py
+++ b/hikari/iterators.py
@@ -28,13 +28,7 @@ wish to extend this API further!
 """
 from __future__ import annotations
 
-__all__: typing.Sequence[str] = (
-    "LazyIterator",
-    "FlatLazyIterator",
-    "All",
-    "AttrComparator",
-    "BufferedLazyIterator",
-)
+__all__: typing.Sequence[str] = ("LazyIterator", "FlatLazyIterator", "All", "AttrComparator", "BufferedLazyIterator")
 
 import abc
 import asyncio
@@ -234,8 +228,7 @@ class LazyIterator(typing.Generic[ValueT], abc.ABC):
         return _ChunkedLazyIterator(self, chunk_size)
 
     def map(
-        self,
-        transformation: typing.Union[typing.Callable[[ValueT], AnotherValueT], str],
+        self, transformation: typing.Union[typing.Callable[[ValueT], AnotherValueT], str]
     ) -> LazyIterator[AnotherValueT]:
         """Map the values to a different value.
 
@@ -956,9 +949,7 @@ class _MappingLazyIterator(typing.Generic[AnotherValueT, ValueT], LazyIterator[V
     __slots__: typing.Sequence[str] = ("_iterator", "_transformation")
 
     def __init__(
-        self,
-        iterator: LazyIterator[AnotherValueT],
-        transformation: typing.Callable[[AnotherValueT], ValueT],
+        self, iterator: LazyIterator[AnotherValueT], transformation: typing.Callable[[AnotherValueT], ValueT]
     ) -> None:
         self._iterator = iterator
         self._transformation = transformation

--- a/hikari/messages.py
+++ b/hikari/messages.py
@@ -341,11 +341,7 @@ class MessageApplication(guilds.PartialApplication):
             return None
 
         return routes.CDN_APPLICATION_COVER.compile_to_file(
-            urls.CDN_URL,
-            application_id=self.id,
-            hash=self.cover_image_hash,
-            size=size,
-            file_format=ext,
+            urls.CDN_URL, application_id=self.id, hash=self.cover_image_hash, size=size, file_format=ext
         )
 
 
@@ -368,8 +364,7 @@ class MessageInteraction:
 
 
 def _map_cache_maybe_discover(
-    ids: typing.Iterable[snowflakes.Snowflake],
-    cache_call: typing.Callable[[snowflakes.Snowflake], typing.Optional[_T]],
+    ids: typing.Iterable[snowflakes.Snowflake], cache_call: typing.Callable[[snowflakes.Snowflake], typing.Optional[_T]]
 ) -> typing.Dict[snowflakes.Snowflake, _T]:
     results: typing.Dict[snowflakes.Snowflake, _T] = {}
     for id_ in ids:
@@ -1099,18 +1094,11 @@ class PartialMessage(snowflakes.Unique):
         await self.app.rest.delete_message(self.channel_id, self.id)
 
     @typing.overload
-    async def add_reaction(
-        self,
-        emoji: typing.Union[str, emojis_.Emoji],
-    ) -> None:
+    async def add_reaction(self, emoji: typing.Union[str, emojis_.Emoji]) -> None:
         ...
 
     @typing.overload
-    async def add_reaction(
-        self,
-        emoji: str,
-        emoji_id: snowflakes.SnowflakeishOr[emojis_.CustomEmoji],
-    ) -> None:
+    async def add_reaction(self, emoji: str, emoji_id: snowflakes.SnowflakeishOr[emojis_.CustomEmoji]) -> None:
         ...
 
     async def add_reaction(
@@ -1268,18 +1256,11 @@ class PartialMessage(snowflakes.Unique):
         ...
 
     @typing.overload
-    async def remove_all_reactions(
-        self,
-        emoji: typing.Union[str, emojis_.Emoji],
-    ) -> None:
+    async def remove_all_reactions(self, emoji: typing.Union[str, emojis_.Emoji]) -> None:
         ...
 
     @typing.overload
-    async def remove_all_reactions(
-        self,
-        emoji: str,
-        emoji_id: snowflakes.SnowflakeishOr[emojis_.CustomEmoji],
-    ) -> None:
+    async def remove_all_reactions(self, emoji: str, emoji_id: snowflakes.SnowflakeishOr[emojis_.CustomEmoji]) -> None:
         ...
 
     async def remove_all_reactions(

--- a/hikari/presences.py
+++ b/hikari/presences.py
@@ -157,11 +157,7 @@ class ActivityAssets:
         except ValueError:
             assert self._application_id is not None
             return routes.CDN_APPLICATION_ASSET.compile_to_file(
-                urls.CDN_URL,
-                application_id=self._application_id,
-                hash=asset,
-                size=size,
-                file_format=ext,
+                urls.CDN_URL, application_id=self._application_id, hash=asset, size=size, file_format=ext
             )
 
     @property

--- a/hikari/scheduled_events.py
+++ b/hikari/scheduled_events.py
@@ -182,11 +182,7 @@ class ScheduledEvent(snowflakes.Unique):
             return None
 
         return routes.SCHEDULED_EVENT_COVER.compile_to_file(
-            urls.CDN_URL,
-            scheduled_event_id=self.id,
-            hash=self.image_hash,
-            size=size,
-            file_format=ext,
+            urls.CDN_URL, scheduled_event_id=self.id, hash=self.image_hash, size=size, file_format=ext
         )
 
 

--- a/hikari/traits.py
+++ b/hikari/traits.py
@@ -208,12 +208,7 @@ class VoiceAware(fast_protocol.FastProtocolChecking, typing.Protocol):
 
 @typing.runtime_checkable
 class ShardAware(
-    IntentsAware,
-    NetworkSettingsAware,
-    ExecutorAware,
-    VoiceAware,
-    fast_protocol.FastProtocolChecking,
-    typing.Protocol,
+    IntentsAware, NetworkSettingsAware, ExecutorAware, VoiceAware, fast_protocol.FastProtocolChecking, typing.Protocol
 ):
     """Structural supertype for a shard-aware object.
 
@@ -501,17 +496,13 @@ class RESTBotAware(InteractionServerAware, Runnable, fast_protocol.FastProtocolC
 
     @property
     @abc.abstractmethod
-    def on_shutdown(
-        self,
-    ) -> typing.Sequence[typing.Callable[[Self], typing.Coroutine[typing.Any, typing.Any, None]]]:
+    def on_shutdown(self) -> typing.Sequence[typing.Callable[[Self], typing.Coroutine[typing.Any, typing.Any, None]]]:
         """Sequence of the bot's asynchronous shutdown callbacks."""
         raise NotImplementedError
 
     @property
     @abc.abstractmethod
-    def on_startup(
-        self,
-    ) -> typing.Sequence[typing.Callable[[Self], typing.Coroutine[typing.Any, typing.Any, None]]]:
+    def on_startup(self) -> typing.Sequence[typing.Callable[[Self], typing.Coroutine[typing.Any, typing.Any, None]]]:
         """Sequence of the bot's asynchronous startup callbacks."""
         raise NotImplementedError
 

--- a/hikari/users.py
+++ b/hikari/users.py
@@ -485,9 +485,7 @@ class User(PartialUser, abc.ABC):
     def default_avatar_url(self) -> files.URL:
         """Default avatar URL for this user."""
         return routes.CDN_DEFAULT_USER_AVATAR.compile_to_file(
-            urls.CDN_URL,
-            discriminator=int(self.discriminator) % 5,
-            file_format="png",
+            urls.CDN_URL, discriminator=int(self.discriminator) % 5, file_format="png"
         )
 
     @property
@@ -575,11 +573,7 @@ class User(PartialUser, abc.ABC):
                 ext = "png"
 
         return routes.CDN_USER_AVATAR.compile_to_file(
-            urls.CDN_URL,
-            user_id=self.id,
-            hash=self.avatar_hash,
-            size=size,
-            file_format=ext,
+            urls.CDN_URL, user_id=self.id, hash=self.avatar_hash, size=size, file_format=ext
         )
 
     def make_banner_url(self, *, ext: typing.Optional[str] = None, size: int = 4096) -> typing.Optional[files.URL]:
@@ -620,11 +614,7 @@ class User(PartialUser, abc.ABC):
                 ext = "png"
 
         return routes.CDN_USER_BANNER.compile_to_file(
-            urls.CDN_URL,
-            user_id=self.id,
-            hash=self.banner_hash,
-            size=size,
-            file_format=ext,
+            urls.CDN_URL, user_id=self.id, hash=self.banner_hash, size=size, file_format=ext
         )
 
 

--- a/hikari/webhooks.py
+++ b/hikari/webhooks.py
@@ -526,11 +526,7 @@ class PartialWebhook(snowflakes.Unique):
     @property
     def default_avatar_url(self) -> files_.URL:
         """Default avatar URL for the user."""
-        return routes.CDN_DEFAULT_USER_AVATAR.compile_to_file(
-            urls.CDN_URL,
-            discriminator=0,
-            file_format="png",
-        )
+        return routes.CDN_DEFAULT_USER_AVATAR.compile_to_file(urls.CDN_URL, discriminator=0, file_format="png")
 
     def make_avatar_url(self, ext: str = "png", size: int = 4096) -> typing.Optional[files_.URL]:
         """Generate the avatar URL for this webhook's custom avatar if set.
@@ -563,11 +559,7 @@ class PartialWebhook(snowflakes.Unique):
             return None
 
         return routes.CDN_USER_AVATAR.compile_to_file(
-            urls.CDN_URL,
-            user_id=self.id,
-            hash=self.avatar_hash,
-            size=size,
-            file_format=ext,
+            urls.CDN_URL, user_id=self.id, hash=self.avatar_hash, size=size, file_format=ext
         )
 
 
@@ -706,12 +698,7 @@ class IncomingWebhook(PartialWebhook, ExecutableWebhook):
             token = self.token
 
         webhook = await self.app.rest.edit_webhook(
-            self.id,
-            token=token,
-            name=name,
-            avatar=avatar,
-            channel=channel,
-            reason=reason,
+            self.id, token=token, name=name, avatar=avatar, channel=channel, reason=reason
         )
         assert isinstance(webhook, IncomingWebhook)
         return webhook
@@ -882,13 +869,7 @@ class ChannelFollowerWebhook(PartialWebhook):
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
         """
-        webhook = await self.app.rest.edit_webhook(
-            self.id,
-            name=name,
-            avatar=avatar,
-            channel=channel,
-            reason=reason,
-        )
+        webhook = await self.app.rest.edit_webhook(self.id, name=name, avatar=avatar, channel=channel, reason=reason)
         assert isinstance(webhook, ChannelFollowerWebhook)
         return webhook
 

--- a/pipelines/codespell.nox.py
+++ b/pipelines/codespell.nox.py
@@ -22,11 +22,7 @@
 from pipelines import config
 from pipelines import nox
 
-IGNORED_WORDS = [
-    "ro",
-    "falsy",
-    "ws",
-]
+IGNORED_WORDS = ["ro", "falsy", "ws"]
 
 
 @nox.session()

--- a/pipelines/format.nox.py
+++ b/pipelines/format.nox.py
@@ -73,7 +73,7 @@ def remove_trailing_whitespaces(session: nox.Session, check_only: bool = False) 
     call(
         f"{message} {count} file(s). "
         f"{remark}Took {1_000 * (end - start):.2f}ms to check {total} files in this project."
-        + ("\nTry running 'nox -s reformat-code' to fix them" if check_only and count else ""),
+        + ("\nTry running 'nox -s reformat-code' to fix them" if check_only and count else "")
     )
 
 

--- a/pipelines/pytest.nox.py
+++ b/pipelines/pytest.nox.py
@@ -25,11 +25,7 @@ import typing
 from pipelines import config
 from pipelines import nox
 
-RUN_FLAGS = [
-    "-c",
-    config.PYPROJECT_TOML,
-    "--showlocals",
-]
+RUN_FLAGS = ["-c", config.PYPROJECT_TOML, "--showlocals"]
 COVERAGE_FLAGS = [
     "--cov",
     config.MAIN_PACKAGE,
@@ -70,12 +66,7 @@ def pytest_all_features(session: nox.Session) -> None:
 def _pytest(
     session: nox.Session, *, extra_install: typing.Sequence[str] = (), python_flags: typing.Sequence[str] = ()
 ) -> None:
-    session.install(
-        "-r",
-        "requirements.txt",
-        *extra_install,
-        *nox.dev_requirements("pytest"),
-    )
+    session.install("-r", "requirements.txt", *extra_install, *nox.dev_requirements("pytest"))
 
     if "--skip-coverage" in session.posargs:
         session.posargs.remove("--skip-coverage")

--- a/pipelines/sphinx.nox.py
+++ b/pipelines/sphinx.nox.py
@@ -45,11 +45,7 @@ def sphinx(session: nox.Session):
     session.install("-e", ".", *nox.dev_requirements("sphinx"))
 
     session.run(
-        "sphinx-build",
-        "-M",
-        "dirhtml",
-        config.DOCUMENTATION_DIRECTORY,
-        os.path.join(config.ARTIFACT_DIRECTORY, "docs"),
+        "sphinx-build", "-M", "dirhtml", config.DOCUMENTATION_DIRECTORY, os.path.join(config.ARTIFACT_DIRECTORY, "docs")
     )
 
 

--- a/pipelines/utils.nox.py
+++ b/pipelines/utils.nox.py
@@ -36,15 +36,9 @@ DIRECTORIES_TO_DELETE = [
     "node_modules",
 ]
 
-FILES_TO_DELETE = [
-    ".coverage",
-    "package-lock.json",
-]
+FILES_TO_DELETE = [".coverage", "package-lock.json"]
 
-TO_DELETE = [
-    (shutil.rmtree, DIRECTORIES_TO_DELETE),
-    (os.remove, FILES_TO_DELETE),
-]
+TO_DELETE = [(shutil.rmtree, DIRECTORIES_TO_DELETE), (os.remove, FILES_TO_DELETE)]
 
 
 @nox.session(venv_backend="none")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 line-length = 120
 include = ".*pyi?$"
+skip-magic-trailing-comma = true
 target-version = ["py38"]
 
 [tool.coverage.run]

--- a/scripts/benchmarks/protocol_benchmark.py
+++ b/scripts/benchmarks/protocol_benchmark.py
@@ -136,45 +136,29 @@ for i in range(100_000):
     assert sum(i for i in range(10)) > 0
 
 py_protocol_isinstance_long_time = timeit.timeit(
-    "isinstance(isinstance_long, BasicPyProtocol)",
-    number=1_000_000,
-    globals=globals(),
+    "isinstance(isinstance_long, BasicPyProtocol)", number=1_000_000, globals=globals()
 )
 hikari_protocol_isinstance_long_time = timeit.timeit(
-    "isinstance(isinstance_long, BasicHikariProtocol)",
-    number=1_000_000,
-    globals=globals(),
+    "isinstance(isinstance_long, BasicHikariProtocol)", number=1_000_000, globals=globals()
 )
 py_protocol_isinstance_failfast_time = timeit.timeit(
-    "isinstance(isinstance_failfast, BasicPyProtocol)",
-    number=1_000_000,
-    globals=globals(),
+    "isinstance(isinstance_failfast, BasicPyProtocol)", number=1_000_000, globals=globals()
 )
 hikari_protocol_isinstance_failfast_time = timeit.timeit(
-    "isinstance(isinstance_failfast, BasicHikariProtocol)",
-    number=1_000_000,
-    globals=globals(),
+    "isinstance(isinstance_failfast, BasicHikariProtocol)", number=1_000_000, globals=globals()
 )
 
 py_protocol_issubclass_long_time = timeit.timeit(
-    "issubclass(Invalid, BasicPyProtocol)",
-    number=1_000_000,
-    globals=globals(),
+    "issubclass(Invalid, BasicPyProtocol)", number=1_000_000, globals=globals()
 )
 hikari_protocol_issubclass_long_time = timeit.timeit(
-    "issubclass(Invalid, BasicHikariProtocol)",
-    number=1_000_000,
-    globals=globals(),
+    "issubclass(Invalid, BasicHikariProtocol)", number=1_000_000, globals=globals()
 )
 py_protocol_issubclass_failfast_time = timeit.timeit(
-    "issubclass(Valid, BasicPyProtocol)",
-    number=1_000_000,
-    globals=globals(),
+    "issubclass(Valid, BasicPyProtocol)", number=1_000_000, globals=globals()
 )
 hikari_protocol_issubclass_failfast_time = timeit.timeit(
-    "issubclass(Valid, BasicHikariProtocol)",
-    number=1_000_000,
-    globals=globals(),
+    "issubclass(Valid, BasicHikariProtocol)", number=1_000_000, globals=globals()
 )
 
 print("isinstance(long, BasicPyProtocol)", py_protocol_isinstance_long_time, "µs")

--- a/scripts/gateway_stub.py
+++ b/scripts/gateway_stub.py
@@ -61,11 +61,7 @@ def v8_get_gateway_bot(_):
         {
             "url": gateway_uri_v8,
             "shards": 1,
-            "session_start_limit": {
-                "total": 1000,
-                "remaining": 1000,
-                "reset_after": 1,
-            },
+            "session_start_limit": {"total": 1000, "remaining": 1000, "reset_after": 1},
         }
     )
 

--- a/tests/hikari/events/test_base_events.py
+++ b/tests/hikari/events/test_base_events.py
@@ -36,12 +36,7 @@ class DummyGuildEvent(base_events.Event):
 
 @base_events.no_recursive_throw()
 @base_events.requires_intents(intents.Intents.GUILD_PRESENCES)
-@attrs.define(
-    eq=False,
-    hash=False,
-    init=False,
-    kw_only=True,
-)
+@attrs.define(eq=False, hash=False, init=False, kw_only=True)
 class DummyPresenceEvent(base_events.Event):
     pass
 
@@ -52,12 +47,7 @@ class ErrorEvent(base_events.Event):
     pass
 
 
-@attrs.define(
-    eq=False,
-    hash=False,
-    init=False,
-    kw_only=True,
-)
+@attrs.define(eq=False, hash=False, init=False, kw_only=True)
 class DummyGuildDerivedEvent(DummyGuildEvent):
     pass
 
@@ -102,9 +92,7 @@ class TestExceptionEvent:
     @pytest.fixture()
     def event(self, error):
         return base_events.ExceptionEvent(
-            exception=error,
-            failed_event=mock.Mock(base_events.Event),
-            failed_callback=mock.AsyncMock(),
+            exception=error, failed_event=mock.Mock(base_events.Event), failed_callback=mock.AsyncMock()
         )
 
     def test_app_property(self, event):

--- a/tests/hikari/events/test_member_events.py
+++ b/tests/hikari/events/test_member_events.py
@@ -47,10 +47,7 @@ class TestMemberEvent:
         event.user_id == 456
 
     def test_guild_when_no_cache_trait(self):
-        event = hikari_test_helpers.mock_class_namespace(
-            member_events.MemberEvent,
-            app=None,
-        )()
+        event = hikari_test_helpers.mock_class_namespace(member_events.MemberEvent, app=None)()
 
         assert event.get_guild() is None
 

--- a/tests/hikari/events/test_message_events.py
+++ b/tests/hikari/events/test_message_events.py
@@ -37,12 +37,7 @@ class TestMessageCreateEvent:
     def event(self):
         cls = hikari_test_helpers.mock_class_namespace(
             message_events.MessageCreateEvent,
-            message=mock.Mock(
-                spec_set=messages.Message,
-                author=mock.Mock(
-                    spec_set=users.User,
-                ),
-            ),
+            message=mock.Mock(spec_set=messages.Message, author=mock.Mock(spec_set=users.User)),
             shard=mock.Mock(),
         )
 
@@ -73,12 +68,7 @@ class TestMessageCreateEvent:
 
     @pytest.mark.parametrize(
         ("author_is_bot", "webhook_id", "expected_is_human"),
-        [
-            (True, 123, False),
-            (True, None, False),
-            (False, 123, False),
-            (False, None, True),
-        ],
+        [(True, 123, False), (True, None, False), (False, 123, False), (False, None, True)],
     )
     def test_is_human_property(self, event, author_is_bot, webhook_id, expected_is_human):
         event.message.author.is_bot = author_is_bot
@@ -99,12 +89,7 @@ class TestMessageUpdateEvent:
     def event(self):
         cls = hikari_test_helpers.mock_class_namespace(
             message_events.MessageUpdateEvent,
-            message=mock.Mock(
-                spec_set=messages.Message,
-                author=mock.Mock(
-                    spec_set=users.User,
-                ),
-            ),
+            message=mock.Mock(spec_set=messages.Message, author=mock.Mock(spec_set=users.User)),
             shard=mock.Mock(),
         )
 
@@ -120,10 +105,7 @@ class TestMessageUpdateEvent:
 
     @pytest.mark.parametrize(
         ("author", "expected_id"),
-        [
-            (mock.Mock(spec_set=users.User, id=91827), 91827),
-            (undefined.UNDEFINED, undefined.UNDEFINED),
-        ],
+        [(mock.Mock(spec_set=users.User, id=91827), 91827), (undefined.UNDEFINED, undefined.UNDEFINED)],
     )
     def test_author_id_property(self, event, author, expected_id):
         event.message.author = author

--- a/tests/hikari/events/test_typing_events.py
+++ b/tests/hikari/events/test_typing_events.py
@@ -32,11 +32,7 @@ class TestTypingEvent:
     @pytest.fixture()
     def event(self):
         cls = hikari_test_helpers.mock_class_namespace(
-            typing_events.TypingEvent,
-            channel_id=123,
-            user_id=456,
-            timestamp=object(),
-            shard=object(),
+            typing_events.TypingEvent, channel_id=123, user_id=456, timestamp=object(), shard=object()
         )
 
         return cls()
@@ -144,11 +140,7 @@ class TestDMTypingEvent:
         cls = hikari_test_helpers.mock_class_namespace(typing_events.DMTypingEvent)
 
         return cls(
-            channel_id=123,
-            timestamp=object(),
-            shard=object(),
-            app=mock.Mock(rest=mock.AsyncMock()),
-            user_id=456,
+            channel_id=123, timestamp=object(), shard=object(), app=mock.Mock(rest=mock.AsyncMock()), user_id=456
         )
 
     async def test_fetch_channel(self, event):

--- a/tests/hikari/impl/test_bot.py
+++ b/tests/hikari/impl/test_bot.py
@@ -437,7 +437,7 @@ class TestGatewayBot:
                 mock.call(shard1.close()),
                 mock.call(shard2.close()),
                 mock.call(rest.close()),
-            ],
+            ]
         )
 
         rest.close.assert_awaited_once()
@@ -449,11 +449,7 @@ class TestGatewayBot:
         # Error handling
         get_running_loop.assert_called_once_with()
         get_running_loop.return_value.call_exception_handler.assert_called_once_with(
-            {
-                "message": "shard 1 raised an exception during shut down",
-                "future": shard1.close(),
-                "exception": error,
-            }
+            {"message": "shard 1 raised an exception during shut down", "future": shard1.close(), "exception": error}
         )
 
         # Clear out maps
@@ -464,7 +460,7 @@ class TestGatewayBot:
             [
                 mock.call(event_factory.deserialize_stopping_event.return_value),
                 mock.call(event_factory.deserialize_stopped_event.return_value),
-            ],
+            ]
         )
 
     def test_dispatch(self, bot, event_manager):
@@ -622,10 +618,7 @@ class TestGatewayBot:
             )
 
         loop.run_until_complete.assert_has_calls(
-            [
-                mock.call(start_function.return_value),
-                mock.call(join_function.return_value),
-            ]
+            [mock.call(start_function.return_value), mock.call(join_function.return_value)]
         )
         start_function.assert_called_once_with(
             activity=activity,
@@ -930,23 +923,13 @@ class TestGatewayBot:
         with mock.patch.object(bot_impl.GatewayBot, "_get_shard", return_value=shard) as get_shard:
             with mock.patch.object(bot_impl.GatewayBot, "_check_if_alive") as check_if_alive:
                 await bot.request_guild_members(
-                    115590097100865541,
-                    include_presences=True,
-                    query="indeed",
-                    limit=42,
-                    users=[123],
-                    nonce="NONCE",
+                    115590097100865541, include_presences=True, query="indeed", limit=42, users=[123], nonce="NONCE"
                 )
 
         check_if_alive.assert_called_once_with()
         get_shard.assert_called_once_with(115590097100865541)
         shard.request_guild_members.assert_awaited_once_with(
-            guild=115590097100865541,
-            include_presences=True,
-            query="indeed",
-            limit=42,
-            users=[123],
-            nonce="NONCE",
+            guild=115590097100865541, include_presences=True, query="indeed", limit=42, users=[123], nonce="NONCE"
         )
 
     @pytest.mark.asyncio()
@@ -1019,9 +1002,7 @@ class TestGatewayBot:
         status = object()
         bot._shards = {}
         shard_obj = mock.Mock(
-            is_alive=is_alive,
-            start=mock.AsyncMock(side_effect=RuntimeError("exit in tests")),
-            close=mock.AsyncMock(),
+            is_alive=is_alive, start=mock.AsyncMock(side_effect=RuntimeError("exit in tests")), close=mock.AsyncMock()
         )
 
         with mock.patch.object(shard_impl, "GatewayShardImpl", return_value=shard_obj):

--- a/tests/hikari/impl/test_cache.py
+++ b/tests/hikari/impl/test_cache.py
@@ -390,10 +390,7 @@ class TestCacheImpl:
 
         result = cache_impl.get_emojis_view()
 
-        assert result == {
-            snowflakes.Snowflake(123123123): mock_emoji_1,
-            snowflakes.Snowflake(43156234): mock_emoji_2,
-        }
+        assert result == {snowflakes.Snowflake(123123123): mock_emoji_1, snowflakes.Snowflake(43156234): mock_emoji_2}
         cache_impl._build_emoji.assert_has_calls([mock.call(mock_emoji_data_1), mock.call(mock_emoji_data_2)])
 
     def test_get_emojis_view_for_guild(self, cache_impl):
@@ -420,10 +417,7 @@ class TestCacheImpl:
 
         result = cache_impl.get_emojis_view_for_guild(StubModel(9342123))
 
-        assert result == {
-            snowflakes.Snowflake(65123): mock_emoji_1,
-            snowflakes.Snowflake(43156234): mock_emoji_2,
-        }
+        assert result == {snowflakes.Snowflake(65123): mock_emoji_1, snowflakes.Snowflake(43156234): mock_emoji_2}
         cache_impl._build_emoji.assert_has_calls([mock.call(mock_emoji_data_1), mock.call(mock_emoji_data_2)])
 
     def test_get_emojis_view_for_guild_for_unknown_emoji_cache(self, cache_impl):
@@ -822,10 +816,7 @@ class TestCacheImpl:
 
         result = cache_impl.get_stickers_view_for_guild(StubModel(9342123))
 
-        assert result == {
-            snowflakes.Snowflake(65123): mock_sticker_1,
-            snowflakes.Snowflake(43156234): mock_sticker_2,
-        }
+        assert result == {snowflakes.Snowflake(65123): mock_sticker_1, snowflakes.Snowflake(43156234): mock_sticker_2}
         cache_impl._build_sticker.assert_has_calls([mock.call(mock_sticker_data_1), mock.call(mock_sticker_data_2)])
 
     def test_get_stickers_view_for_guild_for_unknown_sticker_cache(self, cache_impl):
@@ -943,8 +934,7 @@ class TestCacheImpl:
                 snowflakes.Snowflake(423123): cache_utilities.GuildRecord(),
                 snowflakes.Snowflake(675345): cache_utilities.GuildRecord(guild=mock_guild_1),
                 snowflakes.Snowflake(32142): cache_utilities.GuildRecord(
-                    guild=mock_guild_2,
-                    members=collections.FreezableDict({snowflakes.Snowflake(3241123): mock_member}),
+                    guild=mock_guild_2, members=collections.FreezableDict({snowflakes.Snowflake(3241123): mock_member})
                 ),
                 snowflakes.Snowflake(765345): cache_utilities.GuildRecord(guild=mock_guild_3),
                 snowflakes.Snowflake(321132): cache_utilities.GuildRecord(),
@@ -1185,10 +1175,7 @@ class TestCacheImpl:
 
         result = cache_impl.get_available_guilds_view()
 
-        assert result == {
-            snowflakes.Snowflake(4312312): mock_guild_1,
-            snowflakes.Snowflake(73453): mock_guild_2,
-        }
+        assert result == {snowflakes.Snowflake(4312312): mock_guild_1, snowflakes.Snowflake(73453): mock_guild_2}
 
     def test_get_available_guilds_view_when_no_guilds_cached(self, cache_impl):
         cache_impl._guild_entries = collections.FreezableDict(
@@ -1217,10 +1204,7 @@ class TestCacheImpl:
 
         result = cache_impl.get_unavailable_guilds_view()
 
-        assert result == {
-            snowflakes.Snowflake(4312312): mock_guild_1,
-            snowflakes.Snowflake(73453): mock_guild_2,
-        }
+        assert result == {snowflakes.Snowflake(4312312): mock_guild_1, snowflakes.Snowflake(73453): mock_guild_2}
 
     def test_get_unavailable_guilds_view_when_no_guilds_cached(self, cache_impl):
         cache_impl._guild_entries = collections.FreezableDict(
@@ -1405,10 +1389,7 @@ class TestCacheImpl:
 
         result = cache_impl.clear_invites_for_guild(StubModel(999888777))
 
-        assert result == {
-            "oeoeoeoeooe": mock_invite_1,
-            "owowowowoowowow": mock_invite_2,
-        }
+        assert result == {"oeoeoeoeooe": mock_invite_1, "owowowowoowowow": mock_invite_2}
         assert cache_impl._invite_entries == {"oeoeoeoeoeoeoe": mock_other_invite_data}
         cache_impl._garbage_collect_user.assert_has_calls(
             [mock.call(mock_target_user, decrement=1), mock.call(mock_inviter, decrement=1)], any_order=True
@@ -1483,10 +1464,7 @@ class TestCacheImpl:
 
         result = cache_impl.clear_invites_for_channel(StubModel(999888777), StubModel(34123123))
 
-        assert result == {
-            "oeoeoeoeooe": mock_invite_1,
-            "owowowowoowowow": mock_invite_2,
-        }
+        assert result == {"oeoeoeoeooe": mock_invite_1, "owowowowoowowow": mock_invite_2}
         cache_impl._garbage_collect_user.assert_has_calls(
             [mock.call(mock_target_user, decrement=1), mock.call(mock_inviter, decrement=1)], any_order=True
         )
@@ -1625,9 +1603,7 @@ class TestCacheImpl:
         assert result is mock_invite
         cache_impl._build_invite.assert_called_once_with(mock_invite_data)
         cache_impl._garbage_collect_user.assert_not_called()
-        assert cache_impl._invite_entries == {
-            "blamSpat": mock_other_invite_data,
-        }
+        assert cache_impl._invite_entries == {"blamSpat": mock_other_invite_data}
         assert cache_impl._guild_entries[snowflakes.Snowflake(999999999)].invites == ["ok", "blat"]
 
     def test_delete_invite_for_unknown_invite(self, cache_impl):
@@ -1711,10 +1687,7 @@ class TestCacheImpl:
 
         result = cache_impl.get_invites_view_for_guild(StubModel(4444444))
 
-        assert result == {
-            "okok": mock_invite_1,
-            "dsaytert": mock_invite_2,
-        }
+        assert result == {"okok": mock_invite_1, "dsaytert": mock_invite_2}
         cache_impl._build_invite.assert_has_calls([mock.call(mock_invite_data_1), mock.call(mock_invite_data_2)])
 
     def test_get_invites_view_for_guild_unknown_emoji_cache(self, cache_impl):
@@ -2236,10 +2209,7 @@ class TestCacheImpl:
 
         result = cache_impl.get_members_view_for_guild(StubModel(42334))
 
-        assert result == {
-            snowflakes.Snowflake(3214321): mock_member_1,
-            snowflakes.Snowflake(53224): mock_member_2,
-        }
+        assert result == {snowflakes.Snowflake(3214321): mock_member_1, snowflakes.Snowflake(53224): mock_member_2}
         cache_impl._build_member.assert_has_calls([mock.call(mock_member_data_1), mock.call(mock_member_data_2)])
 
     def test_set_member(self, cache_impl):
@@ -2397,10 +2367,7 @@ class TestCacheImpl:
         mock_user = cache_utilities.RefCell(mock.Mock(id=snowflakes.Snowflake(21231234)), ref_count=1)
         mock_other_user = mock.Mock(cache_utilities.RefCell, ref_count=1)
         cache_impl._user_entries = collections.FreezableDict(
-            {
-                snowflakes.Snowflake(21231234): mock_user,
-                snowflakes.Snowflake(645234): mock_other_user,
-            }
+            {snowflakes.Snowflake(21231234): mock_user, snowflakes.Snowflake(645234): mock_other_user}
         )
 
         cache_impl._garbage_collect_user(mock_user, decrement=1)
@@ -2412,10 +2379,7 @@ class TestCacheImpl:
         cache_impl._dm_channel_entries = collections.FreezableDict({21231234: 123123123})
         mock_other_user = mock.Mock(cache_utilities.RefCell, ref_count=1)
         cache_impl._user_entries = collections.FreezableDict(
-            {
-                snowflakes.Snowflake(21231234): mock_user,
-                snowflakes.Snowflake(645234): mock_other_user,
-            }
+            {snowflakes.Snowflake(21231234): mock_user, snowflakes.Snowflake(645234): mock_other_user}
         )
 
         cache_impl._garbage_collect_user(mock_user, decrement=1)
@@ -2472,10 +2436,7 @@ class TestCacheImpl:
 
         result = cache_impl.get_users_view()
 
-        assert result == {
-            snowflakes.Snowflake(54123): mock_user_1,
-            snowflakes.Snowflake(76345): mock_user_2,
-        }
+        assert result == {snowflakes.Snowflake(54123): mock_user_1, snowflakes.Snowflake(76345): mock_user_2}
 
     def test_get_users_view_for_empty_user_cache(self, cache_impl):
         assert cache_impl.get_users_view() == {}

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -784,10 +784,7 @@ class TestGatewayGuildDefinition:
 
         entity_factory_impl.deserialize_guild_thread.assert_not_called()
 
-    def test_threads_ignores_unrecognised_and_threads(
-        self,
-        entity_factory_impl: entity_factory.EntityFactoryImpl,
-    ):
+    def test_threads_ignores_unrecognised_and_threads(self, entity_factory_impl: entity_factory.EntityFactoryImpl):
         thread_types = {*channel_models.ChannelType, -99999}.difference(
             {
                 channel_models.ChannelType.GUILD_PRIVATE_THREAD,
@@ -813,8 +810,7 @@ class TestGatewayGuildDefinition:
                 voice_state_payload,
                 guild_id=snowflakes.Snowflake(265828729970753537),
                 member=entity_factory_impl.deserialize_member(
-                    member_payload,
-                    guild_id=snowflakes.Snowflake(265828729970753537),
+                    member_payload, guild_id=snowflakes.Snowflake(265828729970753537)
                 ),
             )
         }
@@ -928,10 +924,7 @@ class TestEntityFactoryImpl:
         return {
             "platform_name": "Muck",
             "platform_username": "Muck Muck Muck",
-            "metadata": {
-                "key": "value",
-                "key2": "value2",
-            },
+            "metadata": {"key": "value", "key2": "value2"},
         }
 
     def test_deserialize_own_application_role_connection(self, entity_factory_impl, role_connection_payload):
@@ -939,10 +932,7 @@ class TestEntityFactoryImpl:
 
         assert role_connection.platform_name == "Muck"
         assert role_connection.platform_username == "Muck Muck Muck"
-        assert role_connection.metadata == {
-            "key": "value",
-            "key2": "value2",
-        }
+        assert role_connection.metadata == {"key": "value", "key2": "value2"}
         assert isinstance(role_connection, application_models.OwnApplicationRoleConnection)
 
     @pytest.fixture()
@@ -977,10 +967,7 @@ class TestEntityFactoryImpl:
             "role_connections_verification_url": "https://verifymethis.com",
             "custom_install_url": "https://dontinstallme.com",
             "tags": ["i", "like", "hikari"],
-            "install_params": {
-                "scopes": ["bot", "applications.commands"],
-                "permissions": 8,
-            },
+            "install_params": {"scopes": ["bot", "applications.commands"], "permissions": 8},
         }
 
     def test_deserialize_application(
@@ -1164,10 +1151,7 @@ class TestEntityFactoryImpl:
             "key": "developer_value",
             "name": "A thing",
             "description": "Description of the thing",
-            "name_localizations": {
-                "en-UK": "A thing (but in Bri'ish)",
-                "es": "Una cosa",
-            },
+            "name_localizations": {"en-UK": "A thing (but in Bri'ish)", "es": "Una cosa"},
             "description_localizations": {
                 "en-UK": "Description of the thing (but in Bri'ish)",
                 "es": "Descripción de la cosa",
@@ -1185,10 +1169,7 @@ class TestEntityFactoryImpl:
         assert record.key == "developer_value"
         assert record.name == "A thing"
         assert record.description == "Description of the thing"
-        assert record.name_localizations == {
-            "en-UK": "A thing (but in Bri'ish)",
-            "es": "Una cosa",
-        }
+        assert record.name_localizations == {"en-UK": "A thing (but in Bri'ish)", "es": "Una cosa"}
         assert record.description_localizations == {
             "en-UK": "Description of the thing (but in Bri'ish)",
             "es": "Descripción de la cosa",
@@ -1213,12 +1194,8 @@ class TestEntityFactoryImpl:
             key="some_key",
             name="Testing this out",
             description="Describing this out",
-            name_localizations={
-                "some_language": "Its name localization",
-            },
-            description_localizations={
-                "some_other_language": "Its description localization",
-            },
+            name_localizations={"some_language": "Its name localization"},
+            description_localizations={"some_other_language": "Its description localization"},
         )
 
         expected_result = {
@@ -1226,12 +1203,8 @@ class TestEntityFactoryImpl:
             "key": "some_key",
             "name": "Testing this out",
             "description": "Describing this out",
-            "name_localizations": {
-                "some_language": "Its name localization",
-            },
-            "description_localizations": {
-                "some_other_language": "Its description localization",
-            },
+            "name_localizations": {"some_language": "Its name localization"},
+            "description_localizations": {"some_other_language": "Its description localization"},
         }
 
         assert entity_factory_impl.serialize_application_connection_metadata_record(record) == expected_result
@@ -1326,9 +1299,7 @@ class TestEntityFactoryImpl:
     #####################
 
     def test__deserialize_audit_log_change_roles(self, entity_factory_impl):
-        test_role_payloads = [
-            {"id": "24", "name": "roleA"},
-        ]
+        test_role_payloads = [{"id": "24", "name": "roleA"}]
         roles = entity_factory_impl._deserialize_audit_log_change_roles(test_role_payloads)
         assert len(roles) == 1
         role = roles[24]
@@ -1364,10 +1335,7 @@ class TestEntityFactoryImpl:
 
     @pytest.fixture()
     def message_pin_info_payload(self):
-        return {
-            "channel_id": "123123123",
-            "message_id": "69696969",
-        }
+        return {"channel_id": "123123123", "message_id": "69696969"}
 
     def test__deserialize_message_pin_entry_info(self, entity_factory_impl, message_pin_info_payload):
         message_pin_info = entity_factory_impl._deserialize_message_pin_entry_info(message_pin_info_payload)
@@ -1377,10 +1345,7 @@ class TestEntityFactoryImpl:
 
     @pytest.fixture()
     def member_prune_info_payload(self):
-        return {
-            "delete_member_days": "7",
-            "members_removed": "1",
-        }
+        return {"delete_member_days": "7", "members_removed": "1"}
 
     def test__deserialize_member_prune_entry_info(self, entity_factory_impl, member_prune_info_payload):
         member_prune_info = entity_factory_impl._deserialize_member_prune_entry_info(member_prune_info_payload)
@@ -1451,12 +1416,7 @@ class TestEntityFactoryImpl:
 
     @pytest.fixture()
     def partial_integration_payload(self):
-        return {
-            "id": "4949494949",
-            "name": "Blah blah",
-            "type": "twitch",
-            "account": {"id": "543453", "name": "Blam"},
-        }
+        return {"id": "4949494949", "name": "Blah blah", "type": "twitch", "account": {"id": "543453", "name": "Blam"}}
 
     def test_deserialize_audit_log_entry(self, entity_factory_impl, audit_log_entry_payload, mock_app):
         entry = entity_factory_impl.deserialize_audit_log_entry(
@@ -1628,10 +1588,7 @@ class TestEntityFactoryImpl:
         assert len(audit_log.entries) == 0
 
     def test_deserialize_audit_log_skips_unknown_webhook_type(
-        self,
-        entity_factory_impl,
-        incoming_webhook_payload,
-        application_webhook_payload,
+        self, entity_factory_impl, incoming_webhook_payload, application_webhook_payload
     ):
         audit_log = entity_factory_impl.deserialize_audit_log(
             {
@@ -1650,10 +1607,7 @@ class TestEntityFactoryImpl:
         }
 
     def test_deserialize_audit_log_skips_unknown_thread_type(
-        self,
-        entity_factory_impl,
-        guild_public_thread_payload,
-        guild_private_thread_payload,
+        self, entity_factory_impl, guild_public_thread_payload, guild_private_thread_payload
     ):
         audit_log = entity_factory_impl.deserialize_audit_log(
             {
@@ -1698,8 +1652,7 @@ class TestEntityFactoryImpl:
         assert isinstance(overwrite, channel_models.PermissionOverwrite)
 
     @pytest.mark.parametrize(
-        "type",
-        [channel_models.PermissionOverwriteType.MEMBER, channel_models.PermissionOverwriteType.ROLE],
+        "type", [channel_models.PermissionOverwriteType.MEMBER, channel_models.PermissionOverwriteType.ROLE]
     )
     def test_serialize_permission_overwrite(self, entity_factory_impl, type):
         overwrite = channel_models.PermissionOverwrite(id=123123, type=type, allow=42, deny=62)
@@ -1723,12 +1676,7 @@ class TestEntityFactoryImpl:
 
     @pytest.fixture()
     def dm_channel_payload(self, user_payload):
-        return {
-            "id": "123",
-            "last_message_id": "456",
-            "type": 1,
-            "recipients": [user_payload],
-        }
+        return {"id": "123", "last_message_id": "456", "type": 1, "recipients": [user_payload]}
 
     def test_deserialize_dm_channel(self, entity_factory_impl, mock_app, dm_channel_payload, user_payload):
         dm_channel = entity_factory_impl.deserialize_dm(dm_channel_payload)
@@ -2127,10 +2075,7 @@ class TestEntityFactoryImpl:
             "default_thread_rate_limit_per_user": 1400,
             "default_sort_order": 1,
             "default_forum_layout": 1,
-            "default_reaction_emoji": {
-                "emoji_id": "654395854798716938",
-                "emoji_name": "some_emoji_name",
-            },
+            "default_reaction_emoji": {"emoji_id": "654395854798716938", "emoji_name": "some_emoji_name"},
             "available_tags": [
                 {
                     "id": "924798733516800000",
@@ -2139,13 +2084,7 @@ class TestEntityFactoryImpl:
                     "emoji_id": "51685451281621",
                     "emoji_name": None,
                 },
-                {
-                    "id": "970821992448000000",
-                    "name": "Big!",
-                    "moderated": False,
-                    "emoji_id": None,
-                    "emoji_name": "B",
-                },
+                {"id": "970821992448000000", "name": "Big!", "moderated": False, "emoji_id": None, "emoji_name": "B"},
             ],
         }
 
@@ -2684,13 +2623,7 @@ class TestEntityFactoryImpl:
 
         expected_fn.assert_called_once_with(payload, guild_id=123)
 
-    @pytest.mark.parametrize(
-        ("type_", "fn"),
-        [
-            (1, "deserialize_dm"),
-            (3, "deserialize_group_dm"),
-        ],
-    )
+    @pytest.mark.parametrize(("type_", "fn"), [(1, "deserialize_dm"), (3, "deserialize_group_dm")])
     def test_deserialize_channel_when_dm(self, mock_app, type_, fn):
         payload = {"type": type_}
 
@@ -3442,13 +3375,7 @@ class TestEntityFactoryImpl:
         assert integration.application.icon_hash == "123abc"
         assert integration.application.description == "same as desc2"
         assert integration.application.bot == entity_factory_impl.deserialize_user(
-            {
-                "id": "456",
-                "username": "some rando bot",
-                "avatar": "123456avc",
-                "discriminator": "6127",
-                "bot": True,
-            }
+            {"id": "456", "username": "some rando bot", "avatar": "123456avc", "discriminator": "6127", "bot": True}
         )
         assert isinstance(integration, guild_models.Integration)
 
@@ -3569,12 +3496,7 @@ class TestEntityFactoryImpl:
         assert guild_preview.description is None
 
     @pytest.fixture()
-    def rest_guild_payload(
-        self,
-        known_custom_emoji_payload,
-        guild_sticker_payload,
-        guild_role_payload,
-    ):
+    def rest_guild_payload(self, known_custom_emoji_payload, guild_sticker_payload, guild_role_payload):
         return {
             "afk_channel_id": "99998888777766",
             "afk_timeout": 1200,
@@ -3934,8 +3856,7 @@ class TestEntityFactoryImpl:
                 voice_state_payload,
                 guild_id=snowflakes.Snowflake(265828729970753537),
                 member=entity_factory_impl.deserialize_member(
-                    member_payload,
-                    guild_id=snowflakes.Snowflake(265828729970753537),
+                    member_payload, guild_id=snowflakes.Snowflake(265828729970753537)
                 ),
             )
         }
@@ -4291,12 +4212,7 @@ class TestEntityFactoryImpl:
             "permissions": "17179869183",
             "premium_since": "2020-10-01T23:06:10.431000+00:00",
             "communication_disabled_until": "2021-10-18T23:06:10.431000+00:00",
-            "roles": [
-                "582345963851743243",
-                "582689893965365248",
-                "734164204679856290",
-                "757331666388910181",
-            ],
+            "roles": ["582345963851743243", "582689893965365248", "734164204679856290", "757331666388910181"],
         }
 
     def test__deserialize_interaction_member(self, entity_factory_impl, interaction_member_payload, user_payload):
@@ -4449,7 +4365,7 @@ class TestEntityFactoryImpl:
                             {"name": "go ice", "type": 4, "value": "42"},
                             {"name": "go fire", "type": 6, "value": 123123123},
                         ],
-                    },
+                    }
                 ],
                 "resolved": interaction_resolved_data_payload,
             },
@@ -4532,11 +4448,7 @@ class TestEntityFactoryImpl:
                 "name": "okokokok",
                 "type": 2,
                 "target_id": "115590097100865541",
-                "resolved": {
-                    "users": {
-                        "115590097100865541": user_payload,
-                    }
-                },
+                "resolved": {"users": {"115590097100865541": user_payload}},
             },
             "channel_id": "49949494",
             "member": interaction_member_payload,
@@ -4595,7 +4507,7 @@ class TestEntityFactoryImpl:
                             {"name": "meat", "type": 6, "value": 123312, "focused": True},
                             {"name": "yeet", "type": 3, "value": "ea"},
                         ],
-                    },
+                    }
                 ],
             },
             "channel_id": "49949494",
@@ -4765,13 +4677,7 @@ class TestEntityFactoryImpl:
                     "description": "you're drunk",
                     "name": "go home",
                     "required": False,
-                    "choices": [
-                        {
-                            "name": "boo",
-                            "name_localizations": {},
-                            "value": "hoo",
-                        }
-                    ],
+                    "choices": [{"name": "boo", "name_localizations": {}, "value": "hoo"}],
                     "description_localizations": {"tr": "c"},
                     "name_localizations": {"tr": "b"},
                 }
@@ -4806,11 +4712,7 @@ class TestEntityFactoryImpl:
         assert command.is_nsfw is True
         assert command.version == 123321123
 
-    def test_deserialize_context_menu_command_with_guild_id(
-        self,
-        entity_factory_impl,
-        context_menu_command_payload,
-    ):
+    def test_deserialize_context_menu_command_with_guild_id(self, entity_factory_impl, context_menu_command_payload):
         command = entity_factory_impl.deserialize_command(context_menu_command_payload, guild_id=123)
         assert isinstance(command, commands.ContextMenuCommand)
 
@@ -4958,12 +4860,7 @@ class TestEntityFactoryImpl:
         }
 
     def test_deserialize_modal_interaction(
-        self,
-        entity_factory_impl,
-        mock_app,
-        modal_interaction_payload,
-        interaction_member_payload,
-        message_payload,
+        self, entity_factory_impl, mock_app, modal_interaction_payload, interaction_member_payload, message_payload
     ):
         interaction = entity_factory_impl.deserialize_modal_interaction(modal_interaction_payload)
         assert interaction.app is mock_app
@@ -4990,10 +4887,7 @@ class TestEntityFactoryImpl:
         assert short_text_input.custom_id == "name"
 
     def test_deserialize_modal_interaction_with_user(
-        self,
-        entity_factory_impl,
-        modal_interaction_payload,
-        user_payload,
+        self, entity_factory_impl, modal_interaction_payload, user_payload
     ):
         modal_interaction_payload["member"] = None
         modal_interaction_payload["user"] = user_payload
@@ -5002,9 +4896,7 @@ class TestEntityFactoryImpl:
         assert interaction.user.id == 115590097100865541
 
     def test_deserialize_modal_interaction_with_unrecognized_component(
-        self,
-        entity_factory_impl,
-        modal_interaction_payload,
+        self, entity_factory_impl, modal_interaction_payload
     ):
         modal_interaction_payload["data"]["components"] = [{"type": 0}]
 
@@ -5017,11 +4909,7 @@ class TestEntityFactoryImpl:
 
     @pytest.fixture()
     def partial_sticker_payload(self):
-        return {
-            "id": "749046696482439188",
-            "name": "Thinking",
-            "format_type": 3,
-        }
+        return {"id": "749046696482439188", "name": "Thinking", "format_type": 3}
 
     @pytest.fixture()
     def standard_sticker_payload(self):
@@ -5132,9 +5020,7 @@ class TestEntityFactoryImpl:
         )
 
         assert guild_definition.stickers() == {
-            749046696482439188: entity_factory_impl.deserialize_guild_sticker(
-                guild_sticker_payload,
-            )
+            749046696482439188: entity_factory_impl.deserialize_guild_sticker(guild_sticker_payload)
         }
 
     def test_stickers_returns_cached_values(self, entity_factory_impl):
@@ -5542,11 +5428,7 @@ class TestEntityFactoryImpl:
 
     def test__deserialize_text_select_menu_partial(self, entity_factory_impl):
         menu = entity_factory_impl._deserialize_text_select_menu(
-            {
-                "type": 3,
-                "custom_id": "Not an ID",
-                "options": [{"label": "Trans", "value": "very trans"}],
-            }
+            {"type": 3, "custom_id": "Not an ID", "options": [{"label": "Trans", "value": "very trans"}]}
         )
 
         # SelectMenuOption
@@ -5724,11 +5606,7 @@ class TestEntityFactoryImpl:
         assert attachment.is_ephemeral is True
         assert isinstance(attachment, message_models.Attachment)
 
-    def test__deserialize_message_attachment_with_null_fields(
-        self,
-        entity_factory_impl,
-        attachment_payload,
-    ):
+    def test__deserialize_message_attachment_with_null_fields(self, entity_factory_impl, attachment_payload):
         attachment_payload["height"] = None
         attachment_payload["width"] = None
 
@@ -5738,11 +5616,7 @@ class TestEntityFactoryImpl:
         assert attachment.width is None
         assert isinstance(attachment, message_models.Attachment)
 
-    def test__deserialize_message_attachment_with_unset_fields(
-        self,
-        entity_factory_impl,
-        attachment_payload,
-    ):
+    def test__deserialize_message_attachment_with_unset_fields(self, entity_factory_impl, attachment_payload):
         del attachment_payload["content_type"]
         del attachment_payload["height"]
         del attachment_payload["width"]
@@ -6065,12 +5939,7 @@ class TestEntityFactoryImpl:
         assert message.application.icon_hash is None
         assert isinstance(message.application, message_models.MessageApplication)
 
-    def test_deserialize_message_with_null_and_unset_fields(
-        self,
-        entity_factory_impl,
-        mock_app,
-        user_payload,
-    ):
+    def test_deserialize_message_with_null_and_unset_fields(self, entity_factory_impl, mock_app, user_payload):
         message_payload = {
             "id": "123",
             "channel_id": "456",
@@ -6228,13 +6097,7 @@ class TestEntityFactoryImpl:
                 "game": None,
                 "guild_id": "44004040",
                 "status": "dnd",
-                "activities": [
-                    {
-                        "name": "an activity",
-                        "type": 1,
-                        "created_at": 1584996792798,
-                    }
-                ],
+                "activities": [{"name": "an activity", "type": 1, "created_at": 1584996792798}],
                 "client_status": {},
             }
         )
@@ -6266,10 +6129,7 @@ class TestEntityFactoryImpl:
                         "type": 1,
                         "url": None,
                         "created_at": 1584996792798,
-                        "timestamps": {
-                            "start": 1584996792798,
-                            "end": 1999999792798,
-                        },
+                        "timestamps": {"start": 1584996792798, "end": 1999999792798},
                         "application_id": "40404040404040",
                         "details": None,
                         "state": None,
@@ -6614,9 +6474,7 @@ class TestEntityFactoryImpl:
 
     @pytest.fixture()
     def scheduled_event_user_payload(
-        self,
-        user_payload: typing.Dict[str, typing.Any],
-        member_payload: typing.Dict[str, typing.Any],
+        self, user_payload: typing.Dict[str, typing.Any], member_payload: typing.Dict[str, typing.Any]
     ) -> typing.Dict[str, typing.Any]:
         member_payload = member_payload.copy()
         del member_payload["user"]

--- a/tests/hikari/impl/test_event_factory.py
+++ b/tests/hikari/impl/test_event_factory.py
@@ -155,10 +155,7 @@ class TestEventFactoryImpl:
         assert event.last_pin_timestamp is None
 
     def test_deserialize_guild_thread_create_event(
-        self,
-        event_factory: event_factory_.EventFactoryImpl,
-        mock_app: mock.Mock,
-        mock_shard: shard.GatewayShard,
+        self, event_factory: event_factory_.EventFactoryImpl, mock_app: mock.Mock, mock_shard: shard.GatewayShard
     ):
         mock_payload = mock.Mock()
 
@@ -170,10 +167,7 @@ class TestEventFactoryImpl:
         assert isinstance(event, channel_events.GuildThreadCreateEvent)
 
     def test_deserialize_guild_thread_access_event(
-        self,
-        event_factory: event_factory_.EventFactoryImpl,
-        mock_app: mock.Mock,
-        mock_shard: shard.GatewayShard,
+        self, event_factory: event_factory_.EventFactoryImpl, mock_app: mock.Mock, mock_shard: shard.GatewayShard
     ):
         mock_payload = mock.Mock()
 
@@ -185,10 +179,7 @@ class TestEventFactoryImpl:
         assert isinstance(event, channel_events.GuildThreadAccessEvent)
 
     def test_deserialize_guild_thread_update_event(
-        self,
-        event_factory: event_factory_.EventFactoryImpl,
-        mock_app: mock.Mock,
-        mock_shard: shard.GatewayShard,
+        self, event_factory: event_factory_.EventFactoryImpl, mock_app: mock.Mock, mock_shard: shard.GatewayShard
     ):
         mock_payload = mock.Mock()
 
@@ -200,17 +191,9 @@ class TestEventFactoryImpl:
         assert isinstance(event, channel_events.GuildThreadUpdateEvent)
 
     def test_deserialize_guild_thread_delete_event(
-        self,
-        event_factory: event_factory_.EventFactoryImpl,
-        mock_app: mock.Mock,
-        mock_shard: shard.GatewayShard,
+        self, event_factory: event_factory_.EventFactoryImpl, mock_app: mock.Mock, mock_shard: shard.GatewayShard
     ):
-        mock_payload = {
-            "id": "12332123321",
-            "guild_id": "54544234342",
-            "parent_id": "9494949",
-            "type": 11,
-        }
+        mock_payload = {"id": "12332123321", "guild_id": "54544234342", "parent_id": "9494949", "type": 11}
 
         event = event_factory.deserialize_guild_thread_delete_event(mock_shard, mock_payload)
 
@@ -223,10 +206,7 @@ class TestEventFactoryImpl:
         assert isinstance(event, channel_events.GuildThreadDeleteEvent)
 
     def test_deserialize_thread_members_update_event(
-        self,
-        event_factory: event_factory_.EventFactoryImpl,
-        mock_app: mock.Mock,
-        mock_shard: shard.GatewayShard,
+        self, event_factory: event_factory_.EventFactoryImpl, mock_app: mock.Mock, mock_shard: shard.GatewayShard
     ):
         mock_thread_member_payload = {"id": "393939393", "user_id": "3933993"}
         mock_other_thread_member_payload = {"id": "393994954", "user_id": "123321123"}
@@ -256,10 +236,7 @@ class TestEventFactoryImpl:
         )
 
     def test_deserialize_thread_members_update_event_when_presences_and_real_members(
-        self,
-        event_factory: event_factory_.EventFactoryImpl,
-        mock_app: mock.Mock,
-        mock_shard: shard.GatewayShard,
+        self, event_factory: event_factory_.EventFactoryImpl, mock_app: mock.Mock, mock_shard: shard.GatewayShard
     ):
         mock_presence_payload = mock.Mock()
         mock_other_presence_payload = mock.Mock()
@@ -321,9 +298,7 @@ class TestEventFactoryImpl:
         )
 
     def test_deserialize_thread_members_update_event_partial(
-        self,
-        event_factory: event_factory_.EventFactoryImpl,
-        mock_shard: shard.GatewayShard,
+        self, event_factory: event_factory_.EventFactoryImpl, mock_shard: shard.GatewayShard
     ):
         payload = {"id": "92929929", "guild_id": "92929292", "member_count": "32"}
 
@@ -335,10 +310,7 @@ class TestEventFactoryImpl:
         assert event.guild_presences == {}
 
     def test_deserialize_thread_list_sync_event(
-        self,
-        event_factory: event_factory_.EventFactoryImpl,
-        mock_app: mock.Mock,
-        mock_shard: shard.GatewayShard,
+        self, event_factory: event_factory_.EventFactoryImpl, mock_app: mock.Mock, mock_shard: shard.GatewayShard
     ):
         mock_thread_payload = {"id": "342123123", "name": "nyaa"}
         mock_other_thread_payload = {"id": "5454123123", "name": "meow"}
@@ -369,11 +341,7 @@ class TestEventFactoryImpl:
         assert event.shard is mock_shard
         assert event.guild_id == 43123123
         assert event.channel_ids == [54123, 123431, 43939, 12343123]
-        assert event.threads == {
-            342123123: mock_thread,
-            5454123123: mock_other_thread,
-            94949494: mock_not_in_thread,
-        }
+        assert event.threads == {342123123: mock_thread, 5454123123: mock_other_thread, 94949494: mock_not_in_thread}
         mock_app.entity_factory.deserialize_thread_member.assert_has_calls(
             [mock.call(mock_other_member_payload), mock.call(mokc_member_payload)]
         )
@@ -386,10 +354,7 @@ class TestEventFactoryImpl:
         )
 
     def test_deserialize_thread_list_sync_event_when_not_channel_ids(
-        self,
-        event_factory: event_factory_.EventFactoryImpl,
-        mock_app: mock.Mock,
-        mock_shard: shard.GatewayShard,
+        self, event_factory: event_factory_.EventFactoryImpl, mock_app: mock.Mock, mock_shard: shard.GatewayShard
     ):
         mock_payload = {"guild_id": "123321", "threads": [], "members": []}
 
@@ -1435,12 +1400,7 @@ class TestEventFactoryImpl:
 
     def test_deserialize_guild_member_chunk_event_without_optional_fields(self, event_factory, mock_app, mock_shard):
         mock_member_payload = {"user": {"id": "4222222"}}
-        mock_payload = {
-            "guild_id": "123432123",
-            "members": [mock_member_payload],
-            "chunk_index": 3,
-            "chunk_count": 54,
-        }
+        mock_payload = {"guild_id": "123432123", "members": [mock_member_payload], "chunk_index": 3, "chunk_count": 54}
 
         event = event_factory.deserialize_guild_member_chunk_event(mock_shard, mock_payload)
 

--- a/tests/hikari/impl/test_event_manager.py
+++ b/tests/hikari/impl/test_event_manager.py
@@ -248,10 +248,7 @@ class TestEventManagerImpl:
 
     @pytest.mark.asyncio()
     async def test_on_thread_create_when_create_stateful(
-        self,
-        event_manager_impl: event_manager.EventManagerImpl,
-        shard: mock.Mock,
-        event_factory: mock.Mock,
+        self, event_manager_impl: event_manager.EventManagerImpl, shard: mock.Mock, event_factory: mock.Mock
     ):
         mock_payload = {"id": "123321", "newly_created": True}
         await event_manager_impl.on_thread_create(shard, mock_payload)
@@ -263,10 +260,7 @@ class TestEventManagerImpl:
 
     @pytest.mark.asyncio()
     async def test_on_thread_create_stateless(
-        self,
-        stateless_event_manager_impl: event_manager.EventManagerImpl,
-        shard: mock.Mock,
-        event_factory: mock.Mock,
+        self, stateless_event_manager_impl: event_manager.EventManagerImpl, shard: mock.Mock, event_factory: mock.Mock
     ):
         mock_payload = {"id": "123321", "newly_created": True}
         await stateless_event_manager_impl.on_thread_create(shard, mock_payload)
@@ -278,10 +272,7 @@ class TestEventManagerImpl:
 
     @pytest.mark.asyncio()
     async def test_on_thread_create_for_access_stateful(
-        self,
-        event_manager_impl: event_manager.EventManagerImpl,
-        shard: mock.Mock,
-        event_factory: mock.Mock,
+        self, event_manager_impl: event_manager.EventManagerImpl, shard: mock.Mock, event_factory: mock.Mock
     ):
         mock_payload = {"id": "123321"}
         await event_manager_impl.on_thread_create(shard, mock_payload)
@@ -293,10 +284,7 @@ class TestEventManagerImpl:
 
     @pytest.mark.asyncio()
     async def test_on_thread_create_for_access_stateless(
-        self,
-        stateless_event_manager_impl: event_manager.EventManagerImpl,
-        shard: mock.Mock,
-        event_factory: mock.Mock,
+        self, stateless_event_manager_impl: event_manager.EventManagerImpl, shard: mock.Mock, event_factory: mock.Mock
     ):
         mock_payload = {"id": "123321"}
         await stateless_event_manager_impl.on_thread_create(shard, mock_payload)
@@ -308,10 +296,7 @@ class TestEventManagerImpl:
 
     @pytest.mark.asyncio()
     async def test_on_thread_update_stateful(
-        self,
-        event_manager_impl: event_manager.EventManagerImpl,
-        shard: mock.Mock,
-        event_factory: mock.Mock,
+        self, event_manager_impl: event_manager.EventManagerImpl, shard: mock.Mock, event_factory: mock.Mock
     ):
         mock_payload = mock.Mock()
         await event_manager_impl.on_thread_update(shard, mock_payload)
@@ -323,10 +308,7 @@ class TestEventManagerImpl:
 
     @pytest.mark.asyncio()
     async def test_on_thread_update_stateless(
-        self,
-        stateless_event_manager_impl: event_manager.EventManagerImpl,
-        shard: mock.Mock,
-        event_factory: mock.Mock,
+        self, stateless_event_manager_impl: event_manager.EventManagerImpl, shard: mock.Mock, event_factory: mock.Mock
     ):
         mock_payload = mock.Mock()
         await stateless_event_manager_impl.on_thread_update(shard, mock_payload)
@@ -338,10 +320,7 @@ class TestEventManagerImpl:
 
     @pytest.mark.asyncio()
     async def test_on_thread_delete_stateful(
-        self,
-        event_manager_impl: event_manager.EventManagerImpl,
-        shard: mock.Mock,
-        event_factory: mock.Mock,
+        self, event_manager_impl: event_manager.EventManagerImpl, shard: mock.Mock, event_factory: mock.Mock
     ):
         mock_payload = mock.Mock()
         await event_manager_impl.on_thread_delete(shard, mock_payload)
@@ -353,10 +332,7 @@ class TestEventManagerImpl:
 
     @pytest.mark.asyncio()
     async def test_on_thread_delete_stateless(
-        self,
-        stateless_event_manager_impl: event_manager.EventManagerImpl,
-        shard: mock.Mock,
-        event_factory: mock.Mock,
+        self, stateless_event_manager_impl: event_manager.EventManagerImpl, shard: mock.Mock, event_factory: mock.Mock
     ):
         mock_payload = mock.Mock()
         await stateless_event_manager_impl.on_thread_delete(shard, mock_payload)
@@ -368,10 +344,7 @@ class TestEventManagerImpl:
 
     @pytest.mark.asyncio()
     async def test_on_thread_list_sync_stateful_when_channel_ids(
-        self,
-        event_manager_impl: event_manager.EventManagerImpl,
-        shard: mock.Mock,
-        event_factory: mock.Mock,
+        self, event_manager_impl: event_manager.EventManagerImpl, shard: mock.Mock, event_factory: mock.Mock
     ):
         event = event_factory.deserialize_thread_list_sync_event.return_value
         event.channel_ids = ["1", "2"]
@@ -390,10 +363,7 @@ class TestEventManagerImpl:
 
     @pytest.mark.asyncio()
     async def test_on_thread_list_sync_stateful_when_not_channel_ids(
-        self,
-        event_manager_impl: event_manager.EventManagerImpl,
-        shard: mock.Mock,
-        event_factory: mock.Mock,
+        self, event_manager_impl: event_manager.EventManagerImpl, shard: mock.Mock, event_factory: mock.Mock
     ):
         event = event_factory.deserialize_thread_list_sync_event.return_value
         event.channel_ids = None
@@ -409,10 +379,7 @@ class TestEventManagerImpl:
 
     @pytest.mark.asyncio()
     async def test_on_thread_list_sync_stateless(
-        self,
-        stateless_event_manager_impl: event_manager.EventManagerImpl,
-        shard: mock.Mock,
-        event_factory: mock.Mock,
+        self, stateless_event_manager_impl: event_manager.EventManagerImpl, shard: mock.Mock, event_factory: mock.Mock
     ):
         mock_payload = mock.Mock()
         await stateless_event_manager_impl.on_thread_list_sync(shard, mock_payload)
@@ -424,10 +391,7 @@ class TestEventManagerImpl:
 
     @pytest.mark.asyncio()
     async def test_on_thread_members_update_stateful_when_id_in_removed(
-        self,
-        event_manager_impl: event_manager.EventManagerImpl,
-        shard: mock.Mock,
-        event_factory: mock.Mock,
+        self, event_manager_impl: event_manager.EventManagerImpl, shard: mock.Mock, event_factory: mock.Mock
     ):
         event = event_factory.deserialize_thread_members_update_event.return_value
         event.removed_member_ids = [1, 2, 3]
@@ -441,10 +405,7 @@ class TestEventManagerImpl:
 
     @pytest.mark.asyncio()
     async def test_on_thread_members_update_stateful_when_id_not_in_removed(
-        self,
-        event_manager_impl: event_manager.EventManagerImpl,
-        shard: mock.Mock,
-        event_factory: mock.Mock,
+        self, event_manager_impl: event_manager.EventManagerImpl, shard: mock.Mock, event_factory: mock.Mock
     ):
         event = event_factory.deserialize_thread_members_update_event.return_value
         event.removed_member_ids = [1, 2, 3]
@@ -458,10 +419,7 @@ class TestEventManagerImpl:
 
     @pytest.mark.asyncio()
     async def test_on_thread_members_update_stateless(
-        self,
-        stateless_event_manager_impl: event_manager.EventManagerImpl,
-        shard: mock.Mock,
-        event_factory: mock.Mock,
+        self, stateless_event_manager_impl: event_manager.EventManagerImpl, shard: mock.Mock, event_factory: mock.Mock
     ):
         mock_payload = mock.Mock()
         await stateless_event_manager_impl.on_thread_members_update(shard, mock_payload)
@@ -676,11 +634,7 @@ class TestEventManagerImpl:
 
     @pytest.mark.asyncio()
     async def test_on_guild_create_when_members_declared_and_member_cache_enabled(
-        self,
-        stateless_event_manager_impl,
-        shard,
-        event_factory,
-        entity_factory,
+        self, stateless_event_manager_impl, shard, event_factory, entity_factory
     ):
         shard.id = 123
         stateless_event_manager_impl._intents = intents.Intents.GUILD_MEMBERS
@@ -700,11 +654,7 @@ class TestEventManagerImpl:
 
     @pytest.mark.asyncio()
     async def test_on_guild_create_when_members_declared_and_enabled_for_member_chunk_event(
-        self,
-        stateless_event_manager_impl,
-        shard,
-        event_factory,
-        entity_factory,
+        self, stateless_event_manager_impl, shard, event_factory, entity_factory
     ):
         shard.id = 123
         stateless_event_manager_impl._intents = intents.Intents.GUILD_MEMBERS
@@ -733,12 +683,7 @@ class TestEventManagerImpl:
     @pytest.mark.parametrize("enabled_for_event", [True, False])
     @pytest.mark.asyncio()
     async def test_on_guild_create_when_chunk_members_disabled(
-        self,
-        stateless_event_manager_impl,
-        shard,
-        large,
-        cache_enabled,
-        enabled_for_event,
+        self, stateless_event_manager_impl, shard, large, cache_enabled, enabled_for_event
     ):
         shard.id = 123
         stateless_event_manager_impl._intents = intents.Intents.GUILD_MEMBERS

--- a/tests/hikari/impl/test_event_manager_base.py
+++ b/tests/hikari/impl/test_event_manager_base.py
@@ -79,9 +79,7 @@ def mock_app():
 
 
 class TestEventStream:
-    def test___enter___and___exit__(
-        self,
-    ):
+    def test___enter___and___exit__(self):
         stub_stream = hikari_test_helpers.mock_class_namespace(
             event_manager_base.EventStream, open=mock.Mock(), close=mock.Mock()
         )(mock_app, base_events.Event, timeout=None)
@@ -314,9 +312,7 @@ class TestEventStream:
         mock_listener = object()
         mock_manager = mock.Mock()
         stream = hikari_test_helpers.mock_class_namespace(event_manager_base.EventStream)(
-            event_manager=mock_manager,
-            event_type=base_events.Event,
-            timeout=float("inf"),
+            event_manager=mock_manager, event_type=base_events.Event, timeout=float("inf")
         )
 
         stream._active = True
@@ -363,12 +359,7 @@ class TestEventStream:
 class TestConsumer:
     @pytest.mark.parametrize(
         ("is_caching", "listener_group_count", "waiter_group_count", "expected_result"),
-        [
-            (True, -10000, -10000, True),
-            (False, 0, 1, True),
-            (False, 1, 0, True),
-            (False, 0, 0, False),
-        ],
+        [(True, -10000, -10000, True), (False, 0, 1, True), (False, 1, 0, True), (False, 0, 0, False)],
     )
     def test_is_enabled(self, is_caching, listener_group_count, waiter_group_count, expected_result):
         consumer = event_manager_base._Consumer(object(), 123, is_caching)
@@ -521,8 +512,7 @@ class TestEventManagerBase:
 
         event_manager._handle_dispatch.assert_called_once_with(on_existing_event, shard, {"berp": "baz"})
         create_task.assert_called_once_with(
-            event_manager._handle_dispatch(on_existing_event, shard, {"berp": "baz"}),
-            name="dispatch EXISTING_EVENT",
+            event_manager._handle_dispatch(on_existing_event, shard, {"berp": "baz"}), name="dispatch EXISTING_EVENT"
         )
         event_manager.dispatch.assert_called_once_with(
             event_manager._event_factory.deserialize_shard_payload_event.return_value
@@ -547,8 +537,7 @@ class TestEventManagerBase:
 
         event_manager._handle_dispatch.assert_called_once_with(on_existing_event, shard, {"berp": "baz"})
         create_task.assert_called_once_with(
-            event_manager._handle_dispatch(on_existing_event, shard, {"berp": "baz"}),
-            name="dispatch EXISTING_EVENT",
+            event_manager._handle_dispatch(on_existing_event, shard, {"berp": "baz"}), name="dispatch EXISTING_EVENT"
         )
         event_manager.dispatch.assert_not_called()
         event_manager._event_factory.deserialize_shard_payload_event.vassert_not_called()
@@ -596,11 +585,7 @@ class TestEventManagerBase:
 
         error_handler.assert_called_once_with(
             event_loop,
-            {
-                "exception": exc,
-                "message": "Exception occurred in raw event dispatch conduit",
-                "task": current_task(),
-            },
+            {"exception": exc, "message": "Exception occurred in raw event dispatch conduit", "task": current_task()},
         )
 
     @pytest.mark.asyncio()

--- a/tests/hikari/impl/test_interaction_server.py
+++ b/tests/hikari/impl/test_interaction_server.py
@@ -610,10 +610,7 @@ class TestInteractionServer:
         assert mock_interaction_server._is_closing is False
         assert mock_interaction_server._running_generator_listeners == []
         gather.assert_awaited_once_with(
-            generator_listener_1,
-            generator_listener_2,
-            generator_listener_3,
-            generator_listener_4,
+            generator_listener_1, generator_listener_2, generator_listener_3, generator_listener_4
         )
 
     @pytest.mark.asyncio()

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -189,11 +189,7 @@ class TestClientCredentialsStrategy:
         mock_rest.authorize_client_credentials_token.assert_awaited_once_with(
             client=6512312, client_secret="453123123", scopes=("applications.commands.update", "identify")
         )
-        assert results == [
-            "Bearer okokok.fofofo.ddd",
-            "Bearer okokok.fofofo.ddd",
-            "Bearer okokok.fofofo.ddd",
-        ]
+        assert results == ["Bearer okokok.fofofo.ddd", "Bearer okokok.fofofo.ddd", "Bearer okokok.fofofo.ddd"]
 
     @pytest.mark.asyncio()
     async def test_acquire_after_invalidation(self, mock_token):
@@ -442,12 +438,7 @@ def file_resource():
         async def __aenter__(self):
             return self
 
-        async def __aexit__(
-            self,
-            exc_type,
-            exc,
-            exc_tb,
-        ) -> None:
+        async def __aexit__(self, exc_type, exc, exc_tb) -> None:
             pass
 
     class FileResource(files.Resource):
@@ -508,11 +499,7 @@ class TestTransformEmojiToUrlFormat:
         assert rest._transform_emoji_to_url_format("rooYay", 123) == "rooYay:123"
 
     @pytest.mark.parametrize(
-        "emoji",
-        [
-            emojis.CustomEmoji(id=123, name="rooYay", is_animated=False),
-            emojis.UnicodeEmoji("\N{OK HAND SIGN}"),
-        ],
+        "emoji", [emojis.CustomEmoji(id=123, name="rooYay", is_animated=False), emojis.UnicodeEmoji("\N{OK HAND SIGN}")]
     )
     def test_when_id_passed_with_emoji_object(self, rest_client, emoji):
         with pytest.raises(ValueError, match="emoji_id shouldn't be passed when an Emoji object is passed for emoji"):
@@ -1072,9 +1059,7 @@ class TestRESTClientImpl:
             assert rest_client.fetch_members(guild) == stub_iterator
 
             iterator.assert_called_once_with(
-                entity_factory=rest_client._entity_factory,
-                request_call=rest_client._request,
-                guild=guild,
+                entity_factory=rest_client._entity_factory, request_call=rest_client._request, guild=guild
             )
 
     def test_kick_member(self, rest_client):
@@ -1109,11 +1094,7 @@ class TestRESTClientImpl:
             iterator = rest_client.fetch_bans(187, newest_first=True, start_at=StubModel(65652342134))
 
         iterator_cls.assert_called_once_with(
-            rest_client._entity_factory,
-            rest_client._request,
-            187,
-            True,
-            "65652342134",
+            rest_client._entity_factory, rest_client._request, 187, True, "65652342134"
         )
         assert iterator is iterator_cls.return_value
 
@@ -1123,11 +1104,7 @@ class TestRESTClientImpl:
             iterator = rest_client.fetch_bans(9000, newest_first=True, start_at=start_at)
 
         iterator_cls.assert_called_once_with(
-            rest_client._entity_factory,
-            rest_client._request,
-            9000,
-            True,
-            "950000286338908160",
+            rest_client._entity_factory, rest_client._request, 9000, True, "950000286338908160"
         )
         assert iterator is iterator_cls.return_value
 
@@ -1136,11 +1113,7 @@ class TestRESTClientImpl:
             iterator = rest_client.fetch_bans(8844)
 
         iterator_cls.assert_called_once_with(
-            rest_client._entity_factory,
-            rest_client._request,
-            8844,
-            False,
-            str(snowflakes.Snowflake.min()),
+            rest_client._entity_factory, rest_client._request, 8844, False, str(snowflakes.Snowflake.min())
         )
         assert iterator is iterator_cls.return_value
 
@@ -1149,11 +1122,7 @@ class TestRESTClientImpl:
             iterator = rest_client.fetch_bans(3848, newest_first=True)
 
         iterator_cls.assert_called_once_with(
-            rest_client._entity_factory,
-            rest_client._request,
-            3848,
-            True,
-            str(snowflakes.Snowflake.max()),
+            rest_client._entity_factory, rest_client._request, 3848, True, str(snowflakes.Snowflake.max())
         )
         assert iterator is iterator_cls.return_value
 
@@ -1611,12 +1580,7 @@ class TestRESTClientImpl:
             )
 
         iterator_cls.assert_called_once_with(
-            rest_client._entity_factory,
-            rest_client._request,
-            True,
-            "65652342134",
-            33432234,
-            6666655555,
+            rest_client._entity_factory, rest_client._request, True, "65652342134", 33432234, 6666655555
         )
         assert iterator is iterator_cls.return_value
 
@@ -1626,12 +1590,7 @@ class TestRESTClientImpl:
             iterator = rest_client.fetch_scheduled_event_users(54123, 656324, newest_first=True, start_at=start_at)
 
         iterator_cls.assert_called_once_with(
-            rest_client._entity_factory,
-            rest_client._request,
-            True,
-            "950000286338908160",
-            54123,
-            656324,
+            rest_client._entity_factory, rest_client._request, True, "950000286338908160", 54123, 656324
         )
         assert iterator is iterator_cls.return_value
 
@@ -1656,12 +1615,7 @@ class TestRESTClientImpl:
             iterator = rest_client.fetch_scheduled_event_users(6423, 65456234, newest_first=True)
 
         iterator_cls.assert_called_once_with(
-            rest_client._entity_factory,
-            rest_client._request,
-            True,
-            str(snowflakes.Snowflake.max()),
-            6423,
-            65456234,
+            rest_client._entity_factory, rest_client._request, True, str(snowflakes.Snowflake.max()), 6423, 65456234
         )
         assert iterator is iterator_cls.return_value
 
@@ -2061,9 +2015,7 @@ class TestRESTClientImplAsync:
         class StubResponse:
             status = http.HTTPStatus.TOO_MANY_REQUESTS
             content_type = rest._APPLICATION_JSON
-            headers = {
-                rest._X_RATELIMIT_REMAINING_HEADER: "0",
-            }
+            headers = {rest._X_RATELIMIT_REMAINING_HEADER: "0"}
             real_url = "https://some.url"
 
             async def json(self):
@@ -2146,11 +2098,7 @@ class TestRESTClientImplAsync:
     )
     @pytest.mark.parametrize(
         ("auto_archive_duration", "default_auto_archive_duration"),
-        [
-            (12322, 445123),
-            (datetime.timedelta(minutes=12322), datetime.timedelta(minutes=445123)),
-            (12322.0, 445123.1),
-        ],
+        [(12322, 445123), (datetime.timedelta(minutes=12322), datetime.timedelta(minutes=445123)), (12322.0, 445123.1)],
     )
     async def test_edit_channel(
         self,
@@ -2187,10 +2135,7 @@ class TestRESTClientImplAsync:
             "default_thread_rate_limit_per_user": 40,
             "default_forum_layout": 1,
             "default_sort_order": 0,
-            "default_reaction_emoji": {
-                "emoji_id": expected_emoji_id,
-                "emoji_name": expected_emoji_name,
-            },
+            "default_reaction_emoji": {"emoji_id": expected_emoji_id, "emoji_name": expected_emoji_name},
             "available_tags": [{"id": 0, "name": "testing", "moderated": True, "emoji_id": None, "emoji_name": None}],
             "archived": True,
             "locked": False,
@@ -2727,10 +2672,7 @@ class TestRESTClientImplAsync:
         await rest_client.delete_messages(StubModel(123), *messages)
 
         rest_client._request.assert_has_awaits(
-            [
-                mock.call(expected_route, json=expected_json1),
-                mock.call(expected_route, json=expected_json2),
-            ]
+            [mock.call(expected_route, json=expected_json1), mock.call(expected_route, json=expected_json2)]
         )
 
     async def test_delete_messages_when_one_message_left_in_chunk_and_delete_message_raises_message_not_found(
@@ -2995,11 +2937,7 @@ class TestRESTClientImplAsync:
     async def test_edit_webhook(self, rest_client):
         webhook = StubModel(456)
         expected_route = routes.PATCH_WEBHOOK_WITH_TOKEN.compile(webhook=123, token="token")
-        expected_json = {
-            "name": "some other name",
-            "channel": "789",
-            "avatar": None,
-        }
+        expected_json = {"name": "some other name", "channel": "789", "avatar": None}
         rest_client._request = mock.AsyncMock(return_value={"id": "456"})
         rest_client._entity_factory.deserialize_webhook = mock.Mock(return_value=webhook)
 
@@ -3122,10 +3060,7 @@ class TestRESTClientImplAsync:
             content_type="application/json",
         )
         rest_client._request.assert_awaited_once_with(
-            expected_route,
-            form_builder=mock_form,
-            query={"wait": "true"},
-            auth=None,
+            expected_route, form_builder=mock_form, query={"wait": "true"}, auth=None
         )
         rest_client._entity_factory.deserialize_message.assert_called_once_with({"message_id": 123})
 
@@ -3160,10 +3095,7 @@ class TestRESTClientImplAsync:
             "payload_json", b'{"testing":"ensure_in_test"}', content_type="application/json"
         )
         rest_client._request.assert_awaited_once_with(
-            expected_route,
-            form_builder=mock_form,
-            query={"wait": "true", "thread_id": "1234543123"},
-            auth=None,
+            expected_route, form_builder=mock_form, query={"wait": "true", "thread_id": "1234543123"}, auth=None
         )
         rest_client._entity_factory.deserialize_message.assert_called_once_with({"message_id": 123})
 
@@ -3701,10 +3633,7 @@ class TestRESTClientImplAsync:
             result = await rest_client.refresh_access_token(454123, "123123", "a.codet")
 
         mock_url_encoded_form.add_field.assert_has_calls(
-            [
-                mock.call("grant_type", "refresh_token"),
-                mock.call("refresh_token", "a.codet"),
-            ]
+            [mock.call("grant_type", "refresh_token"), mock.call("refresh_token", "a.codet")]
         )
         assert result is rest_client._entity_factory.deserialize_authorization_token.return_value
         rest_client._entity_factory.deserialize_authorization_token.assert_called_once_with(
@@ -3954,22 +3883,12 @@ class TestRESTClientImplAsync:
         file = object()
 
         sticker = await rest_client.create_sticker(
-            90210,
-            "NewSticker",
-            "funny",
-            file,
-            description="A sticker",
-            reason="blah blah blah",
+            90210, "NewSticker", "funny", file, description="A sticker", reason="blah blah blah"
         )
         assert sticker is rest_client.create_sticker.return_value
 
         rest_client.create_sticker.assert_awaited_once_with(
-            90210,
-            "NewSticker",
-            "funny",
-            file,
-            description="A sticker",
-            reason="blah blah blah",
+            90210, "NewSticker", "funny", file, description="A sticker", reason="blah blah blah"
         )
 
     async def test_edit_sticker(self, rest_client):
@@ -4375,11 +4294,7 @@ class TestRESTClientImplAsync:
         rest_client._create_guild_channel = mock.AsyncMock()
 
         returned = await rest_client.create_guild_category(
-            guild,
-            "general",
-            position=1,
-            permission_overwrites=[overwrite1, overwrite2],
-            reason="because we need one",
+            guild, "general", position=1, permission_overwrites=[overwrite1, overwrite2], reason="because we need one"
         )
         assert returned is rest_client._entity_factory.deserialize_guild_category.return_value
 
@@ -4423,10 +4338,7 @@ class TestRESTClientImplAsync:
             "default_thread_rate_limit_per_user": 40,
             "default_forum_layout": 1,
             "default_sort_order": 0,
-            "default_reaction_emoji": {
-                "emoji_id": expected_emoji_id,
-                "emoji_name": expected_emoji_name,
-            },
+            "default_reaction_emoji": {"emoji_id": expected_emoji_id, "emoji_name": expected_emoji_name},
             "available_tags": [{"id": "321"}, {"id": "123"}],
         }
         rest_client._request = mock.AsyncMock(return_value={"id": "456"})
@@ -4915,10 +4827,7 @@ class TestRESTClientImplAsync:
         rest_client._request = mock.AsyncMock(return_value={"id": "789"})
 
         result = await rest_client.edit_member(
-            StubModel(123),
-            StubModel(456),
-            communication_disabled_until=None,
-            reason="because i can",
+            StubModel(123), StubModel(456), communication_disabled_until=None, reason="because i can"
         )
         assert result is rest_client._entity_factory.deserialize_member.return_value
 
@@ -5252,10 +5161,7 @@ class TestRESTClientImplAsync:
     async def test_edit_widget(self, rest_client):
         widget = StubModel(456)
         expected_route = routes.PATCH_GUILD_WIDGET.compile(guild=123)
-        expected_json = {
-            "enabled": True,
-            "channel": "456",
-        }
+        expected_json = {"enabled": True, "channel": "456"}
         rest_client._request = mock.AsyncMock(return_value={"id": "456"})
         rest_client._entity_factory.deserialize_guild_widget = mock.Mock(return_value=widget)
 
@@ -5272,10 +5178,7 @@ class TestRESTClientImplAsync:
     async def test_edit_widget_when_channel_is_None(self, rest_client):
         widget = StubModel(456)
         expected_route = routes.PATCH_GUILD_WIDGET.compile(guild=123)
-        expected_json = {
-            "enabled": True,
-            "channel": None,
-        }
+        expected_json = {"enabled": True, "channel": None}
         rest_client._request = mock.AsyncMock(return_value={"id": "456"})
         rest_client._entity_factory.deserialize_guild_widget = mock.Mock(return_value=widget)
 
@@ -5343,11 +5246,7 @@ class TestRESTClientImplAsync:
         assert result is rest_client._entity_factory.deserialize_welcome_screen.return_value
 
         rest_client._request.assert_awaited_once_with(
-            expected_route,
-            json={
-                "description": None,
-                "welcome_channels": None,
-            },
+            expected_route, json={"description": None, "welcome_channels": None}
         )
         rest_client._entity_factory.deserialize_welcome_screen.assert_called_once_with(
             rest_client._request.return_value
@@ -5586,12 +5485,7 @@ class TestRESTClientImplAsync:
 
         assert result is rest_client._request.return_value
         rest_client._request.assert_awaited_once_with(
-            expected_route,
-            json={
-                "type": 100,
-                "name": "okokok",
-                "description": "not ok anymore",
-            },
+            expected_route, json={"type": 100, "name": "okokok", "description": "not ok anymore"}
         )
 
     async def test__create_application_command_standardizes_default_member_permissions(
@@ -5611,12 +5505,7 @@ class TestRESTClientImplAsync:
         assert result is rest_client._request.return_value
         rest_client._request.assert_awaited_once_with(
             expected_route,
-            json={
-                "type": 100,
-                "name": "okokok",
-                "description": "not ok anymore",
-                "default_member_permissions": None,
-            },
+            json={"type": 100, "name": "okokok", "description": "not ok anymore", "default_member_permissions": None},
         )
 
     async def test_create_slash_command(self, rest_client: rest.RESTClientImpl):
@@ -5729,10 +5618,7 @@ class TestRESTClientImplAsync:
 
         assert result == [mock_command]
         rest_client._entity_factory.deserialize_command.assert_has_calls(
-            [
-                mock.call({"id": "435765"}, guild_id=453123),
-                mock.call({"id": "4949493933"}, guild_id=453123),
-            ]
+            [mock.call({"id": "435765"}, guild_id=453123), mock.call({"id": "4949493933"}, guild_id=453123)]
         )
         rest_client._request.assert_awaited_once_with(expected_route, json=[mock_command_builder.build.return_value])
         mock_command_builder.build.assert_called_once_with(rest_client._entity_factory)
@@ -5775,10 +5661,7 @@ class TestRESTClientImplAsync:
         expected_route = routes.PATCH_APPLICATION_COMMAND.compile(application=1235432, command=3451231)
         rest_client._request = mock.AsyncMock(return_value={"id": "94594994"})
 
-        result = await rest_client.edit_application_command(
-            StubModel(1235432),
-            StubModel(3451231),
-        )
+        result = await rest_client.edit_application_command(StubModel(1235432), StubModel(3451231))
 
         assert result is rest_client._entity_factory.deserialize_command.return_value
         rest_client._entity_factory.deserialize_command.assert_called_once_with(
@@ -5793,19 +5676,14 @@ class TestRESTClientImplAsync:
         rest_client._request = mock.AsyncMock(return_value={"id": "94594994"})
 
         result = await rest_client.edit_application_command(
-            StubModel(1235432),
-            StubModel(3451231),
-            default_member_permissions=permissions.Permissions.NONE,
+            StubModel(1235432), StubModel(3451231), default_member_permissions=permissions.Permissions.NONE
         )
 
         assert result is rest_client._entity_factory.deserialize_command.return_value
         rest_client._entity_factory.deserialize_command.assert_called_once_with(
             rest_client._request.return_value, guild_id=None
         )
-        rest_client._request.assert_awaited_once_with(
-            expected_route,
-            json={"default_member_permissions": None},
-        )
+        rest_client._request.assert_awaited_once_with(expected_route, json={"default_member_permissions": None})
 
     async def test_delete_application_command_with_guild(self, rest_client):
         expected_route = routes.DELETE_APPLICATION_GUILD_COMMAND.compile(

--- a/tests/hikari/impl/test_rest_bot.py
+++ b/tests/hikari/impl/test_rest_bot.py
@@ -415,9 +415,7 @@ class TestRESTBot:
 
         check_for_updates.assert_not_called()
         handle_interrupts.assert_called_once_with(
-            enabled=True,
-            loop=get_or_make_loop.return_value,
-            propagate_interrupts=True,
+            enabled=True, loop=get_or_make_loop.return_value, propagate_interrupts=True
         )
         handle_interrupts.return_value.assert_used_once()
 
@@ -437,10 +435,7 @@ class TestRESTBot:
 
         assert get_or_make_loop.return_value.run_until_complete.call_count == 2
         get_or_make_loop.return_value.run_until_complete.assert_has_calls(
-            [
-                mock.call(mock_rest_bot.start.return_value),
-                mock.call(mock_rest_bot.join.return_value),
-            ]
+            [mock.call(mock_rest_bot.start.return_value), mock.call(mock_rest_bot.join.return_value)]
         )
         get_or_make_loop.return_value.close.assert_not_called()
 

--- a/tests/hikari/impl/test_shard.py
+++ b/tests/hikari/impl/test_shard.py
@@ -82,13 +82,7 @@ def proxy_settings():
 
 
 class StubResponse:
-    def __init__(
-        self,
-        *,
-        type=None,
-        data=None,
-        extra=None,
-    ):
+    def __init__(self, *, type=None, data=None, extra=None):
         self.type = type
         self.data = data
         self.extra = extra
@@ -225,10 +219,7 @@ class TestGatewayTransport:
         assert exception.code == int(code)
         assert exception.can_reconnect is True
 
-    @pytest.mark.parametrize(
-        "code",
-        [*range(4010, 4020), 5000],
-    )
+    @pytest.mark.parametrize("code", [*range(4010, 4020), 5000])
     def test__handle_other_message_when_message_type_is_CLOSE_and_should_not_reconnect(self, code, transport_impl):
         stub_response = StubResponse(type=aiohttp.WSMsgType.CLOSE, extra="don't reconnect", data=code)
 
@@ -551,10 +542,7 @@ class TestGatewayShardImpl:
         client._intents = mock_intents
         assert client.intents is mock_intents
 
-    @pytest.mark.parametrize(
-        ("keep_alive_task", "expected"),
-        [(None, False), ("some", True)],
-    )
+    @pytest.mark.parametrize(("keep_alive_task", "expected"), [(None, False), ("some", True)])
     def test_is_alive_property(self, client, keep_alive_task, expected):
         client._keep_alive_task = keep_alive_task
 
@@ -610,11 +598,7 @@ class TestGatewayShardImpl:
         actual_result = client._serialize_and_store_presence_payload()
 
         if activity is not None:
-            expected_activity = {
-                "name": activity.name,
-                "type": activity.type,
-                "url": activity.url,
-            }
+            expected_activity = {"name": activity.name, "type": activity.type, "url": activity.url}
         else:
             expected_activity = None
 
@@ -775,10 +759,7 @@ class TestGatewayShardImplAsync:
                 await client.request_guild_members(123, query="test", limit=1, include_presences=False)
 
         send_json.assert_awaited_once_with(
-            {
-                "op": 8,
-                "d": {"guild_id": "123", "query": "test", "presences": False, "limit": 1},
-            }
+            {"op": 8, "d": {"guild_id": "123", "query": "test", "presences": False, "limit": 1}}
         )
 
         check_if_alive.assert_called_once_with()
@@ -830,10 +811,7 @@ class TestGatewayShardImplAsync:
                 await client.request_guild_members(123, include_presences=include_presences)
 
         send_json.assert_awaited_once_with(
-            {
-                "op": 8,
-                "d": {"guild_id": "123", "query": "", "presences": include_presences, "limit": 0},
-            }
+            {"op": 8, "d": {"guild_id": "123", "query": "", "presences": include_presences, "limit": 0}}
         )
         check_if_alive.assert_called_once_with()
 
@@ -889,10 +867,7 @@ class TestGatewayShardImplAsync:
             with mock.patch.object(shard.GatewayShardImpl, "_check_if_connected") as check_if_alive:
                 with mock.patch.object(shard.GatewayShardImpl, "_send_json") as send_json:
                     await client.update_presence(
-                        idle_since=datetime.datetime.now(),
-                        afk=True,
-                        status=presences.Status.IDLE,
-                        activity=None,
+                        idle_since=datetime.datetime.now(), afk=True, status=presences.Status.IDLE, activity=None
                     )
 
         send_json.assert_awaited_once_with({"op": 3, "d": presence.return_value})
@@ -904,15 +879,7 @@ class TestGatewayShardImplAsync:
                 await client.update_voice_state(123456, 6969420, self_mute=False, self_deaf=True)
 
         send_json.assert_awaited_once_with(
-            {
-                "op": 4,
-                "d": {
-                    "guild_id": "123456",
-                    "channel_id": "6969420",
-                    "self_mute": False,
-                    "self_deaf": True,
-                },
-            }
+            {"op": 4, "d": {"guild_id": "123456", "channel_id": "6969420", "self_mute": False, "self_deaf": True}}
         )
         check_if_alive.assert_called_once_with()
 
@@ -1031,7 +998,7 @@ class TestGatewayShardImplAsync:
             [
                 mock.call(heartbeat.return_value, name="heartbeat (shard 20)"),
                 mock.call(poll_events.return_value, name="poll events (shard 20)"),
-            ],
+            ]
         )
         heartbeat.assert_called_once_with(0.01)
 
@@ -1120,20 +1087,13 @@ class TestGatewayShardImplAsync:
             [
                 mock.call(heartbeat.return_value, name="heartbeat (shard 20)"),
                 mock.call(poll_events.return_value, name="poll events (shard 20)"),
-            ],
+            ]
         )
         heartbeat.assert_called_once_with(0.01)
 
         ws.receive_json.assert_awaited_once_with()
         send_json.assert_called_once_with(
-            {
-                "op": 6,
-                "d": {
-                    "token": "sometoken",
-                    "seq": 1234,
-                    "session_id": "some session id",
-                },
-            }
+            {"op": 6, "d": {"token": "sometoken", "seq": 1234, "session_id": "some session id"}}
         )
 
         assert shield.call_count == 2
@@ -1198,11 +1158,7 @@ class TestGatewayShardImplAsync:
             "v": 10,
             "session_id": 100001,
             "resume_gateway_url": "testing_endpoint",
-            "user": {
-                "id": 123,
-                "username": "davfsa",
-                "discriminator": "7026",
-            },
+            "user": {"id": 123, "username": "davfsa", "discriminator": "7026"},
             "guilds": ["1"] * 100,
         }
 

--- a/tests/hikari/impl/test_special_endpoints.py
+++ b/tests/hikari/impl/test_special_endpoints.py
@@ -198,11 +198,7 @@ class TestGuildBanIterator:
             side_effect=[[mock_payload_1, mock_payload_2, mock_payload_3], [mock_payload_4, mock_payload_5], []]
         )
         iterator = special_endpoints.GuildBanIterator(
-            entity_factory=mock_entity_factory,
-            request_call=mock_request,
-            guild=10000,
-            newest_first=False,
-            first_id="0",
+            entity_factory=mock_entity_factory, request_call=mock_request, guild=10000, newest_first=False, first_id="0"
         )
 
         result = await iterator
@@ -500,12 +496,7 @@ class TestGuildThreadIterator:
         )
         mock_route = mock.Mock()
         thread_iterator = special_endpoints.GuildThreadIterator(
-            mock_deserialize,
-            mock_entity_factory,
-            mock_request,
-            mock_route,
-            "eatmyshinymetal",
-            before_is_timestamp=True,
+            mock_deserialize, mock_entity_factory, mock_request, mock_route, "eatmyshinymetal", before_is_timestamp=True
         )
 
         results = await thread_iterator
@@ -611,12 +602,7 @@ class TestGuildThreadIterator:
         )
         mock_route = mock.Mock()
         thread_iterator = special_endpoints.GuildThreadIterator(
-            mock_deserialize,
-            mock_entity_factory,
-            mock_request,
-            mock_route,
-            "3451231231231",
-            before_is_timestamp=False,
+            mock_deserialize, mock_entity_factory, mock_request, mock_route, "3451231231231", before_is_timestamp=False
         )
 
         result = await thread_iterator
@@ -835,10 +821,7 @@ class TestInteractionDeferredBuilder:
 
         result, attachments = builder.build(object())
 
-        assert result == {
-            "type": base_interactions.ResponseType.DEFERRED_MESSAGE_CREATE,
-            "data": {"flags": 64},
-        }
+        assert result == {"type": base_interactions.ResponseType.DEFERRED_MESSAGE_CREATE, "data": {"flags": 64}}
         assert attachments == ()
 
 
@@ -986,10 +969,7 @@ class TestInteractionMessageBuilder:
         mock_entity_factory.serialize_embed.assert_not_called()
         assert result == {
             "type": base_interactions.ResponseType.MESSAGE_UPDATE,
-            "data": {
-                "components": [],
-                "embeds": [],
-            },
+            "data": {"components": [], "embeds": []},
         }
         assert attachments == []
 
@@ -1030,10 +1010,7 @@ class TestInteractionMessageBuilder:
 
         result, attachments = builder.build(mock_entity_factory)
 
-        assert result == {
-            "type": base_interactions.ResponseType.MESSAGE_UPDATE,
-            "data": {"attachments": None},
-        }
+        assert result == {"type": base_interactions.ResponseType.MESSAGE_UPDATE, "data": {"attachments": None}}
 
         assert attachments == []
 
@@ -1063,11 +1040,7 @@ class TestInteractionModalBuilder:
         result, attachments = builder.build(mock.Mock())
         assert result == {
             "type": 9,
-            "data": {
-                "title": "title",
-                "custom_id": "custom_id",
-                "components": [component.build.return_value],
-            },
+            "data": {"title": "title", "custom_id": "custom_id", "components": [component.build.return_value]},
         }
         assert attachments == ()
 
@@ -1220,10 +1193,7 @@ class TestSlashCommandBuilder:
 class TestContextMenuBuilder:
     def test_build_with_optional_data(self):
         builder = (
-            special_endpoints.ContextMenuCommandBuilder(
-                commands.CommandType.USER,
-                "we are number",
-            )
+            special_endpoints.ContextMenuCommandBuilder(commands.CommandType.USER, "we are number")
             .set_id(3412312)
             .set_name_localizations({locales.Locale.TR: "merhaba"})
             .set_default_member_permissions(permissions.Permissions.ADMINISTRATOR)
@@ -1423,11 +1393,7 @@ class Test_ButtonBuilder:
 
 class TestLinkButtonBuilder:
     def test_url_property(self):
-        button = special_endpoints.LinkButtonBuilder(
-            url="hihihihi",
-            label="no u",
-            is_disabled=True,
-        )
+        button = special_endpoints.LinkButtonBuilder(url="hihihihi", label="no u", is_disabled=True)
 
         assert button.url == "hihihihi"
 
@@ -1435,10 +1401,7 @@ class TestLinkButtonBuilder:
 class TestInteractiveButtonBuilder:
     def test_custom_id_property(self):
         button = special_endpoints.InteractiveButtonBuilder(
-            style=components.ButtonStyle.DANGER,
-            label="no u",
-            custom_id="ooga booga",
-            is_disabled=True,
+            style=components.ButtonStyle.DANGER, label="no u", custom_id="ooga booga", is_disabled=True
         )
 
         assert button.custom_id == "ooga booga"
@@ -1704,10 +1667,7 @@ class TestChannelSelectMenuBuilder:
 class TestTextInput:
     @pytest.fixture()
     def text_input(self):
-        return special_endpoints.TextInputBuilder(
-            custom_id="o2o2o2",
-            label="label",
-        )
+        return special_endpoints.TextInputBuilder(custom_id="o2o2o2", label="label")
 
     def test_type_property(self, text_input):
         assert text_input.type is components.ComponentType.TEXT_INPUT

--- a/tests/hikari/impl/test_voice.py
+++ b/tests/hikari/impl/test_voice.py
@@ -213,12 +213,7 @@ class TestVoiceComponentImpl:
             )
 
         assert voice_client._voice_listener is True
-        mock_shard.update_voice_state.assert_awaited_once_with(
-            123,
-            4532,
-            self_deaf=False,
-            self_mute=True,
-        )
+        mock_shard.update_voice_state.assert_awaited_once_with(123, 4532, self_deaf=False, self_mute=True)
         assert voice_client._connections == {
             123: mock_connection_type.initialize.return_value,
             555: mock_other_connection,
@@ -235,10 +230,7 @@ class TestVoiceComponentImpl:
         mock_app.shards = {0: mock_shard}
         mock_connection_type = mock.AsyncMock()
 
-        with pytest.raises(
-            errors.VoiceError,
-            match="Could not connect to voice channel 4532 in guild 123.",
-        ):
+        with pytest.raises(errors.VoiceError, match="Could not connect to voice channel 4532 in guild 123."):
             await voice_client.connect_to(123, 4532, mock_connection_type)
 
     @pytest.mark.asyncio()
@@ -333,7 +325,7 @@ class TestVoiceComponentImpl:
                     timeout=None,
                     predicate=voice_client._init_server_update_predicate.return_value,
                 ),
-            ],
+            ]
         )
         mock_app.cache.get_me.assert_called_once_with()
         voice_client._init_state_update_predicate.assert_called_once_with(123, mock_app.cache.get_me.return_value.id)

--- a/tests/hikari/interactions/test_base_interactions.py
+++ b/tests/hikari/interactions/test_base_interactions.py
@@ -215,12 +215,7 @@ class TestModalResponseMixin:
         await mock_modal_response_mixin.create_modal_response("title", "custom_id", None, [])
 
         mock_app.rest.create_modal_response.assert_awaited_once_with(
-            34123,
-            "399393939doodsodso",
-            title="title",
-            custom_id="custom_id",
-            component=None,
-            components=[],
+            34123, "399393939doodsodso", title="title", custom_id="custom_id", component=None, components=[]
         )
 
     def test_build_response(self, mock_modal_response_mixin, mock_app):

--- a/tests/hikari/interactions/test_modal_interactions.py
+++ b/tests/hikari/interactions/test_modal_interactions.py
@@ -60,7 +60,7 @@ class TestModalInteraction:
                     components.TextInputComponent(
                         type=components.ComponentType.TEXT_INPUT, custom_id="le id", value="le value"
                     )
-                ],
+                ]
             ),
         )
 

--- a/tests/hikari/internal/test_attr_extensions.py
+++ b/tests/hikari/internal/test_attr_extensions.py
@@ -208,9 +208,7 @@ def test_generate_deep_copier():
     memo = {123: object()}
 
     with mock.patch.object(
-        stdlib_copy,
-        "deepcopy",
-        side_effect=[copied_recursor, copied_field, copied_foo, copied_end, copied_blam],
+        stdlib_copy, "deepcopy", side_effect=[copied_recursor, copied_field, copied_foo, copied_end, copied_blam]
     ):
         attrs_extensions.generate_deep_copier(StubBaseClass)(model, memo)
 
@@ -245,11 +243,7 @@ def test_generate_deep_copier_with_only_init_attributes():
     copied_foo = object()
     memo = {123: object()}
 
-    with mock.patch.object(
-        stdlib_copy,
-        "deepcopy",
-        side_effect=[copied_recursor, copied_field, copied_foo],
-    ):
+    with mock.patch.object(stdlib_copy, "deepcopy", side_effect=[copied_recursor, copied_field, copied_foo]):
         attrs_extensions.generate_deep_copier(StubBaseClass)(model, memo)
 
         stdlib_copy.deepcopy.assert_has_calls(
@@ -279,18 +273,11 @@ def test_generate_deep_copier_with_only_non_init_attributes():
     copied_blam = object()
     memo = {123: object()}
 
-    with mock.patch.object(
-        stdlib_copy,
-        "deepcopy",
-        side_effect=[copied_end, copied_blam],
-    ):
+    with mock.patch.object(stdlib_copy, "deepcopy", side_effect=[copied_end, copied_blam]):
         attrs_extensions.generate_deep_copier(StubBaseClass)(model, memo)
 
         stdlib_copy.deepcopy.assert_has_calls(
-            [
-                mock.call(old_model_fields.end, memo),
-                mock.call(old_model_fields._blam, memo),
-            ]
+            [mock.call(old_model_fields.end, memo), mock.call(old_model_fields._blam, memo)]
         )
 
     assert model.end is copied_end
@@ -305,11 +292,7 @@ def test_generate_deep_copier_with_no_attributes():
     model = StubBaseClass()
     memo = {123: object()}
 
-    with mock.patch.object(
-        stdlib_copy,
-        "deepcopy",
-        side_effect=NotImplementedError,
-    ):
+    with mock.patch.object(stdlib_copy, "deepcopy", side_effect=NotImplementedError):
         attrs_extensions.generate_deep_copier(StubBaseClass)(model, memo)
 
         stdlib_copy.deepcopy.assert_not_called()

--- a/tests/hikari/internal/test_enums.py
+++ b/tests/hikari/internal/test_enums.py
@@ -68,11 +68,7 @@ class TestEnum:
                 pass
 
     @pytest.mark.parametrize(
-        ("args", "kwargs"),
-        [
-            ([enums.Enum, str], {"metaclass": enums._EnumMeta}),
-            ([enums.Enum, str], {}),
-        ],
+        ("args", "kwargs"), [([enums.Enum, str], {"metaclass": enums._EnumMeta}), ([enums.Enum, str], {})]
     )
     def test_init_enum_type_with_bases_in_wrong_order_is_TypeError(self, args, kwargs):
         with pytest.raises(TypeError):
@@ -751,10 +747,7 @@ class TestIntFlag:
         # All present
         assert val.any(TestFlag.FOO, TestFlag.BAR, TestFlag.BAZ, TestFlag.BORK)
         # One present, one not
-        assert val.any(
-            TestFlag.FOO,
-            TestFlag.QUX,
-        )
+        assert val.any(TestFlag.FOO, TestFlag.QUX)
 
     def test_any_negative_case(self):
         class TestFlag(enums.Flag):
@@ -1090,10 +1083,7 @@ class TestIntFlag:
         # All present
         assert not val.none(TestFlag.FOO, TestFlag.BAR, TestFlag.BAZ, TestFlag.BORK)
         # One present, one not
-        assert not val.none(
-            TestFlag.FOO,
-            TestFlag.QUX,
-        )
+        assert not val.none(TestFlag.FOO, TestFlag.QUX)
 
     def test_split(self):
         class TestFlag(enums.Flag):

--- a/tests/hikari/internal/test_net.py
+++ b/tests/hikari/internal/test_net.py
@@ -158,10 +158,7 @@ async def test_generate_bad_request_error_without_json_response():
 @pytest.mark.parametrize(
     ("data", "expected_errors"),
     [
-        (
-            '{"message": "raw message", "code": 123, "errors": {"component": []}}',
-            {"component": []},
-        ),
+        ('{"message": "raw message", "code": 123, "errors": {"component": []}}', {"component": []}),
         ('{"message": "raw message", "code": 123, "errors": {}}', {}),
         ('{"message": "raw message", "code": 123}', None),
     ],

--- a/tests/hikari/internal/test_routes.py
+++ b/tests/hikari/internal/test_routes.py
@@ -135,13 +135,7 @@ class TestCDNRoute:
         assert hash(route3) != hash(route4)
 
     @pytest.mark.parametrize(
-        ("input_file_format", "expected_file_format"),
-        [
-            ("jpg", "jpg"),
-            ("JPG", "jpg"),
-            ("png", "png"),
-            ("PNG", "png"),
-        ],
+        ("input_file_format", "expected_file_format"), [("jpg", "jpg"), ("JPG", "jpg"), ("png", "png"), ("PNG", "png")]
     )
     def test_compile_uses_lowercase_file_format_always(self, input_file_format, expected_file_format):
         route = routes.CDNRoute("/foo/bar", {"png", "jpg"}, is_sizable=False)
@@ -283,15 +277,7 @@ class TestCDNRoute:
                 "bork qux",
                 "http://example.com/baz/bork%20qux.webp",
             ),
-            (
-                "http://example.com",
-                "/{foo}/bar",
-                "GIF",
-                {},
-                "baz",
-                "bork qux",
-                "http://example.com/baz/bar.gif",
-            ),
+            ("http://example.com", "/{foo}/bar", "GIF", {}, "baz", "bork qux", "http://example.com/baz/bar.gif"),
         ],
     )
     def test_compile_generates_expected_url(self, base_url, template, format, size_kwds, foo, bar, expected_url):

--- a/tests/hikari/internal/test_signals.py
+++ b/tests/hikari/internal/test_signals.py
@@ -64,10 +64,7 @@ class TestHandleInterrupt:
 
                 assert register_signal_handler.call_count == 2
                 register_signal_handler.assert_has_calls(
-                    [
-                        mock.call(2, interrupt_handler.return_value),
-                        mock.call(15, interrupt_handler.return_value),
-                    ]
+                    [mock.call(2, interrupt_handler.return_value), mock.call(15, interrupt_handler.return_value)]
                 )
 
                 register_signal_handler.reset_mock()

--- a/tests/hikari/internal/test_typing_extensions.py
+++ b/tests/hikari/internal/test_typing_extensions.py
@@ -87,10 +87,7 @@ class TestFastProtocolChecking:
                 ...
 
     def test_new_when_fastprotocolchecking_in_bases_but_not_protocol(self):
-        with pytest.raises(
-            TypeError,
-            match=r"FastProtocolChecking can only be used with protocols",
-        ):
+        with pytest.raises(TypeError, match=r"FastProtocolChecking can only be used with protocols"):
 
             class MyProtocol(fast_protocol.FastProtocolChecking):
                 ...

--- a/tests/hikari/internal/test_ux.py
+++ b/tests/hikari/internal/test_ux.py
@@ -110,9 +110,7 @@ class TestInitLogging:
         logging_file_config.assert_not_called()
         logging_dict_config.assert_called_once_with({"incremental": True, "hikari": {"level": "INFO"}})
         logging_basic_config.assert_called_once_with(
-            level=None,
-            stream=sys.stdout,
-            format="%(levelname)-1.1s %(asctime)23.23s %(name)s: %(message)s",
+            level=None, stream=sys.stdout, format="%(levelname)-1.1s %(asctime)23.23s %(name)s: %(message)s"
         )
         colored_formatter.assert_not_called()
         handler.setFormatter.assert_not_called()
@@ -162,9 +160,7 @@ class TestInitLogging:
         logging_dict_config.assert_not_called()
         logging_file_config.assert_not_called()
         logging_basic_config.assert_called_once_with(
-            level="LOGGING_LEVEL",
-            format="%(levelname)-1.1s %(asctime)23.23s %(name)s: %(message)s",
-            stream=sys.stdout,
+            level="LOGGING_LEVEL", format="%(levelname)-1.1s %(asctime)23.23s %(name)s: %(message)s", stream=sys.stdout
         )
         colored_formatter.assert_not_called()
         supports_color.assert_called_once_with(True, False)
@@ -391,10 +387,7 @@ class TestPrintBanner:
         stack.enter_context(mock.patch.object(os.path, "abspath", return_value="some path"))
         stdout = stack.enter_context(mock.patch.object(sys, "stdout"))
 
-        extra_args = {
-            "extra_argument_1": "one",
-            "extra_argument_2": "two",
-        }
+        extra_args = {"extra_argument_1": "one", "extra_argument_2": "two"}
 
         with stack:
             ux.print_banner("hikaru", True, False, extra_args=extra_args)
@@ -432,9 +425,7 @@ class TestPrintBanner:
         stack.enter_context(mock.patch.object(sys.stdout, "write"))
         stack.enter_context(mock.patch.object(os.path, "abspath", return_value="some path"))
 
-        extra_args = {
-            "hikari_version": "overwrite",
-        }
+        extra_args = {"hikari_version": "overwrite"}
 
         with stack:
             with pytest.raises(

--- a/tests/hikari/test_channels.py
+++ b/tests/hikari/test_channels.py
@@ -98,10 +98,7 @@ class TestPartialChannel:
     @pytest.fixture()
     def model(self, mock_app):
         return hikari_test_helpers.mock_class_namespace(channels.PartialChannel, rename_impl_=False)(
-            app=mock_app,
-            id=snowflakes.Snowflake(1234567),
-            name="foo",
-            type=channels.ChannelType.GUILD_NEWS,
+            app=mock_app, id=snowflakes.Snowflake(1234567), name="foo", type=channels.ChannelType.GUILD_NEWS
         )
 
     def test_str_operator(self, model):
@@ -153,10 +150,7 @@ class TestGroupDMChannel:
             last_message_id=snowflakes.Snowflake(3232),
             owner_id=snowflakes.Snowflake(1066),
             icon_hash="1a2b3c",
-            nicknames={
-                snowflakes.Snowflake(1): "person 1",
-                snowflakes.Snowflake(2): "person 2",
-            },
+            nicknames={snowflakes.Snowflake(1): "person 1", snowflakes.Snowflake(2): "person 2"},
             recipients={
                 snowflakes.Snowflake(1): mock.Mock(spec_set=users.User, __str__=mock.Mock(return_value="snoop#0420")),
                 snowflakes.Snowflake(2): mock.Mock(spec_set=users.User, __str__=mock.Mock(return_value="yeet#1012")),
@@ -198,10 +192,7 @@ class TestTextChannel:
     @pytest.fixture()
     def model(self, mock_app):
         return hikari_test_helpers.mock_class_namespace(channels.TextableChannel)(
-            app=mock_app,
-            id=snowflakes.Snowflake(12345679),
-            name="foo1",
-            type=channels.ChannelType.GUILD_TEXT,
+            app=mock_app, id=snowflakes.Snowflake(12345679), name="foo1", type=channels.ChannelType.GUILD_TEXT
         )
 
     @pytest.mark.asyncio()
@@ -459,10 +450,7 @@ class TestPermissibleGuildChannel:
 
         await model.remove_overwrite(333)
 
-        model.app.rest.delete_permission_overwrite.assert_called_once_with(
-            69420,
-            333,
-        )
+        model.app.rest.delete_permission_overwrite.assert_called_once_with(69420, 333)
 
     def test_get_guild(self, model):
         guild = mock.Mock(id=123456789)
@@ -496,11 +484,7 @@ class TestPermissibleGuildChannel:
 class TestForumTag:
     @pytest.mark.parametrize(
         ("emoji", "expected_unicode_emoji", "expected_emoji_id"),
-        [
-            (123, None, 123),
-            ("emoji", "emoji", None),
-            (None, None, None),
-        ],
+        [(123, None, 123), ("emoji", "emoji", None), (None, None, None)],
     )
     def test_emoji_parameters(self, emoji, expected_emoji_id, expected_unicode_emoji):
         tag = channels.ForumTag(name="testing", emoji=emoji)

--- a/tests/hikari/test_errors.py
+++ b/tests/hikari/test_errors.py
@@ -76,12 +76,7 @@ class TestHTTPResponseError:
     @pytest.fixture()
     def error(self):
         return errors.HTTPResponseError(
-            "https://some.url",
-            http.HTTPStatus.BAD_REQUEST,
-            {},
-            "raw body",
-            "message",
-            12345,
+            "https://some.url", http.HTTPStatus.BAD_REQUEST, {}, "raw body", "message", 12345
         )
 
     def test_str(self, error):
@@ -113,24 +108,16 @@ class TestBadRequestError:
             {},
             "raw body",
             errors={
-                "": [
-                    {"code": "012", "message": "test error"},
-                ],
+                "": [{"code": "012", "message": "test error"}],
                 "components": {
                     "0": {
                         "_errors": [
                             {"code": "123", "message": "something went wrong"},
                             {"code": "456", "message": "but more things too!"},
-                        ],
-                    },
+                        ]
+                    }
                 },
-                "attachments": {
-                    "1": {
-                        "_errors": [
-                            {"code": "789", "message": "at this point, all wrong!"},
-                        ],
-                    },
-                },
+                "attachments": {"1": {"_errors": [{"code": "789", "message": "at this point, all wrong!"}]}},
             },
         )
 

--- a/tests/hikari/test_guilds.py
+++ b/tests/hikari/test_guilds.py
@@ -46,11 +46,7 @@ def mock_app():
 class TestPartialRole:
     @pytest.fixture()
     def model(self, mock_app):
-        return guilds.PartialRole(
-            app=mock_app,
-            id=snowflakes.Snowflake(1106913972),
-            name="The Big Cool",
-        )
+        return guilds.PartialRole(app=mock_app, id=snowflakes.Snowflake(1106913972), name="The Big Cool")
 
     def test_str_operator(self, model):
         assert str(model) == "The Big Cool"
@@ -69,11 +65,7 @@ class TestPartialApplication:
     @pytest.fixture()
     def model(self):
         return hikari_test_helpers.mock_class_namespace(
-            guilds.PartialApplication,
-            init_=False,
-            slots_=False,
-            id=123,
-            icon_hash="ahashicon",
+            guilds.PartialApplication, init_=False, slots_=False, id=123, icon_hash="ahashicon"
         )()
 
     def test_icon_url_property(self, model):
@@ -234,10 +226,7 @@ class TestMember:
             nickname="davb",
             guild_avatar_hash="dab",
             premium_since=None,
-            role_ids=[
-                snowflakes.Snowflake(456),
-                snowflakes.Snowflake(1234),
-            ],
+            role_ids=[snowflakes.Snowflake(456), snowflakes.Snowflake(1234)],
             user=mock_user,
             raw_communication_disabled_until=None,
         )
@@ -550,12 +539,7 @@ class TestMember:
 class TestPartialGuild:
     @pytest.fixture()
     def model(self, mock_app):
-        return guilds.PartialGuild(
-            app=mock_app,
-            id=snowflakes.Snowflake(90210),
-            icon_hash="yeet",
-            name="hikari",
-        )
+        return guilds.PartialGuild(app=mock_app, id=snowflakes.Snowflake(90210), icon_hash="yeet", name="hikari")
 
     def test_str_operator(self, model):
         assert str(model) == "hikari"
@@ -589,11 +573,7 @@ class TestPartialGuild:
             assert model.make_icon_url(ext=None, size=1024) == "file"
 
         route.compile_to_file.assert_called_once_with(
-            urls.CDN_URL,
-            guild_id=90210,
-            hash="a_yeet",
-            size=1024,
-            file_format="gif",
+            urls.CDN_URL, guild_id=90210, hash="a_yeet", size=1024, file_format="gif"
         )
 
     def test_make_icon_url_when_format_is_None_and_avatar_hash_is_not_for_gif(self, model):
@@ -603,11 +583,7 @@ class TestPartialGuild:
             assert model.make_icon_url(ext=None, size=4096) == "file"
 
         route.compile_to_file.assert_called_once_with(
-            urls.CDN_URL,
-            guild_id=90210,
-            hash="yeet",
-            size=4096,
-            file_format="png",
+            urls.CDN_URL, guild_id=90210, hash="yeet", size=4096, file_format="png"
         )
 
     def test_make_icon_url_with_all_args(self, model):
@@ -617,11 +593,7 @@ class TestPartialGuild:
             assert model.make_icon_url(ext="url", size=2048) == "file"
 
         route.compile_to_file.assert_called_once_with(
-            urls.CDN_URL,
-            guild_id=90210,
-            hash="yeet",
-            size=2048,
-            file_format="url",
+            urls.CDN_URL, guild_id=90210, hash="yeet", size=2048, file_format="url"
         )
 
     @pytest.mark.asyncio()
@@ -723,21 +695,12 @@ class TestPartialGuild:
         file = object()
 
         sticker = await model.create_sticker(
-            "NewSticker",
-            "funny",
-            file,
-            description="A sticker",
-            reason="blah blah blah",
+            "NewSticker", "funny", file, description="A sticker", reason="blah blah blah"
         )
         assert sticker is model.app.rest.create_sticker.return_value
 
         model.app.rest.create_sticker.assert_awaited_once_with(
-            90210,
-            "NewSticker",
-            "funny",
-            file,
-            description="A sticker",
-            reason="blah blah blah",
+            90210, "NewSticker", "funny", file, description="A sticker", reason="blah blah blah"
         )
 
     @pytest.mark.asyncio()
@@ -747,12 +710,7 @@ class TestPartialGuild:
         sticker = await model.edit_sticker(4567, name="Brilliant", tag="parmesan", description="amazing")
 
         model.app.rest.edit_sticker.assert_awaited_once_with(
-            90210,
-            4567,
-            name="Brilliant",
-            tag="parmesan",
-            description="amazing",
-            reason=undefined.UNDEFINED,
+            90210, 4567, name="Brilliant", tag="parmesan", description="amazing", reason=undefined.UNDEFINED
         )
 
         assert sticker is model.app.rest.edit_sticker.return_value
@@ -763,11 +721,7 @@ class TestPartialGuild:
 
         sticker = await model.delete_sticker(951)
 
-        model.app.rest.delete_sticker.assert_awaited_once_with(
-            90210,
-            951,
-            reason=undefined.UNDEFINED,
-        )
+        model.app.rest.delete_sticker.assert_awaited_once_with(90210, 951, reason=undefined.UNDEFINED)
 
         assert sticker is model.app.rest.delete_sticker.return_value
 
@@ -961,11 +915,7 @@ class TestGuildPreview:
             assert model.make_splash_url(ext="url", size=1024) == "file"
 
         route.compile_to_file.assert_called_once_with(
-            urls.CDN_URL,
-            guild_id=123,
-            hash="18dnf8dfbakfdh",
-            size=1024,
-            file_format="url",
+            urls.CDN_URL, guild_id=123, hash="18dnf8dfbakfdh", size=1024, file_format="url"
         )
 
     def test_make_splash_url_when_no_hash(self, model):
@@ -987,11 +937,7 @@ class TestGuildPreview:
             assert model.make_discovery_splash_url(ext="url", size=2048) == "file"
 
         route.compile_to_file.assert_called_once_with(
-            urls.CDN_URL,
-            guild_id=123,
-            hash="18dnf8dfbakfdh",
-            size=2048,
-            file_format="url",
+            urls.CDN_URL, guild_id=123, hash="18dnf8dfbakfdh", size=2048, file_format="url"
         )
 
     def test_make_discovery_splash_url_when_no_hash(self, model):
@@ -1129,11 +1075,7 @@ class TestGuild:
             assert model.make_splash_url(ext="url", size=2) == "file"
 
         route.compile_to_file.assert_called_once_with(
-            urls.CDN_URL,
-            guild_id=123,
-            hash="18dnf8dfbakfdh",
-            size=2,
-            file_format="url",
+            urls.CDN_URL, guild_id=123, hash="18dnf8dfbakfdh", size=2, file_format="url"
         )
 
     def test_make_splash_url_when_no_hash(self, model):
@@ -1155,11 +1097,7 @@ class TestGuild:
             assert model.make_discovery_splash_url(ext="url", size=1024) == "file"
 
         route.compile_to_file.assert_called_once_with(
-            urls.CDN_URL,
-            guild_id=123,
-            hash="18dnf8dfbakfdh",
-            size=1024,
-            file_format="url",
+            urls.CDN_URL, guild_id=123, hash="18dnf8dfbakfdh", size=1024, file_format="url"
         )
 
     def test_make_discovery_splash_url_when_no_hash(self, model):
@@ -1179,11 +1117,7 @@ class TestGuild:
             assert model.make_banner_url(ext="url", size=512) == "file"
 
         route.compile_to_file.assert_called_once_with(
-            urls.CDN_URL,
-            guild_id=123,
-            hash="banner_hash",
-            size=512,
-            file_format="url",
+            urls.CDN_URL, guild_id=123, hash="banner_hash", size=512, file_format="url"
         )
 
     def test_make_banner_url_when_format_is_None_and_banner_hash_is_for_gif(self, model):
@@ -1195,11 +1129,7 @@ class TestGuild:
             assert model.make_banner_url(ext=None, size=4096) == "file"
 
         route.compile_to_file.assert_called_once_with(
-            urls.CDN_URL,
-            guild_id=model.id,
-            hash="a_18dnf8dfbakfdh",
-            size=4096,
-            file_format="gif",
+            urls.CDN_URL, guild_id=model.id, hash="a_18dnf8dfbakfdh", size=4096, file_format="gif"
         )
 
     def test_make_banner_url_when_format_is_None_and_banner_hash_is_not_for_gif(self, model):
@@ -1211,11 +1141,7 @@ class TestGuild:
             assert model.make_banner_url(ext=None, size=4096) == "file"
 
         route.compile_to_file.assert_called_once_with(
-            urls.CDN_URL,
-            guild_id=model.id,
-            hash=model.banner_hash,
-            size=4096,
-            file_format="png",
+            urls.CDN_URL, guild_id=model.id, hash=model.banner_hash, size=4096, file_format="png"
         )
 
     def test_make_banner_url_when_no_hash(self, model):

--- a/tests/hikari/test_invites.py
+++ b/tests/hikari/test_invites.py
@@ -69,11 +69,7 @@ class TestInviteGuild:
             assert model.make_splash_url(ext="url", size=2) == "file"
 
         route.compile_to_file.assert_called_once_with(
-            urls.CDN_URL,
-            guild_id=123321,
-            hash="18dnf8dfbakfdh",
-            size=2,
-            file_format="url",
+            urls.CDN_URL, guild_id=123321, hash="18dnf8dfbakfdh", size=2, file_format="url"
         )
 
     def test_make_splash_url_when_no_hash(self, model: invites.InviteGuild):
@@ -93,11 +89,7 @@ class TestInviteGuild:
             assert model.make_banner_url(ext="url", size=512) == "file"
 
         route.compile_to_file.assert_called_once_with(
-            urls.CDN_URL,
-            guild_id=123321,
-            hash="fofoof",
-            size=512,
-            file_format="url",
+            urls.CDN_URL, guild_id=123321, hash="fofoof", size=512, file_format="url"
         )
 
     def test_make_banner_url_when_format_is_None_and_banner_hash_is_for_gif(self, model: invites.InviteGuild):
@@ -109,11 +101,7 @@ class TestInviteGuild:
             assert model.make_banner_url(ext=None, size=4096) == "file"
 
         route.compile_to_file.assert_called_once_with(
-            urls.CDN_URL,
-            guild_id=model.id,
-            hash="a_18dnf8dfbakfdh",
-            size=4096,
-            file_format="gif",
+            urls.CDN_URL, guild_id=model.id, hash="a_18dnf8dfbakfdh", size=4096, file_format="gif"
         )
 
     def test_make_banner_url_when_format_is_None_and_banner_hash_is_not_for_gif(self, model: invites.InviteGuild):
@@ -125,11 +113,7 @@ class TestInviteGuild:
             assert model.make_banner_url(ext=None, size=4096) == "file"
 
         route.compile_to_file.assert_called_once_with(
-            urls.CDN_URL,
-            guild_id=model.id,
-            hash=model.banner_hash,
-            size=4096,
-            file_format="png",
+            urls.CDN_URL, guild_id=model.id, hash=model.banner_hash, size=4096, file_format="png"
         )
 
     def test_make_banner_url_when_no_hash(self, model: invites.InviteGuild):

--- a/tests/hikari/test_messages.py
+++ b/tests/hikari/test_messages.py
@@ -60,11 +60,7 @@ class TestMessageApplication:
     @pytest.fixture()
     def message_application(self):
         return messages.MessageApplication(
-            id=123,
-            name="test app",
-            description="",
-            icon_hash="123abc",
-            cover_image_hash="abc123",
+            id=123, name="test app", description="", icon_hash="123abc", cover_image_hash="abc123"
         )
 
     def test_cover_image_url(self, message_application):

--- a/tests/hikari/test_presences.py
+++ b/tests/hikari/test_presences.py
@@ -39,11 +39,7 @@ def mock_app():
 class TestActivityAssets:
     def test_large_image_url_property(self):
         asset = presences.ActivityAssets(
-            application_id=None,
-            large_image=None,
-            large_text=None,
-            small_image=None,
-            small_text=None,
+            application_id=None, large_image=None, large_text=None, small_image=None, small_text=None
         )
 
         with mock.patch.object(presences.ActivityAssets, "make_large_image_url") as make_large_image_url:
@@ -54,11 +50,7 @@ class TestActivityAssets:
 
     def test_large_image_url_property_when_runtime_error(self):
         asset = presences.ActivityAssets(
-            application_id=None,
-            large_image=None,
-            large_text=None,
-            small_image=None,
-            small_text=None,
+            application_id=None, large_image=None, large_text=None, small_image=None, small_text=None
         )
 
         with mock.patch.object(
@@ -71,31 +63,19 @@ class TestActivityAssets:
 
     def test_make_large_image_url(self):
         asset = presences.ActivityAssets(
-            application_id=45123123,
-            large_image="541sdfasdasd",
-            large_text=None,
-            small_image=None,
-            small_text=None,
+            application_id=45123123, large_image="541sdfasdasd", large_text=None, small_image=None, small_text=None
         )
 
         with mock.patch.object(routes, "CDN_APPLICATION_ASSET") as route:
             assert asset.make_large_image_url(ext="fa", size=3121) is route.compile_to_file.return_value
 
         route.compile_to_file.assert_called_once_with(
-            urls.CDN_URL,
-            application_id=45123123,
-            hash="541sdfasdasd",
-            size=3121,
-            file_format="fa",
+            urls.CDN_URL, application_id=45123123, hash="541sdfasdasd", size=3121, file_format="fa"
         )
 
     def test_make_large_image_url_when_no_hash(self):
         asset = presences.ActivityAssets(
-            application_id=None,
-            large_image=None,
-            large_text=None,
-            small_image=None,
-            small_text=None,
+            application_id=None, large_image=None, large_text=None, small_image=None, small_text=None
         )
 
         assert asset.make_large_image_url() is None
@@ -105,22 +85,14 @@ class TestActivityAssets:
     )
     def test_make_large_image_url_when_dynamic_url(self, asset_hash: str, expected: str):
         asset = presences.ActivityAssets(
-            application_id=None,
-            large_image=asset_hash,
-            large_text=None,
-            small_image=None,
-            small_text=None,
+            application_id=None, large_image=asset_hash, large_text=None, small_image=None, small_text=None
         )
 
         assert asset.make_large_image_url() == files.URL(expected)
 
     def test_make_large_image_url_when_unknown_dynamic_url(self):
         asset = presences.ActivityAssets(
-            application_id=None,
-            large_image="uwu:nou",
-            large_text=None,
-            small_image=None,
-            small_text=None,
+            application_id=None, large_image="uwu:nou", large_text=None, small_image=None, small_text=None
         )
 
         with pytest.raises(RuntimeError, match="Unknown asset type"):
@@ -128,11 +100,7 @@ class TestActivityAssets:
 
     def test_small_image_url_property(self):
         asset = presences.ActivityAssets(
-            application_id=None,
-            large_image=None,
-            large_text=None,
-            small_image=None,
-            small_text=None,
+            application_id=None, large_image=None, large_text=None, small_image=None, small_text=None
         )
 
         with mock.patch.object(presences.ActivityAssets, "make_small_image_url") as make_small_image_url:
@@ -143,11 +111,7 @@ class TestActivityAssets:
 
     def test_small_image_url_property_when_runtime_error(self):
         asset = presences.ActivityAssets(
-            application_id=None,
-            large_image=None,
-            large_text=None,
-            small_image=None,
-            small_text=None,
+            application_id=None, large_image=None, large_text=None, small_image=None, small_text=None
         )
 
         with mock.patch.object(
@@ -160,31 +124,19 @@ class TestActivityAssets:
 
     def test_make_small_image_url(self):
         asset = presences.ActivityAssets(
-            application_id=123321,
-            large_image=None,
-            large_text=None,
-            small_image="aseqwsdas",
-            small_text=None,
+            application_id=123321, large_image=None, large_text=None, small_image="aseqwsdas", small_text=None
         )
 
         with mock.patch.object(routes, "CDN_APPLICATION_ASSET") as route:
             assert asset.make_small_image_url(ext="eat", size=123312) is route.compile_to_file.return_value
 
         route.compile_to_file.assert_called_once_with(
-            urls.CDN_URL,
-            application_id=123321,
-            hash="aseqwsdas",
-            size=123312,
-            file_format="eat",
+            urls.CDN_URL, application_id=123321, hash="aseqwsdas", size=123312, file_format="eat"
         )
 
     def test_make_small_image_url_when_no_hash(self):
         asset = presences.ActivityAssets(
-            application_id=None,
-            large_image=None,
-            large_text=None,
-            small_image=None,
-            small_text=None,
+            application_id=None, large_image=None, large_text=None, small_image=None, small_text=None
         )
 
         assert asset.make_small_image_url() is None
@@ -192,22 +144,14 @@ class TestActivityAssets:
     @pytest.mark.parametrize(("asset_hash", "expected"), [("mp:4123fdssdf", "https://media.discordapp.net/4123fdssdf")])
     def test_make_small_image_url_when_dynamic_url(self, asset_hash: str, expected: str):
         asset = presences.ActivityAssets(
-            application_id=None,
-            large_image=None,
-            large_text=None,
-            small_image=asset_hash,
-            small_text=None,
+            application_id=None, large_image=None, large_text=None, small_image=asset_hash, small_text=None
         )
 
         assert asset.make_small_image_url() == files.URL(expected)
 
     def test_make_small_image_url_when_unknown_dynamic_url(self):
         asset = presences.ActivityAssets(
-            application_id=None,
-            large_image=None,
-            large_text=None,
-            small_image="meow:nyaa",
-            small_text=None,
+            application_id=None, large_image=None, large_text=None, small_image="meow:nyaa", small_text=None
         )
 
         with pytest.raises(RuntimeError, match="Unknown asset type"):

--- a/tests/hikari/test_sessions.py
+++ b/tests/hikari/test_sessions.py
@@ -34,10 +34,7 @@ def test_SessionStartLimit_used_property():
 
 def test_SessionStartLimit_reset_at_property():
     obj = sessions.SessionStartLimit(
-        total=100,
-        remaining=2,
-        reset_after=datetime.timedelta(hours=1, days=10),
-        max_concurrency=1,
+        total=100, remaining=2, reset_after=datetime.timedelta(hours=1, days=10), max_concurrency=1
     )
     obj._created_at = datetime.datetime(2020, 7, 22, 22, 22, 36, 988017, tzinfo=datetime.timezone.utc)
 

--- a/tests/hikari/test_stickers.py
+++ b/tests/hikari/test_stickers.py
@@ -53,12 +53,7 @@ class TestStickerPack:
         ) as route:
             assert model.make_banner_url(ext="url", size=512) == "file"
 
-        route.compile_to_file.assert_called_once_with(
-            urls.CDN_URL,
-            hash=541231,
-            size=512,
-            file_format="url",
-        )
+        route.compile_to_file.assert_called_once_with(urls.CDN_URL, hash=541231, size=512, file_format="url")
 
     def test_make_banner_url_when_no_banner_asset(self, model):
         model.banner_asset_id = None

--- a/tests/hikari/test_templates.py
+++ b/tests/hikari/test_templates.py
@@ -80,10 +80,7 @@ class TestTemplate:
     async def test_create_guild(self, obj):
         obj.app.rest.create_guild_from_template = mock.AsyncMock()
 
-        returned = await obj.create_guild(
-            name="Test guild",
-            icon="https://avatars.githubusercontent.com/u/72694042",
-        )
+        returned = await obj.create_guild(name="Test guild", icon="https://avatars.githubusercontent.com/u/72694042")
         assert returned == obj.app.rest.create_guild_from_template.return_value
 
         obj.app.rest.create_guild_from_template.assert_awaited_once_with(

--- a/tests/hikari/test_users.py
+++ b/tests/hikari/test_users.py
@@ -209,11 +209,7 @@ class TestUser:
             assert obj.make_avatar_url(ext=None, size=4096) == "file"
 
         route.compile_to_file.assert_called_once_with(
-            urls.CDN_URL,
-            user_id=obj.id,
-            hash="a_18dnf8dfbakfdh",
-            size=4096,
-            file_format="gif",
+            urls.CDN_URL, user_id=obj.id, hash="a_18dnf8dfbakfdh", size=4096, file_format="gif"
         )
 
     def test_make_avatar_url_when_format_is_None_and_avatar_hash_is_not_for_gif(self, obj):
@@ -225,11 +221,7 @@ class TestUser:
             assert obj.make_avatar_url(ext=None, size=4096) == "file"
 
         route.compile_to_file.assert_called_once_with(
-            urls.CDN_URL,
-            user_id=obj.id,
-            hash=obj.avatar_hash,
-            size=4096,
-            file_format="png",
+            urls.CDN_URL, user_id=obj.id, hash=obj.avatar_hash, size=4096, file_format="png"
         )
 
     def test_make_avatar_url_with_all_args(self, obj):
@@ -241,11 +233,7 @@ class TestUser:
             assert obj.make_avatar_url(ext="url", size=4096) == "file"
 
         route.compile_to_file.assert_called_once_with(
-            urls.CDN_URL,
-            user_id=obj.id,
-            hash=obj.avatar_hash,
-            size=4096,
-            file_format="url",
+            urls.CDN_URL, user_id=obj.id, hash=obj.avatar_hash, size=4096, file_format="url"
         )
 
     def test_display_avatar_url_when_avatar_url(self, obj):
@@ -266,11 +254,7 @@ class TestUser:
         ) as route:
             assert obj.default_avatar_url == "file"
 
-        route.compile_to_file.assert_called_once_with(
-            urls.CDN_URL,
-            discriminator=4,
-            file_format="png",
-        )
+        route.compile_to_file.assert_called_once_with(urls.CDN_URL, discriminator=4, file_format="png")
 
     def test_banner_url_property(self, obj):
         with mock.patch.object(users.User, "make_banner_url") as make_banner_url:
@@ -293,11 +277,7 @@ class TestUser:
             assert obj.make_banner_url(ext=None, size=4096) == "file"
 
         route.compile_to_file.assert_called_once_with(
-            urls.CDN_URL,
-            user_id=obj.id,
-            hash="a_18dnf8dfbakfdh",
-            size=4096,
-            file_format="gif",
+            urls.CDN_URL, user_id=obj.id, hash="a_18dnf8dfbakfdh", size=4096, file_format="gif"
         )
 
     def test_make_banner_url_when_format_is_None_and_banner_hash_is_not_for_gif(self, obj):
@@ -309,11 +289,7 @@ class TestUser:
             assert obj.make_banner_url(ext=None, size=4096) == "file"
 
         route.compile_to_file.assert_called_once_with(
-            urls.CDN_URL,
-            user_id=obj.id,
-            hash=obj.banner_hash,
-            size=4096,
-            file_format="png",
+            urls.CDN_URL, user_id=obj.id, hash=obj.banner_hash, size=4096, file_format="png"
         )
 
     def test_make_banner_url_with_all_args(self, obj):
@@ -325,11 +301,7 @@ class TestUser:
             assert obj.make_banner_url(ext="url", size=4096) == "file"
 
         route.compile_to_file.assert_called_once_with(
-            urls.CDN_URL,
-            user_id=obj.id,
-            hash=obj.banner_hash,
-            size=4096,
-            file_format="url",
+            urls.CDN_URL, user_id=obj.id, hash=obj.banner_hash, size=4096, file_format="url"
         )
 
 


### PR DESCRIPTION
### Summary
These are usually accidental or coincidental and this just makes the behaviour more consistent.

The only place I can think of where you'd actively want this behaviour is for examples, but examples in documentation aren't reformatted by black right now anyways.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
