### PR TITLE
Freeze macos image to macos-12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       # Allows for matrix sub-jobs to fail without cancelling the rest
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-12, windows-latest]
         python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
### Summary
It seems like there are no python builds for macos-14-arm64, which is now the default cluster macos-latest points to. Until this is resolved, I'll be worth freezing it to macos-12

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
~~- [ ] I have run `nox` and all the pipelines have passed.~~ N/A
~~- [ ] I have made unittests according to the code I have added/modified/deleted~~ N/A

### Related issues
https://github.com/actions/setup-python/issues/850
