### PR TITLE
Allow closing the bot during StartingEvent

### DIFF
--- a/hikari/impl/gateway_bot.py
+++ b/hikari/impl/gateway_bot.py
@@ -823,7 +823,9 @@ class GatewayBot(traits.GatewayBotAware):
                     )
                 )
 
-                loop.run_until_complete(self.join())
+                if self._closed_event is not None:
+                    # The user might have closed the bot during startup, respect it
+                    loop.run_until_complete(self.join())
 
             finally:
                 try:
@@ -929,6 +931,10 @@ class GatewayBot(traits.GatewayBotAware):
         self._voice.start()
 
         await self._event_manager.dispatch(self._event_factory.deserialize_starting_event())
+        if self._closed_event is None:
+            # If the user requested to close the bot before startup, respect it
+            return
+
         requirements = await self._rest.fetch_gateway_bot_info()
 
         if shard_count is None:

--- a/hikari/impl/rest_bot.py
+++ b/hikari/impl/rest_bot.py
@@ -586,7 +586,10 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
                         ssl_context=ssl_context,
                     )
                 )
-                loop.run_until_complete(self.join())
+
+                if self._close_event is not None:
+                    # The user might have closed the bot during startup, respect it
+                    loop.run_until_complete(self.join())
 
             finally:
                 try:
@@ -676,6 +679,10 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
         except Exception:
             await self._rest.close()
             raise
+
+        if self._close_event is None:
+            # If the user requested to close the bot before startup, respect it
+            return
 
         await self._server.start(
             backlog=backlog,


### PR DESCRIPTION
### Summary
Allows the following use-case:

```py
bot = hikari.GatewayBot("TOKEN")

@bot.listen()
async def connect_to_db(event: hikari.StartingEvent) -> None:
    try:
        database = Database.connect()
    except ConnectionFailureException:
        print("Failed to connect to database")
        await bot.close()

bot.run()
```

---

This would be the gist of the change as things currently stand, but I am not entirely happy with it. Ideally, we would want any interrupt or call to `bot.close()` (which should really resolve to the same thing internally to streamline the shutdown process, imo) at any point in time to immediately start the shutdown sequence.

When I get some time, I will play around with implementing the signal handling directly into the loop and (maybe) an event being set stops the loop and makes it continue to the shutdown phase rather than having to keep checking for the the event being set.

**Any feedback on this is welcome!**

---

Note for myself (probably wont be changed):
I also dislike how its a bit counter intuitive to check for `None` other than the event being set, but until CPython 3.11 we will not be able to change that since `asyncio.Event` tries to get the loop in `__init__`.

### Checklist
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.
