### PR TITLE
Allow changing guild features (community, etc.)

### DIFF
--- a/changes/1828.feature.md
+++ b/changes/1828.feature.md
@@ -1,0 +1,1 @@
+Allow changing guild features (community, etc.)

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -3889,6 +3889,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             snowflakes.SnowflakeishOr[channels_.GuildTextChannel]
         ] = undefined.UNDEFINED,
         preferred_locale: undefined.UndefinedOr[typing.Union[str, locales.Locale]] = undefined.UNDEFINED,
+        features: undefined.UndefinedOr[typing.Sequence[guilds.MutableGuildFeature]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> guilds.RESTGuild:
         """Edit a guild.
@@ -3936,6 +3937,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If provided, the new public updates channel.
         preferred_locale : hikari.undefined.UndefinedNoneOr[str]
             If provided, the new preferred locale.
+        features : hikari.undefined.UndefinedOr[typing.Sequence[hikari.guilds.MutableGuildFeature]]
+            If provided, the guild features to be enabled. Features not provided will be disabled.
         reason : hikari.undefined.UndefinedOr[str]
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -3889,7 +3889,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             snowflakes.SnowflakeishOr[channels_.GuildTextChannel]
         ] = undefined.UNDEFINED,
         preferred_locale: undefined.UndefinedOr[typing.Union[str, locales.Locale]] = undefined.UNDEFINED,
-        features: undefined.UndefinedOr[typing.Sequence[guilds.MutableGuildFeature]] = undefined.UNDEFINED,
+        features: undefined.UndefinedOr[typing.Sequence[guilds.GuildFeature]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> guilds.RESTGuild:
         """Edit a guild.
@@ -3937,8 +3937,15 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             If provided, the new public updates channel.
         preferred_locale : hikari.undefined.UndefinedNoneOr[str]
             If provided, the new preferred locale.
-        features : hikari.undefined.UndefinedOr[typing.Sequence[hikari.guilds.MutableGuildFeature]]
+        features : hikari.undefined.UndefinedOr[typing.Sequence[hikari.guilds.GuildFeature]]
             If provided, the guild features to be enabled. Features not provided will be disabled.
+
+            .. warning::
+                At the time of writing, Discord ignores non-`mutable features
+                <https://discord.com/developers/docs/resources/guild#guild-object-mutable-guild-features>`_.
+                This behaviour can change in the future. You should refer to the
+                aforementioned link for the most up-to-date information, and
+                only supply mutable features.
         reason : hikari.undefined.UndefinedOr[str]
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -183,6 +183,12 @@ class GuildFeature(str, enums.Enum):
     ROLE_SUBSCRIPTIONS_AVAILABLE_FOR_PURCHASE = "ROLE_SUBSCRIPTIONS_AVAILABLE_FOR_PURCHASE"
     """Guild has role subscriptions available for purchase."""
 
+    INVITES_DISABLED = "INVITES_DISABLED"
+    """Guild has paused invites, preventing new users from joining."""
+
+    RAID_ALERTS_DISABLED = "RAID_ALERTS_DISABLED"
+    """Guild has disabled alerts for join raids in the configured safety alerts channel."""
+
 
 @typing.final
 class GuildMessageNotificationsLevel(int, enums.Enum):

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -191,6 +191,28 @@ class GuildFeature(str, enums.Enum):
 
 
 @typing.final
+class MutableGuildFeature(str, enums.Enum):
+    """Features of a guild that can be modified."""
+
+    COMMUNITY = "COMMUNITY"
+    """Enable guild's community features.
+
+    Guild must have, in conjunction, verification level set to at
+    least Low, explicit content filter set to All Members, a rule
+    channel and an update channel.
+    """
+
+    DISCOVERABLE = "DISCOVERABLE"
+    """Enable guild's discoverability in the directory."""
+
+    INVITES_DISABLED = "INVITES_DISABLED"
+    """Disable invites for the guild."""
+
+    RAID_ALERTS_DISABLED = "RAID_ALERTS_DISABLED"
+    """Disable alerts for join raids in the configured safety alerts channel."""
+
+
+@typing.final
 class GuildMessageNotificationsLevel(int, enums.Enum):
     """Represents the default notification level for new messages in a guild."""
 
@@ -1554,6 +1576,7 @@ class PartialGuild(snowflakes.Unique):
             snowflakes.SnowflakeishOr[channels_.GuildTextChannel]
         ] = undefined.UNDEFINED,
         preferred_locale: undefined.UndefinedOr[typing.Union[str, locales.Locale]] = undefined.UNDEFINED,
+        features: undefined.UndefinedOr[typing.Sequence[MutableGuildFeature]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> RESTGuild:
         """Edit the guild.
@@ -1595,6 +1618,8 @@ class PartialGuild(snowflakes.Unique):
             If provided, the new public updates channel.
         preferred_locale : hikari.undefined.UndefinedNoneOr[str]
             If provided, the new preferred locale.
+        features : hikari.undefined.UndefinedOr[typing.Sequence[hikari.guilds.MutableGuildFeatures]]
+            If provided, the guild features to be enabled. Features not provided will be disabled.
         reason : hikari.undefined.UndefinedOr[str]
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
@@ -1638,6 +1663,7 @@ class PartialGuild(snowflakes.Unique):
             rules_channel=rules_channel,
             public_updates_channel=public_updates_channel,
             preferred_locale=preferred_locale,
+            features=features,
             reason=reason,
         )
 

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -191,28 +191,6 @@ class GuildFeature(str, enums.Enum):
 
 
 @typing.final
-class MutableGuildFeature(str, enums.Enum):
-    """Features of a guild that can be modified."""
-
-    COMMUNITY = "COMMUNITY"
-    """Enable guild's community features.
-
-    Guild must have, in conjunction, verification level set to at
-    least Low, explicit content filter set to All Members, a rule
-    channel and an update channel.
-    """
-
-    DISCOVERABLE = "DISCOVERABLE"
-    """Enable guild's discoverability in the directory."""
-
-    INVITES_DISABLED = "INVITES_DISABLED"
-    """Disable invites for the guild."""
-
-    RAID_ALERTS_DISABLED = "RAID_ALERTS_DISABLED"
-    """Disable alerts for join raids in the configured safety alerts channel."""
-
-
-@typing.final
 class GuildMessageNotificationsLevel(int, enums.Enum):
     """Represents the default notification level for new messages in a guild."""
 
@@ -1576,7 +1554,7 @@ class PartialGuild(snowflakes.Unique):
             snowflakes.SnowflakeishOr[channels_.GuildTextChannel]
         ] = undefined.UNDEFINED,
         preferred_locale: undefined.UndefinedOr[typing.Union[str, locales.Locale]] = undefined.UNDEFINED,
-        features: undefined.UndefinedOr[typing.Sequence[MutableGuildFeature]] = undefined.UNDEFINED,
+        features: undefined.UndefinedOr[typing.Sequence[GuildFeature]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> RESTGuild:
         """Edit the guild.
@@ -1618,7 +1596,7 @@ class PartialGuild(snowflakes.Unique):
             If provided, the new public updates channel.
         preferred_locale : hikari.undefined.UndefinedNoneOr[str]
             If provided, the new preferred locale.
-        features : hikari.undefined.UndefinedOr[typing.Sequence[hikari.guilds.MutableGuildFeatures]]
+        features : hikari.undefined.UndefinedOr[typing.Sequence[hikari.guilds.GuildFeatures]]
             If provided, the guild features to be enabled. Features not provided will be disabled.
         reason : hikari.undefined.UndefinedOr[str]
             If provided, the reason that will be recorded in the audit logs.

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -2544,7 +2544,9 @@ class RESTClientImpl(rest_api.RESTClient):
             snowflakes.SnowflakeishOr[channels_.GuildTextChannel]
         ] = undefined.UNDEFINED,
         preferred_locale: undefined.UndefinedOr[typing.Union[str, locales.Locale]] = undefined.UNDEFINED,
-        features: undefined.UndefinedOr[typing.Sequence[guilds.MutableGuildFeature]] = undefined.UNDEFINED,
+        features: undefined.UndefinedOr[
+            typing.Sequence[typing.Union[str, guilds.MutableGuildFeature]]
+        ] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> guilds.RESTGuild:
         route = routes.PATCH_GUILD.compile(guild=guild)

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -2544,9 +2544,7 @@ class RESTClientImpl(rest_api.RESTClient):
             snowflakes.SnowflakeishOr[channels_.GuildTextChannel]
         ] = undefined.UNDEFINED,
         preferred_locale: undefined.UndefinedOr[typing.Union[str, locales.Locale]] = undefined.UNDEFINED,
-        features: undefined.UndefinedOr[
-            typing.Sequence[typing.Union[str, guilds.MutableGuildFeature]]
-        ] = undefined.UNDEFINED,
+        features: undefined.UndefinedOr[typing.Sequence[typing.Union[str, guilds.GuildFeature]]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> guilds.RESTGuild:
         route = routes.PATCH_GUILD.compile(guild=guild)

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -2544,6 +2544,7 @@ class RESTClientImpl(rest_api.RESTClient):
             snowflakes.SnowflakeishOr[channels_.GuildTextChannel]
         ] = undefined.UNDEFINED,
         preferred_locale: undefined.UndefinedOr[typing.Union[str, locales.Locale]] = undefined.UNDEFINED,
+        features: undefined.UndefinedOr[typing.Sequence[guilds.MutableGuildFeature]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> guilds.RESTGuild:
         route = routes.PATCH_GUILD.compile(guild=guild)
@@ -2554,6 +2555,8 @@ class RESTClientImpl(rest_api.RESTClient):
         body.put("explicit_content_filter", explicit_content_filter_level)
         body.put("afk_timeout", afk_timeout, conversion=time.timespan_to_int)
         body.put("preferred_locale", preferred_locale, conversion=str)
+        if features is not undefined.UNDEFINED:
+            body.put_array("features", features, conversion=str)
         body.put_snowflake("afk_channel_id", afk_channel)
         body.put_snowflake("owner_id", owner)
         body.put_snowflake("system_channel_id", system_channel)

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -2555,8 +2555,7 @@ class RESTClientImpl(rest_api.RESTClient):
         body.put("explicit_content_filter", explicit_content_filter_level)
         body.put("afk_timeout", afk_timeout, conversion=time.timespan_to_int)
         body.put("preferred_locale", preferred_locale, conversion=str)
-        if features is not undefined.UNDEFINED:
-            body.put_array("features", features, conversion=str)
+        body.put_array("features", features, conversion=str)
         body.put_snowflake("afk_channel_id", afk_channel)
         body.put_snowflake("owner_id", owner)
         body.put_snowflake("system_channel_id", system_channel)

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -4029,7 +4029,7 @@ class TestRESTClientImplAsync:
                 rules_channel=StubModel(987),
                 public_updates_channel=(654),
                 preferred_locale="en-UK",
-                features=[guilds.MutableGuildFeature.COMMUNITY, guilds.MutableGuildFeature.RAID_ALERTS_DISABLED],
+                features=[guilds.GuildFeature.COMMUNITY, guilds.GuildFeature.RAID_ALERTS_DISABLED],
                 reason="hikari best",
             )
             assert result is rest_client._entity_factory.deserialize_rest_guild.return_value
@@ -4074,7 +4074,7 @@ class TestRESTClientImplAsync:
             rules_channel=StubModel(987),
             public_updates_channel=(654),
             preferred_locale="en-UK",
-            features=[guilds.MutableGuildFeature.COMMUNITY, guilds.MutableGuildFeature.RAID_ALERTS_DISABLED],
+            features=[guilds.GuildFeature.COMMUNITY, guilds.GuildFeature.RAID_ALERTS_DISABLED],
             reason="hikari best",
         )
         assert result is rest_client._entity_factory.deserialize_rest_guild.return_value

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -4008,6 +4008,7 @@ class TestRESTClientImplAsync:
             "icon": "icon data",
             "splash": "splash data",
             "banner": "banner data",
+            "features": ["COMMUNITY", "RAID_ALERTS_DISABLED"],
         }
         rest_client._request = mock.AsyncMock(return_value={"id": "123"})
 
@@ -4028,6 +4029,7 @@ class TestRESTClientImplAsync:
                 rules_channel=StubModel(987),
                 public_updates_channel=(654),
                 preferred_locale="en-UK",
+                features=[guilds.MutableGuildFeature.COMMUNITY, guilds.MutableGuildFeature.RAID_ALERTS_DISABLED],
                 reason="hikari best",
             )
             assert result is rest_client._entity_factory.deserialize_rest_guild.return_value
@@ -4052,6 +4054,7 @@ class TestRESTClientImplAsync:
             "icon": None,
             "splash": None,
             "banner": None,
+            "features": ["COMMUNITY", "RAID_ALERTS_DISABLED"],
         }
         rest_client._request = mock.AsyncMock(return_value={"ok": "NO"})
 
@@ -4071,6 +4074,7 @@ class TestRESTClientImplAsync:
             rules_channel=StubModel(987),
             public_updates_channel=(654),
             preferred_locale="en-UK",
+            features=[guilds.MutableGuildFeature.COMMUNITY, guilds.MutableGuildFeature.RAID_ALERTS_DISABLED],
             reason="hikari best",
         )
         assert result is rest_client._entity_factory.deserialize_rest_guild.return_value

--- a/tests/hikari/test_guilds.py
+++ b/tests/hikari/test_guilds.py
@@ -629,6 +629,7 @@ class TestPartialGuild:
             owner=6996,
             afk_timeout=400,
             preferred_locale="us-en",
+            features=[guilds.MutableGuildFeature.COMMUNITY, guilds.MutableGuildFeature.RAID_ALERTS_DISABLED],
             reason="beep boop",
         )
 
@@ -648,6 +649,7 @@ class TestPartialGuild:
             rules_channel=undefined.UNDEFINED,
             public_updates_channel=undefined.UNDEFINED,
             preferred_locale="us-en",
+            features=[guilds.MutableGuildFeature.COMMUNITY, guilds.MutableGuildFeature.RAID_ALERTS_DISABLED],
             reason="beep boop",
         )
 

--- a/tests/hikari/test_guilds.py
+++ b/tests/hikari/test_guilds.py
@@ -629,7 +629,7 @@ class TestPartialGuild:
             owner=6996,
             afk_timeout=400,
             preferred_locale="us-en",
-            features=[guilds.MutableGuildFeature.COMMUNITY, guilds.MutableGuildFeature.RAID_ALERTS_DISABLED],
+            features=[guilds.GuildFeature.COMMUNITY, guilds.GuildFeature.RAID_ALERTS_DISABLED],
             reason="beep boop",
         )
 
@@ -649,7 +649,7 @@ class TestPartialGuild:
             rules_channel=undefined.UNDEFINED,
             public_updates_channel=undefined.UNDEFINED,
             preferred_locale="us-en",
-            features=[guilds.MutableGuildFeature.COMMUNITY, guilds.MutableGuildFeature.RAID_ALERTS_DISABLED],
+            features=[guilds.GuildFeature.COMMUNITY, guilds.GuildFeature.RAID_ALERTS_DISABLED],
             reason="beep boop",
         )
 


### PR DESCRIPTION
### Summary
This PR adds two missing mutable guild features to `GuildFeature` enums, introduces `MutableGuildFeature` for ease of use, and a `features` argument to `edit_guild()` to address the lack of support for editing guild features. Relevant docstrings and tests had been updated accordingly.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
Resolves #1768.
Partially addresses #1827.