### PR TITLE
Remove renaming "idk" changelog files 

### DIFF
--- a/.github/workflows/fragments-check.yml
+++ b/.github/workflows/fragments-check.yml
@@ -42,34 +42,3 @@ jobs:
           if [ "$changelog_fragments" != "$valid_changelog_fragments" ]; then
             exit 1
           fi
-
-      # We can also detect and rename idk.{}.md to valid changelog files
-      #
-      # The PR checkout is needed because we don't actually run on the checked
-      # out version of the PR.
-      - name: Try to rename 'idk' changelog fragments
-        if: always()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr checkout ${{ github.event.pull_request.number }}
-
-          diff=$(git diff origin/${{ github.base_ref }} HEAD --name-only)
-          idk_changelog_fragments=$(echo "$diff" | grep "^changes/idk\.")
-
-          if [ -z "idk_changelog_fragments" ]; then
-            # Nothing to change
-            echo "Nothing to change, leaving as is"
-            exit 0
-          fi
-
-          while IFS= read -r filename; do
-            mv "$filename" ${filename/idk/${{ github.event.number }}}
-          done <<< "$idk_changelog_fragments"
-
-          git config --global user.name "hikari-bot"
-          git config --global user.email "90276125+hikari-bot[bot]@users.noreply.github.com"
-
-          git add -A
-          git commit -m "[ci] rename 'idk' changelog fragments"
-          git push


### PR DESCRIPTION
This can only be done with a personal access token, which is not something worth having out there publically