### PR TITLE
Use a stack to keep streams open until usage in `RESTClient.edit_guild`

### DIFF
--- a/changes/1627.bugfix.md
+++ b/changes/1627.bugfix.md
@@ -1,0 +1,1 @@
+Fix a bug in `RESTClient.edit_guild` which load to closed stream errors

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -430,16 +430,21 @@ def rest_client(rest_client_class, mock_cache):
 def file_resource():
     class Stream:
         def __init__(self, data):
+            self.open = False
             self.data = data
 
         async def data_uri(self):
+            if not self.open:
+                raise RuntimeError("Tried to read off a closed stream")
+
             return self.data
 
         async def __aenter__(self):
+            self.open = True
             return self
 
         async def __aexit__(self, exc_type, exc, exc_tb) -> None:
-            pass
+            self.open = False
 
     class FileResource(files.Resource):
         filename = None


### PR DESCRIPTION
### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Closes #1613
