### PR TITLE
Add defaults for auto-populated selects

### DIFF
--- a/changes/1804.feature.md
+++ b/changes/1804.feature.md
@@ -1,0 +1,1 @@
+Add `default_values` to autopopulating select menus

--- a/changes/1804.removal.md
+++ b/changes/1804.removal.md
@@ -1,0 +1,1 @@
+Deprecate `hikari.api.MessageActionRowBuilder.add_select_menu()`

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -5467,9 +5467,9 @@ class TestEntityFactoryImpl:
         [
             (2, "_deserialize_button", "_message_component_type_mapping"),
             (3, "_deserialize_text_select_menu", "_message_component_type_mapping"),
-            (5, "_deserialize_select_menu", "_message_component_type_mapping"),
-            (6, "_deserialize_select_menu", "_message_component_type_mapping"),
-            (7, "_deserialize_select_menu", "_message_component_type_mapping"),
+            (5, "_deserialize_user_select_menu", "_message_component_type_mapping"),
+            (6, "_deserialize_role_select_menu", "_message_component_type_mapping"),
+            (7, "_deserialize_mentionable_select_menu", "_message_component_type_mapping"),
             (8, "_deserialize_channel_select_menu", "_message_component_type_mapping"),
             (4, "_deserialize_text_input", "_modal_component_type_mapping"),
         ],


### PR DESCRIPTION
### Summary
Add `default_values` attribute for auto-populated selects. This did require some fairly **significant restructuring** to make type-safe, and honestly I'm still not quite happy with the result, so feedback is welcome.

The select types have been completely seperated, so the new hierarchy of components looks something like this:

```
SelectMenu
TextSelect(SelectMenu)
AutoPopulatingSelect(SelectMenu)
ChannelSelect(AutoPopulatingSelect) 
RoleSelect(AutoPopulatingSelect)
UserSelect(AutoPopulatingSelect)
MentionableSelect(AutoPopulatingSelect)
```

This PR also deprecates `ActionRowBuilder.add_select_menu()` as type-specific methods have been added for each select type. I feel like seperating the select types is better for type safety and potentially more future-proof if Discord decides add specific behaviours to a given select type down the line.

### Example

```py
row = rest.build_message_action_row().add_user_menu(
    "Test",
    placeholder="Amongus",
    min_values=1,
    max_values=2,
    default_values=[
        hikari.impl.SelectDefaultBuilder(
            163979124820541440, type=hikari.SelectDefaultType.USER
        ),
        hikari.impl.SelectDefaultBuilder(
            1184650183401803906, type=hikari.SelectDefaultType.USER
        ),
    ],
)
```

I tried an alternative interface where the snowflake's type could be inferred from the select's type, however this is not possible due to it being possible to mix default types in mentionable selects, so at the moment this is the best I could come up with. 

The implementation tries to be type-safe to the extent that adding an invalid default type fails type-checking:

```py
row = rest.build_message_action_row().add_user_menu(
    "Test",
    placeholder="Amongus",
    min_values=1,
    max_values=2,
    default_values=[
        hikari.impl.SelectDefaultBuilder( # Type error
            163979124820541440, type=hikari.SelectDefaultType.ROLE
        )
    ],
)
``` 

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues

Closes #1776 
