### PR TITLE
Fix incorrectly replaced backticks in strings

### DIFF
--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -1655,27 +1655,27 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
                 # Yep, these are technically two unreachable branches. However, this is an incredibly
                 # common mistake to make when working with embeds and not using a static type
                 # checker, so I have added these as additional safeguards for UX and ease
-                # of debugging. The case that there are [`None`][] should be detected immediately by
+                # of debugging. The case that there are `None` should be detected immediately by
                 # static type checkers, regardless.
                 name = str(field.name) if field.name is not None else None
                 value = str(field.value) if field.value is not None else None
 
                 if name is None:
-                    raise TypeError(f"in embed.fields[{i}].name - cannot have [`None`][]")
+                    raise TypeError(f"in embed.fields[{i}].name - cannot have `None`")
                 if not name:
                     raise TypeError(f"in embed.fields[{i}].name - cannot have empty string")
                 if not name.strip():
                     raise TypeError(f"in embed.fields[{i}].name - cannot have only whitespace")
 
                 if value is None:
-                    raise TypeError(f"in embed.fields[{i}].value - cannot have [`None`][]")
+                    raise TypeError(f"in embed.fields[{i}].value - cannot have `None`")
                 if not value:
                     raise TypeError(f"in embed.fields[{i}].value - cannot have empty string")
                 if not value.strip():
                     raise TypeError(f"in embed.fields[{i}].value - cannot have only whitespace")
 
                 # Name and value always have to be specified; we can always
-                # send a default [`inline`][] value also just to keep this simpler.
+                # send a default `inline` value also just to keep this simpler.
                 field_payloads.append({"name": name, "value": value, "inline": field.is_inline})
             payload["fields"] = field_payloads
 

--- a/hikari/internal/enums.py
+++ b/hikari/internal/enums.py
@@ -232,7 +232,7 @@ class _EnumMeta(type):
             return _EnumNamespace(object)
 
         try:
-            # Fails if Enum is not defined. We check this in [`__new__`][] properly.
+            # Fails if Enum is not defined. We check this in `__new__` properly.
             base, enum_type = bases
 
             if isinstance(base, _EnumMeta):

--- a/hikari/internal/ux.py
+++ b/hikari/internal/ux.py
@@ -330,7 +330,7 @@ def warn_if_not_optimized(suppress: bool) -> None:
     if __debug__ and not suppress:
         _LOGGER.warning(
             "You are running on optimization level 0 (no optimizations), which may slow down your application. "
-            "For production, consider using at least level 1 optimization by passing [-O][] to the python "
+            "For production, consider using at least level 1 optimization by passing `-O` to the python "
             "interpreter call"
         )
 


### PR DESCRIPTION
### Summary
Fix incorrectly replaced backticks in strings

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
~~- [ ] I have made unittests according to the code I have added/modified/deleted.~~ N/A

### Related issues
None
