### PR TITLE
Default `enable_cleanup_closed` to False

### DIFF
--- a/changes/1585.bugfix.md
+++ b/changes/1585.bugfix.md
@@ -1,0 +1,2 @@
+Default `HTTPSettings.enable_cleanup_closed` to `False`.
+- CPython3.11 changes around SSLProto have made this quite unstable and prone to errors when dealing with unclosed TLS transports, which ends up in aiohttp calling close and abort twice.

--- a/hikari/impl/config.py
+++ b/hikari/impl/config.py
@@ -200,12 +200,12 @@ class HTTPTimeoutSettings:
 class HTTPSettings(config.HTTPSettings):
     """Settings to control HTTP clients."""
 
-    enable_cleanup_closed: bool = attrs.field(default=True, validator=attrs.validators.instance_of(bool))
+    enable_cleanup_closed: bool = attrs.field(default=False, validator=attrs.validators.instance_of(bool))
     """Toggle whether to clean up closed transports.
 
-    This defaults to `True` to combat various protocol and asyncio
-    issues present when using Microsoft Windows. If you are sure you know
-    what you are doing, you may instead set this to `False` to disable this
+    This defaults to `False` to combat various protocol and asyncio
+    issues present. If you are sure you know  what you are doing,
+    you may instead set this to `True` to enable this
     behavior internally.
     """
 


### PR DESCRIPTION
CPython3.11 changes around SSLProto have made this quite unstable and prone to errors when dealing with unclosed TLS transports, which ends up in aiohttp calling close and abort twice.

This has been battle tested by several people on different OS's (both Linux and Windows) and seems to work fine and solve the issues.