### PR TITLE
Add ability to edit own user banner

### DIFF
--- a/changes/1871.feature.md
+++ b/changes/1871.feature.md
@@ -1,0 +1,1 @@
+Add ability to edit own user banner

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -2567,6 +2567,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         *,
         username: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         avatar: undefined.UndefinedNoneOr[files.Resourceish] = undefined.UNDEFINED,
+        banner: undefined.UndefinedNoneOr[files.Resourceish] = undefined.UNDEFINED,
     ) -> users.OwnUser:
         """Edit the token's associated user.
 
@@ -2577,6 +2578,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         avatar : undefined.UndefinedNoneOr[hikari.files.Resourceish]
             If provided, the new avatar. If [`None`][],
             the avatar will be removed.
+        banner : undefined.UndefinedNoneOr[hikari.files.Resourceish]
+            If provided, the new banner. If [`None`][],
+            the banner will be removed.
 
         Returns
         -------

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -2062,6 +2062,7 @@ class RESTClientImpl(rest_api.RESTClient):
         *,
         username: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         avatar: undefined.UndefinedNoneOr[files.Resourceish] = undefined.UNDEFINED,
+        banner: undefined.UndefinedNoneOr[files.Resourceish] = undefined.UNDEFINED,
     ) -> users.OwnUser:
         route = routes.PATCH_MY_USER.compile()
         body = data_binding.JSONObjectBuilder()
@@ -2073,6 +2074,13 @@ class RESTClientImpl(rest_api.RESTClient):
             avatar_resource = files.ensure_resource(avatar)
             async with avatar_resource.stream(executor=self._executor) as stream:
                 body.put("avatar", await stream.data_uri())
+
+        if banner is None:
+            body.put("banner", None)
+        elif banner is not undefined.UNDEFINED:
+            banner_resource = files.ensure_resource(banner)
+            async with banner_resource.stream(executor=self._executor) as stream:
+                body.put("banner", await stream.data_uri())
 
         response = await self._request(route, json=body)
         assert isinstance(response, dict)

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -3519,6 +3519,30 @@ class TestRESTClientImplAsync:
         rest_client._request.assert_awaited_once_with(expected_route, json=expected_json)
         rest_client._entity_factory.deserialize_my_user.assert_called_once_with({"id": "123"})
 
+    async def test_edit_my_user_when_banner_is_None(self, rest_client):
+        user = StubModel(123)
+        expected_route = routes.PATCH_MY_USER.compile()
+        expected_json = {"username": "new username", "banner": None}
+        rest_client._request = mock.AsyncMock(return_value={"id": "123"})
+        rest_client._entity_factory.deserialize_my_user = mock.Mock(return_value=user)
+
+        assert await rest_client.edit_my_user(username="new username", banner=None) is user
+
+        rest_client._request.assert_awaited_once_with(expected_route, json=expected_json)
+        rest_client._entity_factory.deserialize_my_user.assert_called_once_with({"id": "123"})
+
+    async def test_edit_my_user_when_banner_is_file(self, rest_client, file_resource_patch):
+        user = StubModel(123)
+        expected_route = routes.PATCH_MY_USER.compile()
+        expected_json = {"username": "new username", "banner": "some data"}
+        rest_client._request = mock.AsyncMock(return_value={"id": "123"})
+        rest_client._entity_factory.deserialize_my_user = mock.Mock(return_value=user)
+
+        assert await rest_client.edit_my_user(username="new username", banner="somebanner.png") is user
+
+        rest_client._request.assert_awaited_once_with(expected_route, json=expected_json)
+        rest_client._entity_factory.deserialize_my_user.assert_called_once_with({"id": "123"})
+
     async def test_fetch_my_connections(self, rest_client):
         connection1 = StubModel(123)
         connection2 = StubModel(456)


### PR DESCRIPTION
### Summary
Allow editing own user banner

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
https://github.com/discord/discord-api-docs/pull/6710
