### PR TITLE
Ensure we have a loop when running ratelimit tests

### DIFF
--- a/tests/hikari/impl/test_rate_limits.py
+++ b/tests/hikari/impl/test_rate_limits.py
@@ -65,16 +65,18 @@ class TestBurstRateLimiter:
         mock_burst_limiter.queue = queue
         assert mock_burst_limiter.is_empty is is_empty
 
-    def test_close_removes_all_futures_from_queue(self, mock_burst_limiter):
-        event_loop = asyncio.get_event_loop()
+    @pytest.mark.asyncio()
+    async def test_close_removes_all_futures_from_queue(self, mock_burst_limiter):
+        event_loop = asyncio.get_running_loop()
         mock_burst_limiter.throttle_task = None
         futures = [event_loop.create_future() for _ in range(10)]
         mock_burst_limiter.queue = list(futures)
         mock_burst_limiter.close()
         assert len(mock_burst_limiter.queue) == 0
 
-    def test_close_cancels_all_futures_pending_when_futures_pending(self, mock_burst_limiter):
-        event_loop = asyncio.get_event_loop()
+    @pytest.mark.asyncio()
+    async def test_close_cancels_all_futures_pending_when_futures_pending(self, mock_burst_limiter):
+        event_loop = asyncio.get_running_loop()
         mock_burst_limiter.throttle_task = None
         futures = [event_loop.create_future() for _ in range(10)]
         mock_burst_limiter.queue = list(futures)
@@ -82,21 +84,24 @@ class TestBurstRateLimiter:
         for i, future in enumerate(futures):
             assert future.cancelled(), f"future {i} was not cancelled"
 
-    def test_close_is_silent_when_no_futures_pending(self, mock_burst_limiter):
+    @pytest.mark.asyncio()
+    async def test_close_is_silent_when_no_futures_pending(self, mock_burst_limiter):
         mock_burst_limiter.throttle_task = None
         mock_burst_limiter.queue = []
         mock_burst_limiter.close()
         assert True, "passed successfully"
 
-    def test_close_cancels_throttle_task_if_running(self, mock_burst_limiter):
-        event_loop = asyncio.get_event_loop()
+    @pytest.mark.asyncio()
+    async def test_close_cancels_throttle_task_if_running(self, mock_burst_limiter):
+        event_loop = asyncio.get_running_loop()
         task = event_loop.create_future()
         mock_burst_limiter.throttle_task = task
         mock_burst_limiter.close()
         assert mock_burst_limiter.throttle_task is None, "task was not overwritten with None"
         assert task.cancelled(), "throttle_task is not cancelled"
 
-    def test_close_when_closed(self, mock_burst_limiter):
+    @pytest.mark.asyncio()
+    async def test_close_when_closed(self, mock_burst_limiter):
         # Double-running shouldn't do anything adverse.
         mock_burst_limiter.close()
         mock_burst_limiter.close()
@@ -105,7 +110,7 @@ class TestBurstRateLimiter:
 class TestManualRateLimiter:
     @pytest.mark.asyncio()
     async def test_acquire_returns_completed_future_if_throttle_task_is_None(self):
-        event_loop = asyncio.get_event_loop()
+        event_loop = asyncio.get_running_loop()
 
         with rate_limits.ManualRateLimiter() as limiter:
             limiter.throttle_task = None
@@ -117,7 +122,7 @@ class TestManualRateLimiter:
 
     @pytest.mark.asyncio()
     async def test_acquire_returns_incomplete_future_if_throttle_task_is_not_None(self):
-        event_loop = asyncio.get_event_loop()
+        event_loop = asyncio.get_running_loop()
 
         with rate_limits.ManualRateLimiter() as limiter:
             limiter.throttle_task = event_loop.create_future()
@@ -129,7 +134,7 @@ class TestManualRateLimiter:
 
     @pytest.mark.asyncio()
     async def test_acquire_places_future_on_queue_if_throttle_task_is_not_None(self):
-        event_loop = asyncio.get_event_loop()
+        event_loop = asyncio.get_running_loop()
 
         with rate_limits.ManualRateLimiter() as limiter:
             limiter.throttle_task = event_loop.create_future()
@@ -163,7 +168,7 @@ class TestManualRateLimiter:
 
     @pytest.mark.asyncio()
     async def test_throttle_chews_queue_completing_futures(self):
-        event_loop = asyncio.get_event_loop()
+        event_loop = asyncio.get_running_loop()
 
         with rate_limits.ManualRateLimiter() as limiter:
             futures = [event_loop.create_future() for _ in range(10)]
@@ -174,7 +179,7 @@ class TestManualRateLimiter:
 
     @pytest.mark.asyncio()
     async def test_throttle_sleeps_before_popping_queue(self):
-        event_loop = asyncio.get_event_loop()
+        event_loop = asyncio.get_running_loop()
         # GIVEN
         slept_at = float("nan")
         popped_at = []


### PR DESCRIPTION
This has been causing warnings (and, by extension, errors) occasionally when running pytest, more specifically when these tests are the first to run and no event loop exists