### PR TITLE
Remove explicit type hints from the doc parameter sections

### DIFF
--- a/hikari/api/cache.py
+++ b/hikari/api/cache.py
@@ -95,7 +95,7 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             Object or ID of the user to get the DM channel ID for.
 
         Returns
@@ -123,7 +123,7 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        emoji : hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]
+        emoji
             Object or ID of the emoji to get from the cache.
 
         Returns
@@ -151,7 +151,7 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to get the cached emoji objects for.
 
         Returns
@@ -169,7 +169,7 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        sticker : hikari.snowflakes.SnowflakeishOr[hikari.stickers.GuildSticker]
+        sticker
             Object or ID of the sticker to get from the cache.
 
         Returns
@@ -196,7 +196,7 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to get the cached sticker objects for.
 
         Returns
@@ -220,7 +220,7 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to get from the cache.
 
         Returns
@@ -237,7 +237,7 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to get from the cache.
 
         Returns
@@ -260,7 +260,7 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to get from the cache.
 
         Returns
@@ -313,7 +313,7 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+        channel
             Object or ID of the guild channel to get from the cache.
 
         Returns
@@ -342,7 +342,7 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to get the cached channels for.
 
         Returns
@@ -360,7 +360,7 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        thread : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+        thread
             Object or ID of the thread to get from the cache.
 
         Returns
@@ -392,9 +392,9 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to get the cached thread channels for.
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+        channel
             Object or ID of the channel to get the cached thread channels for.
 
         Returns
@@ -412,7 +412,7 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to get the cached thread channels for.
 
         Returns
@@ -428,7 +428,7 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        code : typing.Union[hikari.invites.InviteCode, str]
+        code
             The object or string code of the invite to get from the cache.
 
         Returns
@@ -456,7 +456,7 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to get invite objects for.
 
         Returns
@@ -477,9 +477,9 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to get invite objects for.
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+        channel
             Object or ID of the channel to get invite objects for.
 
         Returns
@@ -510,9 +510,9 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to get a cached member for.
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             Object or ID of the user to get a cached member for.
 
         Returns
@@ -540,7 +540,7 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        guild_id : hikari.snowflakes.Snowflakeish
+        guild_id
             The ID of the guild to get the cached member view for.
 
         Returns
@@ -557,7 +557,7 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        message
             Object or ID of the message to get from the cache.
 
         Returns
@@ -587,9 +587,9 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to get a presence for.
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             Object or ID of the user to get a presence for.
 
         Returns
@@ -620,7 +620,7 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to get the cached presence objects for.
 
         Returns
@@ -636,7 +636,7 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        role : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialRole]
+        role
             Object or ID of the role to get from the cache.
 
         Returns
@@ -663,7 +663,7 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to get the cached roles for.
 
         Returns
@@ -679,7 +679,7 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             Object or ID of the user to get from the cache.
 
         Returns
@@ -710,9 +710,9 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to get a voice state for.
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             Object or ID of the user to get a voice state for.
 
         Returns
@@ -746,9 +746,9 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to get the cached voice states for.
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+        channel
             Object or ID of the channel to get the cached voice states for.
 
         Returns
@@ -766,7 +766,7 @@ class Cache(abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to get the cached voice states for.
 
         Returns
@@ -809,7 +809,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             Object or ID of the user to remove the cached DM channel ID for.
 
         Returns
@@ -830,9 +830,9 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             Object or ID of the user to add a DM channel ID to the cache for.
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+        channel
             Object or ID of the DM channel to add to the cache.
         """
 
@@ -863,7 +863,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to remove the cached emoji objects for.
 
         Returns
@@ -885,7 +885,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        emoji : hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]
+        emoji
             Object or ID of the emoji to remove from the cache.
 
         Returns
@@ -901,7 +901,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        emoji : hikari.emojis.KnownCustomEmoji
+        emoji
             The object of the known custom emoji to add to the cache.
         """
 
@@ -913,7 +913,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        emoji : hikari.emojis.KnownCustomEmoji
+        emoji
             The object of the emoji to update in the cache.
 
         Returns
@@ -949,7 +949,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to remove the cached sticker objects for.
 
         Returns
@@ -970,7 +970,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        sticker : hikari.snowflakes.SnowflakeishOr[hikari.stickers.GuildSticker]
+        sticker
             Object or ID of the sticker to remove from the cache.
 
         Returns
@@ -986,7 +986,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        sticker : hikari.stickers.GuildSticker
+        sticker
             The object of the sticker to add to the cache.
         """
 
@@ -1009,7 +1009,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to remove from the cache.
 
         Returns
@@ -1025,7 +1025,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.guilds.GatewayGuild
+        guild
             The object of the guild to add to the cache.
         """
 
@@ -1037,9 +1037,9 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to set the availability for.
-        is_available : bool
+        is_available
             The availability to set for the guild.
         """
 
@@ -1051,7 +1051,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.guilds.GatewayGuild
+        guild
             The object of the guild to update in the cache.
 
         Returns
@@ -1081,7 +1081,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to remove cached channels for.
 
         Returns
@@ -1099,7 +1099,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+        channel
             Object or ID of the guild channel to remove from the cache.
 
         Returns
@@ -1115,7 +1115,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.channels.PermissibleGuildChannel
+        channel
             The guild channel based object to add to the cache.
         """
 
@@ -1129,7 +1129,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.channels.PermissibleGuildChannel
+        channel
             The object of the channel to update in the cache.
 
         Returns
@@ -1162,9 +1162,9 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to remove cached threads for.
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+        channel
             Object or ID of the channel to remove cached threads for.
 
         Returns
@@ -1182,7 +1182,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to remove cached threads for.
 
         Returns
@@ -1200,7 +1200,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        thread : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+        thread
             Object or ID of the thread to remove from the cache.
 
         Returns
@@ -1216,7 +1216,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.channels.GuildThreadChannel
+        channel
             The thread channel based object to add to the cache.
         """
 
@@ -1228,7 +1228,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        thread : hikari.channels.GuildThreadChannel
+        thread
             The object of the thread channel to update in the cache.
 
         Returns
@@ -1258,7 +1258,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to remove invite objects for.
 
         Returns
@@ -1279,9 +1279,9 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to remove invite objects for.
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+        channel
             Object or ID of the channel to remove invite objects for.
 
         Returns
@@ -1299,7 +1299,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        code : typing.Union[hikari.invites.InviteCode, str]
+        code
             Object or string code of the invite to remove from the cache.
 
         Returns
@@ -1315,7 +1315,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        invite : hikari.invites.InviteWithMetadata
+        invite
             The object of the invite to add to the cache.
         """
 
@@ -1327,7 +1327,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        invite : hikari.invites.InviteWithMetadata
+        invite
             The object of the invite to update in the cache.
 
         Returns
@@ -1355,7 +1355,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        user : hikari.users.OwnUser
+        user
             The own user object to set in the cache.
         """
 
@@ -1367,7 +1367,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        user : hikari.users.OwnUser
+        user
             The own user object to update in the cache.
 
         Returns
@@ -1401,7 +1401,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to remove cached members for.
 
         Returns
@@ -1427,9 +1427,9 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to remove a member from the cache for.
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             Object or ID of the user to remove a member from the cache for.
 
         Returns
@@ -1445,7 +1445,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        member : hikari.guilds.Member
+        member
             The object of the member to add to the cache.
         """
 
@@ -1457,7 +1457,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        member : hikari.guilds.Member
+        member
             The object of the member to update in the cache.
 
         Returns
@@ -1489,7 +1489,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to remove presences for.
 
         Returns
@@ -1510,9 +1510,9 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to remove a presence for.
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             Object or ID of the user to remove a presence for.
 
         Returns
@@ -1528,7 +1528,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        presence : hikari.presences.MemberPresence
+        presence
             The object of the presence to add to the cache.
         """
 
@@ -1540,7 +1540,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        presence : hikari.presences.MemberPresence
+        presence
             The object of the presence to update in the cache.
 
         Returns
@@ -1570,7 +1570,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to remove roles for.
 
         Returns
@@ -1586,7 +1586,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        role : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialRole]
+        role
             Object or ID of the role to remove from the cache.
 
         Returns
@@ -1602,7 +1602,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        role : hikari.guilds.Role
+        role
             The object of the role to add to the cache.
         """
 
@@ -1614,7 +1614,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        role : hikari.guilds.Role
+        role
             The object of the role to update in the cache.
 
         Returns
@@ -1644,7 +1644,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to remove cached voice states for.
 
         Returns
@@ -1665,9 +1665,9 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to remove voice states for.
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+        channel
             Object or ID of the channel to remove voice states for.
 
         Returns
@@ -1688,9 +1688,9 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild the voice state to remove is related to.
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             Object or ID of the user who the voice state to remove belongs to.
 
         Returns
@@ -1706,7 +1706,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        voice_state : hikari.voices.VoiceState
+        voice_state
             The object of the voice state to add to the cache.
         """
 
@@ -1718,7 +1718,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        voice_state : hikari.voices.VoiceState
+        voice_state
             The object of the voice state to update in the cache.
 
         Returns
@@ -1747,7 +1747,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        message
             Object or ID of the messages to remove the cache.
 
         Returns
@@ -1763,7 +1763,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        message : hikari.messages.Message
+        message
             The object of the message to add to the cache.
         """
 
@@ -1775,7 +1775,7 @@ class MutableCache(Cache, abc.ABC):
 
         Parameters
         ----------
-        message : typing.Union[hikari.messages.PartialMessage, hikari.messages.Message]
+        message
             The object of the message to update in the cache.
 
         Returns

--- a/hikari/api/entity_factory.py
+++ b/hikari/api/entity_factory.py
@@ -133,7 +133,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -148,7 +148,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -165,7 +165,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -180,7 +180,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -197,7 +197,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -214,7 +214,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -231,7 +231,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        record : hikari.applications.ApplicationRoleConnectionMetadataRecord
+        record
             The record object to serialize.
 
         Returns
@@ -246,7 +246,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -263,7 +263,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -278,7 +278,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        query : hikari.internal.data_binding.Query
+        query
             The query parameters to deserialize.
 
         Returns
@@ -299,9 +299,9 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
-        guild_id : hikari.undefined.UndefinedOr[hikari.snowflakes.Snowflake]
+        guild_id
             The ID of the guild this audit log belongs to.
 
         Returns
@@ -321,12 +321,12 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Other Parameters
         ----------------
-        guild_id : hikari.undefined.UndefinedOr[hikari.snowflakes.Snowflake]
+        guild_id
             The ID of the guild this entry belongs to. If passed then this
             will be prioritised over `"guild_id"` in the payload.
 
@@ -352,7 +352,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -367,7 +367,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -382,7 +382,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        overwrite : hikari.channels.PermissionOverwrite
+        overwrite
             The permission overwrite object to serialize.
 
         Returns
@@ -397,7 +397,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -412,7 +412,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -427,7 +427,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -447,12 +447,12 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Other Parameters
         ----------------
-        guild_id : hikari.undefined.UndefinedOr[hikari.snowflakes.Snowflake]
+        guild_id
             The ID of the guild this channel belongs to. If passed then this
             will be prioritised over `"guild_id"` in the payload.
 
@@ -482,12 +482,12 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Other Parameters
         ----------------
-        guild_id : hikari.undefined.UndefinedOr[hikari.snowflakes.Snowflake]
+        guild_id
             The ID of the guild this channel belongs to. If passed then this
             will be prioritised over `"guild_id"` in the payload.
 
@@ -517,12 +517,12 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Other Parameters
         ----------------
-        guild_id : hikari.snowflakes.Snowflake
+        guild_id
             The ID of the guild this channel belongs to. If passed then this
             will be prioritised over `"guild_id"` in the payload.
 
@@ -552,12 +552,12 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Other Parameters
         ----------------
-        guild_id : hikari.snowflakes.Snowflake
+        guild_id
             The ID of the guild this channel belongs to. If passed then this
             will be prioritised over `"guild_id"` in the payload.
 
@@ -587,12 +587,12 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Other Parameters
         ----------------
-        guild_id : hikari.snowflakes.Snowflake
+        guild_id
             The ID of the guild this channel belongs to. If passed then this
             will be prioritised over `"guild_id"` in the payload.
 
@@ -622,12 +622,12 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Other Parameters
         ----------------
-        guild_id : hikari.snowflakes.Snowflake
+        guild_id
             The ID of the guild this channel belongs to. If passed then this
             will be prioritised over `"guild_id"` in the payload.
 
@@ -652,7 +652,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        tag : hikari.channels.ForumTag
+        tag
             The forum tag object to serialize.
 
         Returns
@@ -672,12 +672,12 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Other Parameters
         ----------------
-        thread_id : hikari.undefined.UndefinedOr[hikari.snowflakes.Snowflake]
+        thread_id
             ID of the thread this member belongs to. This will be
             prioritised over `"id"` in the payload when passed.
 
@@ -709,14 +709,14 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        guild_id : hikari.undefined.UndefinedOr[hikari.snowflakes.Snowflake]
+        guild_id
             The ID of the guild this channel belongs to. If passed then this
             will be prioritised over `"guild_id"` in the payload.
 
             !!! note
                 `guild_id` currently only covers the gateway `GUILD_CREATE` event
                 where `"guild_id"` is not included in the channel's payload.
-        member : hikari.undefined.UndefinedNoneOr[hikari.channels.ThreadMember]
+        member
             The member object for the thread. If passed then this will be
             prioritised over `"member"` in the payload when passed.
 
@@ -744,19 +744,19 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Other Parameters
         ----------------
-        guild_id : hikari.undefined.UndefinedOr[hikari.snowflakes.Snowflake]
+        guild_id
             The ID of the guild this channel belongs to. This will be
             prioritised over `"guild_id"` in the payload when passed.
 
             !!! note
                 `guild_id` currently only covers the gateway `GUILD_CREATE` event
                 where `"guild_id"` is not included in the channel's payload.
-        member : hikari.undefined.UndefinedNoneOr[hikari.channels.ThreadMember]
+        member
             The member object for the thread. If passed then this will be
             prioritised over `"member"` in the payload when passed.
 
@@ -784,19 +784,19 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Other Parameters
         ----------------
-        guild_id : hikari.undefined.UndefinedOr[hikari.snowflakes.Snowflake]
+        guild_id
             The ID of the guild this channel belongs to. This will be
             prioritised over `"guild_id"` in the payload when passed.
 
             !!! note
                 `guild_id` currently only covers the gateway `GUILD_CREATE` event
                 where `"guild_id"` is not included in the channel's payload.
-        member : hikari.undefined.UndefinedNoneOr[hikari.channels.ThreadMember]
+        member
             The member object for the thread. If passed then this will be
             prioritised over `"member"` in the payload when passed.
 
@@ -824,19 +824,19 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Other Parameters
         ----------------
-        guild_id : hikari.undefined.UndefinedOr[hikari.snowflakes.Snowflake]
+        guild_id
             The ID of the guild this channel belongs to. This will be
             prioritised over `"guild_id"` in the payload when passed.
 
             !!! note
                 `guild_id` currently only covers the gateway `GUILD_CREATE` event
                 where `"guild_id"` is not included in the channel's payload.
-        member : hikari.undefined.UndefinedNoneOr[hikari.channels.ThreadMember]
+        member
             The member object for the thread. If passed then this will be
             prioritised over `"member"` in the payload when passed.
 
@@ -866,12 +866,12 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Other Parameters
         ----------------
-        guild_id : hikari.undefined.UndefinedOr[hikari.snowflakes.Snowflake]
+        guild_id
             The ID of the guild this channel belongs to. This will be ignored
             for DM and group DM channels and will be prioritised over
             `"guild_id"` in the payload when passed.
@@ -904,7 +904,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -921,7 +921,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        embed : hikari.embeds.Embed
+        embed
             The embed object to serialize.
 
         Returns
@@ -942,7 +942,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -957,7 +957,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -974,9 +974,9 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
-        guild_id : hikari.snowflakes.Snowflake
+        guild_id
             The ID of the guild this emoji belongs to. This is used to ensure
             that the guild a known custom emoji belongs to is remembered by
             allowing for a context based artificial `guild_id` attribute.
@@ -995,7 +995,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1014,7 +1014,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1033,7 +1033,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1048,7 +1048,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1063,7 +1063,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        welcome_channel : hikari.guilds.WelcomeChannel
+        welcome_channel
             The guild welcome channel object to serialize.
 
         Returns
@@ -1089,15 +1089,15 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Other Parameters
         ----------------
-        user : hikari.undefined.UndefinedOr[hikari.users.User]
+        user
             The user to attach to this member, should only be passed in
             situations where "user" is not included in the payload.
-        guild_id : hikari.undefined.UndefinedOr[hikari.snowflakes.Snowflake]
+        guild_id
             The ID of the guild this member belongs to. If this is specified
             then this will be prioritised over `"guild_id"` in the payload.
 
@@ -1121,9 +1121,9 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
-        guild_id : hikari.snowflakes.Snowflake
+        guild_id
             The ID of the guild this role belongs to. This is used to ensure
             that the guild a role belongs to is remembered by allowing for a
             context based artificial `guild_id` attribute.
@@ -1140,7 +1140,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1160,12 +1160,12 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Other Parameters
         ----------------
-        guild_id : hikari.undefined.UndefinedOr[hikari.snowflakes.Snowflake]
+        guild_id
             The ID of the guild this integration belongs to. If this is specified
             then this will be prioritised over `"guild_id"` in the payload.
 
@@ -1188,7 +1188,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1203,7 +1203,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1218,7 +1218,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1235,9 +1235,9 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
-        user_id : hikari.snowflakes.Snowflake
+        user_id
             The current user's ID.
 
         Returns
@@ -1271,12 +1271,12 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Other Parameters
         ----------------
-        guild_id : hikari.undefined.UndefinedNoneOr[hikari.snowflakes.Snowflake]
+        guild_id
             The ID of the guild this command belongs to. If this is specified
             then this will be prioritised over `"guild_id"` in the payload.
 
@@ -1304,12 +1304,12 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Other Parameters
         ----------------
-        guild_id : hikari.undefined.UndefinedNoneOr[hikari.snowflakes.Snowflake]
+        guild_id
             The ID of the guild this command belongs to. If this is specified
             then this will be prioritised over `"guild_id"` in the payload.
 
@@ -1337,12 +1337,12 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Other Parameters
         ----------------
-        guild_id : hikari.undefined.UndefinedNoneOr[hikari.snowflakes.Snowflake]
+        guild_id
             The ID of the guild this command belongs to. If this is specified
             then this will be prioritised over `"guild_id"` in the payload.
 
@@ -1369,7 +1369,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1384,7 +1384,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        permission : hikari.commands.CommandPermission
+        permission
             The command permission object to serialize.
 
         Returns
@@ -1399,7 +1399,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1416,7 +1416,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1433,7 +1433,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1448,7 +1448,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1468,7 +1468,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1488,7 +1488,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        option : hikari.commands.CommandOption
+        option
             The command option object to serialize.
 
         Returns
@@ -1505,7 +1505,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1524,7 +1524,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1539,7 +1539,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1554,7 +1554,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1573,7 +1573,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1588,7 +1588,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1603,7 +1603,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1618,7 +1618,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1637,7 +1637,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1652,7 +1652,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1682,12 +1682,12 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Other Parameters
         ----------------
-        guild_id : hikari.undefined.UndefinedOr[hikari.snowflakes.Snowflake]
+        guild_id
             The ID of the guild the presence belongs to. If this is specified
             then it is prioritised over `guild_id` in the payload.
 
@@ -1715,7 +1715,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1732,7 +1732,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1749,7 +1749,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1764,7 +1764,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1789,12 +1789,12 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Other Parameters
         ----------------
-        guild_id : hikari.undefined.UndefinedOr[hikari.snowflakes.Snowflake]
+        guild_id
             The ID of the guild the user belongs to. If this is specified
             then it is prioritised over `guild_id` in the payload.
 
@@ -1814,7 +1814,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1833,7 +1833,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1848,7 +1848,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1879,15 +1879,15 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Other Parameters
         ----------------
-        guild_id : hikari.undefined.UndefinedOr[hikari.snowflakes.Snowflake]
+        guild_id
             The ID of the guild this voice state belongs to. If this is specified
             then this will be prioritised over `"guild_id"` in the payload.
-        member : hikari.undefined.UndefinedOr[hikari.guilds.Member]
+        member
             The object of the member this voice state belongs to. If this is
             specified then this will be prioritised over `"member"` in the
             payload.
@@ -1914,7 +1914,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1933,7 +1933,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1950,7 +1950,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1965,7 +1965,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -1980,7 +1980,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -2004,7 +2004,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns
@@ -2019,7 +2019,7 @@ class EntityFactory(abc.ABC):
 
         Parameters
         ----------
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The JSON payload to deserialize.
 
         Returns

--- a/hikari/api/event_factory.py
+++ b/hikari/api/event_factory.py
@@ -76,9 +76,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -99,9 +99,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -122,14 +122,14 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Other Parameters
         ----------------
-        old_channel : typing.Optional[hikari.channels.PermissibleGuildChannel]
+        old_channel
             The guild channel object or [`None`][].
 
         Returns
@@ -146,9 +146,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -165,9 +165,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -184,9 +184,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -203,9 +203,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -222,9 +222,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -241,9 +241,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -260,9 +260,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -279,9 +279,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -298,9 +298,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -317,9 +317,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -340,14 +340,14 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Other Parameters
         ----------------
-        old_invite : typing.Optional[hikari.invites.InviteWithMetadata]
+        old_invite
             The invite object or [`None`][].
 
         Returns
@@ -368,9 +368,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -391,9 +391,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -410,9 +410,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -433,14 +433,14 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Other Parameters
         ----------------
-        old_guild : typing.Optional[hikari.guilds.GatewayGuild]
+        old_guild
             The guild object or [`None`][].
 
         Returns
@@ -461,14 +461,14 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Other Parameters
         ----------------
-        old_guild : typing.Optional[hikari.guilds.GatewayGuild]
+        old_guild
             The guild object or [`None`][].
 
         Returns
@@ -485,9 +485,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -504,9 +504,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -523,9 +523,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -546,14 +546,14 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Other Parameters
         ----------------
-        old_emojis : typing.Optional[typing.Sequence[hikari.emojis.KnownCustomEmoji]]
+        old_emojis
             The sequence of emojis or [`None`][].
 
         Returns
@@ -574,14 +574,14 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Other Parameters
         ----------------
-        old_stickers : typing.Optional[typing.Sequence[hikari.stickers.GuildSticker]]
+        old_stickers
             The sequence of stickers or [`None`][].
 
         Returns
@@ -598,9 +598,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -617,9 +617,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -636,9 +636,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -659,14 +659,14 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Other Parameters
         ----------------
-        old_presence : typing.Optional[hikari.presences.MemberPresence]
+        old_presence
             The presence object or [`None`][].
 
         Returns
@@ -683,9 +683,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -706,9 +706,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -729,9 +729,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -752,14 +752,14 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Other Parameters
         ----------------
-        old_member : typing.Optional[hikari.guilds.Member]
+        old_member
             The member object or [`None`][].
 
         Returns
@@ -780,14 +780,14 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Other Parameters
         ----------------
-        old_member : typing.Optional[hikari.guilds.Member]
+        old_member
             The member object or [`None`][].
 
         Returns
@@ -808,9 +808,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -831,14 +831,14 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Other Parameters
         ----------------
-        old_role : typing.Optional[hikari.guilds.Role]
+        old_role
             The role object or [`None`][].
 
         Returns
@@ -859,14 +859,14 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Other Parameters
         ----------------
-        old_role : typing.Optional[hikari.guilds.Role]
+        old_role
             The role object or [`None`][].
 
         Returns
@@ -887,9 +887,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -906,9 +906,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -925,9 +925,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -944,9 +944,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -963,9 +963,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -1030,9 +1030,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -1053,14 +1053,14 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Other Parameters
         ----------------
-        old_message : typing.Optional[hikari.messages.PartialMessage]
+        old_message
             The message object or [`None`][].
 
         Returns
@@ -1081,14 +1081,14 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Other Parameters
         ----------------
-        old_message : typing.Optional[hikari.messages.Message]
+        old_message
             The old message object.
 
         Returns
@@ -1109,14 +1109,14 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Other Parameters
         ----------------
-        old_messages : typing.Optional[typing.Mapping[hikari.snowflakes.Snowflake, hikari.messages.Message]]
+        old_messages
             A mapping of the old message objects.
 
         Returns
@@ -1137,9 +1137,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -1156,9 +1156,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -1175,9 +1175,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -1194,9 +1194,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -1217,11 +1217,11 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
-        name : str
+        name
             Name of the event.
 
         Returns
@@ -1238,9 +1238,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -1255,7 +1255,7 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
 
         Returns
@@ -1270,7 +1270,7 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
 
         Returns
@@ -1285,7 +1285,7 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
 
         Returns
@@ -1302,9 +1302,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -1329,14 +1329,14 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Other Parameters
         ----------------
-        old_user : typing.Optional[hikari.users.OwnUser]
+        old_user
             The OwnUser object or [`None`][].
 
         Returns
@@ -1361,14 +1361,14 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Other Parameters
         ----------------
-        old_state : typing.Optional[hikari.voices.VoiceState]
+        old_state
             The VoiceState object or [`None`][].
 
         Returns
@@ -1385,9 +1385,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -1408,9 +1408,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -1427,9 +1427,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns
@@ -1446,9 +1446,9 @@ class EventFactory(abc.ABC):
 
         Parameters
         ----------
-        shard : hikari.api.shard.GatewayShard
+        shard
             The shard that emitted this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             The dict payload to parse.
 
         Returns

--- a/hikari/api/event_manager.py
+++ b/hikari/api/event_manager.py
@@ -125,7 +125,7 @@ class EventStream(iterators.LazyIterator[base_events.EventT], abc.ABC):
 
         Parameters
         ----------
-        *predicates : typing.Union[typing.Callable[[ValueT], bool], typing.Tuple[str, typing.Any]]
+        *predicates
             Predicates to invoke. These are functions that take a value and
             return [`True`][] if it is of interest, or [`False`][]
             otherwise. These may instead include 2-[`tuple`][] objects
@@ -133,7 +133,7 @@ class EventStream(iterators.LazyIterator[base_events.EventT], abc.ABC):
             are referred to using the `.` operator), and values to compare for
             equality. This allows you to specify conditions such as
             `members.filter(("user.bot", True))`.
-        **attrs : typing.Any
+        **attrs
             Alternative to passing 2-tuples. Cannot specify nested attributes
             using this method.
 
@@ -175,11 +175,11 @@ class EventManager(abc.ABC):
 
         Parameters
         ----------
-        event_name : str
+        event_name
             The case-insensitive name of the event being triggered.
-        shard : hikari.api.shard.GatewayShard
+        shard
             Object of the shard that received this event.
-        payload : hikari.internal.data_binding.JSONObject
+        payload
             Payload of the event being triggered.
 
         Raises
@@ -194,7 +194,7 @@ class EventManager(abc.ABC):
 
         Parameters
         ----------
-        event : hikari.events.base_events.Event
+        event
             The event to dispatch.
 
         Examples
@@ -281,7 +281,7 @@ class EventManager(abc.ABC):
 
         Parameters
         ----------
-        event_type : typing.Type[T]
+        event_type
             The event type to listen for. This will also listen for any
             subclasses of the given type.
             `T` must be a subclass of [`hikari.events.base_events.Event`][].
@@ -323,7 +323,7 @@ class EventManager(abc.ABC):
 
         Parameters
         ----------
-        event_type : typing.Type[T]
+        event_type
             The event type to unsubscribe from. This must be the same exact
             type as was originally subscribed with to be removed correctly.
             `T` must derive from [`hikari.events.base_events.Event`][].
@@ -361,10 +361,10 @@ class EventManager(abc.ABC):
 
         Parameters
         ----------
-        event_type : typing.Type[T]
+        event_type
             The event type to look for.
             `T` must be a subclass of [`hikari.events.base_events.Event`][].
-        polymorphic : bool
+        polymorphic
             If [`True`][], this will also return the listeners for all the
             event types `event_type` will dispatch. If [`False`][], then
             only listeners for this class specifically are returned. The
@@ -387,7 +387,7 @@ class EventManager(abc.ABC):
 
         Parameters
         ----------
-        *event_types : typing.Optional[typing.Type[T]]
+        *event_types
             The event types to subscribe to. The implementation may allow this
             to be undefined. If this is the case, the event type will be inferred
             instead from the type hints on the function signature.
@@ -426,14 +426,14 @@ class EventManager(abc.ABC):
 
         Parameters
         ----------
-        event_type : typing.Type[hikari.events.base_events.Event]
+        event_type
             The event type to listen for. This will listen for subclasses of
             this type additionally.
-        timeout : typing.Optional[int, float]
+        timeout
             How long this streamer should wait for the next event before
             ending the iteration. If [`None`][] then this will continue
             until explicitly broken from.
-        limit : typing.Optional[int]
+        limit
             The limit for how many events this should queue at one time before
             dropping extra incoming events, leave this as [`None`][] for
             the cache size to be unlimited.
@@ -489,7 +489,7 @@ class EventManager(abc.ABC):
 
         Parameters
         ----------
-        event_type : typing.Type[hikari.events.base_events.Event]
+        event_type
             The event type to listen for. This will listen for subclasses of
             this type additionally.
         predicate
@@ -498,7 +498,7 @@ class EventManager(abc.ABC):
             return, or [`False`][] if the event should not be returned.
             If left as [`None`][] (the default), then the first matching event type
             that the bot receives (or any subtype) will be the one returned.
-        timeout : typing.Union[float, int, None]
+        timeout
             The amount of time to wait before raising an [`asyncio.TimeoutError`][]
             and giving up instead. This is measured in seconds. If
             [`None`][], then no timeout will be waited for (no timeout can

--- a/hikari/api/interaction_server.py
+++ b/hikari/api/interaction_server.py
@@ -119,11 +119,11 @@ class InteractionServer(abc.ABC):
 
         Parameters
         ----------
-        body : bytes
+        body
             The interaction payload.
-        signature : bytes
+        signature
             Value of the `"X-Signature-Ed25519"` header used to verify the body.
-        timestamp : bytes
+        timestamp
             Value of the `"X-Signature-Timestamp"` header used to verify the body.
 
         Returns
@@ -173,7 +173,7 @@ class InteractionServer(abc.ABC):
 
         Parameters
         ----------
-        interaction_type : typing.Type[hikari.interactions.base_interactions.PartialInteraction]
+        interaction_type
             Type of the interaction to get the registered listener for.
 
         Returns
@@ -244,9 +244,9 @@ class InteractionServer(abc.ABC):
 
         Parameters
         ----------
-        interaction_type : typing.Type[hikari.interactions.base_interactions.PartialInteraction]
+        interaction_type
             The type of interaction this listener should be registered for.
-        listener : typing.Optional[ListenerT[hikari.interactions.base_interactions.PartialInteraction, hikari.api.special_endpoints.InteractionResponseBuilder]]
+        listener
             The asynchronous listener callback to set or [`None`][] to unset the previous listener.
 
             An asynchronous listener can be either a normal coroutine or an
@@ -256,11 +256,11 @@ class InteractionServer(abc.ABC):
 
         Other Parameters
         ----------------
-        replace : bool
+        replace
             Whether this call should replace the previously set listener or not.
 
         Raises
         ------
         TypeError
             If `replace` is [`False`][] when a listener is already set.
-        """  # noqa: E501 - Line too long
+        """

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -78,7 +78,7 @@ class TokenStrategy(abc.ABC):
 
         Parameters
         ----------
-        client : hikari.api.rest.RESTClient
+        client
             The rest client to use to acquire the token.
 
         Returns
@@ -99,7 +99,7 @@ class TokenStrategy(abc.ABC):
 
         Parameters
         ----------
-        token : typing.Optional[str]
+        token
             The token to specifically invalidate. If provided then this will only
             invalidate the cached token if it matches this, otherwise it'll be
             invalidated regardless.
@@ -142,7 +142,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+        channel
             The channel to fetch. This may be the object or the ID of an
             existing channel.
 
@@ -226,86 +226,86 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildChannel]
+        channel
             The channel to edit. This may be the object or the ID of an
             existing channel.
 
         Other Parameters
         ----------------
-        name : hikari.undefined.UndefinedOr[str]
+        name
             If provided, the new name for the channel.
-        flags : hikari.undefined.UndefinedOr[hikari.channels.ChannelFlag]
+        flags
             If provided, the new channel flags to use for the channel. This can
             only be used on a forum channel to apply [`hikari.channels.ChannelFlag.REQUIRE_TAG`][], or
             on a forum thread to apply [`hikari.channels.ChannelFlag.PINNED`][].
-        position : hikari.undefined.UndefinedOr[int]
+        position
             If provided, the new position for the channel.
-        topic : hikari.undefined.UndefinedOr[str]
+        topic
             If provided, the new topic for the channel.
-        nsfw : hikari.undefined.UndefinedOr[bool]
+        nsfw
             If provided, whether the channel should be marked as NSFW or not.
-        bitrate : hikari.undefined.UndefinedOr[int]
+        bitrate
             If provided, the new bitrate for the channel.
-        video_quality_mode : hikari.undefined.UndefinedOr[typing.Union[hikari.channels.VideoQualityMode, int]]
+        video_quality_mode
             If provided, the new video quality mode for the channel.
-        user_limit : hikari.undefined.UndefinedOr[int]
+        user_limit
             If provided, the new user limit in the channel.
-        rate_limit_per_user : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        rate_limit_per_user
             If provided, the new rate limit per user in the channel.
-        region : hikari.undefined.UndefinedNoneOr[typing.Union[str, hikari.voices.VoiceRegion]]
+        region
             If provided, the voice region to set for this channel. Passing
             [`None`][] here will set it to "auto" mode where the used
             region will be decided based on the first person who connects to it
             when it's empty.
-        permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
+        permission_overwrites
             If provided, the new permission overwrites for the channel.
-        parent_category : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildCategory]]
+        parent_category
             If provided, the new guild category for the channel.
-        default_auto_archive_duration : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        default_auto_archive_duration
             If provided, the auto archive duration Discord's end user client
             should default to when creating threads in this channel.
 
             This should be either 60, 1440, 4320 or 10080 minutes and, as of
             writing, ignores the parent channel's set default_auto_archive_duration
             when passed as [`hikari.undefined.UNDEFINED`][].
-        default_thread_rate_limit_per_user : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        default_thread_rate_limit_per_user
             If provided, the ratelimit that should be set in threads derived
             from this channel.
 
             This only applies to forum channels.
-        default_forum_layout : hikari.undefined.UndefinedOr[typing.Union[hikari.channels.ForumLayoutType, int]]
+        default_forum_layout
             If provided, the default forum layout to show in the client.
-        default_sort_order : hikari.undefined.UndefinedOr[typing.Union[hikari.channels.ForumSortOrderType, int]]
+        default_sort_order
             If provided, the default sort order to show in the client.
-        available_tags : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.ForumTag]]
+        available_tags
             If provided, the new available tags to select from when creating a thread.
 
             This only applies to forum channels.
-        default_reaction_emoji : typing.Union[str, hikari.emojis.Emoji, hikari.undefined.UndefinedType, hikari.snowflakes.Snowflake]
+        default_reaction_emoji
             If provided, the new default reaction emoji for threads created in a forum channel.
 
             This only applies to forum channels.
-        archived : hikari.undefined.UndefinedOr[bool]
+        archived
             If provided, the new archived state for the thread. This only
             applies to threads.
-        locked : hikari.undefined.UndefinedOr[bool]
+        locked
             If provided, the new locked state for the thread. This only applies
             to threads.
 
             If it's locked then only people with [`hikari.permissions.Permissions.MANAGE_THREADS`][] can unarchive it.
-        invitable : undefined.UndefinedOr[bool]
+        invitable
             If provided, the new setting for whether non-moderators can invite
             new members to a private thread. This only applies to threads.
-        auto_archive_duration : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        auto_archive_duration
             If provided, the new auto archive duration for this thread. This
             only applies to threads.
 
             This should be either 60, 1440, 4320 or 10080 minutes, as of
             writing.
-        applied_tags : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishSequence[hikari.channels.ForumTag]]
+        applied_tags
             If provided, the new tags to apply to the thread. This only applies
             to threads in a forum channel.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -329,7 +329,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
-        """  # noqa: E501 - Line too long
+        """
 
     @abc.abstractmethod
     async def follow_channel(
@@ -341,9 +341,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        news_channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildNewsChannel]
+        news_channel
             The object or ID of the news channel to follow.
-        target_channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildChannel]
+        target_channel
             The object or ID of the channel to target.
 
         Returns
@@ -384,7 +384,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+        channel
             The channel to delete. This may be the object or the ID of an
             existing channel.
 
@@ -425,18 +425,18 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or Id of the guild to edit a voice state in.
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildStageChannel]
+        channel
             Object or Id of the channel to edit a voice state in.
 
         Other Parameters
         ----------------
-        suppress : hikari.undefined.UndefinedOr[bool]
+        suppress
             If specified, whether the user should be allowed to become a speaker
             in the target stage channel with [`True`][] suppressing them from
             becoming one.
-        request_to_speak : typing.Union[hikari.undefined.UndefinedType, bool, datetime.datetime]
+        request_to_speak
             Whether to request to speak. This may be one of the following:
 
             * [`True`][] to indicate that the bot wants to speak.
@@ -479,16 +479,16 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to edit a voice state in.
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildStageChannel]
+        channel
             Object or ID of the channel to edit a voice state in.
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             Object or ID of the user to edit the voice state of.
 
         Other Parameters
         ----------------
-        suppress : hikari.undefined.UndefinedOr[bool]
+        suppress
             If defined, whether the user should be allowed to become a speaker
             in the target stage channel.
 
@@ -553,23 +553,23 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildChannel]
+        channel
             The channel to edit a permission overwrite in. This may be the
             object, or the ID of an existing channel.
-        target : typing.Union[hikari.users.PartialUser, hikari.guilds.PartialRole, hikari.channels.PermissionOverwrite, hikari.snowflakes.Snowflakeish]
+        target
             The channel overwrite to edit. This may be the object or the ID of an
             existing overwrite.
 
         Other Parameters
         ----------------
-        target_type : hikari.undefined.UndefinedOr[typing.Union[hikari.channels.PermissionOverwriteType, int]]
+        target_type
             If provided, the type of the target to update. If unset, will attempt to get
             the type from `target`.
-        allow : hikari.undefined.UndefinedOr[hikari.permissions.Permissions]
+        allow
             If provided, the new value of all allowed permissions.
-        deny : hikari.undefined.UndefinedOr[hikari.permissions.Permissions]
+        deny
             If provided, the new value of all disallowed permissions.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -593,7 +593,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
-        """  # noqa: E501 - Line too long
+        """
 
     @abc.abstractmethod
     async def delete_permission_overwrite(
@@ -607,10 +607,10 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildChannel]
+        channel
             The channel to delete a permission overwrite in. This may be the
             object, or the ID of an existing channel.
-        target : typing.Union[hikari.users.PartialUser, hikari.guilds.PartialRole, hikari.channels.PermissionOverwrite, hikari.snowflakes.Snowflakeish]
+        target
             The channel overwrite to delete.
 
         Raises
@@ -627,7 +627,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
-        """  # noqa: E501 - Line too long
+        """
 
     @abc.abstractmethod
     async def fetch_channel_invites(
@@ -637,7 +637,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildChannel]
+        channel
             The channel to fetch the invites from. This may be a channel
             object, or the ID of an existing channel.
 
@@ -681,37 +681,37 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildChannel]
+        channel
             The channel to create a invite for. This may be the object
             or the ID of an existing channel.
 
         Other Parameters
         ----------------
-        max_age : hikari.undefined.UndefinedOr[typing.Union[datetime.timedelta, float, int]]
+        max_age
             If provided, the duration of the invite before expiry.
-        max_uses : hikari.undefined.UndefinedOr[int]
+        max_uses
             If provided, the max uses the invite can have.
-        temporary : hikari.undefined.UndefinedOr[bool]
+        temporary
             If provided, whether the invite only grants temporary membership.
-        unique : hikari.undefined.UndefinedOr[bool]
+        unique
             If provided, whether the invite should be unique.
-        target_type : hikari.undefined.UndefinedOr[hikari.invites.TargetType]
+        target_type
             If provided, the target type of this invite.
-        target_user : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]]
+        target_user
             If provided, the target user id for this invite. This may be the
             object or the ID of an existing user.
 
             !!! note
                 This is required if `target_type` is [`hikari.invites.TargetType.STREAM`][] and the targeted
                 user must be streaming into the channel.
-        target_application : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]]
+        target_application
             If provided, the target application id for this invite. This may be
             the object or the ID of an existing application.
 
             !!! note
                 This is required if `target_type` is [`hikari.invites.TargetType.EMBEDDED_APPLICATION`][] and
                 the targeted application must have the [`hikari.applications.ApplicationFlags.EMBEDDED`][] flag.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -766,7 +766,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
+        channel
             The channel to trigger typing in. This may be the object or
             the ID of an existing channel.
 
@@ -798,7 +798,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
+        channel
             The channel to fetch pins from. This may be the object or
             the ID of an existing channel.
 
@@ -832,10 +832,10 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
+        channel
             The channel to pin a message in. This may be the object or
             the ID of an existing channel.
-        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        message
             The message to pin. This may be the object or the ID
             of an existing message.
 
@@ -865,10 +865,10 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
+        channel
             The channel to unpin a message in. This may be the object or
             the ID of an existing channel.
-        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        message
             The message to unpin. This may be the object or the ID of an
             existing message.
 
@@ -908,23 +908,23 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
+        channel
             The channel to fetch messages in. This may be the object or
             the ID of an existing channel.
 
         Other Parameters
         ----------------
-        before : hikari.undefined.UndefinedOr[snowflakes.SearchableSnowflakeishOr[hikari.snowflakes.Unique]]
+        before
             If provided, fetch messages before this snowflake. If you provide
             a datetime object, it will be transformed into a snowflake. This
             may be any other Discord entity that has an ID. In this case, the
             date the object was first created will be used.
-        after : hikari.undefined.UndefinedOr[snowflakes.SearchableSnowflakeishOr[hikari.snowflakes.Unique]]
+        after
             If provided, fetch messages after this snowflake. If you provide
             a datetime object, it will be transformed into a snowflake. This
             may be any other Discord entity that has an ID. In this case, the
             date the object was first created will be used.
-        around : hikari.undefined.UndefinedOr[snowflakes.SearchableSnowflakeishOr[hikari.snowflakes.Unique]]
+        around
             If provided, fetch messages around this snowflake. If you provide
             a datetime object, it will be transformed into a snowflake. This
             may be any other Discord entity that has an ID. In this case, the
@@ -962,10 +962,10 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
+        channel
             The channel to fetch messages in. This may be the object or
             the ID of an existing channel.
-        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        message
             The message to fetch. This may be the object or the ID of an
             existing message.
 
@@ -1023,9 +1023,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
+        channel
             The channel to create the message in.
-        content : hikari.undefined.UndefinedOr[typing.Any]
+        content
             If provided, the message contents. If
             [`hikari.undefined.UNDEFINED`][], then nothing will be sent
             in the content. Any other value here will be cast to a
@@ -1041,7 +1041,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Other Parameters
         ----------------
-        attachment : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
+        attachment
             If provided, the message attachment. This can be a resource,
             or string of a path on your computer or a URL.
 
@@ -1070,46 +1070,46 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
                 type of [`concurrent.futures.Executor`][] that is being used for
                 the application (default is a thread pool which supports this
                 behaviour).
-        attachments : hikari.undefined.UndefinedOr[typing.Sequence[hikari.files.Resourceish]]
+        attachments
             If provided, the message attachments. These can be resources, or
             strings consisting of paths on your computer or URLs.
-        component : hikari.undefined.UndefinedOr[hikari.api.special_endpoints.ComponentBuilder]
+        component
             If provided, builder object of the component to include in this message.
-        components : hikari.undefined.UndefinedOr[typing.Sequence[hikari.api.special_endpoints.ComponentBuilder]]
+        components
             If provided, a sequence of the component builder objects to include
             in this message.
-        embed : hikari.undefined.UndefinedOr[hikari.embeds.Embed]
+        embed
             If provided, the message embed.
-        embeds : hikari.undefined.UndefinedOr[typing.Sequence[hikari.embeds.Embed]]
+        embeds
             If provided, the message embeds.
-        sticker : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.stickers.PartialSticker]]
+        sticker
             If provided, the object or ID of a sticker to send on the message.
 
             As of writing, bots can only send custom stickers from the current guild.
-        stickers : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishSequence[hikari.stickers.PartialSticker]]
+        stickers
             If provided, a sequence of the objects and IDs of up to 3 stickers
             to send on the message.
 
             As of writing, bots can only send custom stickers from the current guild.
-        tts : hikari.undefined.UndefinedOr[bool]
+        tts
             If provided, whether the message will be read out by a screen
             reader using Discord's TTS (text-to-speech) system.
-        reply : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]]
+        reply
             If provided, the message to reply to.
-        reply_must_exist : hikari.undefined.UndefinedOr[bool]
+        reply_must_exist
             If provided, whether to error if the message being replied to does
             not exist instead of sending as a normal (non-reply) message.
 
             This will not do anything if not being used with `reply`.
-        mentions_everyone : hikari.undefined.UndefinedOr[bool]
+        mentions_everyone
             If provided, whether the message should parse @everyone/@here
             mentions.
-        mentions_reply : hikari.undefined.UndefinedOr[bool]
+        mentions_reply
             If provided, whether to mention the author of the message
             that is being replied to.
 
             This will not do anything if not being used with `reply`.
-        user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], bool]]
+        user_mentions
             If provided, and [`True`][], all user mentions will be detected.
             If provided, and [`False`][], all user mentions will be ignored
             if appearing in the message body.
@@ -1117,7 +1117,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             [`hikari.snowflakes.Snowflake`][], or
             [`hikari.users.PartialUser`][] derivatives to enforce mentioning
             specific users.
-        role_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole], bool]]
+        role_mentions
             If provided, and [`True`][], all role mentions will be detected.
             If provided, and [`False`][], all role mentions will be ignored
             if appearing in the message body.
@@ -1125,7 +1125,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             [`hikari.snowflakes.Snowflake`][], or
             [`hikari.guilds.PartialRole`][] derivatives to enforce mentioning
             specific roles.
-        flags : hikari.undefined.UndefinedOr[hikari.messages.MessageFlag]
+        flags
             If provided, optional flags to set on the message. If
             [`hikari.undefined.UNDEFINED`][], then nothing is changed.
 
@@ -1165,7 +1165,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
-        """  # noqa: E501 - Line too long
+        """
 
     @abc.abstractmethod
     async def crosspost_message(
@@ -1177,9 +1177,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildNewsChannel]
+        channel
             The object or ID of the news channel to crosspost a message in.
-        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        message
             The object or ID of the message to crosspost.
 
         Returns
@@ -1261,13 +1261,13 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
+        channel
             The channel to create the message in. This may be
             the object or the ID of an existing channel.
-        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        message
             The message to edit. This may be the object or the ID
             of an existing message.
-        content : hikari.undefined.UndefinedOr[typing.Any]
+        content
             If provided, the message content to update with. If
             [`hikari.undefined.UNDEFINED`][], then the content will not
             be changed. If [`None`][], then the content will be removed.
@@ -1283,51 +1283,51 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Other Parameters
         ----------------
-        attachment : hikari.undefined.UndefinedNoneOr[typing.Union[hikari.files.Resourceish, hikari.messages.Attachment]]
+        attachment
             If provided, the attachment to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous attachment, if
             present, is not changed. If this is [`None`][], then the
             attachment is removed, if present. Otherwise, the new attachment
             that was provided will be attached.
-        attachments : hikari.undefined.UndefinedNoneOr[typing.Sequence[typing.Union[hikari.files.Resourceish, hikari.messages.Attachment]]]
+        attachments
             If provided, the attachments to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous attachments, if
             present, are not changed. If this is [`None`][], then the
             attachments is removed, if present. Otherwise, the new attachments
             that were provided will be attached.
-        component : hikari.undefined.UndefinedNoneOr[hikari.api.special_endpoints.ComponentBuilder]
+        component
             If provided, builder object of the component to set for this message.
             This component will replace any previously set components and passing
             [`None`][] will remove all components.
-        components : hikari.undefined.UndefinedNoneOr[typing.Sequence[hikari.api.special_endpoints.ComponentBuilder]]
+        components
             If provided, a sequence of the component builder objects set for
             this message. These components will replace any previously set
             components and passing [`None`][] or an empty sequence will
             remove all components.
-        embed : hikari.undefined.UndefinedNoneOr[hikari.embeds.Embed]
+        embed
             If provided, the embed to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous embed(s) are not changed.
             If this is [`None`][] then any present embeds are removed.
             Otherwise, the new embed that was provided will be used as the
             replacement.
-        embeds : hikari.undefined.UndefinedNoneOr[typing.Sequence[hikari.embeds.Embed]]
+        embeds
             If provided, the embeds to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous embed(s) are not changed.
             If this is [`None`][] then any present embeds are removed.
             Otherwise, the new embeds that were provided will be used as the
             replacement.
-        mentions_everyone : hikari.undefined.UndefinedOr[bool]
+        mentions_everyone
             If provided, sanitation for `@everyone` mentions. If
             [`hikari.undefined.UNDEFINED`][], then the previous setting is
             not changed. If [`True`][], then `@everyone`/`@here` mentions
             in the message content will show up as mentioning everyone that can
             view the chat.
-        mentions_reply : hikari.undefined.UndefinedOr[bool]
+        mentions_reply
             If provided, whether to mention the author of the message
             that is being replied to.
 
             This will not do anything if `message` is not a reply message.
-        user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], bool]]
+        user_mentions
             If provided, sanitation for user mentions. If
             [`hikari.undefined.UNDEFINED`][], then the previous setting is
             not changed. If [`True`][], all valid user mentions will behave
@@ -1337,7 +1337,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             You may alternatively pass a collection of
             [`hikari.snowflakes.Snowflake`][] user IDs, or
             [`hikari.users.PartialUser`][]-derived objects.
-        role_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole], bool]]
+        role_mentions
             If provided, sanitation for role mentions. If
             [`hikari.undefined.UNDEFINED`][], then the previous setting is
             not changed. If [`True`][], all valid role mentions will behave
@@ -1347,7 +1347,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             You may alternatively pass a collection of
             [hikari.snowflakes.Snowflake] role IDs, or
             [hikari.guilds.PartialRole]-derived objects.
-        flags : hikari.undefined.UndefinedOr[hikari.messages.MessageFlag]
+        flags
             If provided, optional flags to set on the message. If
             [`hikari.undefined.UNDEFINED`][], then nothing is changed.
 
@@ -1386,7 +1386,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
-        """  # noqa: E501 - Line too long
+        """
 
     @abc.abstractmethod
     async def delete_message(
@@ -1398,10 +1398,10 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
+        channel
             The channel to delete the message in. This may be
             the object or the ID of an existing channel.
-        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        message
             The message to delete. This may be the object or the ID of
             an existing message.
 
@@ -1458,7 +1458,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
+        channel
             The channel to bulk delete the messages in. This may be
             the object or the ID of an existing channel.
         messages
@@ -1467,7 +1467,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Other Parameters
         ----------------
-        *other_messages : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        *other_messages
             The objects and/or IDs of other existing messages to delete.
 
         Raises
@@ -1491,19 +1491,19 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
+        channel
             The channel where the message to add the reaction to is. This
             may be a [`hikari.channels.TextableChannel`][] or the ID of an existing
             channel.
-        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        message
             The message to add a reaction to. This may be the
             object or the ID of an existing message.
-        emoji : typing.Union[str, hikari.emojis.Emoji]
+        emoji
             Object or name of the emoji to react with.
 
         Other Parameters
         ----------------
-        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]]
+        emoji_id
             ID of the custom emoji to react with.
             This should only be provided when a custom emoji's name is passed
             for `emoji`.
@@ -1539,18 +1539,18 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
+        channel
             The channel where the message to delete the reaction from is.
             This may be the object or the ID of an existing channel.
-        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        message
             The message to delete a reaction from. This may be the
             object or the ID of an existing message.
-        emoji : typing.Union[str, hikari.emojis.Emoji]
+        emoji
             Object or name of the emoji to remove your reaction for.
 
         Other Parameters
         ----------------
-        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]]
+        emoji_id
             ID of the custom emoji to remove your reaction for.
             This should only be provided when a custom emoji's name is passed
             for `emoji`.
@@ -1583,18 +1583,18 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
+        channel
             The channel where the message to delete the reactions from is.
             This may be the object or the ID of an existing channel.
-        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        message
             The message to delete a reactions from. This may be the
             object or the ID of an existing message.
-        emoji : typing.Union[str, hikari.emojis.Emoji]
+        emoji
             Object or name of the emoji to remove all the reactions for.
 
         Other Parameters
         ----------------
-        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]]
+        emoji_id
             ID of the custom emoji to remove all the reactions for.
             This should only be provided when a custom emoji's name is passed
             for `emoji`.
@@ -1633,20 +1633,20 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
+        channel
             The channel where the message to delete the reaction from is.
             This may be the object or the ID of an existing channel.
-        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        message
             The message to delete a reaction from. This may be the
             object or the ID of an existing message.
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             Object or ID of the user to remove the reaction of.
-        emoji : typing.Union[str, hikari.emojis.Emoji]
+        emoji
             Object or name of the emoji to react with.
 
         Other Parameters
         ----------------
-        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]]
+        emoji_id
             ID of the custom emoji to react with.
             This should only be provided when a custom emoji's name is passed
             for `emoji`.
@@ -1679,10 +1679,10 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
+        channel
             The channel where the message to delete all reactions from is.
             This may be the object or the ID of an existing channel.
-        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        message
             The message to delete all reaction from. This may be the
             object or the ID of an existing message.
 
@@ -1723,18 +1723,18 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.TextableChannel]
+        channel
             The channel where the message to delete all reactions from is.
             This may be the object or the ID of an existing channel.
-        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        message
             The message to delete all reaction from. This may be the
             object or the ID of an existing message.
-        emoji : typing.Union[str, hikari.emojis.Emoji]
+        emoji
             Object or name of the emoji to get the reactions for.
 
         Other Parameters
         ----------------
-        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]]
+        emoji_id
             ID of the custom emoji to get the reactions for.
             This should only be provided when a custom emoji's name is passed
             for `emoji`.
@@ -1773,17 +1773,17 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.WebhookChannelT]
+        channel
             The channel where the webhook will be created. This may be
             the object or the ID of an existing channel.
-        name : str
+        name
             The name for the webhook. This cannot be `clyde`.
 
         Other Parameters
         ----------------
-        avatar : typing.Optional[hikari.files.Resourceish]
+        avatar
             If provided, the avatar for the webhook.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -1820,13 +1820,13 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        webhook : hikari.snowflakes.SnowflakeishOr[hikari.webhooks.PartialWebhook]
+        webhook
             The webhook to fetch. This may be the object or the ID
             of an existing webhook.
 
         Other Parameters
         ----------------
-        token : hikari.undefined.UndefinedOr[str]
+        token
             If provided, the webhook token that will be used to fetch
             the webhook instead of the token the client was initialized with.
 
@@ -1859,7 +1859,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.WebhookChannelT]
+        channel
             The channel to fetch the webhooks for. This may be an instance of any
             of the classes which are valid for [`hikari.channels.WebhookChannelT`][]
             or the ID of an existing channel.
@@ -1892,7 +1892,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to fetch the webhooks for. This may be the object
             or the ID of an existing guild.
 
@@ -1931,23 +1931,23 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        webhook : hikari.snowflakes.SnowflakeishOr[hikari.webhooks.PartialWebhook]
+        webhook
             The webhook to edit. This may be the object or the
             ID of an existing webhook.
 
         Other Parameters
         ----------------
-        token : hikari.undefined.UndefinedOr[str]
+        token
             If provided, the webhook token that will be used to edit
             the webhook instead of the token the client was initialized with.
-        name : hikari.undefined.UndefinedOr[str]
+        name
             If provided, the new webhook name.
-        avatar : hikari.undefined.UndefinedNoneOr[hikari.files.Resourceish]
+        avatar
             If provided, the new webhook avatar. If [`None`][], will
             remove the webhook avatar.
-        channel : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.WebhookChannelT]]
+        channel
             If provided, the text channel to move the webhook to.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -1983,13 +1983,13 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        webhook : hikari.snowflakes.SnowflakeishOr[hikari.webhooks.PartialWebhook]
+        webhook
             The webhook to delete. This may be the object or the
             ID of an existing webhook.
 
         Other Parameters
         ----------------
-        token : hikari.undefined.UndefinedOr[str]
+        token
             If provided, the webhook token that will be used to delete
             the webhook instead of the token the client was initialized with.
 
@@ -2044,18 +2044,20 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             At the time of writing, `username` and `avatar_url` are ignored for
             interaction webhooks.
 
-            Additionally, [`hikari.messages.MessageFlag.SUPPRESS_EMBEDS`][], [`hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`][] and [`hikari.messages.MessageFlag.EPHEMERAL`][]
-            are the only flags that can be set, with [`hikari.messages.MessageFlag.EPHEMERAL`][] limited to
+            Additionally, [`hikari.messages.MessageFlag.SUPPRESS_EMBEDS`][],
+            [`hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`][] and
+            [`hikari.messages.MessageFlag.EPHEMERAL`][] are the only flags that
+            can be set, with [`hikari.messages.MessageFlag.EPHEMERAL`][] limited to
             interaction webhooks.
 
         Parameters
         ----------
-        webhook : typing.Union[hikari.snowflakes.Snowflakeish, hikari.webhooks.ExecutableWebhook]
+        webhook
             The webhook to execute. This may be the object
             or the ID of an existing webhook.
-        token : str
+        token
             The webhook token.
-        content : hikari.undefined.UndefinedOr[typing.Any]
+        content
             If provided, the message contents. If
             [`hikari.undefined.UNDEFINED`][], then nothing will be sent
             in the content. Any other value here will be cast to a
@@ -2072,19 +2074,19 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Other Parameters
         ----------------
-        thread : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildThreadChannel]]
+        thread
             If provided then the message will be created in the target thread
             within the webhook's channel, otherwise it will be created in
             the webhook's target channel.
 
             This is required when trying to create a thread message.
-        username : hikari.undefined.UndefinedOr[str]
+        username
             If provided, the username to override the webhook's username
             for this request.
-        avatar_url : typing.Union[hikari.undefined.UndefinedType, hikari.files.URL, str]
+        avatar_url
             If provided, the url of an image to override the webhook's
             avatar with for this request.
-        attachment : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
+        attachment
             If provided, the message attachment. This can be a resource,
             or string of a path on your computer or a URL.
 
@@ -2113,25 +2115,25 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
                 type of [`concurrent.futures.Executor`][] that is being used for
                 the application (default is a thread pool which supports this
                 behaviour).
-        attachments : hikari.undefined.UndefinedOr[typing.Sequence[hikari.files.Resourceish]]
+        attachments
             If provided, the message attachments. These can be resources, or
             strings consisting of paths on your computer or URLs.
-        component : hikari.undefined.UndefinedOr[hikari.api.special_endpoints.ComponentBuilder]
+        component
             If provided, builder object of the component to include in this message.
-        components : hikari.undefined.UndefinedOr[typing.Sequence[hikari.api.special_endpoints.ComponentBuilder]]
+        components
             If provided, a sequence of the component builder objects to include
             in this message.
-        embed : hikari.undefined.UndefinedOr[hikari.embeds.Embed]
+        embed
             If provided, the message embed.
-        embeds : hikari.undefined.UndefinedOr[typing.Sequence[hikari.embeds.Embed]]
+        embeds
             If provided, the message embeds.
-        tts : hikari.undefined.UndefinedOr[bool]
+        tts
             If provided, whether the message will be read out by a screen
             reader using Discord's TTS (text-to-speech) system.
-        mentions_everyone : hikari.undefined.UndefinedOr[bool]
+        mentions_everyone
             If provided, whether the message should parse @everyone/@here
             mentions.
-        user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], bool]]
+        user_mentions
             If provided, and [`True`][], all user mentions will be detected.
             If provided, and [`False`][], all user mentions will be ignored
             if appearing in the message body.
@@ -2139,7 +2141,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             [`hikari.snowflakes.Snowflake`][], or
             [`hikari.users.PartialUser`][] derivatives to enforce mentioning
             specific users.
-        role_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole], bool]]
+        role_mentions
             If provided, and [`True`][], all role mentions will be detected.
             If provided, and [`False`][], all role mentions will be ignored
             if appearing in the message body.
@@ -2147,7 +2149,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             [`hikari.snowflakes.Snowflake`][], or
             [`hikari.guilds.PartialRole`][] derivatives to enforce mentioning
             specific roles.
-        flags : typing.Union[hikari.undefined.UndefinedType, int, hikari.messages.MessageFlag]
+        flags
             The flags to set for this webhook message.
 
         Returns
@@ -2176,7 +2178,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
-        """  # noqa: E501 - Line too long
+        """
 
     @abc.abstractmethod
     async def fetch_webhook_message(
@@ -2194,18 +2196,18 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        webhook : typing.Union[hikari.snowflakes.Snowflakeish, hikari.webhooks.ExecutableWebhook]
+        webhook
             The webhook to execute. This may be the object
             or the ID of an existing webhook.
-        token : str
+        token
             The webhook token.
-        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        message
             The message to fetch. This may be the object or the ID of an
             existing channel.
 
         Other Parameters
         ----------------
-        thread : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildThreadChannel]]
+        thread
             If provided then the message will be fetched from the target thread
             within the webhook's channel, otherwise it will be fetched from
             the webhook's target channel.
@@ -2280,15 +2282,15 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        webhook : typing.Union[hikari.snowflakes.Snowflakeish, hikari.webhooks.ExecutableWebhook]
+        webhook
             The webhook to execute. This may be the object
             or the ID of an existing webhook.
-        token : str
+        token
             The webhook token.
-        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        message
             The message to delete. This may be the object or the ID of
             an existing message.
-        content : hikari.undefined.UndefinedOr[typing.Any]
+        content
             If provided, the message content to update with. If
             [`hikari.undefined.UNDEFINED`][], then the content will not
             be changed. If [`None`][], then the content will be removed.
@@ -2304,52 +2306,52 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Other Parameters
         ----------------
-        thread : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildThreadChannel]]
+        thread
             If provided then the message will be edited in the target thread
             within the webhook's channel, otherwise it will be edited in
             the webhook's target channel.
 
             This is required when trying to edit a thread message.
-        attachment : hikari.undefined.UndefinedNoneOr[typing.Union[hikari.files.Resourceish, hikari.messages.Attachment]]
+        attachment
             If provided, the attachment to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous attachment, if
             present, is not changed. If this is [`None`][], then the
             attachment is removed, if present. Otherwise, the new attachment
             that was provided will be attached.
-        attachments : hikari.undefined.UndefinedNoneOr[typing.Sequence[typing.Union[hikari.files.Resourceish, hikari.messages.Attachment]]]
+        attachments
             If provided, the attachments to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous attachments, if
             present, are not changed. If this is [`None`][], then the
             attachments is removed, if present. Otherwise, the new attachments
             that were provided will be attached.
-        component : hikari.undefined.UndefinedNoneOr[hikari.api.special_endpoints.ComponentBuilder]
+        component
             If provided, builder object of the component to set for this message.
             This component will replace any previously set components and passing
             [`None`][] will remove all components.
-        components : hikari.undefined.UndefinedNoneOr[typing.Sequence[hikari.api.special_endpoints.ComponentBuilder]]
+        components
             If provided, a sequence of the component builder objects set for
             this message. These components will replace any previously set
             components and passing [`None`][] or an empty sequence will
             remove all components.
-        embed : hikari.undefined.UndefinedNoneOr[hikari.embeds.Embed]
+        embed
             If provided, the embed to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous embed(s) are not changed.
             If this is [`None`][] then any present embeds are removed.
             Otherwise, the new embed that was provided will be used as the
             replacement.
-        embeds : hikari.undefined.UndefinedNoneOr[typing.Sequence[hikari.embeds.Embed]]
+        embeds
             If provided, the embeds to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous embed(s) are not changed.
             If this is [`None`][] then any present embeds are removed.
             Otherwise, the new embeds that were provided will be used as the
             replacement.
-        mentions_everyone : hikari.undefined.UndefinedOr[bool]
+        mentions_everyone
             If provided, sanitation for `@everyone` mentions. If
             [`hikari.undefined.UNDEFINED`][], then the previous setting is
             not changed. If [`True`][], then `@everyone`/`@here` mentions
             in the message content will show up as mentioning everyone that can
             view the chat.
-        user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], bool]]
+        user_mentions
             If provided, and [`True`][], all user mentions will be detected.
             If provided, and [`False`][], all user mentions will be ignored
             if appearing in the message body.
@@ -2357,7 +2359,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             [`hikari.snowflakes.Snowflake`][], or
             [`hikari.users.PartialUser`][] derivatives to enforce mentioning
             specific users.
-        role_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole], bool]]
+        role_mentions
             If provided, and [`True`][], all role mentions will be detected.
             If provided, and [`False`][], all role mentions will be ignored
             if appearing in the message body.
@@ -2391,7 +2393,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
-        """  # noqa: E501 - Line too long
+        """
 
     @abc.abstractmethod
     async def delete_webhook_message(
@@ -2409,18 +2411,18 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        webhook : typing.Union[hikari.snowflakes.Snowflakeish, hikari.webhooks.ExecutableWebhook]
+        webhook
             The webhook to execute. This may be the object
             or the ID of an existing webhook.
-        token : str
+        token
             The webhook token.
-        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        message
             The message to delete. This may be the object or the ID of
             an existing message.
 
         Other Parameters
         ----------------
-        thread : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildThreadChannel]]
+        thread
             If provided then the message will be deleted from the target thread
             within the webhook's channel, otherwise it will be deleted from
             the webhook's target channel.
@@ -2484,12 +2486,12 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        invite : typing.Union[hikari.invites.InviteCode, str]
+        invite
             The invite to fetch. This may be an invite object or
             the code of an existing invite.
-        with_counts : bool
+        with_counts
             Whether the invite should contain the approximate member counts.
-        with_expiration: bool
+        with_expiration
             Whether the invite should contain the expiration date.
 
         Returns
@@ -2516,7 +2518,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        invite : typing.Union[hikari.invites.InviteCode, str]
+        invite
             The invite to delete. This may be an invite object or
             the code of an existing invite.
 
@@ -2574,12 +2576,12 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Other Parameters
         ----------------
-        username : undefined.UndefinedOr[str]
+        username
             If provided, the new username.
-        avatar : undefined.UndefinedNoneOr[hikari.files.Resourceish]
+        avatar
             If provided, the new avatar. If [`None`][],
             the avatar will be removed.
-        banner : undefined.UndefinedNoneOr[hikari.files.Resourceish]
+        banner
             If provided, the new banner. If [`None`][],
             the banner will be removed.
 
@@ -2639,9 +2641,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Other Parameters
         ----------------
-        newest_first : bool
+        newest_first
             Whether to fetch the newest first or the oldest first.
-        start_at : hikari.undefined.UndefinedOr[hikari.snowflakes.SearchableSnowflakeishOr[hikari.guilds.PartialGuild]]
+        start_at
             If provided, will start at this snowflake. If you provide
             a datetime object, it will be transformed into a snowflake. This
             may also be a guild object. In this case, the
@@ -2671,7 +2673,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to leave. This may be the object or
             the ID of an existing guild.
 
@@ -2700,7 +2702,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        application : hikari.snowflakes.SnowflakeishOr[hikari.applications.PartialApplication]
+        application
             The application to fetch the application role connections for.
 
         Returns
@@ -2739,16 +2741,16 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        application : hikari.snowflakes.SnowflakeishOr[hikari.applications.PartialApplication]
+        application
             The application to set the application role connections for.
 
         Other Parameters
         ----------------
-        platform_name : hikari.undefined.UndefinedOr[str]
+        platform_name
             If provided, the name of the platform that will be connected.
-        platform_username : hikari.undefined.UndefinedOr[str]
+        platform_username
             If provided, the name of the user in the platform.
-        metadata : hikari.undefined.UndefinedOr[typing.Mapping[str, typing.Union[str, int, bool, datetime.datetime]]
+        metadata
             If provided, the role connection metadata.
 
             Depending on the time of the previously created application role
@@ -2785,7 +2787,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             The user to create the DM channel with. This may be the
             object or the ID of an existing user.
 
@@ -2869,7 +2871,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        application : hikari.snowflakes.SnowflakeishOr[hikari.applications.PartialApplication]
+        application
             The application to fetch the application role connection metadata records for.
 
         Returns
@@ -2904,9 +2906,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        application : hikari.snowflakes.SnowflakeishOr[hikari.applications.PartialApplication]
+        application
             The application to set the application role connection metadata records for.
-        records : typing.Sequence[hikari.applications.ApplicationRoleConnectionMetadataRecord]
+        records
             The records to set for the application.
 
         Returns
@@ -2941,11 +2943,11 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        client : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]
+        client
             Object or ID of the application to authorize as.
-        client_secret : str
+        client_secret
             Secret of the application to authorize as.
-        scopes : typing.Sequence[typing.Union[hikari.applications.OAuth2Scope, str]]
+        scopes
             The scopes to authorize for.
 
         Returns
@@ -2978,13 +2980,13 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        client : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]
+        client
             Object or ID of the application to authorize with.
-        client_secret : str
+        client_secret
             Secret of the application to authorize with.
-        code : str
+        code
             The authorization code to exchange for an OAuth2 access token.
-        redirect_uri : str
+        redirect_uri
             The redirect uri that was included in the authorization request.
 
         Returns
@@ -3026,16 +3028,16 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        client : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]
+        client
             Object or ID of the application to authorize with.
-        client_secret : str
+        client_secret
             Secret of the application to authorize with.
-        refresh_token : str
+        refresh_token
             The refresh token to use.
 
         Other Parameters
         ----------------
-        scopes : typing.Sequence[typing.Union[hikari.applications.OAuth2Scope, str]]
+        scopes
             The scope of the access request.
 
         Returns
@@ -3067,11 +3069,11 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        client : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]
+        client
             Object or ID of the application to authorize with.
-        client_secret : str
+        client_secret
             Secret of the application to authorize with.
-        token : typing.Union[str, hikari.applications.PartialOAuth2Token]
+        token
             Object or string of the access token to revoke.
 
         Raises
@@ -3108,31 +3110,31 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        access_token : typing.Union[str, hikari.applications.PartialOAuth2Token]
+        access_token
             Object or string of the access token to use for this request.
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to add the user to. This may be the object
             or the ID of an existing guild.
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             The user to add to the guild. This may be the object
             or the ID of an existing user.
 
         Other Parameters
         ----------------
-        nickname : hikari.undefined.UndefinedOr[str]
+        nickname
             If provided, the nick to add to the user when he joins the guild.
 
             Requires the [`hikari.permissions.Permissions.MANAGE_NICKNAMES`][] permission on the guild.
-        roles : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole]]
+        roles
             If provided, the roles to add to the user when he joins the guild.
             This may be a collection objects or IDs of existing roles.
 
             Requires the [`hikari.permissions.Permissions.MANAGE_ROLES`][] permission on the guild.
-        mute : hikari.undefined.UndefinedOr[bool]
+        mute
             If provided, the mute state to add the user when he joins the guild.
 
             Requires the [`hikari.permissions.Permissions.MUTE_MEMBERS`][] permission on the guild.
-        deaf : hikari.undefined.UndefinedOr[bool]
+        deaf
             If provided, the deaf state to add the user when he joins the guild.
 
             Requires the [`hikari.permissions.Permissions.DEAFEN_MEMBERS`][] permission on the guild.
@@ -3190,7 +3192,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             The user to fetch. This can be the object
             or the ID of an existing user.
 
@@ -3232,20 +3234,20 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to fetch the audit logs from. This can be a
             guild object or the ID of an existing guild.
 
         Other Parameters
         ----------------
-        before : hikari.undefined.UndefinedOr[hikari.snowflakes.SearchableSnowflakeishOr[hikari.snowflakes.Unique]]
+        before
             If provided, filter to only actions before this snowflake. If you provide
             a datetime object, it will be transformed into a snowflake. This
             may be any other Discord entity that has an ID. In this case, the
             date the object was first created will be used.
-        user : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]]
+        user
             If provided, the user to filter for.
-        event_type : hikari.undefined.UndefinedOr[typing.Union[hikari.audit_logs.AuditLogEventType, int]]
+        event_type
             If provided, the event type to filter for.
 
         Returns
@@ -3278,10 +3280,10 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to fetch the emoji from. This can be a
             guild object or the ID of an existing guild.
-        emoji : hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]
+        emoji
             The emoji to fetch. This can be a [`hikari.emojis.CustomEmoji`][]
             or the ID of an existing emoji.
 
@@ -3311,7 +3313,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to fetch the emojis from. This can be a
             guild object or the ID of an existing guild.
 
@@ -3347,22 +3349,22 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to create the emoji on. This can be a
             guild object or the ID of an existing guild.
-        name : str
+        name
             The name for the emoji.
-        image : hikari.files.Resourceish
+        image
             The 128x128 image for the emoji. Maximum upload size is 256kb.
             This can be a still or an animated image.
 
         Other Parameters
         ----------------
-        roles : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole]]
+        roles
             If provided, a collection of the roles that will be able to
             use this emoji. This can be a [`hikari.guilds.PartialRole`][] or
             the ID of an existing role.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -3404,22 +3406,22 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to edit the emoji on. This can be a
             guild object or the ID of an existing guild.
-        emoji : hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]
+        emoji
             The emoji to edit. This can be a [`hikari.emojis.CustomEmoji`][]
             or the ID of an existing emoji.
 
         Other Parameters
         ----------------
-        name : hikari.undefined.UndefinedOr[str]
+        name
             If provided, the new name for the emoji.
-        roles : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole]]
+        roles
             If provided, the new collection of roles that will be able to
             use this emoji. This can be a [`hikari.guilds.PartialRole`][] or
             the ID of an existing role.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -3458,16 +3460,16 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to delete the emoji on. This can be a guild object or the
             ID of an existing guild.
-        emoji : hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]
+        emoji
             The emoji to delete. This can be a [`hikari.emojis.CustomEmoji`][]
             or the ID of an existing emoji.
 
         Other Parameters
         ----------------
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -3513,7 +3515,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        sticker : hikari.snowflakes.SnowflakeishOr[hikari.stickers.PartialSticker]
+        sticker
             The sticker to fetch. This can be a sticker object or the
             ID of an existing sticker.
 
@@ -3543,7 +3545,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.stickers.PartialGuild]
+        guild
             The guild to request stickers for. This can be a guild object or the
             ID of an existing guild.
 
@@ -3577,10 +3579,10 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.stickers.PartialGuild]
+        guild
             The guild the sticker is in. This can be a guild object or the
             ID of an existing guild.
-        sticker : hikari.snowflakes.SnowflakeishOr[hikari.stickers.PartialSticker]
+        sticker
             The sticker to fetch. This can be a sticker object or the
             ID of an existing sticker.
 
@@ -3619,14 +3621,14 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to create the sticker on. This can be a guild object or the
             ID of an existing guild.
-        name : str
+        name
             The name for the sticker.
-        tag : str
+        tag
             The tag for the sticker.
-        image : hikari.files.Resourceish
+        image
             The 320x320 image for the sticker. Maximum upload size is 500kb.
             This can be a still PNG, an animated PNG, a Lottie, or a GIF.
 
@@ -3636,9 +3638,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Other Parameters
         ----------------
-        description : hikari.undefined.UndefinedOr[str]
+        description
             If provided, the description of the sticker.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -3681,22 +3683,22 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to edit the sticker on. This can be a guild object or the
             ID of an existing guild.
-        sticker : hikari.snowflakes.SnowflakeishOr[hikari.stickers.PartialSticker]
+        sticker
             The sticker to edit. This can be a sticker object or the ID of an
             existing sticker.
 
         Other Parameters
         ----------------
-        name : hikari.undefined.UndefinedOr[str]
+        name
             If provided, the new name for the sticker.
-        description : hikari.undefined.UndefinedOr[str]
+        description
             If provided, the new description for the sticker.
-        tag : hikari.undefined.UndefinedOr[str]
+        tag
             If provided, the new sticker tag.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -3735,16 +3737,16 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to delete the sticker on. This can be a guild object or
             the ID of an existing guild.
-        sticker : hikari.snowflakes.SnowflakeishOr[hikari.stickers.PartialSticker]
+        sticker
             The sticker to delete. This can be a sticker object or the ID
             of an existing sticker.
 
         Other Parameters
         ----------------
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -3780,7 +3782,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        name : str
+        name
             The new guilds name.
 
         Returns
@@ -3813,7 +3815,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to fetch. This can be the object
             or the ID of an existing guild.
 
@@ -3846,7 +3848,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to fetch the preview of. This can be a
             guild object or the ID of an existing guild.
 
@@ -3906,48 +3908,48 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to edit. This may be the object
             or the ID of an existing guild.
 
         Other Parameters
         ----------------
-        name : hikari.undefined.UndefinedOr[str]
+        name
             If provided, the new name for the guild.
-        verification_level : hikari.undefined.UndefinedOr[hikari.guilds.GuildVerificationLevel]
+        verification_level
             If provided, the new verification level.
-        default_message_notifications : hikari.undefined.UndefinedOr[hikari.guilds.GuildMessageNotificationsLevel]
+        default_message_notifications
             If provided, the new default message notifications level.
-        explicit_content_filter_level : hikari.undefined.UndefinedOr[hikari.guilds.GuildExplicitContentFilterLevel]
+        explicit_content_filter_level
             If provided, the new explicit content filter level.
-        afk_channel : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildVoiceChannel]]
+        afk_channel
             If provided, the new afk channel. Requires `afk_timeout` to
             be set to work.
-        afk_timeout : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        afk_timeout
             If provided, the new afk timeout.
-        icon : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
+        icon
             If provided, the new guild icon. Must be a 1024x1024 image or can be
             an animated gif when the guild has the [`hikari.guilds.GuildFeature.ANIMATED_ICON`][] feature.
-        owner : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]]]
+        owner
             If provided, the new guild owner.
 
             !!! warning
                 You need to be the owner of the server to use this.
-        splash : hikari.undefined.UndefinedNoneOr[hikari.files.Resourceish]
+        splash
             If provided, the new guild splash. Must be a 16:9 image and the
             guild must have the [`hikari.guilds.GuildFeature.INVITE_SPLASH`][] feature.
-        banner : hikari.undefined.UndefinedNoneOr[hikari.files.Resourceish]
+        banner
             If provided, the new guild banner. Must be a 16:9 image and the
             guild must have the [`hikari.guilds.GuildFeature.BANNER`][] feature.
-        system_channel : hikari.undefined.UndefinedNoneOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildTextChannel]]
+        system_channel
             If provided, the new system channel.
-        rules_channel : hikari.undefined.UndefinedNoneOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildTextChannel]]
+        rules_channel
             If provided, the new rules channel.
-        public_updates_channel : hikari.undefined.UndefinedNoneOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildTextChannel]]
+        public_updates_channel
             If provided, the new public updates channel.
-        preferred_locale : hikari.undefined.UndefinedNoneOr[str]
+        preferred_locale
             If provided, the new preferred locale.
-        features : hikari.undefined.UndefinedOr[typing.Sequence[hikari.guilds.GuildFeature]]
+        features
             If provided, the guild features to be enabled. Features not provided will be disabled.
 
             .. warning::
@@ -3956,7 +3958,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
                 This behaviour can change in the future. You should refer to the
                 aforementioned link for the most up-to-date information, and
                 only supply mutable features.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -3982,7 +3984,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
-        """  # noqa: E501 - Line too long
+        """
 
     @abc.abstractmethod
     async def delete_guild(self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild]) -> None:
@@ -3990,7 +3992,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to delete. This may be the object or
             the ID of an existing guild.
 
@@ -4017,7 +4019,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to fetch the channels from. This may be the
             object or the ID of an existing guild.
 
@@ -4060,38 +4062,38 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to create the channel in. This may be the
             object or the ID of an existing guild.
-        name : str
+        name
             The channels name. Must be between 2 and 1000 characters.
 
         Other Parameters
         ----------------
-        position : hikari.undefined.UndefinedOr[int]
+        position
             If provided, the position of the channel (relative to the
             category, if any).
-        topic : hikari.undefined.UndefinedOr[str]
+        topic
             If provided, the channels topic. Maximum 1024 characters.
-        nsfw : hikari.undefined.UndefinedOr[bool]
+        nsfw
             If provided, whether to mark the channel as NSFW.
-        rate_limit_per_user : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        rate_limit_per_user
             If provided, the amount of seconds a user has to wait
             before being able to send another message in the channel.
             Maximum 21600 seconds.
-        permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
+        permission_overwrites
             If provided, the permission overwrites for the channel.
-        category : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildCategory]]
+        category
             The category to create the channel under. This may be the
             object or the ID of an existing category.
-        default_auto_archive_duration : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        default_auto_archive_duration
             If provided, the auto archive duration Discord's end user client
             should default to when creating threads in this channel.
 
             This should be either 60, 1440, 4320 or 10080 minutes and, as of
             writing, ignores the parent channel's set default_auto_archive_duration
             when passed as [`hikari.undefined.UNDEFINED`][].
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -4138,38 +4140,38 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to create the channel in. This may be the
             object or the ID of an existing guild.
-        name : str
+        name
             The channels name. Must be between 2 and 1000 characters.
 
         Other Parameters
         ----------------
-        position : hikari.undefined.UndefinedOr[int]
+        position
             If provided, the position of the channel (relative to the
             category, if any).
-        topic : hikari.undefined.UndefinedOr[str]
+        topic
             If provided, the channels topic. Maximum 1024 characters.
-        nsfw : hikari.undefined.UndefinedOr[bool]
+        nsfw
             If provided, whether to mark the channel as NSFW.
-        rate_limit_per_user : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        rate_limit_per_user
             If provided, the amount of seconds a user has to wait
             before being able to send another message in the channel.
             Maximum 21600 seconds.
-        permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
+        permission_overwrites
             If provided, the permission overwrites for the channel.
-        category : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildCategory]]
+        category
             The category to create the channel under. This may be the
             object or the ID of an existing category.
-        default_auto_archive_duration : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        default_auto_archive_duration
             If provided, the auto archive duration Discord's end user client
             should default to when creating threads in this channel.
 
             This should be either 60, 1440, 4320 or 10080 minutes and, as of
             writing, ignores the parent channel's set default_auto_archive_duration
             when passed as [`hikari.undefined.UNDEFINED`][].
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -4225,48 +4227,48 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to create the channel in. This may be the
             object or the ID of an existing guild.
-        name : str
+        name
             The channels name. Must be between 2 and 1000 characters.
 
         Other Parameters
         ----------------
-        position : hikari.undefined.UndefinedOr[int]
+        position
             If provided, the position of the category.
-        category : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildCategory]]
+        category
             The category to create the channel under. This may be the
             object or the ID of an existing category.
-        permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
+        permission_overwrites
             If provided, the permission overwrites for the category.
-        topic : hikari.undefined.UndefinedOr[str]
+        topic
             If provided, the channels topic. Maximum 1024 characters.
-        nsfw : hikari.undefined.UndefinedOr[bool]
+        nsfw
             If provided, whether to mark the channel as NSFW.
-        rate_limit_per_user : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        rate_limit_per_user
             If provided, the amount of seconds a user has to wait
             before being able to send another message in the channel.
             Maximum 21600 seconds.
-        default_auto_archive_duration : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        default_auto_archive_duration
             If provided, the auto archive duration Discord's end user client
             should default to when creating threads in this channel.
 
             This should be either 60, 1440, 4320 or 10080 minutes and, as of
             writing, ignores the parent channel's set default_auto_archive_duration
             when passed as [`hikari.undefined.UNDEFINED`][].
-        default_thread_rate_limit_per_user : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        default_thread_rate_limit_per_user
             If provided, the ratelimit that should be set in threads created
             from the forum.
-        default_forum_layout : hikari.undefined.UndefinedOr[typing.Union[hikari.channels.ForumLayoutType, int]]
+        default_forum_layout
             If provided, the default forum layout to show in the client.
-        default_sort_order : hikari.undefined.UndefinedOr[typing.Union[hikari.channels.ForumSortOrderType, int]]
+        default_sort_order
             If provided, the default sort order to show in the client.
-        available_tags : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.ForumTag]]
+        available_tags
             If provided, the available tags to select from when creating a thread.
-        default_reaction_emoji : typing.Union[str, hikari.emojis.Emoji, hikari.undefined.UndefinedType, hikari.snowflakes.Snowflake]
+        default_reaction_emoji
             If provided, the new default reaction emoji for threads created in a forum channel.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -4290,7 +4292,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
-        """  # noqa: E501 - Line too long
+        """
 
     @abc.abstractmethod
     async def create_guild_voice_channel(
@@ -4313,37 +4315,37 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to create the channel in. This may be the
             object or the ID of an existing guild.
-        name : str
+        name
             The channels name. Must be between 2 and 1000 characters.
 
         Other Parameters
         ----------------
-        position : hikari.undefined.UndefinedOr[int]
+        position
             If provided, the position of the channel (relative to the
             category, if any).
-        user_limit : hikari.undefined.UndefinedOr[int]
+        user_limit
             If provided, the maximum users in the channel at once.
             Must be between 0 and 99 with 0 meaning no limit.
-        bitrate : hikari.undefined.UndefinedOr[int]
+        bitrate
             If provided, the bitrate for the channel. Must be
             between 8000 and 96000 or 8000 and 128000 for VIP
             servers.
-        video_quality_mode : hikari.undefined.UndefinedOr[typing.Union[hikari.channels.VideoQualityMode, int]]
+        video_quality_mode
             If provided, the new video quality mode for the channel.
-        permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
+        permission_overwrites
             If provided, the permission overwrites for the channel.
-        region : hikari.undefined.UndefinedOr[typing.Union[hikari.voices.VoiceRegion, str]]
+        region
             If provided, the voice region to for this channel. Passing
             [`None`][] here will set it to "auto" mode where the used
             region will be decided based on the first person who connects to it
             when it's empty.
-        category : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildCategory]]
+        category
             The category to create the channel under. This may be the
             object or the ID of an existing category.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -4389,35 +4391,35 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to create the channel in. This may be the
             object or the ID of an existing guild.
-        name : str
+        name
             The channel's name. Must be between 2 and 1000 characters.
 
         Other Parameters
         ----------------
-        position : hikari.undefined.UndefinedOr[int]
+        position
             If provided, the position of the channel (relative to the
             category, if any).
-        user_limit : hikari.undefined.UndefinedOr[int]
+        user_limit
             If provided, the maximum users in the channel at once.
             Must be between 0 and 99 with 0 meaning no limit.
-        bitrate : hikari.undefined.UndefinedOr[int]
+        bitrate
             If provided, the bitrate for the channel. Must be
             between 8000 and 96000 or 8000 and 128000 for VIP
             servers.
-        permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
+        permission_overwrites
             If provided, the permission overwrites for the channel.
-        region : hikari.undefined.UndefinedOr[typing.Union[hikari.voices.VoiceRegion, str]]
+        region
             If provided, the voice region to for this channel. Passing
             [`None`][] here will set it to "auto" mode where the used
             region will be decided based on the first person who connects to it
             when it's empty.
-        category : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildCategory]]
+        category
             The category to create the channel under. This may be the
             object or the ID of an existing category.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -4459,19 +4461,19 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to create the channel in. This may be the
             object or the ID of an existing guild.
-        name : str
+        name
             The channels name. Must be between 2 and 1000 characters.
 
         Other Parameters
         ----------------
-        position : hikari.undefined.UndefinedOr[int]
+        position
             If provided, the position of the category.
-        permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
+        permission_overwrites
             If provided, the permission overwrites for the category.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -4519,26 +4521,26 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PermissibleGuildChannel]
+        channel
             Object or ID of the guild news or text channel to create a public thread in.
-        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        message
             Object or ID of the message to attach the created thread to.
-        name : str
+        name
             Name of the thread channel.
 
         Other Parameters
         ----------------
-        auto_archive_duration : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        auto_archive_duration
             If provided, how long the thread should remain inactive until it's archived.
 
             This should be either 60, 1440, 4320 or 10080 minutes and, as of
             writing, ignores the parent channel's set default_auto_archive_duration
             when passed as [`hikari.undefined.UNDEFINED`][].
-        rate_limit_per_user : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        rate_limit_per_user
             If provided, the amount of seconds a user has to wait
             before being able to send another message in the channel.
             Maximum 21600 seconds.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -4586,30 +4588,30 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PermissibleGuildChannel]
+        channel
             Object or ID of the guild news or text channel to create a thread in.
-        type : typing.Union[hikari.channels.ChannelType, int]
+        type
             The thread type to create.
-        name : str
+        name
             Name of the thread channel.
 
         Other Parameters
         ----------------
-        auto_archive_duration : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        auto_archive_duration
             If provided, how long the thread should remain inactive until it's archived.
 
             This should be either 60, 1440, 4320 or 10080 minutes and, as of
             writing, ignores the parent channel's set default_auto_archive_duration
             when passed as [`hikari.undefined.UNDEFINED`][].
-        invitable : undefined.UndefinedOr[bool]
+        invitable
             If provided, whether non-moderators should be able to add other non-moderators to the thread.
 
             This only applies to private threads.
-        rate_limit_per_user : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        rate_limit_per_user
             If provided, the amount of seconds a user has to wait
             before being able to send another message in the channel.
             Maximum 21600 seconds.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -4673,11 +4675,11 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PermissibleGuildChannel]
+        channel
             Object or ID of the forum channel to create a post in.
-        name : str
+        name
             Name of the post.
-        content : hikari.undefined.UndefinedOr[typing.Any]
+        content
             If provided, the message contents. If
             [`hikari.undefined.UNDEFINED`][], then nothing will be sent
             in the content. Any other value here will be cast to a
@@ -4693,7 +4695,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Other Parameters
         ----------------
-        attachment : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
+        attachment
             If provided, the message attachment. This can be a resource,
             or string of a path on your computer or a URL.
 
@@ -4722,39 +4724,39 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
                 type of [`concurrent.futures.Executor`][] that is being used for
                 the application (default is a thread pool which supports this
                 behaviour).
-        attachments : hikari.undefined.UndefinedOr[typing.Sequence[hikari.files.Resourceish]]
+        attachments
             If provided, the message attachments. These can be resources, or
             strings consisting of paths on your computer or URLs.
-        component : hikari.undefined.UndefinedOr[hikari.api.special_endpoints.ComponentBuilder]
+        component
             If provided, builder object of the component to include in this message.
-        components : hikari.undefined.UndefinedOr[typing.Sequence[hikari.api.special_endpoints.ComponentBuilder]]
+        components
             If provided, a sequence of the component builder objects to include
             in this message.
-        embed : hikari.undefined.UndefinedOr[hikari.embeds.Embed]
+        embed
             If provided, the message embed.
-        embeds : hikari.undefined.UndefinedOr[typing.Sequence[hikari.embeds.Embed]]
+        embeds
             If provided, the message embeds.
-        sticker : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.stickers.PartialSticker]]
+        sticker
             If provided, the object or ID of a sticker to send on the message.
 
             As of writing, bots can only send custom stickers from the current guild.
-        stickers : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishSequence[hikari.stickers.PartialSticker]]
+        stickers
             If provided, a sequence of the objects and IDs of up to 3 stickers
             to send on the message.
 
             As of writing, bots can only send custom stickers from the current guild.
-        tts : hikari.undefined.UndefinedOr[bool]
+        tts
             If provided, whether the message will be read out by a screen
             reader using Discord's TTS (text-to-speech) system.
-        mentions_everyone : hikari.undefined.UndefinedOr[bool]
+        mentions_everyone
             If provided, whether the message should parse @everyone/@here
             mentions.
-        mentions_reply : hikari.undefined.UndefinedOr[bool]
+        mentions_reply
             If provided, whether to mention the author of the message
             that is being replied to.
 
             This will not do anything if not being used with `reply`.
-        user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], bool]]
+        user_mentions
             If provided, and [`True`][], all user mentions will be detected.
             If provided, and [`False`][], all user mentions will be ignored
             if appearing in the message body.
@@ -4762,7 +4764,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             [`hikari.snowflakes.Snowflake`][], or
             [`hikari.users.PartialUser`][] derivatives to enforce mentioning
             specific users.
-        role_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole], bool]]
+        role_mentions
             If provided, and [`True`][], all role mentions will be detected.
             If provided, and [`False`][], all role mentions will be ignored
             if appearing in the message body.
@@ -4770,25 +4772,26 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             [`hikari.snowflakes.Snowflake`][], or
             [`hikari.guilds.PartialRole`][] derivatives to enforce mentioning
             specific roles.
-        flags : hikari.undefined.UndefinedOr[hikari.messages.MessageFlag]
+        flags
             If provided, optional flags to set on the message. If
             [`hikari.undefined.UNDEFINED`][], then nothing is changed.
 
             Note that some flags may not be able to be set. Currently the only
-            flags that can be set are [`hikari.messages.MessageFlag.NONE`][] and [`hikari.messages.MessageFlag.SUPPRESS_EMBEDS`][].
-        auto_archive_duration : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+            flags that can be set are [`hikari.messages.MessageFlag.NONE`][] and
+            [`hikari.messages.MessageFlag.SUPPRESS_EMBEDS`][].
+        auto_archive_duration
             If provided, how long the post should remain inactive until it's archived.
 
             This should be either 60, 1440, 4320 or 10080 minutes and, as of
             writing, ignores the parent channel's set default_auto_archive_duration
             when passed as [`hikari.undefined.UNDEFINED`][].
-        rate_limit_per_user : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        rate_limit_per_user
             If provided, the amount of seconds a user has to wait
             before being able to send another message in the channel.
             Maximum 21600 seconds.
-        tags : hikari.undefined.UndefinedOr[typing.Sequence[hikari.snowflakes.SnowflakeishOr[hikari.channels.ForumTag]]]
+        tags
             If provided, the tags to add to the created post.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -4802,7 +4805,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         hikari.errors.BadRequestError
             If any of the fields that are passed have an invalid value.
         hikari.errors.ForbiddenError
-            If you are missing the [`hikari.permissions.Permissions.SEND_MESSAGES`][] permission in the channel.
+            If you are missing the [`hikari.permissions.Permissions.SEND_MESSAGES`][]
+            permission in the channel.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.RateLimitTooLongError
@@ -4810,7 +4814,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
-        """  # noqa: E501 - Line too long
+        """
 
     @abc.abstractmethod
     async def join_thread(self, channel: snowflakes.SnowflakeishOr[channels_.GuildTextChannel], /) -> None:
@@ -4818,7 +4822,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildTextChannel]
+        channel
             Object or ID of the thread channel to join.
 
         Raises
@@ -4849,9 +4853,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildTextChannel]
+        channel
             Object or ID of the thread channel to add a member to.
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             Object or ID of the user to add to the thread.
 
         Raises
@@ -4877,7 +4881,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildTextChannel]
+        channel
             Object or ID of the thread channel to leave.
 
         Raises
@@ -4906,9 +4910,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildTextChannel]
+        channel
             Object or ID of the thread channel to remove a user from.
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             Object or ID of the user to remove from the thread.
 
         Raises
@@ -4939,9 +4943,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildTextChannel]
+        channel
             Object or ID of the thread channel to fetch the member of.
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             Object or ID of the user to fetch the thread member of.
 
         Returns
@@ -4974,7 +4978,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildTextChannel]
+        channel
             Object or ID of the thread channel to fetch the members of.
 
         Returns
@@ -5007,7 +5011,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.Guild]
+        guild
             Object or ID of the guild to fetch the active threads of.
 
         Returns
@@ -5049,12 +5053,12 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.undefined.UndefinedOr[hikari.channels.PermissibleGuildChannel]
+        channel
             Object or ID of the channel to fetch the archived threads of.
 
         Other Parameters
         ----------------
-        before : hikari.undefined.UndefinedOr[datetime.datetime]
+        before
             The date to fetch threads before.
 
             This is based on the thread's `archive_timestamp` field.
@@ -5101,12 +5105,12 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.undefined.UndefinedOr[hikari.channels.PermissibleGuildChannel]
+        channel
             Object or ID of the channel to fetch the private archived threads of.
 
         Other Parameters
         ----------------
-        before : hikari.undefined.UndefinedOr[datetime.datetime]
+        before
             The date to fetch threads before.
 
             This is based on the thread's `archive_timestamp` field.
@@ -5155,12 +5159,12 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        channel : hikari.undefined.UndefinedOr[hikari.channels.PermissibleGuildChannel]
+        channel
             Object or ID of the channel to fetch the private archived threads of.
 
         Other Parameters
         ----------------
-        before : hikari.undefined.UndefinedOr[hikari.snowflakes.SearchableSnowflakeishOr[hikari.channels.GuildThreadChannel]]
+        before
             If provided, fetch joined threads before this snowflake. If you
             provide a datetime object, it will be transformed into a snowflake.
 
@@ -5199,10 +5203,10 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to reposition the channels in. This may be the
             object or the ID of an existing guild.
-        positions : typing.Mapping[int, hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildChannel]]
+        positions
             A mapping of of the object or the ID of an existing channel to
             the new position, relative to their parent category, if any.
 
@@ -5229,10 +5233,10 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to get the member from. This may be the
             object or the ID of an existing guild.
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             The user to get the member for. This may be the
             object or the ID of an existing user.
 
@@ -5276,7 +5280,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to fetch the members of. This may be the
             object or the ID of an existing guild.
 
@@ -5337,9 +5341,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The object or ID of the guild to search members in.
-        name : str
+        name
             The query to match username(s) and nickname(s) against.
 
         Returns
@@ -5380,33 +5384,33 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to edit. This may be the object
             or the ID of an existing guild.
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             The user to edit. This may be the object
             or the ID of an existing user.
 
         Other Parameters
         ----------------
-        nickname : hikari.undefined.UndefinedNoneOr[str]
+        nickname
             If provided, the new nick for the member. If [`None`][],
             will remove the members nick.
 
             Requires the [`hikari.permissions.Permissions.MANAGE_NICKNAMES`][] permission.
-        roles : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole]]
+        roles
             If provided, the new roles for the member.
 
             Requires the [`hikari.permissions.Permissions.MANAGE_ROLES`][] permission.
-        mute : hikari.undefined.UndefinedOr[bool]
+        mute
             If provided, the new server mute state for the member.
 
             Requires the [`hikari.permissions.Permissions.MUTE_MEMBERS`][] permission.
-        deaf : hikari.undefined.UndefinedOr[bool]
+        deaf
             If provided, the new server deaf state for the member.
 
             Requires the [`hikari.permissions.Permissions.DEAFEN_MEMBERS`][] permission.
-        voice_channel : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildVoiceChannel]]]
+        voice_channel
             If provided, [`None`][] or the object or the ID of
             an existing voice channel to move the member to.
             If [`None`][], will disconnect the member from voice.
@@ -5418,13 +5422,13 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             !!! note
                 If the member is not in a voice channel, this will
                 take no effect.
-        communication_disabled_until : hikari.undefined.UndefinedNoneOr[datetime.datetime]
+        communication_disabled_until
             If provided, the datetime when the timeout (disable communication)
             of the member expires, up to 28 days in the future, or [`None`][]
             to remove the timeout from the member.
 
             Requires the [`hikari.permissions.Permissions.MODERATE_MEMBERS`][] permission.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -5462,20 +5466,20 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to edit the member in. This may be the object
             or the ID of an existing guild.
 
         Other Parameters
         ----------------
-        nickname : hikari.undefined.UndefinedNoneOr[str]
+        nickname
             If provided, the new nickname for the member. If
             [`None`][], will remove the members nickname.
 
             Requires the [`hikari.permissions.Permissions.CHANGE_NICKNAME`][] permission.
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -5514,19 +5518,19 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild where the member is in. This may be the
             object or the ID of an existing guild.
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             The user to add the role to. This may be the
             object or the ID of an existing user.
-        role : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialRole]
+        role
             The role to add. This may be the object or the
             ID of an existing role.
 
         Other Parameters
         ----------------
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -5558,19 +5562,19 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild where the member is in. This may be the
             object or the ID of an existing guild.
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             The user to remove the role from. This may be the
             object or the ID of an existing user.
-        role : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialRole]
+        role
             The role to remove. This may be the object or the
             ID of an existing role.
 
         Other Parameters
         ----------------
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -5601,16 +5605,16 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to kick the member from. This may be the
             object or the ID of an existing guild.
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             The user to kick. This may be the object
             or the ID of an existing user.
 
         Other Parameters
         ----------------
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -5652,20 +5656,20 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to ban the member from. This may be the
             object or the ID of an existing guild.
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             The user to kick. This may be the object
             or the ID of an existing user.
 
         Other Parameters
         ----------------
-        delete_message_seconds : hikari.undefined.UndefinedNoneOr[hikari.internal.time.Intervalish]
+        delete_message_seconds
             If provided, the number of seconds to delete messages for.
             This can be represented as either an int/float between 0 and 604800 (7 days), or
             a [`datetime.timedelta`][] object.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -5709,16 +5713,16 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to unban the member from. This may be the
             object or the ID of an existing guild.
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             The user to unban. This may be the object
             or the ID of an existing user.
 
         Other Parameters
         ----------------
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -5755,10 +5759,10 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to fetch the ban from. This may be the
             object or the ID of an existing guild.
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             The user to fetch the ban of. This may be the
             object or the ID of an existing user.
 
@@ -5801,15 +5805,15 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to fetch the bans from. This may be the
             object or the ID of an existing guild.
 
         Other Parameters
         ----------------
-        newest_first : bool
+        newest_first
             Whether to fetch the newest first or the oldest first.
-        start_at : undefined.UndefinedOr[snowflakes.SearchableSnowflakeishOr[users.PartialUser]]
+        start_at
             If provided, will start at this snowflake. If you provide
             a datetime object, it will be transformed into a snowflake. This
             may also be a scheduled event object object. In this case, the
@@ -5841,7 +5845,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to fetch the roles from. This may be the
             object or the ID of an existing guild.
 
@@ -5882,32 +5886,32 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to create the role in. This may be the
             object or the ID of an existing guild.
 
         Other Parameters
         ----------------
-        name : hikari.undefined.UndefinedOr[str]
+        name
             If provided, the name for the role.
-        permissions : hikari.undefined.UndefinedOr[hikari.permissions.Permissions]
+        permissions
             The permissions to give the role. This will default to setting
             NO roles if left to the default value. This is in contrast to
             default behaviour on Discord where some random permissions will
             be set by default.
-        color : hikari.undefined.UndefinedOr[hikari.colors.Colorish]
+        color
             If provided, the role's color.
-        colour : hikari.undefined.UndefinedOr[hikari.colors.Colorish]
+        colour
             An alias for `color`.
-        hoist : hikari.undefined.UndefinedOr[bool]
+        hoist
             If provided, whether to hoist the role.
-        icon : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
+        icon
             If provided, the role icon. Must be a 64x64 image under 256kb.
-        unicode_emoji : hikari.undefined.UndefinedOr[str]
+        unicode_emoji
             If provided, the standard emoji to set as the role icon.
-        mentionable : hikari.undefined.UndefinedOr[bool]
+        mentionable
             If provided, whether to make the role mentionable.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -5946,10 +5950,10 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to reposition the roles in. This may be
             the object or the ID of an existing guild.
-        positions : typing.Mapping[int, hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialRole]]
+        positions
             A mapping of the position to the role.
 
         Raises
@@ -5987,33 +5991,33 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to edit the role in. This may be the
             object or the ID of an existing guild.
-        role : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialRole]
+        role
             The role to edit. This may be the object or the
             ID of an existing role.
 
         Other Parameters
         ----------------
-        name : hikari.undefined.UndefinedOr[str]
+        name
             If provided, the new name for the role.
-        permissions : hikari.undefined.UndefinedOr[hikari.permissions.Permissions]
+        permissions
             If provided, the new permissions for the role.
-        color : hikari.undefined.UndefinedOr[hikari.colors.Colorish]
+        color
             If provided, the new color for the role.
-        colour : hikari.undefined.UndefinedOr[hikari.colors.Colorish]
+        colour
             An alias for `color`.
-        hoist : hikari.undefined.UndefinedOr[bool]
+        hoist
             If provided, whether to hoist the role.
-        icon : hikari.undefined.UndefinedNoneOr[hikari.files.Resourceish]
+        icon
             If provided, the new role icon. Must be a 64x64 image
             under 256kb.
-        unicode_emoji : hikari.undefined.UndefinedNoneOr[str]
+        unicode_emoji
             If provided, the new unicode emoji to set as the role icon.
-        mentionable : hikari.undefined.UndefinedOr[bool]
+        mentionable
             If provided, whether to make the role mentionable.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -6050,10 +6054,10 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to delete the role in. This may be the
             object or the ID of an existing guild.
-        role : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialRole]
+        role
             The role to delete. This may be the object or the
             ID of an existing role.
 
@@ -6084,15 +6088,15 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to estimate the guild prune count for. This may be the object
             or the ID of an existing guild.
 
         Other Parameters
         ----------------
-        days : hikari.undefined.UndefinedOr[int]
+        days
             If provided, number of days to count prune for.
-        include_roles : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole]]]
+        include_roles
             If provided, the role(s) to include. By default, this endpoint will
             not count users with roles. Providing roles using this attribute
             will make members with the specified roles also get included into
@@ -6134,23 +6138,23 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to begin the guild prune in. This may be the object
             or the ID of an existing guild.
 
         Other Parameters
         ----------------
-        days : hikari.undefined.UndefinedOr[int]
+        days
             If provided, number of days to count prune for.
-        compute_prune_count : hikari.snowflakes.SnowflakeishOr[bool]
+        compute_prune_count
             If provided, whether to return the prune count. This is discouraged
             for large guilds.
-        include_roles : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole]]
+        include_roles
             If provided, the role(s) to include. By default, this endpoint will
             not count users with roles. Providing roles using this attribute
             will make members with the specified roles also get included into
             the count.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -6185,7 +6189,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to fetch the voice regions for. This may be the object
             or the ID of an existing guild.
 
@@ -6215,7 +6219,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to fetch the invites for. This may be the object
             or the ID of an existing guild.
 
@@ -6247,7 +6251,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to fetch the integrations for. This may be the object
             or the ID of an existing guild.
 
@@ -6277,7 +6281,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to fetch the widget from. This can be the object
             or the ID of an existing guild.
 
@@ -6314,18 +6318,18 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to edit the widget in. This can be the object
             or the ID of an existing guild.
 
         Other Parameters
         ----------------
-        channel : hikari.undefined.UndefinedNoneOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildChannel]]
+        channel
             If provided, the channel to set the widget to. If [`None`][],
             will not set to any.
-        enabled : hikari.undefined.UndefinedOr[bool]
+        enabled
             If provided, whether to enable the widget.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -6355,7 +6359,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to fetch the welcome screen for.
 
         Returns
@@ -6391,17 +6395,17 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             ID or object of the guild to edit the welcome screen for.
 
         Other Parameters
         ----------------
-        description : undefined.UndefinedNoneOr[str]
+        description
             If provided, the description to set for the guild's welcome screen.
             This may be [`None`][] to unset the description.
-        enabled : undefined.UndefinedOr[bool]
+        enabled
             If provided, Whether the guild's welcome screen should be enabled.
-        channels : hikari.undefined.UndefinedNoneOr[typing.Sequence[hikari.guilds.WelcomeChannel]]
+        channels
             If provided, a sequence of up to 5 public channels to set in this
             guild's welcome screen. This may be passed as [`None`][] to
             remove all welcome channels
@@ -6443,7 +6447,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to fetch the vanity url from. This can
             be the object or the ID of an existing guild.
 
@@ -6479,14 +6483,14 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to create a template from.
-        name : str
+        name
             The name to use for the created template.
 
         Other Parameters
         ----------------
-        description : hikari.undefined.UndefinedNoneOr[str]
+        description
             The description to set for the template.
 
         Returns
@@ -6525,14 +6529,14 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        template : typing.Union[str, hikari.templates.Template]
+        template
             The object or string code of the template to create a guild based on.
-        name : str
+        name
             The new guilds name.
 
         Other Parameters
         ----------------
-        icon : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
+        icon
             If provided, the guild icon to set. Must be a 1024x1024 image or can
             be an animated gif when the guild has the [`hikari.guilds.GuildFeature.ANIMATED_ICON`][] feature.
 
@@ -6563,9 +6567,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to delete a template in.
-        template : typing.Union[str, hikari.templates.Template]
+        template
             Object or string code of the template to delete.
 
         Returns
@@ -6602,16 +6606,16 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to edit a template in.
-        template : typing.Union[str, hikari.templates.Template]
+        template
             Object or string code of the template to modify.
 
         Other Parameters
         ----------------
-        name : hikari.undefined.UndefinedOr[str]
+        name
             The name to set for this template.
-        description : hikari.undefined.UndefinedNoneOr[str]
+        description
             The description to set for the template.
 
         Returns
@@ -6641,7 +6645,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        template : typing.Union[str, hikari.templates.Template]
+        template
             The object or string code of the template to fetch.
 
         Returns
@@ -6670,7 +6674,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The object or ID of the guild to get the templates for.
 
         Returns
@@ -6702,9 +6706,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to sync a template in.
-        template : typing.Union[str, hikari.templates.Template]
+        template
             Object or code of the template to sync.
 
         Returns
@@ -6734,10 +6738,10 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        name : str
+        name
             The command's name. This should match the regex `^[-_\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$` in
             Unicode mode and be lowercase.
-        description : str
+        description
             The description to set for the command if this is a slash command.
             This should be inclusively between 1-100 characters in length.
 
@@ -6751,13 +6755,13 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     def context_menu_command_builder(
         self, type: typing.Union[commands.CommandType, int], name: str
     ) -> special_endpoints.ContextMenuCommandBuilder:
-        r"""Create a command builder to use in [`hikari.api.rest.RESTClient.set_application_commands`][].
+        """Create a command builder to use in [`hikari.api.rest.RESTClient.set_application_commands`][].
 
         Parameters
         ----------
-        type : commands.CommandType
+        type
             The commands's type.
-        name : str
+        name
             The command's name.
 
         Returns
@@ -6777,14 +6781,14 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        application : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]
+        application
             Object or ID of the application to fetch a command for.
-        command : hikari.snowflakes.SnowflakeishOr[hikari.commands.PartialCommand]
+        command
             Object or ID of the command to fetch.
 
         Other Parameters
         ----------------
-        guild : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to fetch the command for. If left as
             [`hikari.undefined.UNDEFINED`][] then this will return a global command,
             otherwise this will return a command made for the specified guild.
@@ -6819,12 +6823,12 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        application : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]
+        application
             Object or ID of the application to fetch the commands for.
 
         Other Parameters
         ----------------
-        guild : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to fetch the commands for. If left as
             [`hikari.undefined.UNDEFINED`][] then this will only return the global
             commands, otherwise this will only return the commands set exclusively
@@ -6873,41 +6877,42 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         dm_enabled: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         nsfw: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
     ) -> commands.SlashCommand:
-        r"""Create an application command.
+        r"""Create an application slash command.
 
         Parameters
         ----------
-        application : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]
+        application
             Object or ID of the application to create a command for.
-        name : str
-            The command's name. This should match the regex `^[\w-]{1,32}$` in
-            Unicode mode and be lowercase.
-        description : str
+        name
+            The command's name. This should match the regex
+            `^[-_\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$` in Unicode mode and
+            be lowercase.
+        description
             The description to set for the command.
             This should be inclusively between 1-100 characters in length.
 
         Other Parameters
         ----------------
-        guild : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the specific guild this should be made for.
             If left as [`hikari.undefined.UNDEFINED`][] then this call will create
             a global command rather than a guild specific one.
-        options : hikari.undefined.UndefinedOr[typing.Sequence[hikari.commands.CommandOption]]
+        options
             A sequence of up to 10 options for this command.
-        name_localizations : hikari.undefined.UndefinedOr[typing.Mapping[typing.Union[hikari.locales.Locale, str], str]]
+        name_localizations
             The name localizations for this command.
-        description_localizations : hikari.undefined.UndefinedOr[typing.Mapping[typing.Union[hikari.locales.Locale, str], str]]
+        description_localizations
             The description localizations for this command.
-        default_member_permissions : typing.Union[hikari.undefined.UndefinedType, int, hikari.permissions.Permissions]
+        default_member_permissions
             Member permissions necessary to utilize this command by default.
 
             If `0`, then it will be available for all members. Note that this doesn't affect
             administrators of the guild and overwrites.
-        dm_enabled : hikari.undefined.UndefinedOr[bool]
+        dm_enabled
             Whether this command is enabled in DMs with the bot.
 
             This can only be applied to non-guild commands.
-        nsfw : hikari.undefined.UndefinedOr[bool]
+        nsfw
             Whether this command should be age-restricted.
 
         Returns
@@ -6949,38 +6954,37 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         dm_enabled: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         nsfw: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
     ) -> commands.ContextMenuCommand:
-        r"""Create an application command.
+        r"""Create an application context menu command.
 
         Parameters
         ----------
-        application : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]
+        application
             Object or ID of the application to create a command for.
-        type : typing.Union[hikari.commands.CommandType, int]
+        type
             The type of menu command to make.
 
             Only USER and MESSAGE are valid here.
-        name : str
-            The command's name. This should match the regex `^[-_\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$` in
-            Unicode mode and be lowercase.
+        name
+            The command's name.
 
         Other Parameters
         ----------------
-        guild : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the specific guild this should be made for.
             If left as [`hikari.undefined.UNDEFINED`][] then this call will create
             a global command rather than a guild specific one.
-        name_localizations : hikari.undefined.UndefinedOr[typing.Mapping[typing.Union[hikari.locales.Locale, str], str]]
+        name_localizations
             The name localizations for this command.
-        default_member_permissions : typing.Union[hikari.undefined.UndefinedType, int, hikari.permissions.Permissions]
+        default_member_permissions
             Member permissions necessary to utilize this command by default.
 
             If `0`, then it will be available for all members. Note that this doesn't affect
             administrators of the guild and overwrites.
-        dm_enabled : hikari.undefined.UndefinedOr[bool]
+        dm_enabled
             Whether this command is enabled in DMs with the bot.
 
             This can only be applied to non-guild commands.
-        nsfw : hikari.undefined.UndefinedOr[bool]
+        nsfw
             Whether this command should be age-restricted.
 
         Returns
@@ -7020,15 +7024,15 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        application : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]
+        application
             Object or ID of the application to create a command for.
-        commands : typing.Sequence[hikari.api.special_endpoints.CommandBuilder]
+        commands
             A sequence of up to 100 initialised command builder objects of the
             commands to set for this the application.
 
         Other Parameters
         ----------------
-        guild : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the specific guild to set the commands for.
             If left as [`hikari.undefined.UNDEFINED`][] then this set the global
             commands rather than guild specific commands.
@@ -7074,32 +7078,32 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        application : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]
+        application
             Object or ID of the application to edit a command for.
-        command : hikari.snowflakes.SnowflakeishOr[hikari.commands.PartialCommand]
+        command
             Object or ID of the command to modify.
 
         Other Parameters
         ----------------
-        guild : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]]
+        guild
             Object or ID of the guild to edit a command for if this is a guild
             specific command. Leave this as [`hikari.undefined.UNDEFINED`][] to delete
             a global command.
-        name : hikari.undefined.UndefinedOr[str]
+        name
             The name to set for the command. Leave as [`hikari.undefined.UNDEFINED`][]
             to not change.
-        description : hikari.undefined.UndefinedOr[str]
+        description
             The description to set for the command. Leave as [`hikari.undefined.UNDEFINED`][]
             to not change.
-        options : hikari.undefined.UndefinedOr[typing.Sequence[hikari.commands.CommandOption]]
+        options
             A sequence of up to 10 options to set for this command. Leave this as
             [`hikari.undefined.UNDEFINED`][] to not change.
-        default_member_permissions : typing.Union[hikari.undefined.UndefinedType, int, hikari.permissions.Permissions]
+        default_member_permissions
             Member permissions necessary to utilize this command by default.
 
             If `0`, then it will be available for all members. Note that this doesn't affect
             administrators of the guild and overwrites.
-        dm_enabled : hikari.undefined.UndefinedOr[bool]
+        dm_enabled
             Whether this command is enabled in DMs with the bot.
 
             This can only be applied to non-guild commands.
@@ -7137,14 +7141,14 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        application : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]
+        application
             Object or ID of the application to delete a command for.
-        command : hikari.snowflakes.SnowflakeishOr[hikari.commands.PartialCommand]
+        command
             Object or ID of the command to delete.
 
         Other Parameters
         ----------------
-        guild : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]]
+        guild
             Object or ID of the guild to delete a command for if this is a guild
             specific command. Leave this as [`hikari.undefined.UNDEFINED`][] to
             delete a global command.
@@ -7174,9 +7178,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        application : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]
+        application
             Object or ID of the application to fetch the command permissions for.
-        guild : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]]
+        guild
             Object or ID of the guild to fetch the command permissions for.
 
         Returns
@@ -7210,11 +7214,11 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        application : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]
+        application
             Object or ID of the application to fetch the command permissions for.
-        guild : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]]
+        guild
             Object or ID of the guild to fetch the command permissions for.
-        command : hikari.snowflakes.SnowflakeishOr[hikari.commands.PartialCommand]
+        command
             Object or ID of the command to fetch the command permissions for.
 
         Returns
@@ -7260,13 +7264,13 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        application : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]
+        application
             Object or ID of the application to set the command permissions for.
-        guild : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]]
+        guild
             Object or ID of the guild to set the command permissions for.
-        command : hikari.snowflakes.SnowflakeishOr[hikari.commands.PartialCommand]
+        command
             Object or ID of the command to set the permissions for.
-        permissions : typing.Sequence[hikari.commands.CommandPermission]
+        permissions
             Sequence of up to 10 of the permission objects to set.
 
         Returns
@@ -7297,7 +7301,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        type : typing.Union[hikari.interactions.base_interactions.ResponseType, int]
+        type
             The type of deferred message response this builder is for.
 
         Returns
@@ -7314,7 +7318,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        choices : typing.Sequence[hikari.api.special_endpoints.AutocompleteChoiceBuilder]
+        choices
             The autocomplete choices.
 
         Returns
@@ -7331,7 +7335,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        type : typing.Union[hikari.interactions.base_interactions.ResponseType, int]
+        type
             The type of message response this builder is for.
 
         Returns
@@ -7346,9 +7350,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        title : str
+        title
             The title that will show up in the modal.
-        custom_id : str
+        custom_id
             Developer set custom ID used for identifying interactions with this modal.
 
         Returns
@@ -7375,9 +7379,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        application : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]
+        application
             Object or ID of the application to fetch a command for.
-        token : str
+        token
             Token of the interaction to get the initial response for.
 
         Returns
@@ -7436,16 +7440,16 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        interaction : hikari.snowflakes.SnowflakeishOr[hikari.interactions.base_interactions.PartialInteraction]
+        interaction
             Object or ID of the interaction this response is for.
-        token : str
+        token
             The interaction's token.
-        response_type : typing.Union[int, hikari.interactions.base_interactions.ResponseType]
+        response_type
             The type of interaction response this is.
 
         Other Parameters
         ----------------
-        content : hikari.undefined.UndefinedOr[typing.Any]
+        content
             If provided, the message contents. If
             [`hikari.undefined.UNDEFINED`][], then nothing will be sent
             in the content. Any other value here will be cast to a
@@ -7455,34 +7459,35 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             no `embeds` kwarg is provided, then this will instead
             update the embed. This allows for simpler syntax when
             sending an embed alone.
-        attachment : hikari.undefined.UndefinedNoneOr[typing.Union[hikari.files.Resourceish, hikari.messages.Attachment]]
+        attachment
             If provided, the message attachment. This can be a resource,
             or string of a path on your computer or a URL.
-        attachments : hikari.undefined.UndefinedNoneOr[typing.Sequence[typing.Union[hikari.files.Resourceish, hikari.messages.Attachment]]]
+        attachments
             If provided, the message attachments. These can be resources, or
             strings consisting of paths on your computer or URLs.
-        component : hikari.undefined.UndefinedNoneOr[hikari.api.special_endpoints.ComponentBuilder]
+        component
             If provided, builder object of the component to include in this message.
-        components : hikari.undefined.UndefinedNoneOr[typing.Sequence[hikari.api.special_endpoints.ComponentBuilder]]
+        components
             If provided, a sequence of the component builder objects to include
             in this message.
-        embed : hikari.undefined.UndefinedNoneOr[hikari.embeds.Embed]
+        embed
             If provided, the message embed.
-        embeds : hikari.undefined.UndefinedNoneOr[typing.Sequence[hikari.embeds.Embed]]
+        embeds
             If provided, the message embeds.
-        flags : typing.Union[int, hikari.messages.MessageFlag, hikari.undefined.UndefinedType]
+        flags
             If provided, the message flags this response should have.
 
             As of writing the only message flags which can be set here are
-            [`hikari.messages.MessageFlag.EPHEMERAL`][], [`hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`][]
+            [`hikari.messages.MessageFlag.EPHEMERAL`][],
+            [`hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`][]
             and [`hikari.messages.MessageFlag.SUPPRESS_EMBEDS`][].
-        tts : hikari.undefined.UndefinedOr[bool]
+        tts
             If provided, whether the message will be read out by a screen
             reader using Discord's TTS (text-to-speech) system.
-        mentions_everyone : hikari.undefined.UndefinedOr[bool]
+        mentions_everyone
             If provided, whether the message should parse @everyone/@here
             mentions.
-        user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], bool]]
+        user_mentions
             If provided, and [`True`][], all user mentions will be detected.
             If provided, and [`False`][], all user mentions will be ignored
             if appearing in the message body.
@@ -7490,7 +7495,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             [`hikari.snowflakes.Snowflake`][], or
             [`hikari.users.PartialUser`][] derivatives to enforce mentioning
             specific users.
-        role_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole], bool]]
+        role_mentions
             If provided, and [`True`][], all role mentions will be detected.
             If provided, and [`False`][], all role mentions will be ignored
             if appearing in the message body.
@@ -7521,7 +7526,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
-        """  # noqa: E501 - Line too long
+        """
 
     @abc.abstractmethod
     async def edit_interaction_response(
@@ -7568,14 +7573,14 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        application : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]
+        application
             Object or ID of the application to edit a command response for.
-        token : str
+        token
             The interaction's token.
 
         Other Parameters
         ----------------
-        content : hikari.undefined.UndefinedOr[typing.Any]
+        content
             If provided, the message content to update with. If
             [`hikari.undefined.UNDEFINED`][], then the content will not
             be changed. If [`None`][], then the content will be removed.
@@ -7588,43 +7593,43 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             `attachments` kwargs are provided, the values will be overwritten.
             This allows for simpler syntax when sending an embed or an
             attachment alone.
-        attachment : hikari.undefined.UndefinedNoneOr[typing.Union[hikari.files.Resourceish, hikari.messages.Attachment]]
+        attachment
             If provided, the attachment to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous attachment, if
             present, is not changed. If this is [`None`][], then the
             attachment is removed, if present. Otherwise, the new attachment
             that was provided will be attached.
-        attachments : hikari.undefined.UndefinedNoneOr[typing.Sequence[typing.Union[hikari.files.Resourceish, hikari.messages.Attachment]]]
+        attachments
             If provided, the attachments to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous attachments, if
             present, are not changed. If this is [`None`][], then the
             attachments is removed, if present. Otherwise, the new attachments
             that were provided will be attached.
-        component : hikari.undefined.UndefinedNoneOr[hikari.api.special_endpoints.ComponentBuilder]
+        component
             If provided, builder object of the component to set for this message.
             This component will replace any previously set components and passing
             [`None`][] will remove all components.
-        components : hikari.undefined.UndefinedNoneOr[typing.Sequence[hikari.api.special_endpoints.ComponentBuilder]]
+        components
             If provided, a sequence of the component builder objects set for
             this message. These components will replace any previously set
             components and passing [`None`][] or an empty sequence will
             remove all components.
-        embed : hikari.undefined.UndefinedNoneOr[hikari.embeds.Embed]
+        embed
             If provided, the embed to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous embed(s) are not changed.
             If this is [`None`][] then any present embeds are removed.
             Otherwise, the new embed that was provided will be used as the
             replacement.
-        embeds : hikari.undefined.UndefinedNoneOr[typing.Sequence[hikari.embeds.Embed]]
+        embeds
             If provided, the embeds to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous embed(s) are not changed.
             If this is [`None`][] then any present embeds are removed.
             Otherwise, the new embeds that were provided will be used as the
             replacement.
-        mentions_everyone : hikari.undefined.UndefinedOr[bool]
+        mentions_everyone
             If provided, whether the message should parse @everyone/@here
             mentions.
-        user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], bool]]
+        user_mentions
             If provided, and [`True`][], all user mentions will be detected.
             If provided, and [`False`][], all user mentions will be ignored
             if appearing in the message body.
@@ -7632,7 +7637,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             [`hikari.snowflakes.Snowflake`][], or
             [`hikari.users.PartialUser`][] derivatives to enforce mentioning
             specific users.
-        role_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole], bool]]
+        role_mentions
             If provided, and [`True`][], all role mentions will be detected.
             If provided, and [`False`][], all role mentions will be ignored
             if appearing in the message body.
@@ -7666,7 +7671,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
-        """  # noqa: E501 - Line too long
+        """
 
     @abc.abstractmethod
     async def delete_interaction_response(
@@ -7676,9 +7681,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        application : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]
+        application
             Object or ID of the application to delete a command response for.
-        token : str
+        token
             The interaction's token.
 
         Raises
@@ -7705,11 +7710,11 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        interaction : hikari.snowflakes.SnowflakeishOr[hikari.interactions.base_interactions.PartialInteraction]
+        interaction
             Object or ID of the interaction this response is for.
-        token : str
+        token
             The interaction's token.
-        choices : typing.Sequence[hikari.api.special_endpoints.AutocompleteChoiceBuilder]
+        choices
             The autocomplete choices themselves.
 
         Raises
@@ -7741,20 +7746,20 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        interaction : hikari.snowflakes.SnowflakeishOr[hikari.interactions.base_interactions.PartialInteraction]
+        interaction
             Object or ID of the interaction this response is for.
-        token : str
+        token
             The interaction's token.
-        title : str
+        title
             The title that will show up in the modal.
-        custom_id : str
+        custom_id
             Developer set custom ID used for identifying interactions with this modal.
 
         Other Parameters
         ----------------
-        component : hikari.undefined.UndefinedOr[typing.Sequence[hikari.api.special_endpoints.ComponentBuilder]]
+        component
             A component builders to send in this modal.
-        components : hikari.undefined.UndefinedOr[typing.Sequence[hikari.api.special_endpoints.ComponentBuilder]]
+        components
             A sequence of component builders to send in this modal.
 
         Raises
@@ -7773,9 +7778,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        interaction : snowflakes.SnowflakeishOr[base_interactions.PartialInteraction]
+        interaction
             Object or ID of the interaction this response is for.
-        token : str
+        token
             The interaction's token.
         """
 
@@ -7810,10 +7815,10 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialGuild]
+        guild
             The guild the event bellongs to. This may be the object or the
             ID of an existing guild.
-        event : hikari.snowflakes.SnowflakeishOr[hikari.scheduled_events.ScheduledEvent]
+        event
             The event to fetch. This may be the object or the
             ID of an existing event.
 
@@ -7852,7 +7857,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             Object or ID of the guild to fetch scheduled events for.
 
         Returns
@@ -7894,28 +7899,28 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to create the event in.
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+        channel
             The stage channel to create the event in.
-        name : str
+        name
             The name of the event.
-        start_time : datetime.datetime
+        start_time
             When the event is scheduled to start.
 
         Other Parameters
         ----------------
-        description : hikari.undefined.UndefinedOr[str]
+        description
             The event's description.
-        end_time : hikari.undefined.UndefinedOr[datetime.datetime]
+        end_time
             When the event should be scheduled to end.
-        image : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
+        image
             The event's display image.
-        privacy_level : hikari.undefined.UndefinedOr[hikari.scheduled_events.EventPrivacyLevel]
+        privacy_level
             The event's privacy level.
 
             This effects who can view and subscribe to the event.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -7967,28 +7972,28 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to create the event in.
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+        channel
             The voice channel to create the event in.
-        name : str
+        name
             The name of the event.
-        start_time : datetime.datetime
+        start_time
             When the event is scheduled to start.
 
         Other Parameters
         ----------------
-        description : hikari.undefined.UndefinedOr[str]
+        description
             The event's description.
-        end_time : hikari.undefined.UndefinedOr[datetime.datetime]
+        end_time
             When the event should be scheduled to end.
-        image : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
+        image
             The event's display image.
-        privacy_level : hikari.undefined.UndefinedOr[hikari.scheduled_events.EventPrivacyLevel]
+        privacy_level
             The event's privacy level.
 
             This effects who can view and subscribe to the event.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -8040,28 +8045,28 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to create the event in.
-        name : str
+        name
             The name of the event.
-        location : str
+        location
             The location the event.
-        start_time : datetime.datetime
+        start_time
             When the event is scheduled to start.
-        end_time : datetime.datetime
+        end_time
             When the event is scheduled to end.
 
         Other Parameters
         ----------------
-        description : hikari.undefined.UndefinedOr[str]
+        description
             The event's description.
-        image : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
+        image
             The event's display image.
-        privacy_level : hikari.undefined.UndefinedOr[hikari.scheduled_events.EventPrivacyLevel]
+        privacy_level
             The event's privacy level.
 
             This effects who can view and subscribe to the event.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -8114,44 +8119,44 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to edit the event in.
-        event : hikari.snowflakes.SnowflakeishOr[hikari.scheduled_events.ScheduledEvent]
+        event
             The scheduled event to edit.
 
         Other Parameters
         ----------------
-        channel : hikari.undefined.UndefinedNoneOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]]
+        channel
             The channel a `VOICE` or `STAGE` event should be associated with.
-        description : hikari.undefined.UndefinedNoneOr[str]
+        description
             The event's description.
-        entity_type : hikari.undefined.UndefinedOr[hikari.scheduled_events.ScheduledEventType]
+        entity_type
             The type of entity the event should target.
-        image : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
+        image
             The event's display image.
-        location : hikari.undefined.UndefinedOr[str]
+        location
             The location of an `EXTERNAL` event.
 
             Must be passed when changing an event to `EXTERNAL`.
-        name : hikari.undefined.UndefinedOr[str]
+        name
             The event's name.
-        privacy_level : hikari.undefined.UndefinedOr[hikari.scheduled_events.EventPrivacyLevel]
+        privacy_level
             The event's privacy level.
 
             This effects who can view and subscribe to the event.
-        start_time : hikari.undefined.UndefinedOr[datetime.datetime]
+        start_time
             When the event should be scheduled to start.
-        end_time : hikari.undefined.UndefinedNoneOr[datetime.datetime]
+        end_time
             When the event should be scheduled to end.
 
             This can only be set to [`None`][] for `STAGE` and `VOICE` events.
             Must be provided when changing an event to `EXTERNAL`.
-        status : hikari.undefined.UndefinedOr[hikari.scheduled_events.ScheduledEventStatus]
+        status
             The event's new status.
 
             `SCHEDULED` events can be set to `ACTIVE` and `CANCELED`.
             `ACTIVE` events can only be set to `COMPLETED`.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -8194,9 +8199,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to delete the event from.
-        event : hikari.snowflakes.SnowflakeishOr[hikari.scheduled_events.ScheduledEvent]
+        event
             The scheduled event to delete.
 
         Raises
@@ -8235,16 +8240,16 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild to fetch the scheduled event users from.
-        event : hikari.snowflakes.SnowflakeishOr[hikari.scheduled_events.ScheduledEvent]
+        event
             The scheduled event to fetch the subscribed users for.
 
         Other Parameters
         ----------------
-        newest_first : bool
+        newest_first
             Whether to fetch the newest first or the oldest first.
-        start_at : hikari.undefined.UndefinedOr[hikari.snowflakes.SearchableSnowflakeishOr[hikari.guilds.PartialGuild]]
+        start_at
             If provided, will start at this snowflake. If you provide
             a datetime object, it will be transformed into a snowflake. This
             may also be a scheduled event object object. In this case, the
@@ -8284,7 +8289,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        application : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]
+        application
             The application to fetch SKUs for.
 
         Returns
@@ -8320,22 +8325,22 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        application : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]
+        application
             The application to fetch entitlements for.
 
         Other Parameters
         ----------------
-        user : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]]
+        user
             The user to look up entitlements for.
-        guild : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]]
+        guild
             The guild to look up entitlements for.
-        before : hikari.undefined.UndefinedOr[hikari.snowflakes.SearchableSnowflakeish]
+        before
             Retrieve entitlements before this time or ID.
-        after : hikari.undefined.UndefinedOr[hikari.snowflakes.SearchableSnowflakeish]
+        after
             Retrieve entitlements after this time or ID.
-        limit : hikari.undefined.UndefinedOr[int]
+        limit
             Number of entitlements to return, 1-100, default 100.
-        exclude_ended : hikari.undefined.UndefinedOr[bool]
+        exclude_ended
             Whether or not ended entitlements should be omitted.
 
         Returns
@@ -8376,13 +8381,13 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        application : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]
+        application
             The application to create the entitlement for.
-        sku : hikari.snowflakes.SnowflakeishOr[hikari.monetization.SKU]
+        sku
             The SKU to create a test entitlement for.
-        owner_id : hikari.snowflakes.Snowflakeish
+        owner_id
             The ID of the owner of the entitlement.
-        owner_type : hikari.entitlements.EntitlementOwnerType
+        owner_type
             The type of the owner of the entitlement.
 
         Returns
@@ -8416,9 +8421,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Parameters
         ----------
-        application : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]
+        application
             The application to delete the entitlement from.
-        entitlement : hikari.snowflakes.SnowflakeishOr[hikari.entitlements.Entitlement]
+        entitlement
             The entitlement to delete.
 
         Raises

--- a/hikari/api/shard.py
+++ b/hikari/api/shard.py
@@ -147,16 +147,16 @@ class GatewayShard(abc.ABC):
 
         Other Parameters
         ----------------
-        idle_since : hikari.undefined.UndefinedNoneOr[datetime.datetime]
+        idle_since
             The datetime that the user started being idle. If undefined, this
             will not be changed.
-        afk : hikari.undefined.UndefinedOr[bool]
+        afk
             Whether to mark the user as AFK. If undefined, this will not be
             changed.
-        activity : hikari.undefined.UndefinedNoneOr[hikari.presences.Activity]
+        activity
             The activity to appear to be playing. If undefined, this will not be
             changed.
-        status : hikari.undefined.UndefinedOr[hikari.presences.Status]
+        status
             The web status to show. If undefined, this will not be changed.
         """
 
@@ -173,16 +173,16 @@ class GatewayShard(abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild or guild ID to update the voice state for.
-        channel : typing.Optional[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildVoiceChannel]]
+        channel
             The channel or channel ID to update the voice state for. If [`None`][]
             then the bot will leave the voice channel that it is in for the
             given guild.
-        self_mute : bool
+        self_mute
             If specified and [`True`][], the bot will mute itself in that
             voice channel. If [`False`][], then it will unmute itself.
-        self_deaf : bool
+        self_deaf
             If specified and [`True`][], the bot will deafen itself in that
             voice channel. If [`False`][], then it will undeafen itself.
         """
@@ -206,20 +206,20 @@ class GatewayShard(abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.guilds.Guild
+        guild
             The guild to request chunk for.
 
         Other Parameters
         ----------------
-        include_presences : hikari.undefined.UndefinedOr[bool]
+        include_presences
             If provided, whether to request presences.
-        query : str
+        query
             If not `""`, request the members which username starts with the string.
-        limit : int
+        limit
             Maximum number of members to send matching the query.
-        users : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishSequence[hikari.users.User]]
+        users
             If provided, the users to request for.
-        nonce : hikari.undefined.UndefinedOr[str]
+        nonce
             If provided, the nonce to be sent with guild chunks.
 
         Raises

--- a/hikari/api/special_endpoints.py
+++ b/hikari/api/special_endpoints.py
@@ -280,22 +280,22 @@ class GuildBuilder(abc.ABC):
 
         Parameters
         ----------
-        name : str
+        name
             The role's name.
 
         Other Parameters
         ----------------
-        permissions : hikari.undefined.UndefinedOr[hikari.permissions.Permissions]
+        permissions
             If provided, the permissions for the role.
-        color : hikari.undefined.UndefinedOr[hikari.colors.Colorish]
+        color
             If provided, the role's color.
-        colour : hikari.undefined.UndefinedOr[hikari.colors.Colorish]
+        colour
             An alias for `color`.
-        hoist : hikari.undefined.UndefinedOr[bool]
+        hoist
             If provided, whether to hoist the role.
-        mentionable : hikari.undefined.UndefinedOr[bool]
+        mentionable
             If provided, whether to make the role mentionable.
-        position : hikari.undefined.UndefinedOr[int]
+        position
             If provided, the position of the role.
 
         Returns
@@ -332,14 +332,14 @@ class GuildBuilder(abc.ABC):
 
         Parameters
         ----------
-        name : str
+        name
             The channels name. Must be between 2 and 1000 characters.
 
         Other Parameters
         ----------------
-        position : hikari.undefined.UndefinedOr[int]
+        position
             If provided, the position of the category.
-        permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
+        permission_overwrites
             If provided, the permission overwrites for the category.
 
         Returns
@@ -371,25 +371,25 @@ class GuildBuilder(abc.ABC):
 
         Parameters
         ----------
-        name : str
+        name
             The channels name. Must be between 2 and 1000 characters.
 
         Other Parameters
         ----------------
-        position : hikari.undefined.UndefinedOr[int]
+        position
             If provided, the position of the channel (relative to the
             category, if any).
-        topic : hikari.undefined.UndefinedOr[str]
+        topic
             If provided, the channels topic. Maximum 1024 characters.
-        nsfw : hikari.undefined.UndefinedOr[bool]
+        nsfw
             If provided, whether to mark the channel as NSFW.
-        rate_limit_per_user : hikari.undefined.UndefinedOr[int]
+        rate_limit_per_user
             If provided, the amount of seconds a user has to wait
             before being able to send another message in the channel.
             Maximum 21600 seconds.
-        permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
+        permission_overwrites
             If provided, the permission overwrites for the channel.
-        parent_id : hikari.undefined.UndefinedOr[hikari.snowflakes.Snowflake]
+        parent_id
             The ID of the category to create the channel under.
 
         Returns
@@ -422,31 +422,31 @@ class GuildBuilder(abc.ABC):
 
         Parameters
         ----------
-        name : str
+        name
             The channels name. Must be between 2 and 1000 characters.
 
         Other Parameters
         ----------------
-        position : hikari.undefined.UndefinedOr[int]
+        position
             If provided, the position of the channel (relative to the
             category, if any).
-        user_limit : hikari.undefined.UndefinedOr[int]
+        user_limit
             If provided, the maximum users in the channel at once.
             Must be between 0 and 99 with 0 meaning no limit.
-        bitrate : hikari.undefined.UndefinedOr[int]
+        bitrate
             If provided, the bitrate for the channel. Must be
             between 8000 and 96000 or 8000 and 128000 for VIP
             servers.
-        video_quality_mode : hikari.undefined.UndefinedOr[typing.Union[hikari.channels.VideoQualityMode, int]]
+        video_quality_mode
             If provided, the new video quality mode for the channel.
-        permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
+        permission_overwrites
             If provided, the permission overwrites for the channel.
-        region : hikari.undefined.UndefinedOr[typing.Union[hikari.voices.VoiceRegion, str]]
-             If provided, the voice region to for this channel. Passing
-             [`None`][] here will set it to "auto" mode where the used
-             region will be decided based on the first person who connects to it
-             when it's empty.
-        parent_id : hikari.undefined.UndefinedOr[hikari.snowflakes.Snowflake]
+        region
+            If provided, the voice region to for this channel. Passing
+            [`None`][] here will set it to "auto" mode where the used
+            region will be decided based on the first person who connects to it
+            when it's empty.
+        parent_id
             The ID of the category to create the channel under.
 
         Returns
@@ -478,29 +478,29 @@ class GuildBuilder(abc.ABC):
 
         Parameters
         ----------
-        name : str
+        name
             The channels name. Must be between 2 and 1000 characters.
 
         Other Parameters
         ----------------
-        position : hikari.undefined.UndefinedOr[int]
+        position
             If provided, the position of the channel (relative to the
             category, if any).
-        user_limit : hikari.undefined.UndefinedOr[int]
+        user_limit
             If provided, the maximum users in the channel at once.
             Must be between 0 and 99 with 0 meaning no limit.
-        bitrate : hikari.undefined.UndefinedOr[int]
+        bitrate
             If provided, the bitrate for the channel. Must be
             between 8000 and 96000 or 8000 and 128000 for VIP
             servers.
-        permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
+        permission_overwrites
             If provided, the permission overwrites for the channel.
-        region : hikari.undefined.UndefinedOr[typing.Union[hikari.voices.VoiceRegion, str]]
-             If provided, the voice region to for this channel. Passing
-             [`None`][] here will set it to "auto" mode where the used
-             region will be decided based on the first person who connects to it
-             when it's empty.
-        parent_id : hikari.undefined.UndefinedOr[hikari.snowflakes.Snowflake]
+        region
+            If provided, the voice region to for this channel. Passing
+            [`None`][] here will set it to "auto" mode where the used
+            region will be decided based on the first person who connects to it
+            when it's empty.
+        parent_id
             The ID of the category to create the channel under.
 
         Returns
@@ -532,7 +532,7 @@ class InteractionResponseBuilder(abc.ABC):
 
         Parameters
         ----------
-        entity_factory : hikari.api.entity_factory.EntityFactory
+        entity_factory
             The entity factory to use to serialize entities within this builder.
 
         Returns
@@ -575,7 +575,7 @@ class InteractionDeferredBuilder(InteractionResponseBuilder, abc.ABC):
 
         Parameters
         ----------
-        flags : typing.Union[hikari.undefined.UndefinedType, int, hikari.messages.MessageFlag]
+        flags
             The message flags to set for this response.
 
         Returns
@@ -647,7 +647,7 @@ class InteractionAutocompleteBuilder(InteractionResponseBuilder, abc.ABC):
 
         Parameters
         ----------
-        choices : typing.Sequence[AutocompleteChoiceBuilder]
+        choices
             The choices to set.
 
         Returns
@@ -763,7 +763,7 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
 
         Parameters
         ----------
-        attachment : hikari.files.Resourceish
+        attachment
             The attachment to add.
 
         Returns
@@ -778,7 +778,7 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
 
         Parameters
         ----------
-        component : ComponentBuilder
+        component
             The component builder to add to this response.
 
         Returns
@@ -793,7 +793,7 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
 
         Parameters
         ----------
-        embed : hikari.embeds.Embed
+        embed
             Object of the embed to add to this response.
 
         Returns
@@ -808,7 +808,7 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
 
         Parameters
         ----------
-        content : hikari.undefined.UndefinedOr[str]
+        content
             The message content to set for this response.
 
         Returns
@@ -827,7 +827,7 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
 
         Parameters
         ----------
-        flags : typing.Union[hikari.undefined.UndefinedType, int, hikari.messages.MessageFlag]
+        flags
             The message flags to set for this response.
 
         Returns
@@ -842,7 +842,7 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
 
         Parameters
         ----------
-        tts : bool
+        tts
             Whether this response should trigger text-to-speech processing.
 
         Returns
@@ -857,7 +857,7 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
 
         Parameters
         ----------
-        mentions : hikari.undefined.UndefinedOr[bool]
+        mentions
             Whether this response should be able to mention @everyone/@here.
 
         Returns
@@ -878,7 +878,7 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
 
         Parameters
         ----------
-        mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], bool]]
+        mentions
             Either a sequence of object/IDs of the roles mentions should be enabled for,
             [`False`][] or [`hikari.undefined.UNDEFINED`][] to disallow any role
             mentions or [`True`][] to allow all role mentions.
@@ -887,7 +887,7 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
         -------
         InteractionMessageBuilder
             Object of this builder to allow for chained calls.
-        """  # noqa: E501 - Line too long
+        """
 
     @abc.abstractmethod
     def set_user_mentions(
@@ -901,7 +901,7 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
 
         Parameters
         ----------
-        mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], bool]]
+        mentions
             Either a sequence of object/IDs of the users mentions should be enabled for,
             [`False`][] or [`hikari.undefined.UNDEFINED`][] to disallow any user
             mentions or [`True`][] to allow all user mentions.
@@ -910,7 +910,7 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
         -------
         InteractionMessageBuilder
             Object of this builder to allow for chained calls.
-        """  # noqa: E501 - Line too long
+        """
 
 
 class InteractionModalBuilder(InteractionResponseBuilder, abc.ABC):
@@ -949,7 +949,7 @@ class InteractionModalBuilder(InteractionResponseBuilder, abc.ABC):
 
         Parameters
         ----------
-        title : str
+        title
             The title that will show up in the modal.
         """
 
@@ -959,7 +959,7 @@ class InteractionModalBuilder(InteractionResponseBuilder, abc.ABC):
 
         Parameters
         ----------
-        custom_id : str
+        custom_id
             The developer set custom ID used for identifying interactions with this modal.
         """
 
@@ -969,7 +969,7 @@ class InteractionModalBuilder(InteractionResponseBuilder, abc.ABC):
 
         Parameters
         ----------
-        component : ComponentBuilder
+        component
             The component builder to add to this modal.
         """
 
@@ -1048,7 +1048,7 @@ class CommandBuilder(abc.ABC):
 
         Parameters
         ----------
-        name : str
+        name
             The name to set for this command.
 
         Returns
@@ -1063,7 +1063,7 @@ class CommandBuilder(abc.ABC):
 
         Parameters
         ----------
-        id_ : hikari.undefined.UndefinedOr[hikari.snowflakes.Snowflake]
+        id_
             The ID to set for this command.
 
         Returns
@@ -1080,7 +1080,7 @@ class CommandBuilder(abc.ABC):
 
         Parameters
         ----------
-        default_member_permissions : hikari.undefined.UndefinedOr[bool]
+        default_member_permissions
             The default member permissions to utilize this command by default.
 
             If `0`, then it will be available for all members. Note that this doesn't affect
@@ -1098,7 +1098,7 @@ class CommandBuilder(abc.ABC):
 
         Parameters
         ----------
-        state : hikari.undefined.UndefinedOr[bool]
+        state
             Whether this command is enabled in DMs with the bot.
 
         Returns
@@ -1113,7 +1113,7 @@ class CommandBuilder(abc.ABC):
 
         Parameters
         ----------
-        state : hikari.undefined.UndefinedOr[bool]
+        state
             Whether this command is age-restricted.
 
         Returns
@@ -1130,7 +1130,7 @@ class CommandBuilder(abc.ABC):
 
         Parameters
         ----------
-        name_localizations : typing.Mapping[typing.Union[hikari.locales.Locale, str], str]
+        name_localizations
             The name localizations to set for this command.
 
         Returns
@@ -1145,7 +1145,7 @@ class CommandBuilder(abc.ABC):
 
         Parameters
         ----------
-        entity_factory : hikari.api.entity_factory.EntityFactory
+        entity_factory
             The entity factory to use to serialize entities within this builder.
 
         Returns
@@ -1167,14 +1167,14 @@ class CommandBuilder(abc.ABC):
 
         Parameters
         ----------
-        rest : hikari.api.rest.RESTClient
+        rest
             The REST client to use to make this request.
-        application : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]
+        application
             The application to create this command for.
 
         Other Parameters
         ----------------
-        guild : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]]
+        guild
             The guild to create this command for.
 
             If left undefined then this command will be declared globally.
@@ -1216,7 +1216,7 @@ class SlashCommandBuilder(CommandBuilder):
 
         Parameters
         ----------
-        description : str
+        description
             The description to set for this command.
 
         Returns
@@ -1233,7 +1233,7 @@ class SlashCommandBuilder(CommandBuilder):
 
         Parameters
         ----------
-        description_localizations : typing.Mapping[typing.Union[hikari.locales.Locale, str], str]
+        description_localizations
             The description localizations to set for this command.
 
         Returns
@@ -1251,7 +1251,7 @@ class SlashCommandBuilder(CommandBuilder):
 
         Parameters
         ----------
-        option : hikari.commands.CommandOption
+        option
             The option to add to this command.
 
         Returns
@@ -1276,14 +1276,14 @@ class SlashCommandBuilder(CommandBuilder):
 
         Parameters
         ----------
-        rest : hikari.api.rest.RESTClient
+        rest
             The REST client to use to make this request.
-        application : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]
+        application
             The application to create this command for.
 
         Other Parameters
         ----------------
-        guild : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]]
+        guild
             The guild to create this command for.
 
             If left undefined then this command will be declared globally.
@@ -1317,14 +1317,14 @@ class ContextMenuCommandBuilder(CommandBuilder):
 
         Parameters
         ----------
-        rest : hikari.api.rest.RESTClient
+        rest
             The REST client to use to make this request.
-        application : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]
+        application
             The application to create this command for.
 
         Other Parameters
         ----------------
-        guild : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]]
+        guild
             The guild to create this command for.
 
             If left undefined then this command will be declared globally.
@@ -1400,7 +1400,7 @@ class ButtonBuilder(ComponentBuilder, abc.ABC):
 
         Parameters
         ----------
-        emoji : typing.Union[hikari.snowflakes.Snowflakeish, hikari.emojis.Emoji, str, hikari.undefined.UndefinedType]
+        emoji
             Object, ID or raw string of the emoji which should be displayed on
             this button.
 
@@ -1416,7 +1416,7 @@ class ButtonBuilder(ComponentBuilder, abc.ABC):
 
         Parameters
         ----------
-        label : hikari.undefined.UndefinedOr[str]
+        label
             The text label to show on this button.
 
             This may be up to 80 characters long.
@@ -1433,7 +1433,7 @@ class ButtonBuilder(ComponentBuilder, abc.ABC):
 
         Parameters
         ----------
-        state : bool
+        state
             Whether this button should be disabled.
 
         Returns
@@ -1470,7 +1470,7 @@ class InteractiveButtonBuilder(ButtonBuilder, abc.ABC):
 
         Parameters
         ----------
-        custom_id : str
+        custom_id
             Developer set custom ID used for identifying this button.
 
         Returns
@@ -1516,7 +1516,7 @@ class SelectOptionBuilder(abc.ABC):
 
         Parameters
         ----------
-        label : str
+        label
             Label to set for this option. This can be up to 100 characters
             long.
 
@@ -1532,7 +1532,7 @@ class SelectOptionBuilder(abc.ABC):
 
         Parameters
         ----------
-        value : str
+        value
             Value to set for this option. This can be up to 100 characters
             long.
 
@@ -1548,7 +1548,7 @@ class SelectOptionBuilder(abc.ABC):
 
         Parameters
         ----------
-        value : hikari.undefined.UndefinedOr[str]
+        value
             Description to set for this option. This can be up to 100 characters
             long.
 
@@ -1566,7 +1566,7 @@ class SelectOptionBuilder(abc.ABC):
 
         Parameters
         ----------
-        emoji : typing.Union[hikari.snowflakes.Snowflakeish, hikari.emojis.Emoji, str, hikari.undefined.UndefinedType]
+        emoji
             Object, ID or raw string of the emoji which should be displayed on
             this option.
 
@@ -1582,7 +1582,7 @@ class SelectOptionBuilder(abc.ABC):
 
         Parameters
         ----------
-        state : bool
+        state
             Whether this option should be selected by default.
 
         Returns
@@ -1648,7 +1648,7 @@ class SelectMenuBuilder(ComponentBuilder, abc.ABC):
 
         Parameters
         ----------
-        custom_id : str
+        custom_id
             Developer set custom ID used for identifying this menu.
 
         Returns
@@ -1663,7 +1663,7 @@ class SelectMenuBuilder(ComponentBuilder, abc.ABC):
 
         Parameters
         ----------
-        state : bool
+        state
             Whether this option is disabled.
 
         Returns
@@ -1678,7 +1678,7 @@ class SelectMenuBuilder(ComponentBuilder, abc.ABC):
 
         Parameters
         ----------
-        value : hikari.undefined.UndefinedOr[str]
+        value
             Place-holder text to be displayed when no option is selected.
             Max 100 characters.
 
@@ -1698,7 +1698,7 @@ class SelectMenuBuilder(ComponentBuilder, abc.ABC):
 
         Parameters
         ----------
-        value : int
+        value
             The minimum amount of options which need to be selected for this menu.
 
         Returns
@@ -1717,7 +1717,7 @@ class SelectMenuBuilder(ComponentBuilder, abc.ABC):
 
         Parameters
         ----------
-        value : int
+        value
             The maximum amount of options which can selected for this menu.
 
         Returns
@@ -1757,17 +1757,17 @@ class TextSelectMenuBuilder(SelectMenuBuilder, abc.ABC, typing.Generic[_ParentT]
 
         Parameters
         ----------
-        label : str
+        label
             The user-facing name of this option, max 100 characters.
-        value : str
+        value
             The developer defined value of this option, max 100 characters.
-        description : hikari.undefined.UndefinedOr[str]
+        description
             The option's description.
 
             This can be up to 100 characters long.
-        emoji : typing.Union[hikari.snowflakes.Snowflakeish, hikari.emojis.Emoji, str, hikari.undefined.UndefinedType]
+        emoji
             The option's display emoji.
-        is_default : bool
+        is_default
             Whether this option should be selected by default.
 
         Returns
@@ -1793,7 +1793,7 @@ class ChannelSelectMenuBuilder(SelectMenuBuilder, abc.ABC):
 
         Parameters
         ----------
-        value : typing.Sequence[hikari.channels.ChannelType]
+        value
             The valid channel types for this menu.
 
         Returns
@@ -1864,7 +1864,7 @@ class TextInputBuilder(ComponentBuilder, abc.ABC):
 
         Parameters
         ----------
-        style : typing.Union[hikari.modal_interactions.TextInputStyle, int]
+        style
             Style to use for the text input.
 
         Returns
@@ -1879,7 +1879,7 @@ class TextInputBuilder(ComponentBuilder, abc.ABC):
 
         Parameters
         ----------
-        custom_id : str
+        custom_id
             Developer set custom ID used for identifying this text input.
 
         Returns
@@ -1894,7 +1894,7 @@ class TextInputBuilder(ComponentBuilder, abc.ABC):
 
         Parameters
         ----------
-        label : str
+        label
             Label above this text input.
 
         Returns
@@ -1909,7 +1909,7 @@ class TextInputBuilder(ComponentBuilder, abc.ABC):
 
         Parameters
         ----------
-        placeholder : hikari.undefined.UndefinedOr[str]
+        placeholder
             Placeholder text that will disappear when the user types anything.
 
         Returns
@@ -1924,7 +1924,7 @@ class TextInputBuilder(ComponentBuilder, abc.ABC):
 
         Parameters
         ----------
-        value : hikari.undefined.UndefinedOr[str]
+        value
             Pre-filled text that will be sent if the user does not write anything.
 
         Returns
@@ -1939,7 +1939,7 @@ class TextInputBuilder(ComponentBuilder, abc.ABC):
 
         Parameters
         ----------
-        required : bool
+        required
             Whether this text input is required to be filled-in.
 
         Returns
@@ -1954,7 +1954,7 @@ class TextInputBuilder(ComponentBuilder, abc.ABC):
 
         Parameters
         ----------
-        min_length : int
+        min_length
             The minimum length the text should have.
 
         Returns
@@ -1969,7 +1969,7 @@ class TextInputBuilder(ComponentBuilder, abc.ABC):
 
         Parameters
         ----------
-        max_length : int
+        max_length
             The maximum length the text should have.
 
         Returns
@@ -2006,7 +2006,7 @@ class MessageActionRowBuilder(ComponentBuilder, abc.ABC):
 
         Parameters
         ----------
-        component : ComponentBuilder
+        component
             The component builder to add to the action row.
 
         Returns
@@ -2033,16 +2033,16 @@ class MessageActionRowBuilder(ComponentBuilder, abc.ABC):
 
         Parameters
         ----------
-        style : hikari.messages.InteractiveButtonTypesT
+        style
             The button's style.
-        custom_id : str
+        custom_id
             The developer-defined custom identifier used to identify which button
             triggered component interactions.
-        emoji : typing.Union[hikari.snowflakes.Snowflakeish, hikari.emojis.Emoji, str, hikari.undefined.UndefinedType]
+        emoji
             The button's display emoji.
-        label : hikari.undefined.UndefinedOr[str]
+        label
             The button's display label.
-        is_disabled : bool
+        is_disabled
             Whether the button should be marked as disabled.
 
         Returns
@@ -2068,13 +2068,13 @@ class MessageActionRowBuilder(ComponentBuilder, abc.ABC):
 
         Parameters
         ----------
-        url : str
+        url
             The URL the link button should redirect to.
-        emoji : typing.Union[hikari.snowflakes.Snowflakeish, hikari.emojis.Emoji, str, hikari.undefined.UndefinedType]
+        emoji
             The button's display emoji.
-        label : hikari.undefined.UndefinedOr[str]
+        label
             The button's display label.
-        is_disabled : bool
+        is_disabled
             Whether the button should be marked as disabled.
 
         Returns
@@ -2103,18 +2103,18 @@ class MessageActionRowBuilder(ComponentBuilder, abc.ABC):
 
         Parameters
         ----------
-        type_ : typing.Union[hikari.components.ComponentType, int]
+        type_
             The type for the select menu.
-        custom_id : str
+        custom_id
             A developer-defined custom identifier used to identify which menu
             triggered component interactions.
-        placeholder : hikari.undefined.UndefinedOr[str]
+        placeholder
             Placeholder text to show when no entries have been selected.
-        min_values : int
+        min_values
             The minimum amount of entries which need to be selected.
-        max_values : int
+        max_values
             The maximum amount of entries which can be selected.
-        is_disabled : bool
+        is_disabled
             Whether this select menu should be marked as disabled.
 
         Returns
@@ -2144,21 +2144,21 @@ class MessageActionRowBuilder(ComponentBuilder, abc.ABC):
 
         Parameters
         ----------
-        custom_id : str
+        custom_id
             A developer-defined custom identifier used to identify which menu
             triggered component interactions.
-        channel_types : typing.Sequence[hikari.channels.ChannelType]
+        channel_types
             The channel types this select menu should allow.
 
             If left as an empty sequence then there will be no
             channel type restriction.
-        placeholder : hikari.undefined.UndefinedOr[str]
+        placeholder
             Placeholder text to show when no entries have been selected.
-        min_values : int
+        min_values
             The minimum amount of entries which need to be selected.
-        max_values : int
+        max_values
             The maximum amount of entries which can be selected.
-        is_disabled : bool
+        is_disabled
             Whether this select menu should be marked as disabled.
 
         Returns
@@ -2187,16 +2187,16 @@ class MessageActionRowBuilder(ComponentBuilder, abc.ABC):
 
         Parameters
         ----------
-        custom_id : str
+        custom_id
             A developer-defined custom identifier used to identify which menu
             triggered component interactions.
-        placeholder : hikari.undefined.UndefinedOr[str]
+        placeholder
             Placeholder text to show when no entries have been selected.
-        min_values : int
+        min_values
             The minimum amount of entries which need to be selected.
-        max_values : int
+        max_values
             The maximum amount of entries which can be selected.
-        is_disabled : bool
+        is_disabled
             Whether this select menu should be marked as disabled.
 
         Returns
@@ -2243,7 +2243,7 @@ class ModalActionRowBuilder(ComponentBuilder, abc.ABC):
 
         Parameters
         ----------
-        component : ComponentBuilder
+        component
             The component builder to add to the action row.
 
         Returns
@@ -2270,23 +2270,23 @@ class ModalActionRowBuilder(ComponentBuilder, abc.ABC):
 
         Parameters
         ----------
-        custom_id : str
+        custom_id
             Developer set custom ID used for identifying this text input.
-        label : str
+        label
             Label above this text input.
-        style : hikari.components.TextInputStyle
+        style
             The text input's style.
-        placeholder : hikari.undefined.UndefinedOr[str]
+        placeholder
             Placeholder text to display when the text input is empty.
-        value : hikari.undefined.UndefinedOr[str]
+        value
             Default text to pre-fill the field with.
-        required : bool
+        required
             Whether text must be supplied for this text input.
-        min_length : int
+        min_length
             Minimum length the input text can be.
 
             This can be greater than or equal to 0 and less than or equal to 4000.
-        max_length : int
+        max_length
             Maximum length the input text can be.
 
             This can be greater than or equal to 1 and less than or equal to 4000.

--- a/hikari/api/voice.py
+++ b/hikari/api/voice.py
@@ -71,7 +71,7 @@ class VoiceComponent(abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.Guild]
+        guild
             The guild to disconnect from.
         """
 
@@ -95,21 +95,21 @@ class VoiceComponent(abc.ABC):
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.Guild]
+        guild
             The guild to connect to.
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildVoiceChannel]
+        channel
             The channel or channel ID to connect to.
-        voice_connection_type : typing.Type[VoiceConnection]
+        voice_connection_type
             The type of voice connection to use. This should be initialized
             internally using the [`hikari.api.voice.VoiceConnection.initialize`][]
             classmethod.
-        deaf : bool
+        deaf
             If [`True`][], the client will enter the voice channel deafened
             (thus unable to hear other users).
-        mute : bool
+        mute
             If [`True`][], the client will enter the voice channel muted
             (thus unable to send audio).
-        timeout : typing.Optional[int]
+        timeout
             The amount of time, in seconds, to wait before erroring when
             connecting to the voice channel. If timeout is [`None`][] there will be
             no timeout.
@@ -117,8 +117,7 @@ class VoiceComponent(abc.ABC):
             !!! warning
                 If timeout is [`None`][], this function will be awaited forever if an
                 invalid `guild_id` or `channel_id` is provided.
-
-        **kwargs : typing.Any
+        **kwargs
             Any arguments to provide to the
             [`hikari.api.voice.VoiceConnection.initialize`][] method.
 
@@ -165,30 +164,30 @@ class VoiceConnection(abc.ABC):
 
         Parameters
         ----------
-        channel_id : hikari.snowflakes.Snowflake
+        channel_id
             The channel ID that the voice connection is actively connected to.
-        endpoint : str
+        endpoint
             The voice websocket endpoint to connect to. Will contain the
             protocol at the start (i.e. [wss://][]), and end with the **correct**
             port (the port and protocol are sanitized since Discord still
             provide the wrong information four years later).
-        guild_id : hikari.snowflakes.Snowflake
+        guild_id
             The guild ID that the websocket should connect to.
-        on_close : typing.Callable[[T], typing.Awaitable[None]]
+        on_close
             A shutdown hook to invoke when closing a connection to ensure the
             connection is unregistered from the voice component safely.
-        owner : VoiceComponent
+        owner
             The component that made this connection object.
-        session_id : str
+        session_id
             The voice session ID to use.
-        shard_id : int
+        shard_id
             The associated shard ID that the voice connection was generated
             from.
-        token : str
+        token
             The voice token to use.
-        user_id : hikari.snowflakes.Snowflake
+        user_id
             The user ID of the account that just joined the voice channel.
-        **kwargs : typing.Any
+        **kwargs
             Any implementation-specific arguments to provide to the
             voice connection that is being initialized.
 

--- a/hikari/applications.py
+++ b/hikari/applications.py
@@ -487,10 +487,10 @@ class Team(snowflakes.Unique):
 
         Parameters
         ----------
-        ext : str
+        ext
             The extension to use for this URL.
             Supports `png`, `jpeg`, `jpg` and `webp`.
-        size : int
+        size
             The size to set for the URL.
             Can be any power of two between 16 and 4096 inclusive.
 
@@ -539,10 +539,10 @@ class InviteApplication(guilds.PartialApplication):
 
         Parameters
         ----------
-        ext : str
+        ext
             The extension to use for this URL.
             Supports `png`, `jpeg`, `jpg` and `webp`.
-        size : int
+        size
             The size to set for the URL.
             Can be any power of two between `16` and `4096`.
 
@@ -645,10 +645,10 @@ class Application(guilds.PartialApplication):
 
         Parameters
         ----------
-        ext : str
+        ext
             The extension to use for this URL.
             Supports `png`, `jpeg`, `jpg` and `webp`.
-        size : int
+        size
             The size to set for the URL.
             Can be any power of two between `16` and `4096`.
 

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -420,17 +420,17 @@ class TextableChannel(PartialChannel):
 
         Other Parameters
         ----------------
-        before : hikari.undefined.UndefinedOr[snowflakes.SearchableSnowflakeishOr[hikari.snowflakes.Unique]]
+        before
             If provided, fetch messages before this snowflakes. If you provide
             a datetime object, it will be transformed into a snowflakes. This
             may be any other Discord entity that has an ID. In this case, the
             date the object was first created will be used.
-        after : hikari.undefined.UndefinedOr[snowflakes.SearchableSnowflakeishOr[hikari.snowflakes.Unique]]
+        after
             If provided, fetch messages after this snowflakes. If you provide
             a datetime object, it will be transformed into a snowflakes. This
             may be any other Discord entity that has an ID. In this case, the
             date the object was first created will be used.
-        around : hikari.undefined.UndefinedOr[snowflakes.SearchableSnowflakeishOr[hikari.snowflakes.Unique]]
+        around
             If provided, fetch messages around this snowflakes. If you provide
             a datetime object, it will be transformed into a snowflakes. This
             may be any other Discord entity that has an ID. In this case, the
@@ -462,7 +462,7 @@ class TextableChannel(PartialChannel):
 
         Parameters
         ----------
-        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        message
             The message to fetch. This may be the object or the ID of an
             existing channel.
 
@@ -519,7 +519,7 @@ class TextableChannel(PartialChannel):
 
         Parameters
         ----------
-        content : hikari.undefined.UndefinedOr[typing.Any]
+        content
             If provided, the message contents. If
             [`hikari.undefined.UNDEFINED`][], then nothing will be sent
             in the content. Any other value here will be cast to a
@@ -535,7 +535,7 @@ class TextableChannel(PartialChannel):
 
         Other Parameters
         ----------------
-        attachment : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
+        attachment
             If provided, the message attachment. This can be a resource,
             or string of a path on your computer or a URL.
 
@@ -564,64 +564,65 @@ class TextableChannel(PartialChannel):
                 type of [`concurrent.futures.Executor`][] that is being used for
                 the application (default is a thread pool which supports this
                 behaviour).
-        attachments : hikari.undefined.UndefinedOr[typing.Sequence[hikari.files.Resourceish]]
+        attachments
             If provided, the message attachments. These can be resources, or
             strings consisting of paths on your computer or URLs.
-        component : hikari.undefined.UndefinedOr[hikari.api.special_endpoints.ComponentBuilder]
+        component
             If provided, builder object of the component to include in this message.
-        components : hikari.undefined.UndefinedOr[typing.Sequence[hikari.api.special_endpoints.ComponentBuilder]]
+        components
             If provided, a sequence of the component builder objects to include
             in this message.
-        embed : hikari.undefined.UndefinedOr[hikari.embeds.Embed]
+        embed
             If provided, the message embed.
-        embeds : hikari.undefined.UndefinedOr[typing.Sequence[hikari.embeds.Embed]]
+        embeds
             If provided, the message embeds.
-        sticker : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.stickers.PartialSticker]]
+        sticker
             If provided, the object or ID of a sticker to send on the message.
 
             As of writing, bots can only send custom stickers from the current guild.
-        stickers : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishSequence[hikari.stickers.PartialSticker]]
+        stickers
             If provided, a sequence of the objects and IDs of up to 3 stickers
             to send on the message.
 
             As of writing, bots can only send custom stickers from the current guild.
-        tts : hikari.undefined.UndefinedOr[bool]
+        tts
             If provided, whether the message will be TTS (Text To Speech).
-        reply : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]]
+        reply
             If provided, the message to reply to.
-        reply_must_exist : hikari.undefined.UndefinedOr[bool]
+        reply_must_exist
             If provided, whether to error if the message being replied to does
             not exist instead of sending as a normal (non-reply) message.
 
             This will not do anything if not being used with `reply`.
-        mentions_everyone : hikari.undefined.UndefinedOr[bool]
+        mentions_everyone
             If provided, whether the message should parse @everyone/@here
             mentions.
-        mentions_reply : hikari.undefined.UndefinedOr[bool]
+        mentions_reply
             If provided, whether to mention the author of the message
             that is being replied to.
 
             This will not do anything if not being used with `reply`.
-        user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], bool]]
+        user_mentions
             If provided, and [`True`][], all mentions will be parsed.
             If provided, and [`False`][], no mentions will be parsed.
             Alternatively this may be a collection of
             [`hikari.snowflakes.Snowflake`][], or
             [`hikari.users.PartialUser`][] derivatives to enforce mentioning
             specific users.
-        role_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole], bool]]
+        role_mentions
             If provided, and [`True`][], all mentions will be parsed.
             If provided, and [`False`][], no mentions will be parsed.
             Alternatively this may be a collection of
             [`hikari.snowflakes.Snowflake`][], or
             [`hikari.guilds.PartialRole`][] derivatives to enforce mentioning
             specific roles.
-        flags : hikari.undefined.UndefinedOr[hikari.messages.MessageFlag]
+        flags
             If provided, optional flags to set on the message. If
             [`hikari.undefined.UNDEFINED`][], then nothing is changed.
 
             Note that some flags may not be able to be set. Currently the only
-            flags that can be set are [`hikari.messages.MessageFlag.NONE`][] and [`hikari.messages.MessageFlag.SUPPRESS_EMBEDS`][].
+            flags that can be set are [`hikari.messages.MessageFlag.NONE`][] and
+            [`hikari.messages.MessageFlag.SUPPRESS_EMBEDS`][].
 
         Returns
         -------
@@ -650,7 +651,7 @@ class TextableChannel(PartialChannel):
             `role_mentions` or `user_mentions`.
         TypeError
             If both `attachment` and `attachments` are specified.
-        """  # noqa: E501 - Line too long
+        """
         return await self.app.rest.create_message(
             channel=self.id,
             content=content,
@@ -728,7 +729,7 @@ class TextableChannel(PartialChannel):
 
         Parameters
         ----------
-        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        message
             The message to pin. This may be the object or the ID
             of an existing message.
 
@@ -754,7 +755,7 @@ class TextableChannel(PartialChannel):
 
         Parameters
         ----------
-        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        message
             The message to unpin. This may be the object or the ID of an
             existing message.
 
@@ -816,7 +817,7 @@ class TextableChannel(PartialChannel):
 
         Other Parameters
         ----------------
-        *other_messages : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        *other_messages
             The objects and/or IDs of other existing messages to delete.
 
         Raises
@@ -903,10 +904,10 @@ class GroupDMChannel(PrivateChannel):
 
         Parameters
         ----------
-        ext : str
+        ext
             The extension to use for this URL.
             Supports `png`, `jpeg`, `jpg` and `webp`.
-        size : int
+        size
             The size to set for the URL.
             Can be any power of two between `16` and `4096`.
 
@@ -1021,62 +1022,62 @@ class GuildChannel(PartialChannel):
 
         Other Parameters
         ----------------
-        name : hikari.undefined.UndefinedOr[[str]
+        name
             If provided, the new name for the channel.
-        position : hikari.undefined.UndefinedOr[[int]
+        position
             If provided, the new position for the channel.
-        topic : hikari.undefined.UndefinedOr[str]
+        topic
             If provided, the new topic for the channel.
-        nsfw : hikari.undefined.UndefinedOr[bool]
+        nsfw
             If provided, whether the channel should be marked as NSFW or not.
-        bitrate : hikari.undefined.UndefinedOr[int]
+        bitrate
             If provided, the new bitrate for the channel.
         video_quality_mode: hikari.undefined.UndefinedOr[typing.Union[hikari.channels.VideoQualityMode, int]]
             If provided, the new video quality mode for the channel.
-        user_limit : hikari.undefined.UndefinedOr[int]
+        user_limit
             If provided, the new user limit in the channel.
-        rate_limit_per_user : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        rate_limit_per_user
             If provided, the new rate limit per user in the channel.
-        region : hikari.undefined.UndefinedOr[typing.Union[hikari.voices.VoiceRegion, str]]
+        region
             If provided, the voice region to set for this channel. Passing
             [`None`][] here will set it to "auto" mode where the used
             region will be decided based on the first person who connects to it
             when it's empty.
-        permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
+        permission_overwrites
             If provided, the new permission overwrites for the channel.
-        parent_category : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildCategory]]
+        parent_category
             If provided, the new guild category for the channel.
-        default_auto_archive_duration : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        default_auto_archive_duration
             If provided, the auto archive duration Discord's end user client
             should default to when creating threads in this channel.
 
             This should be either 60, 1440, 4320 or 10080 minutes, as of
             writing.
-        flags : hikari.undefined.UndefinedOr[ChannelFlag]
+        flags
             If provided, the new channel flags to use for the channel. This can
             only be used on a forum channel to apply ChannelFlag.REQUIRE_TAG, or
             on a forum thread to apply ChannelFlag.PINNED.
-        archived : hikari.undefined.UndefinedOr[bool]
+        archived
             If provided, the new archived state for the thread. This only
             applies to threads.
-        auto_archive_duration : hikari.undefined.UndefinedOr[time.Intervalish]
+        auto_archive_duration
             If provided, the new auto archive duration for this thread. This
             only applies to threads.
 
             This should be either 60, 1440, 4320 or 10080 minutes, as of
             writing.
-        locked : hikari.undefined.UndefinedOr[bool]
+        locked
             If provided, the new locked state for the thread. This only applies
             to threads.
 
             If it's locked then only people with [`hikari.permissions.Permissions.MANAGE_THREADS`][] can unarchive it.
-        invitable : hikari.undefined.UndefinedOr[bool]
+        invitable
             If provided, the new setting for whether non-moderators can invite
             new members to a private thread. This only applies to threads.
-        applied_tags : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishSequence[hikari.channels.ForumTag]]
+        applied_tags
             If provided, the new tags to apply to the thread. This only applies
             to threads in a forum channel.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -1166,20 +1167,20 @@ class PermissibleGuildChannel(GuildChannel):
 
         Parameters
         ----------
-        target : typing.Union[hikari.users.PartialUser, hikari.guilds.PartialRole, hikari.channels.PermissionOverwrite, hikari.snowflakes.Snowflakeish]
+        target
             The channel overwrite to edit. This may be the object or the ID of an
             existing overwrite.
 
         Other Parameters
         ----------------
-        target_type : hikari.undefined.UndefinedOr[typing.Union[hikari.channels.PermissionOverwriteType, int]]
+        target_type
             If provided, the type of the target to update. If unset, will attempt to get
             the type from `target`.
-        allow : hikari.undefined.UndefinedOr[hikari.permissions.Permissions]
+        allow
             If provided, the new value of all allowed permissions.
-        deny : hikari.undefined.UndefinedOr[hikari.permissions.Permissions]
+        deny
             If provided, the new value of all disallowed permissions.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -1203,7 +1204,7 @@ class PermissibleGuildChannel(GuildChannel):
             longer than `max_rate_limit` when making a request.
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
-        """  # noqa: E501 - Line too long
+        """
         if target_type is undefined.UNDEFINED:
             assert not isinstance(
                 target, int
@@ -1221,7 +1222,7 @@ class PermissibleGuildChannel(GuildChannel):
 
         Parameters
         ----------
-        target : typing.Union[hikari.users.PartialUser, hikari.guilds.PartialRole, hikari.channels.PermissionOverwrite, hikari.snowflakes.Snowflakeish]
+        target
             The channel overwrite to delete.
 
         Raises
@@ -1238,7 +1239,7 @@ class PermissibleGuildChannel(GuildChannel):
             longer than `max_rate_limit` when making a request.
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
-        """  # noqa: E501 - Line too long
+        """
         return await self.app.rest.delete_permission_overwrite(self.id, target)
 
 

--- a/hikari/colors.py
+++ b/hikari/colors.py
@@ -236,11 +236,11 @@ class Color(int):
 
         Parameters
         ----------
-        red : int
+        red
             Red channel.
-        green : int
+        green
             Green channel.
-        blue : int
+        blue
             Blue channel.
 
         Returns
@@ -270,11 +270,11 @@ class Color(int):
 
         Parameters
         ----------
-        red : float
+        red
             Red channel.
-        green : float
+        green
             Green channel.
-        blue : float
+        blue
             Blue channel.
 
         Returns
@@ -305,7 +305,7 @@ class Color(int):
 
         Parameters
         ----------
-        hex_code : str
+        hex_code
             A hexadecimal color code to parse. This may optionally start with
             a case insensitive `0x` or `#`.
 
@@ -343,7 +343,7 @@ class Color(int):
 
         Parameters
         ----------
-        integer : typing.SupportsInt
+        integer
             The raw color integer.
 
         Returns
@@ -393,7 +393,7 @@ class Color(int):
 
         Parameters
         ----------
-        tuple_str : str
+        tuple_str
             The string to parse.
 
         Returns
@@ -432,7 +432,7 @@ class Color(int):
 
         Parameters
         ----------
-        value : Colorish
+        value
             A color compatible values.
 
         Examples
@@ -514,12 +514,12 @@ class Color(int):
 
         Parameters
         ----------
-        length : int
+        length
             The number of bytes to produce. Should be around `3`, but not less.
-        byteorder : str
+        byteorder
             The endianness of the value represented by the bytes.
             Can be `"big"` endian or `"little"` endian.
-        signed : bool
+        signed
             Whether the value is signed or unsigned.
 
         Returns

--- a/hikari/commands.py
+++ b/hikari/commands.py
@@ -303,13 +303,13 @@ class PartialCommand(snowflakes.Unique):
 
         Other Parameters
         ----------------
-        name : hikari.undefined.UndefinedOr[str]
+        name
             The name to set for the command. Leave as [`hikari.undefined.UNDEFINED`][]
             to not change.
-        description : hikari.undefined.UndefinedOr[str]
+        description
             The description to set for the command. Leave as [`hikari.undefined.UNDEFINED`][]
             to not change.
-        options : hikari.undefined.UndefinedOr[typing.Sequence[CommandOption]]
+        options
             A sequence of up to 10 options to set for this command. Leave this as
             [`hikari.undefined.UNDEFINED`][] to not change.
 
@@ -372,7 +372,7 @@ class PartialCommand(snowflakes.Unique):
 
         Parameters
         ----------
-        guild : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]]
+        guild
             Object or ID of the guild to fetch the command permissions for.
 
         Returns
@@ -408,9 +408,9 @@ class PartialCommand(snowflakes.Unique):
 
         Parameters
         ----------
-        guild : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]]
+        guild
             Object or ID of the guild to set the command permissions in.
-        permissions : typing.Sequence[CommandPermission]
+        permissions
             Sequence of up to 10 of the permission objects to set.
 
         Returns

--- a/hikari/embeds.py
+++ b/hikari/embeds.py
@@ -82,11 +82,11 @@ class EmbedResource(files.Resource[files.AsyncReader]):
 
         Parameters
         ----------
-        executor : typing.Optional[concurrent.futures.Executor]
+        executor
             The executor to run in for blocking operations.
             If [`None`][], then the default executor is used for the
             current event loop.
-        head_only : bool
+        head_only
             If [`True`][], then the implementation may only retrieve
             HEAD information if supported. This currently only has
             any effect for web requests.
@@ -622,11 +622,11 @@ class Embed:
 
         Parameters
         ----------
-        name : typing.Optional[str]
+        name
             The optional name of the author.
-        url : typing.Optional[str]
+        url
             The optional URL of the author.
-        icon : typing.Optional[hikari.files.Resourceish]
+        icon
             The optional image to show next to the embed author.
 
             This can be many different things, to aid in convenience.
@@ -666,10 +666,10 @@ class Embed:
 
         Parameters
         ----------
-        text : typing.Optional[str]
+        text
             The mandatory text string to set in the footer.
             If [`None`][], the footer is removed.
-        icon : typing.Optional[hikari.files.Resourceish]
+        icon
             The optional image to show next to the embed footer.
 
             This can be many different things, to aid in convenience.
@@ -715,7 +715,7 @@ class Embed:
 
         Parameters
         ----------
-        image : typing.Optional[hikari.files.Resourceish]
+        image
             The optional resource to show for the embed image.
 
             This can be many different things, to aid in convenience.
@@ -755,7 +755,7 @@ class Embed:
 
         Parameters
         ----------
-        image : typing.Optional[hikari.files.Resourceish]
+        image
             The optional resource to show for the embed thumbnail.
 
             This can be many different things, to aid in convenience.
@@ -794,16 +794,16 @@ class Embed:
 
         Parameters
         ----------
-        name : str
+        name
             The mandatory non-empty field name. This must contain at least one
             non-whitespace character to be valid.
-        value : str
+        value
             The mandatory non-empty field value. This must contain at least one
             non-whitespace character to be valid.
 
         Other Parameters
         ----------------
-        inline : bool
+        inline
             If [`True`][], the embed field may be shown "inline" on some
             Discord clients with other fields. If [`False`][], it is always placed
             on a separate line. This will default to [`False`][].
@@ -831,18 +831,18 @@ class Embed:
 
         Parameters
         ----------
-        index : int
+        index
             The index of the field to edit.
 
         Other Parameters
         ----------------
-        name : hikari.undefined.UndefinedOr[str]
+        name
             The new field name to use. If left to the default ([`hikari.undefined.UNDEFINED`][]),
             then it will not be changed.
-        value : hikari.undefined.UndefinedOr[str]
+        value
             The new field value to use. If left to the default ([`hikari.undefined.UNDEFINED`][]),
             then it will not be changed.
-        inline : hikari.undefined.UndefinedOr[bool]
+        inline
             [`True`][] to inline the field, or [`False`][] to force
             it to be on a separate line. If left to the default ([`hikari.undefined.UNDEFINED`][]),
             then it will not be changed.
@@ -875,7 +875,7 @@ class Embed:
 
         Parameters
         ----------
-        index : int
+        index
             The index of the embed field to remove.
 
         Returns

--- a/hikari/emojis.py
+++ b/hikari/emojis.py
@@ -86,7 +86,7 @@ class Emoji(files.WebResource, abc.ABC):
 
         Parameters
         ----------
-        string : str
+        string
             The emoji object to parse.
 
         Returns
@@ -221,7 +221,7 @@ class UnicodeEmoji(str, Emoji):
 
         Parameters
         ----------
-        string : str
+        string
             The emoji object to parse.
 
         Returns
@@ -302,7 +302,7 @@ class CustomEmoji(snowflakes.Unique, Emoji):
 
         Parameters
         ----------
-        string : str
+        string
             The emoji mention to parse.
 
         Returns

--- a/hikari/events/base_events.py
+++ b/hikari/events/base_events.py
@@ -104,7 +104,7 @@ def get_required_intents_for(event_type: typing.Type[Event]) -> typing.Collectio
 
     Parameters
     ----------
-    event_type : typing.Type[Event]
+    event_type
         The event type to get required intents for.
 
     Returns
@@ -123,10 +123,10 @@ def requires_intents(first: intents.Intents, *rest: intents.Intents) -> typing.C
 
     Parameters
     ----------
-    first : hikari.intents.Intents
+    first
         First combination of intents that are acceptable in order to receive
         the decorated event type.
-    *rest : hikari.intents.Intents
+    *rest
         Zero or more additional combinations of intents to require for this
         event to be subscribed to.
     """

--- a/hikari/events/reaction_events.py
+++ b/hikari/events/reaction_events.py
@@ -133,7 +133,7 @@ class ReactionAddEvent(ReactionEvent, abc.ABC):
 
         Parameters
         ----------
-        emoji : typing.Union[hikari.emojis.Emoji, str]
+        emoji
             The emoji to check.
 
             Passing [`str`][] here indicates a unicode emoji.
@@ -178,7 +178,7 @@ class ReactionDeleteEvent(ReactionEvent, abc.ABC):
 
         Parameters
         ----------
-        emoji : typing.Union[hikari.emojis.Emoji, str]
+        emoji
             The emoji to check.
 
             Passing [`str`][] here indicates a unicode emoji.
@@ -225,7 +225,7 @@ class ReactionDeleteEmojiEvent(ReactionEvent, abc.ABC):
 
         Parameters
         ----------
-        emoji : typing.Union[hikari.emojis.Emoji, str]
+        emoji
             The emoji to check.
 
             Passing [`str`][] here indicates a unicode emoji.

--- a/hikari/files.py
+++ b/hikari/files.py
@@ -168,7 +168,7 @@ def ensure_resource(url_or_resource: Resourceish, /) -> Resource[AsyncReader]:
 
     Parameters
     ----------
-    url_or_resource : Resourceish
+    url_or_resource
         The item to convert. If a [`hikari.files.Resource`][] is passed, it is
         simply returned again. Anything else is converted to a [`hikari.files.Resource`][] first.
 
@@ -205,7 +205,7 @@ def guess_mimetype_from_filename(name: str, /) -> typing.Optional[str]:
 
     Parameters
     ----------
-    name : bytes
+    name
         The filename to inspect.
 
     Returns
@@ -227,7 +227,7 @@ def guess_mimetype_from_data(data: bytes, /) -> typing.Optional[str]:
 
     Parameters
     ----------
-    data : bytes
+    data
         The byte content to inspect.
 
     Returns
@@ -252,7 +252,7 @@ def guess_file_extension(mimetype: str) -> typing.Optional[str]:
 
     Parameters
     ----------
-    mimetype : str
+    mimetype
         The mimetype to guess the extension for.
 
     Examples
@@ -281,11 +281,11 @@ def generate_filename_from_details(
 
     Parameters
     ----------
-    mimetype : typing.Optional[str]
+    mimetype
         The mimetype of the content, or [`None`][] if not known.
-    extension : typing.Optional[str]
+    extension
         The file extension to use, or [`None`][] if not known.
-    data : typing.Optional[bytes]
+    data
         The data to inspect, or [`None`][] if not known.
 
     Returns
@@ -313,9 +313,9 @@ def to_data_uri(data: bytes, mimetype: typing.Optional[str]) -> str:
 
     Parameters
     ----------
-    data : bytes
+    data
         The data to encode as base64.
-    mimetype : typing.Optional[str]
+    mimetype
         The mimetype, or [`None`][] if we should attempt to guess it.
 
     Returns
@@ -468,7 +468,7 @@ class Resource(typing.Generic[ReaderImplT], abc.ABC):
 
         Parameters
         ----------
-        executor : typing.Optional[concurrent.futures.Executor]
+        executor
             The executor to run in for blocking operations.
             If [`None`][], then the default executor is used for the
             current event loop.
@@ -491,14 +491,14 @@ class Resource(typing.Generic[ReaderImplT], abc.ABC):
 
         Parameters
         ----------
-        path : Pathish
+        path
             The path to save this resource to. If this is a string, the
             path will be relative to the current working directory.
-        executor : typing.Optional[concurrent.futures.Executor]
+        executor
             The executor to run in for blocking operations.
             If [`None`][], then the default executor is used for
             the current event loop.
-        force : bool
+        force
             Whether to overwrite an existing file.
         """
         loop = asyncio.get_running_loop()
@@ -519,11 +519,11 @@ class Resource(typing.Generic[ReaderImplT], abc.ABC):
 
         Parameters
         ----------
-        executor : typing.Optional[concurrent.futures.Executor]
+        executor
             The executor to run in for blocking operations.
             If [`None`][], then the default executor is used for the
             current event loop.
-        head_only : bool
+        head_only
             If [`True`][], then only the headers for the HTTP resource this
             object points to will be fetched without downloading the entire
             content, which can be significantly faster if you are scanning
@@ -686,9 +686,9 @@ class WebResource(Resource[WebReader], abc.ABC):
 
         Parameters
         ----------
-        executor : typing.Optional[concurrent.futures.Executor]
+        executor
             Not used. Provided only to match the underlying interface.
-        head_only : bool
+        head_only
             If [`True`][], then the implementation may only retrieve HEAD
             information if supported. This currently only has any
             effect for web requests.
@@ -763,9 +763,9 @@ class URL(WebResource):
 
     Parameters
     ----------
-    url : str
+    url
         The URL of the resource.
-    filename : typing.Optional[str]
+    filename
         The filename for the resource.
 
         If not specified, it will be obtained from the url.
@@ -862,7 +862,7 @@ class File(Resource[ThreadedFileReader]):
 
     Parameters
     ----------
-    path : typing.Union[str, os.PathLike, pathlib.Path]
+    path
         The path to use.
 
         If passing a [`pathlib.Path`][], this must not be a [`pathlib.PurePath`][]
@@ -871,10 +871,10 @@ class File(Resource[ThreadedFileReader]):
 
         This will all be performed as required in an executor to prevent
         blocking the event loop.
-    filename : typing.Optional[str]
+    filename
         The filename to use. If this is [`None`][], the name of the file is taken
         from the path instead.
-    spoiler : bool
+    spoiler
         Whether to mark the file as a spoiler in Discord.
     """
 
@@ -914,13 +914,13 @@ class File(Resource[ThreadedFileReader]):
 
         Parameters
         ----------
-        executor : typing.Optional[concurrent.futures.Executor]
+        executor
             The thread executor to run the blocking read operations in. If
             [`None`][], the default executor for the running event loop
             will be used instead.
 
             Only [`concurrent.futures.ThreadPoolExecutor`][] is supported.
-        head_only : bool
+        head_only
             Not used. Provided only to match the underlying interface.
 
         Returns
@@ -1041,15 +1041,15 @@ class Bytes(Resource[IteratorReader]):
 
     Parameters
     ----------
-    data : typing.Union[Rawish, LazyByteIteratorish]
+    data
         The raw data.
-    filename : str
+    filename
         The filename to use.
-    mimetype : typing.Optional[str]
+    mimetype
         The mimetype, or [`None`][] if you do not wish to specify this.
         If not provided, then this will be generated from the file extension
         of the filename instead.
-    spoiler : bool
+    spoiler
         Whether to mark the file as a spoiler in Discord.
     """
 
@@ -1103,9 +1103,9 @@ class Bytes(Resource[IteratorReader]):
 
         Parameters
         ----------
-        executor : typing.Optional[concurrent.futures.Executor]
+        executor
             Not used. Provided only to match the underlying interface.
-        head_only : bool
+        head_only
             Not used. Provided only to match the underlying interface.
 
         Returns
@@ -1134,9 +1134,9 @@ class Bytes(Resource[IteratorReader]):
 
         Parameters
         ----------
-        data_uri : str
+        data_uri
             The data URI to parse.
-        filename : typing.Optional[str]
+        filename
             Filename to use. If this is not provided, then this is generated
             instead.
 

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -600,7 +600,7 @@ class Member(users.User):
 
         Parameters
         ----------
-        ext : typing.Optional[str]
+        ext
             The ext to use for this URL.
             Supports `png`, `jpeg`, `jpg`, `webp` and `gif` (when
             animated).
@@ -609,7 +609,7 @@ class Member(users.User):
 
             If [`None`][], then the correct default extension is
             determined based on whether the icon is animated or not.
-        size : int
+        size
             The size to set for the URL.
             Can be any power of two between `16` and `4096`.
             Will be ignored for default avatars.
@@ -700,11 +700,11 @@ class Member(users.User):
 
         Other Parameters
         ----------------
-        delete_message_seconds : hikari.undefined.UndefinedNoneOr[hikari.internal.time.Intervalish]
+        delete_message_seconds
             If provided, the number of seconds to delete messages for.
             This can be represented as either an int/float between 0 and 604800 (7 days), or
             a [`datetime.timedelta`][] object.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -733,7 +733,7 @@ class Member(users.User):
 
         Other Parameters
         ----------------
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -760,7 +760,7 @@ class Member(users.User):
 
         Other Parameters
         ----------------
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -789,13 +789,13 @@ class Member(users.User):
 
         Parameters
         ----------
-        role : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialRole]
+        role
             The role to add. This may be the object or the
             ID of an existing role.
 
         Other Parameters
         ----------------
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -822,13 +822,13 @@ class Member(users.User):
 
         Parameters
         ----------
-        role : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialRole]
+        role
             The role to remove. This may be the object or the
             ID of an existing role.
 
         Other Parameters
         ----------------
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -865,24 +865,24 @@ class Member(users.User):
 
         Other Parameters
         ----------------
-        nickname : hikari.undefined.UndefinedNoneOr[str]
+        nickname
             If provided, the new nick for the member. If [`None`][],
             will remove the members nick.
 
             Requires the [`hikari.permissions.Permissions.MANAGE_NICKNAMES`][] permission.
-        roles : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole]]
+        roles
             If provided, the new roles for the member.
 
             Requires the [`hikari.permissions.Permissions.MANAGE_ROLES`][] permission.
-        mute : hikari.undefined.UndefinedOr[bool]
+        mute
             If provided, the new server mute state for the member.
 
             Requires the [`hikari.permissions.Permissions.MUTE_MEMBERS`][] permission.
-        deaf : hikari.undefined.UndefinedOr[bool]
+        deaf
             If provided, the new server deaf state for the member.
 
             Requires the [`hikari.permissions.Permissions.DEAFEN_MEMBERS`][] permission.
-        voice_channel : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildVoiceChannel]]]
+        voice_channel
             If provided, [`None`][] or the object or the ID of
             an existing voice channel to move the member to.
             If [`None`][], will disconnect the member from voice.
@@ -894,13 +894,13 @@ class Member(users.User):
             !!! note
                 If the member is not in a voice channel, this will
                 take no effect.
-        communication_disabled_until : hikari.undefined.UndefinedNoneOr[datetime.datetime]
+        communication_disabled_until
             If provided, the datetime when the timeout (disable communication)
             of the member expires, up to 28 days in the future, or [`None`][]
             to remove the timeout from the member.
 
             Requires the [`hikari.permissions.Permissions.MODERATE_MEMBERS`][] permission.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -1072,10 +1072,10 @@ class Role(PartialRole):
 
         Parameters
         ----------
-        ext : str
+        ext
             The extension to use for this URL.
             Supports `png`, `jpeg`, `jpg` and `webp`.
-        size : int
+        size
             The size to set for the URL.
             Can be any power of two between `16` and `4096`.
 
@@ -1171,10 +1171,10 @@ class PartialApplication(snowflakes.Unique):
 
         Parameters
         ----------
-        ext : str
+        ext
             The extension to use for this URL.
             Supports `png`, `jpeg`, `jpg` and `webp`.
-        size : int
+        size
             The size to set for the URL.
             Can be any power of two between `16` and `4096`.
 
@@ -1378,14 +1378,14 @@ class PartialGuild(snowflakes.Unique):
 
         Parameters
         ----------
-        ext : typing.Optional[str]
+        ext
             The extension to use for this URL.
             Supports `png`, `jpeg`, `jpg`, `webp` and `gif` (when
             animated).
 
             If [`None`][], then the correct default extension is
             determined based on whether the icon is animated or not.
-        size : int
+        size
             The size to set for the URL.
             Can be any power of two between `16` and `4096`.
 
@@ -1423,16 +1423,16 @@ class PartialGuild(snowflakes.Unique):
 
         Parameters
         ----------
-        user : hikari.snowflakes.Snowflakeish[hikari.users.PartialUser]
+        user
             The user to ban from the guild.
 
         Other Parameters
         ----------------
-        delete_message_seconds : hikari.undefined.UndefinedNoneOr[hikari.internal.time.Intervalish]
+        delete_message_seconds
             If provided, the number of seconds to delete messages for.
             This can be represented as either an int/float between 0 and 604800 (7 days), or
             a [`datetime.timedelta`][] object.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -1464,12 +1464,12 @@ class PartialGuild(snowflakes.Unique):
 
         Parameters
         ----------
-        user : hikari.snowflakes.Snowflakeish[hikari.users.PartialUser]
+        user
             The user to unban from the guild.
 
         Other Parameters
         ----------------
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -1501,12 +1501,12 @@ class PartialGuild(snowflakes.Unique):
 
         Parameters
         ----------
-        user : hikari.snowflakes.Snowflakeish[hikari.users.PartialUser]
+        user
             The user to kick from the guild.
 
         Other Parameters
         ----------------
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -1560,44 +1560,44 @@ class PartialGuild(snowflakes.Unique):
 
         Parameters
         ----------
-        name : hikari.undefined.UndefinedOr[str]
+        name
             If provided, the new name for the guild.
-        verification_level : hikari.undefined.UndefinedOr[hikari.guilds.GuildVerificationLevel]
+        verification_level
             If provided, the new verification level.
-        default_message_notifications : hikari.undefined.UndefinedOr[hikari.guilds.GuildMessageNotificationsLevel]
+        default_message_notifications
             If provided, the new default message notifications level.
-        explicit_content_filter_level : hikari.undefined.UndefinedOr[hikari.guilds.GuildExplicitContentFilterLevel]
+        explicit_content_filter_level
             If provided, the new explicit content filter level.
-        afk_channel : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildVoiceChannel]]
+        afk_channel
             If provided, the new afk channel. Requires `afk_timeout` to
             be set to work.
-        afk_timeout : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        afk_timeout
             If provided, the new afk timeout.
-        icon : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
+        icon
             If provided, the new guild icon. Must be a 1024x1024 image or can be
             an animated gif when the guild has the [`hikari.guilds.GuildFeature.ANIMATED_ICON`][] feature.
-        owner : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]]]
+        owner
             If provided, the new guild owner.
 
             !!! warning
                 You need to be the owner of the server to use this.
-        splash : hikari.undefined.UndefinedNoneOr[hikari.files.Resourceish]
+        splash
             If provided, the new guild splash. Must be a 16:9 image and the
             guild must have the [`hikari.guilds.GuildFeature.INVITE_SPLASH`][] feature.
-        banner : hikari.undefined.UndefinedNoneOr[hikari.files.Resourceish]
+        banner
             If provided, the new guild banner. Must be a 16:9 image and the
             guild must have the [`hikari.guilds.GuildFeature.BANNER`][] feature.
-        system_channel : hikari.undefined.UndefinedNoneOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildTextChannel]]
+        system_channel
             If provided, the new system channel.
-        rules_channel : hikari.undefined.UndefinedNoneOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildTextChannel]]
+        rules_channel
             If provided, the new rules channel.
-        public_updates_channel : hikari.undefined.UndefinedNoneOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildTextChannel]]
+        public_updates_channel
             If provided, the new public updates channel.
-        preferred_locale : hikari.undefined.UndefinedNoneOr[str]
+        preferred_locale
             If provided, the new preferred locale.
-        features : hikari.undefined.UndefinedOr[typing.Sequence[hikari.guilds.GuildFeatures]]
+        features
             If provided, the guild features to be enabled. Features not provided will be disabled.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -1612,8 +1612,8 @@ class PartialGuild(snowflakes.Unique):
             If any of the fields that are passed have an invalid value. Or
             you are missing the
         hikari.errors.ForbiddenError
-            If you are missing the [`hikari.permissions.Permissions.MANAGE_GUILD`][] permission or if you tried to
-            pass ownership without being the server owner.
+            If you are missing the [`hikari.permissions.Permissions.MANAGE_GUILD`][] permission
+            or if you tried to pass ownership without being the server owner.
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.NotFoundError
@@ -1623,7 +1623,7 @@ class PartialGuild(snowflakes.Unique):
             longer than `max_rate_limit` when making a request.
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
-        """  # noqa: E501 - Line too long
+        """
         return await self.app.rest.edit_guild(
             self.id,
             name=name,
@@ -1671,7 +1671,7 @@ class PartialGuild(snowflakes.Unique):
 
         Parameters
         ----------
-        emoji : hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]
+        emoji
             The emoji to fetch. This can be a [`hikari.emojis.CustomEmoji`][]
             or the ID of an existing emoji.
 
@@ -1723,7 +1723,7 @@ class PartialGuild(snowflakes.Unique):
 
         Parameters
         ----------
-        sticker : snowflakes.SnowflakeishOr[hikari.stickers.PartialSticker]
+        sticker
             The sticker to fetch. This can be a sticker object or the
             ID of an existing sticker.
 
@@ -1765,19 +1765,19 @@ class PartialGuild(snowflakes.Unique):
 
         Parameters
         ----------
-        name : str
+        name
             The name for the sticker.
-        tag : str
+        tag
             The tag for the sticker.
-        image : hikari.files.Resourceish
+        image
             The 320x320 image for the sticker. Maximum upload size is 500kb.
             This can be a still PNG, an animated PNG, a Lottie, or a GIF.
 
         Other Parameters
         ----------------
-        description : hikari.undefined.UndefinedOr[str]
+        description
             If provided, the description of the sticker.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -1819,19 +1819,19 @@ class PartialGuild(snowflakes.Unique):
 
         Parameters
         ----------
-        sticker : hikari.snowflakes.SnowflakeishOr[hikari.stickers.PartialSticker]
+        sticker
             The sticker to edit. This can be a sticker object or the ID of an
             existing sticker.
 
         Other Parameters
         ----------------
-        name : hikari.undefined.UndefinedOr[str]
+        name
             If provided, the new name for the sticker.
-        description : hikari.undefined.UndefinedOr[str]
+        description
             If provided, the new description for the sticker.
-        tag : hikari.undefined.UndefinedOr[str]
+        tag
             If provided, the new sticker tag.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -1871,13 +1871,13 @@ class PartialGuild(snowflakes.Unique):
 
         Parameters
         ----------
-        sticker : hikari.snowflakes.SnowflakeishOr[hikari.stickers.PartialSticker]
+        sticker
             The sticker to delete. This can be a sticker object or the ID
             of an existing sticker.
 
         Other Parameters
         ----------------
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -1912,16 +1912,16 @@ class PartialGuild(snowflakes.Unique):
 
         Parameters
         ----------
-        name : str
+        name
             The channels name. Must be between 2 and 1000 characters.
 
         Other Parameters
         ----------------
-        position : hikari.undefined.UndefinedOr[int]
+        position
             If provided, the position of the category.
-        permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
+        permission_overwrites
             If provided, the permission overwrites for the category.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -1968,28 +1968,28 @@ class PartialGuild(snowflakes.Unique):
 
         Parameters
         ----------
-        name : str
+        name
             The channels name. Must be between 2 and 1000 characters.
 
         Other Parameters
         ----------------
-        position : hikari.undefined.UndefinedOr[int]
+        position
             If provided, the position of the channel (relative to the
             category, if any).
-        topic : hikari.undefined.UndefinedOr[str]
+        topic
             If provided, the channels topic. Maximum 1024 characters.
-        nsfw : hikari.undefined.UndefinedOr[bool]
+        nsfw
             If provided, whether to mark the channel as NSFW.
-        rate_limit_per_user : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        rate_limit_per_user
             If provided, the amount of seconds a user has to wait
             before being able to send another message in the channel.
             Maximum 21600 seconds.
-        permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
+        permission_overwrites
             If provided, the permission overwrites for the channel.
-        category : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildCategory]]
+        category
             The category to create the channel under. This may be the
             object or the ID of an existing category.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -2044,28 +2044,28 @@ class PartialGuild(snowflakes.Unique):
 
         Parameters
         ----------
-        name : str
+        name
             The channels name. Must be between 2 and 1000 characters.
 
         Other Parameters
         ----------------
-        position : hikari.undefined.UndefinedOr[int]
+        position
             If provided, the position of the channel (relative to the
             category, if any).
-        topic : hikari.undefined.UndefinedOr[str]
+        topic
             If provided, the channels topic. Maximum 1024 characters.
-        nsfw : hikari.undefined.UndefinedOr[bool]
+        nsfw
             If provided, whether to mark the channel as NSFW.
-        rate_limit_per_user : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        rate_limit_per_user
             If provided, the amount of seconds a user has to wait
             before being able to send another message in the channel.
             Maximum 21600 seconds.
-        permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
+        permission_overwrites
             If provided, the permission overwrites for the channel.
-        category : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildCategory]]
+        category
             The category to create the channel under. This may be the
             object or the ID of an existing category.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -2130,45 +2130,45 @@ class PartialGuild(snowflakes.Unique):
 
         Parameters
         ----------
-        name : str
+        name
             The channels name. Must be between 2 and 1000 characters.
 
         Other Parameters
         ----------------
-        position : hikari.undefined.UndefinedOr[int]
+        position
             If provided, the position of the category.
-        category : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildCategory]]
+        category
             The category to create the channel under. This may be the
             object or the ID of an existing category.
-        permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
+        permission_overwrites
             If provided, the permission overwrites for the category.
-        topic : hikari.undefined.UndefinedOr[str]
+        topic
             If provided, the channels topic. Maximum 1024 characters.
-        nsfw : hikari.undefined.UndefinedOr[bool]
+        nsfw
             If provided, whether to mark the channel as NSFW.
-        rate_limit_per_user : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        rate_limit_per_user
             If provided, the amount of seconds a user has to wait
             before being able to send another message in the channel.
             Maximum 21600 seconds.
-        default_auto_archive_duration : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        default_auto_archive_duration
             If provided, the auto archive duration Discord's end user client
             should default to when creating threads in this channel.
 
             This should be either 60, 1440, 4320 or 10080 minutes and, as of
             writing, ignores the parent channel's set default_auto_archive_duration
             when passed as [`hikari.undefined.UNDEFINED`][].
-        default_thread_rate_limit_per_user : hikari.undefined.UndefinedOr[hikari.internal.time.Intervalish]
+        default_thread_rate_limit_per_user
             If provided, the ratelimit that should be set in threads created
             from the forum.
-        default_forum_layout : hikari.undefined.UndefinedOr[typing.Union[hikari.channels.ForumLayoutType, int]]
+        default_forum_layout
             If provided, the default forum layout to show in the client.
-        default_sort_order : hikari.undefined.UndefinedOr[typing.Union[hikari.channels.ForumSortOrderType, int]]
+        default_sort_order
             If provided, the default sort order to show in the client.
-        available_tags : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.ForumTag]]
+        available_tags
             If provided, the available tags to select from when creating a thread.
-        default_reaction_emoji : typing.Union[str, hikari.emojis.Emoji, hikari.undefined.UndefinedType, hikari.snowflakes.Snowflake]
+        default_reaction_emoji
             If provided, the new default reaction emoji for threads created in a forum channel.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -2192,7 +2192,7 @@ class PartialGuild(snowflakes.Unique):
             longer than `max_rate_limit` when making a request.
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
-        """  # noqa: E501 - Line too long
+        """
         return await self.app.rest.create_guild_forum_channel(
             self.id,
             name,
@@ -2230,34 +2230,34 @@ class PartialGuild(snowflakes.Unique):
 
         Parameters
         ----------
-        name : str
+        name
             The channels name. Must be between 2 and 1000 characters.
 
         Other Parameters
         ----------------
-        position : hikari.undefined.UndefinedOr[int]
+        position
             If provided, the position of the channel (relative to the
             category, if any).
-        user_limit : hikari.undefined.UndefinedOr[int]
+        user_limit
             If provided, the maximum users in the channel at once.
             Must be between 0 and 99 with 0 meaning no limit.
-        bitrate : hikari.undefined.UndefinedOr[int]
+        bitrate
             If provided, the bitrate for the channel. Must be
             between 8000 and 96000 or 8000 and 128000 for VIP
             servers.
-        video_quality_mode : hikari.undefined.UndefinedOr[typing.Union[hikari.channels.VideoQualityMode, int]]
+        video_quality_mode
             If provided, the new video quality mode for the channel.
-        permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
+        permission_overwrites
             If provided, the permission overwrites for the channel.
-        region : hikari.undefined.UndefinedOr[typing.Union[hikari.voices.VoiceRegion, str]]
+        region
             If provided, the voice region to for this channel. Passing
             [`None`][] here will set it to "auto" mode where the used
             region will be decided based on the first person who connects to it
             when it's empty.
-        category : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildCategory]]
+        category
             The category to create the channel under. This may be the
             object or the ID of an existing category.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -2313,32 +2313,32 @@ class PartialGuild(snowflakes.Unique):
 
         Parameters
         ----------
-        name : str
+        name
             The channel's name. Must be between 2 and 1000 characters.
 
         Other Parameters
         ----------------
-        position : hikari.undefined.UndefinedOr[int]
+        position
             If provided, the position of the channel (relative to the
             category, if any).
-        user_limit : hikari.undefined.UndefinedOr[int]
+        user_limit
             If provided, the maximum users in the channel at once.
             Must be between 0 and 99 with 0 meaning no limit.
-        bitrate : hikari.undefined.UndefinedOr[int]
+        bitrate
             If provided, the bitrate for the channel. Must be
             between 8000 and 96000 or 8000 and 128000 for VIP
             servers.
-        permission_overwrites : hikari.undefined.UndefinedOr[typing.Sequence[hikari.channels.PermissionOverwrite]]
+        permission_overwrites
             If provided, the permission overwrites for the channel.
-        region : hikari.undefined.UndefinedOr[typing.Union[hikari.voices.VoiceRegion, str]]
+        region
             If provided, the voice region to for this channel. Passing
             [`None`][] here will set it to "auto" mode where the used
             region will be decided based on the first person who connects to it
             when it's empty.
-        category : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildCategory]]
+        category
             The category to create the channel under. This may be the
             object or the ID of an existing category.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
 
@@ -2389,7 +2389,7 @@ class PartialGuild(snowflakes.Unique):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildChannel]
+        channel
             The channel or category to delete. This may be the object or the ID of an
             existing channel.
 
@@ -2506,10 +2506,10 @@ class GuildPreview(PartialGuild):
 
         Parameters
         ----------
-        ext : str
+        ext
             The extension to use for this URL.
             Supports `png`, `jpeg`, `jpg` and `webp`.
-        size : int
+        size
             The size to set for the URL.
             Can be any power of two between `16` and `4096`.
 
@@ -2535,10 +2535,10 @@ class GuildPreview(PartialGuild):
 
         Parameters
         ----------
-        ext : str
+        ext
             The extension to use for this URL.
             Supports `png`, `jpeg`, `jpg` and `webp`.
-        size : int
+        size
             The size to set for the URL.
             Can be any power of two between `16` and `4096`.
 
@@ -2809,14 +2809,14 @@ class Guild(PartialGuild):
 
         Parameters
         ----------
-        ext : typing.Optional[str]
+        ext
             The ext to use for this URL.
             Supports `png`, `jpeg`, `jpg`, `webp` and `gif` (when
             animated).
 
             If [`None`][], then the correct default extension is
             determined based on whether the banner is animated or not.
-        size : int
+        size
             The size to set for the URL.
             Can be any power of two between `16` and `4096`.
 
@@ -2849,10 +2849,10 @@ class Guild(PartialGuild):
 
         Parameters
         ----------
-        ext : str
+        ext
             The extension to use for this URL, defaults to `png`.
             Supports `png`, `jpeg`, `jpg` and `webp`.
-        size : int
+        size
             The size to set for the URL, defaults to `4096`.
             Can be any power of two between `16` and `4096`.
 
@@ -2878,10 +2878,10 @@ class Guild(PartialGuild):
 
         Parameters
         ----------
-        ext : str
+        ext
             The extension to use for this URL, defaults to `png`.
             Supports `png`, `jpeg`, `jpg` and `webp`.
-        size : int
+        size
             The size to set for the URL, defaults to `4096`.
             Can be any power of two between `16` and `4096`.
 
@@ -2909,7 +2909,7 @@ class Guild(PartialGuild):
 
         Parameters
         ----------
-        channel : hikari.snowflakes.SnowflakeishOr[hikari.channels.PartialChannel]
+        channel
             The object or ID of the guild channel to get from the cache.
 
         Returns
@@ -2931,7 +2931,7 @@ class Guild(PartialGuild):
 
         Parameters
         ----------
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             The object or ID of the user to get the cached member for.
 
         Returns
@@ -2968,7 +2968,7 @@ class Guild(PartialGuild):
 
         Parameters
         ----------
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             The object or ID of the user to get the cached presence for.
 
         Returns
@@ -2988,7 +2988,7 @@ class Guild(PartialGuild):
 
         Parameters
         ----------
-        user : hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]
+        user
             The object or ID of the user to get the cached voice state for.
 
         Returns
@@ -3008,7 +3008,7 @@ class Guild(PartialGuild):
 
         Parameters
         ----------
-        emoji : hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]
+        emoji
             The object or ID of the emoji to get from the cache.
 
         Returns
@@ -3033,7 +3033,7 @@ class Guild(PartialGuild):
 
         Parameters
         ----------
-        sticker : hikari.snowflakes.SnowflakeishOr[hikari.stickers.GuildSticker]
+        sticker
             The object or ID of the sticker to get from the cache.
 
         Returns
@@ -3056,7 +3056,7 @@ class Guild(PartialGuild):
 
         Parameters
         ----------
-        role : hikari.snowflakes.SnowflakeishOr[PartialRole]
+        role
             The object or ID of the role to get for this guild from the cache.
 
         Returns

--- a/hikari/impl/buckets.py
+++ b/hikari/impl/buckets.py
@@ -332,11 +332,11 @@ class RESTBucket(rate_limits.WindowedBurstRateLimiter):
 
         Parameters
         ----------
-        remaining : int
+        remaining
             The calls remaining in this time window.
-        limit : int
+        limit
             The total calls allowed in this time window.
-        reset_at : float
+        reset_at
             The epoch at which to reset the limit.
         """
         self.remaining: int = remaining
@@ -349,7 +349,7 @@ class RESTBucket(rate_limits.WindowedBurstRateLimiter):
 
         Parameters
         ----------
-        real_bucket_hash : str
+        real_bucket_hash
             The real bucket hash for this bucket.
 
         Raises
@@ -380,7 +380,7 @@ class RESTBucketManager:
 
     Parameters
     ----------
-    max_rate_limit : float
+    max_rate_limit
         The max number of seconds to backoff for when rate limited. Anything
         greater than this will instead raise an error.
     """
@@ -418,9 +418,9 @@ class RESTBucketManager:
 
         Parameters
         ----------
-        poll_period : float
+        poll_period
             Period to poll the garbage collector at in seconds.
-        expire_after : float
+        expire_after
             Time after which the last [`hikari.impl.buckets.RESTBucket.reset_at`][] was hit for a bucket to
             remove it. Higher values will retain unneeded ratelimit info for
             longer, but may produce more effective rate-limiting logic as a
@@ -513,9 +513,9 @@ class RESTBucketManager:
 
         Parameters
         ----------
-        compiled_route : hikari.internal.routes.CompiledRoute
+        compiled_route
             The route to get the bucket for.
-        authentication : typing.Optional[str]
+        authentication
             The authentication that will be used in the request.
 
         Returns
@@ -555,17 +555,17 @@ class RESTBucketManager:
 
         Parameters
         ----------
-        compiled_route : hikari.internal.routes.CompiledRoute
+        compiled_route
             The compiled route to get the bucket for.
-        authentication : typing.Optional[str]
+        authentication
             The authentication that was used in the request.
-        bucket_header : str
+        bucket_header
             The `X-RateLimit-Bucket` header that was provided in the response.
-        remaining_header : int
+        remaining_header
             The `X-RateLimit-Remaining` header cast to an [`int`][].
-        limit_header : int
+        limit_header
             The `X-RateLimit-Limit` header cast to an [`int`][].
-        reset_after : float
+        reset_after
             The `X-RateLimit-Reset-After` header cast to a [`float`][].
         """
         if not self._gc_task:
@@ -619,7 +619,7 @@ class RESTBucketManager:
 
         Parameters
         ----------
-        retry_after : float
+        retry_after
             How long to throttle for.
         """
         self._global_ratelimit.throttle(retry_after)

--- a/hikari/impl/cache.py
+++ b/hikari/impl/cache.py
@@ -59,9 +59,9 @@ class CacheImpl(cache.MutableCache):
 
     Parameters
     ----------
-    app : hikari.traits.RESTAware
+    app
         The object of the REST aware app this is bound to.
-    settings : hikari.impl.config.CacheSettings
+    settings
         The cache settings to use.
     """
 

--- a/hikari/impl/event_manager_base.py
+++ b/hikari/impl/event_manager_base.py
@@ -275,7 +275,7 @@ def filtered(
 
     Other Parameters
     ----------------
-    cache_components : hikari.api.config.CacheComponents
+    cache_components
         Bitfield of the cache components this event may make altering calls to.
     """
     if isinstance(event_types, typing.Sequence):

--- a/hikari/impl/gateway_bot.py
+++ b/hikari/impl/gateway_bot.py
@@ -118,12 +118,12 @@ class GatewayBot(traits.GatewayBotAware):
 
     Parameters
     ----------
-    token : str
+    token
         The bot token to sign in with.
 
     Other Parameters
     ----------------
-    allow_color : bool
+    allow_color
         Whether enable coloured console logs will be enabled on any platform that is a TTY.
         Setting a `"CLICOLOR"` environment variable to any **non `0`** value
         will override this setting.
@@ -133,15 +133,15 @@ class GatewayBot(traits.GatewayBotAware):
         awkward or not support features in a standard way, the option to
         explicitly disable this is provided. See `force_color` for an
         alternative.
-    banner : typing.Optional[str]
+    banner
         The package to search for a `banner.txt` in.
 
         Setting this to [`None`][] will disable the banner being shown.
-    suppress_optimization_warning : bool
+    suppress_optimization_warning
         By default, hikari warns you if you are not running
         your bot using optimizations (`-O` or `-OO`). If this is [`True`][], you won't
         receive these warnings, even if you are not running using optimizations.
-    executor : typing.Optional[concurrent.futures.Executor]
+    executor
         If non-[`None`][], then this executor
         is used instead of the [`concurrent.futures.ThreadPoolExecutor`][] attached
         to the [`asyncio.AbstractEventLoop`][] that the bot will run on. This
@@ -153,25 +153,25 @@ class GatewayBot(traits.GatewayBotAware):
         relies on all objects used in IPC to be pickleable. Many third-party
         libraries will not support this fully though, so your mileage may vary
         on using ProcessPoolExecutor implementations with this parameter.
-    force_color : bool
+    force_color
         If [`True`][], then this application
         will __force__ colour to be used in console-based output. Specifying a
         `"CLICOLOR_FORCE"` environment variable with a non-`"0"` value will
         override this setting.
 
         This will take precedence over `allow_color` if both are specified.
-    cache_settings : typing.Optional[hikari.impl.config.CacheSettings]
+    cache_settings
         Optional cache settings. If unspecified, will use the defaults.
-    http_settings : typing.Optional[hikari.impl.config.HTTPSettings]
+    http_settings
         Optional custom HTTP configuration settings to use. Allows you to
         customise functionality such as whether SSL-verification is enabled,
         what timeouts [`aiohttp`][] should expect to use for requests, and behavior
         regarding HTTP-redirects.
-    intents : hikari.intents.Intents
+    intents
         This allows you
         to change which intents your application will use on the gateway. This
         can be used to control and change the types of events you will receive.
-    auto_chunk_members : bool
+    auto_chunk_members
         If [`False`][], then no member chunks will be requested automatically,
         even if there are reasons to do so.
 
@@ -195,7 +195,7 @@ class GatewayBot(traits.GatewayBotAware):
                    payload).
                 2. The user is waiting for the member chunks (there is an event
                    listener for it).
-    logs : typing.Union[None, str, int, typing.Dict[str, typing.Any], os.PathLike]
+    logs
         The flavour to set the logging to.
 
         This can be [`None`][] to not enable logging automatically.
@@ -217,7 +217,7 @@ class GatewayBot(traits.GatewayBotAware):
         Note that `"TRACE_HIKARI"` is a library-specific logging level
         which is expected to be more verbose than `"DEBUG"`.
 
-    max_rate_limit : float
+    max_rate_limit
         The max number of seconds to backoff for when rate limited. Anything
         greater than this will instead raise an error.
 
@@ -230,19 +230,19 @@ class GatewayBot(traits.GatewayBotAware):
         Note that this only applies to the REST API component that communicates
         with Discord, and will not affect sharding or third party HTTP endpoints
         that may be in use.
-    max_retries : typing.Optional[int]
+    max_retries
         Maximum number of times a request will be retried if
         it fails with a `5xx` status.
 
         Will default to 3 if set to [`None`][].
-    proxy_settings : typing.Optional[hikari.impl.config.ProxySettings]
+    proxy_settings
         Custom proxy settings to use with network-layer logic
         in your application to get through an HTTP-proxy.
-    dumps : hikari.internal.data_binding.JSONEncoder
+    dumps
         The JSON encoder this application should use.
-    loads : hikari.internal.data_binding.JSONDecoder
+    loads
         The JSON decoder this application should use.
-    rest_url : typing.Optional[str]
+    rest_url
         Defaults to the Discord REST API URL if [`None`][]. Can be
         overridden if you are attempting to point to an unofficial endpoint, or
         if you are attempting to mock/stub the Discord API for any reason.
@@ -496,7 +496,7 @@ class GatewayBot(traits.GatewayBotAware):
 
         Parameters
         ----------
-        event : hikari.events.base_events.Event
+        event
             The event to dispatch.
 
         Examples
@@ -581,10 +581,10 @@ class GatewayBot(traits.GatewayBotAware):
 
         Parameters
         ----------
-        event_type : typing.Type[EventT]
+        event_type
             The event type to look for.
             `EventT` must be a subclass of [`hikari.events.base_events.Event`][].
-        polymorphic : bool
+        polymorphic
             If [`True`][], this will also return the listeners of the
             subclasses of the given event type. If [`False`][], then
             only listeners for this class specifically are returned.
@@ -612,7 +612,7 @@ class GatewayBot(traits.GatewayBotAware):
 
         Parameters
         ----------
-        *event_types : typing.Optional[typing.Type[EventT]]
+        *event_types
             The event types to subscribe to. The implementation may allow this
             to be undefined. If this is the case, the event type will be inferred
             instead from the type hints on the function signature.
@@ -654,19 +654,19 @@ class GatewayBot(traits.GatewayBotAware):
 
         Parameters
         ----------
-        banner : typing.Optional[str]
+        banner
             The package to find a `banner.txt` in.
-        allow_color : bool
+        allow_color
             A flag that allows advising whether to allow color if supported or
             not. Can be overridden by setting a `CLICOLOR` environment
             variable to a non-`"0"` string.
-        force_color : bool
+        force_color
             A flag that allows forcing color to always be output, even if the
             terminal device may not support it. Setting the `CLICOLOR_FORCE`
             environment variable to a non-`"0"` string will override this.
 
             This will take precedence over `allow_color` if both are specified.
-        extra_args : typing.Optional[typing.Dict[str, str]]
+        extra_args
             If provided, extra $-substitutions to use when printing the banner.
             Default substitutions can not be overwritten.
 
@@ -700,25 +700,25 @@ class GatewayBot(traits.GatewayBotAware):
 
         Other Parameters
         ----------------
-        activity : typing.Optional[hikari.presences.Activity]
+        activity
             The initial activity to display in the bot user presence, or
             [`None`][] (default) to not show any.
-        afk : bool
+        afk
             The initial AFK state to display in the bot user presence, or
             [`False`][] (default) to not show any.
-        asyncio_debug : bool
+        asyncio_debug
             If [`True`][], then debugging is enabled for the asyncio event
             loop in use.
-        check_for_updates : bool
+        check_for_updates
             If [`True`][], will check for newer versions of hikari on PyPI
             and notify if available.
-        close_passed_executor : bool
+        close_passed_executor
             If [`True`][], any custom [`concurrent.futures.Executor`][] passed
             to the constructor will be shut down when the application
             terminates. This does not affect the default executor associated
             with the event loop, and will not do anything if you do not
             provide a custom executor to the constructor.
-        close_loop : bool
+        close_loop
             If [`True`][], then once the bot enters a state where all components
             have shut down permanently during application shut down, then
             all asyncgens and background tasks will be destroyed, and the
@@ -728,13 +728,13 @@ class GatewayBot(traits.GatewayBotAware):
             had time to attempt to shut down correctly (around 250ms), and on
             Python 3.9 and newer, will also shut down the default event loop
             executor too.
-        coroutine_tracking_depth : typing.Optional[int]
+        coroutine_tracking_depth
             If an integer value and supported by
             the interpreter, then this many nested coroutine calls will be
             tracked with their call origin state. This allows you to determine
             where non-awaited coroutines may originate from, but generally you
             do not want to leave this enabled for performance reasons.
-        enable_signal_handlers : typing.Optional[bool]
+        enable_signal_handlers
             Defaults to [`True`][] if this is called in the main thread.
 
             If on a non-Windows OS with builtin support for kernel-level
@@ -744,20 +744,20 @@ class GatewayBot(traits.GatewayBotAware):
             rather than just killing the process in a dirty state immediately.
             You should leave this enabled unless you plan to implement your own
             signal handling yourself.
-        idle_since : typing.Optional[datetime.datetime]
+        idle_since
             The [`datetime.datetime`][] the user should be marked as being idle
             since, or [`None`][] to not show this.
-        ignore_session_start_limit : bool
+        ignore_session_start_limit
             If [`False`][], then attempting to start more sessions than
             you are allowed in a 24 hour window will throw a [`RuntimeError`][]
             rather than going ahead and hitting the IDENTIFY limit, which
             may result in your token being reset. Setting to [`True`][]
             disables this behavior.
-        large_threshold : int
+        large_threshold
             Threshold for members in a guild before it is treated as being
             "large" and no longer sending member details in the [GUILD CREATE][]
             event.
-        propagate_interrupts : bool
+        propagate_interrupts
             If [`True`][], then any internal [`hikari.errors.HikariInterrupt`][]
             that is raises as a result of catching an OS level signal will
             result in the exception being rethrown once the application has
@@ -766,7 +766,7 @@ class GatewayBot(traits.GatewayBotAware):
             application received after it closes. When [`False`][], nothing
             is raised and the call will terminate cleanly and silently
             where possible instead.
-        shard_ids : typing.Optional[typing.Sequence[int]]
+        shard_ids
             The shard IDs to create shards for. If not [`None`][], then
             a non-[`None`][] `shard_count` must ALSO be provided.
 
@@ -774,12 +774,12 @@ class GatewayBot(traits.GatewayBotAware):
             is used for your application instead.
 
             Note that the sequence will be de-duplicated.
-        shard_count : typing.Optional[int]
+        shard_count
             The number of shards to use in the entire distributed application.
 
             Defaults to [`None`][] which results in the count being
             determined dynamically on startup.
-        status : hikari.presences.Status
+        status
             The initial status to show for the user presence on startup.
 
         Raises
@@ -866,41 +866,41 @@ class GatewayBot(traits.GatewayBotAware):
 
         Other Parameters
         ----------------
-        activity : typing.Optional[hikari.presences.Activity]
+        activity
             The initial activity to display in the bot user presence, or
             [`None`][] (default) to not show any.
-        afk : bool
+        afk
             The initial AFK state to display in the bot user presence, or
             [`False`][] (default) to not show any.
-        check_for_updates : bool
+        check_for_updates
             If [`True`][], will check for
             newer versions of `hikari` on PyPI and notify if available.
-        idle_since : typing.Optional[datetime.datetime]
+        idle_since
             The [`datetime.datetime`][] the user should be marked as being idle
             since, or [`None`][] (default) to not show this.
-        ignore_session_start_limit : bool
+        ignore_session_start_limit
             If [`False`][], then attempting to start more sessions than you
             are allowed in a 24 hour window will throw a [`RuntimeError`][]
             rather than going ahead and hitting the IDENTIFY limit,
             which may result in your token being reset. Setting to [`True`][]
             disables this behavior.
-        large_threshold : int
+        large_threshold
             Threshold for members in a guild before it is treated as being
             "large" and no longer sending member details in the `GUILD CREATE`
             event.
-        shard_ids : typing.Optional[typing.Sequence[int]]
+        shard_ids
             The shard IDs to create shards for. If not [`None`][], then
             a non-[`None`][] `shard_count` must ALSO be provided. Defaults to
             [`None`][], which means the Discord-recommended count is used
             for your application instead.
 
             Note that the sequence will be de-duplicated.
-        shard_count : typing.Optional[int]
+        shard_count
             The number of shards to use in the entire distributed application.
 
             Defaults to [`None`][] which results in the count being
             determined dynamically on startup.
-        status : hikari.presences.Status
+        status
             The initial status to show for the user presence on startup.
 
         Raises
@@ -1022,14 +1022,14 @@ class GatewayBot(traits.GatewayBotAware):
 
         Parameters
         ----------
-        event_type : typing.Type[hikari.events.base_events.Event]
+        event_type
             The event type to listen for. This will listen for subclasses of
             this type additionally.
-        timeout : typing.Optional[int, float]
+        timeout
             How long this streamer should wait for the next event before
             ending the iteration. If [`None`][] then this will continue
             until explicitly broken from.
-        limit : typing.Optional[int]
+        limit
             The limit for how many events this should queue at one time before
             dropping extra incoming events, leave this as [`None`][] for
             the cache size to be unlimited.
@@ -1081,7 +1081,7 @@ class GatewayBot(traits.GatewayBotAware):
 
         Parameters
         ----------
-        event_type : typing.Type[T]
+        event_type
             The event type to listen for. This will also listen for any
             subclasses of the given type.
             `T` must be a subclass of [`hikari.events.base_events.Event`][].
@@ -1123,7 +1123,7 @@ class GatewayBot(traits.GatewayBotAware):
 
         Parameters
         ----------
-        event_type : typing.Type[T]
+        event_type
             The event type to unsubscribe from. This must be the same exact
             type as was originally subscribed with to be removed correctly.
             `T` must derive from [`hikari.events.base_events.Event`][].
@@ -1168,7 +1168,7 @@ class GatewayBot(traits.GatewayBotAware):
 
         Parameters
         ----------
-        event_type : typing.Type[hikari.events.base_events.Event]
+        event_type
             The event type to listen for. This will listen for subclasses of
             this type additionally.
         predicate
@@ -1177,7 +1177,7 @@ class GatewayBot(traits.GatewayBotAware):
             return, or [`False`][] if the event should not be returned.
             If left as [`None`][] (the default), then the first matching event type
             that the bot receives (or any subtype) will be the one returned.
-        timeout : typing.Union[float, int, None]
+        timeout
             The amount of time to wait before raising an [`asyncio.TimeoutError`][]
             and giving up instead. This is measured in seconds. If
             [`None`][], then no timeout will be waited for (no timeout can

--- a/hikari/impl/interaction_server.py
+++ b/hikari/impl/interaction_server.py
@@ -186,20 +186,20 @@ class InteractionServer(interaction_server.InteractionServer):
 
     Parameters
     ----------
-    entity_factory : hikari.api.entity_factory.EntityFactory
+    entity_factory
         The entity factory instance this server should use.
 
     Other Parameters
     ----------------
-    dumps : hikari.internal.data_binding.JSONEncoder
+    dumps
         The JSON encoder this server should use.
-    loads : hikari.internal.data_binding.JSONDecoder
+    loads
         The JSON decoder this server should use.
-    public_key : typing.Optional[bytes]
+    public_key
         The public key this server should use for verifying request payloads from
         Discord. If left as [`None`][] then the client will try to work this
         out using `rest_client`.
-    rest_client : hikari.api.rest.RESTClient
+    rest_client
         The client this should use for making REST requests.
     """
 
@@ -287,7 +287,7 @@ class InteractionServer(interaction_server.InteractionServer):
 
         Parameters
         ----------
-        request : aiohttp.web.Request
+        request
             The received request.
 
         Returns
@@ -408,11 +408,11 @@ class InteractionServer(interaction_server.InteractionServer):
 
         Parameters
         ----------
-        body : bytes
+        body
             The interaction payload.
-        signature : bytes
+        signature
             Value of the `"X-Signature-Ed25519"` header used to verify the body.
-        timestamp : bytes
+        timestamp
             Value of the `"X-Signature-Timestamp"` header used to verify the body.
 
         Returns
@@ -510,27 +510,27 @@ class InteractionServer(interaction_server.InteractionServer):
 
         Other Parameters
         ----------------
-        backlog : int
+        backlog
             The number of unaccepted connections that the system will allow before
             refusing new connections.
-        host : typing.Optional[typing.Union[str, aiohttp.web.HostSequence]]
+        host
             TCP/IP host or a sequence of hosts for the HTTP server.
-        port : typing.Optional[int]
+        port
             TCP/IP port for the HTTP server.
-        path : typing.Optional[str]
+        path
             File system path for HTTP server unix domain socket.
-        reuse_address : typing.Optional[bool]
+        reuse_address
             Tells the kernel to reuse a local socket in TIME_WAIT state, without
             waiting for its natural timeout to expire.
-        reuse_port : typing.Optional[bool]
+        reuse_port
             Tells the kernel to allow this endpoint to be bound to the same port
             as other existing endpoints are also bound to.
-        socket : typing.Optional[socket.socket]
+        socket
             A pre-existing socket object to accept connections on.
-        shutdown_timeout : float
+        shutdown_timeout
             A delay to wait, in seconds, for graceful server shutdown
             before forcefully disconnecting all open client sockets.
-        ssl_context : typing.Optional[ssl.SSLContext]
+        ssl_context
             SSL context for HTTPS servers.
         """
         if self._server:

--- a/hikari/impl/rate_limits.py
+++ b/hikari/impl/rate_limits.py
@@ -204,7 +204,7 @@ class ManualRateLimiter(BurstRateLimiter):
 
         Parameters
         ----------
-        retry_after : float
+        retry_after
             How long to sleep for before unlocking and releasing any futures
             in the queue.
         """
@@ -228,7 +228,7 @@ class ManualRateLimiter(BurstRateLimiter):
 
         Parameters
         ----------
-        retry_after : float
+        retry_after
             How long to sleep for before unlocking and releasing any futures
             in the queue.
         """
@@ -248,7 +248,7 @@ class ManualRateLimiter(BurstRateLimiter):
 
         Parameters
         ----------
-        now : float
+        now
             The monotonic [`time.monotonic`][] timestamp.
 
         Returns
@@ -352,7 +352,7 @@ class WindowedBurstRateLimiter(BurstRateLimiter):
 
         Parameters
         ----------
-        now : float
+        now
             The monotonic [`time.monotonic`][] timestamp.
 
         Returns
@@ -377,7 +377,7 @@ class WindowedBurstRateLimiter(BurstRateLimiter):
 
         Parameters
         ----------
-        now : float
+        now
             The monotonic [`time.monotonic`][] timestamp.
 
         Returns
@@ -438,17 +438,17 @@ class ExponentialBackOff:
 
     Parameters
     ----------
-    base : float
+    base
         The base to use.
-    maximum : float
+    maximum
         The max value the backoff can be in a single iteration.
 
         All values will be capped to this base value plus some random jitter.
-    jitter_multiplier : float
+    jitter_multiplier
         The multiplier for the random jitter.
 
         Set to `0` to disable jitter.
-    initial_increment : int
+    initial_increment
         The initial increment to start at.
 
     Raises

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -122,15 +122,15 @@ class ClientCredentialsStrategy(rest_api.TokenStrategy):
 
     Parameters
     ----------
-    client : typing.Optional[hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialApplication]]
+    client
         Object or ID of the application this client credentials strategy should
         authorize as.
-    client_secret : typing.Optional[str]
+    client_secret
         Client secret to use when authorizing.
 
     Other Parameters
     ----------------
-    scopes : typing.Sequence[str]
+    scopes
         The scopes to authorize for.
     """
 
@@ -258,18 +258,18 @@ class RESTApp(traits.ExecutorAware):
 
     Parameters
     ----------
-    executor : typing.Optional[concurrent.futures.Executor]
+    executor
         The executor to use for blocking file IO operations. If [`None`][]
         is passed, then the default [`concurrent.futures.ThreadPoolExecutor`][] for
         the [`asyncio.AbstractEventLoop`][] will be used instead.
-    http_settings : typing.Optional[hikari.impl.config.HTTPSettings]
+    http_settings
         HTTP settings to use. Sane defaults are used if this is
         [`None`][].
-    dumps : hikari.internal.data_binding.JSONEncoder
+    dumps
         The JSON encoder this application should use.
-    loads : hikari.internal.data_binding.JSONDecoder
+    loads
         The JSON decoder this application should use.
-    max_rate_limit : float
+    max_rate_limit
         Maximum number of seconds to sleep for when rate limited. If a rate
         limit occurs that is longer than this value, then a
         [`hikari.errors.RateLimitTooLongError`][] will be raised instead of waiting.
@@ -278,15 +278,15 @@ class RESTApp(traits.ExecutorAware):
         rate limits.
 
         Defaults to five minutes if unspecified.
-    max_retries : typing.Optional[int]
+    max_retries
         Maximum number of times a request will be retried if
         it fails with a `5xx` status.
 
         Defaults to 3 if set to [`None`][].
-    proxy_settings : typing.Optional[hikari.impl.config.ProxySettings]
+    proxy_settings
         Proxy settings to use. If [`None`][] then no proxy configuration
         will be used.
-    url : typing.Optional[str]
+    url
         The base URL for the API. You can generally leave this as being
         [`None`][] and the correct default API base URL will be generated.
     """
@@ -393,10 +393,10 @@ class RESTApp(traits.ExecutorAware):
 
         Parameters
         ----------
-        token : typing.Union[str, None, hikari.api.rest.TokenStrategy]
+        token
             The bot or bearer token. If no token is to be used,
             this can be undefined.
-        token_type : typing.Union[str, hikari.applications.TokenType, None]
+        token_type
             The type of token in use. This should only be passed when [`str`][]
             is passed for `token`, can be `"Bot"` or `"Bearer"` and will be
             defaulted to `"Bearer"` in this situation.
@@ -490,32 +490,32 @@ class RESTClientImpl(rest_api.RESTClient):
 
     Parameters
     ----------
-    entity_factory : hikari.api.entity_factory.EntityFactory
+    entity_factory
         The entity factory to use.
-    executor : typing.Optional[concurrent.futures.Executor]
+    executor
         The executor to use for blocking IO.
 
         Defaults to the [`asyncio`][] thread pool if set to [`None`][].
-    max_retries : typing.Optional[int]
+    max_retries
         Maximum number of times a request will be retried if
         it fails with a `5xx` status.
 
         Defaults to 3 if set to [`None`][].
-    dumps : hikari.internal.data_binding.JSONEncoder
+    dumps
         The JSON encoder this application should use.
-    loads : hikari.internal.data_binding.JSONDecoder
+    loads
         The JSON decoder this application should use.
-    token : typing.Union[str, None, hikari.api.rest.TokenStrategy]
+    token
         The bot or bearer token. If no token is to be used,
         this can be undefined.
-    token_type : typing.Union[str, hikari.applications.TokenType, None]
+    token_type
         The type of token in use. This must be passed when a [`str`][] is
         passed for `token` but and can be `"Bot"` or `"Bearer"`.
 
         This should be left as [`None`][] when either
         [`hikari.api.rest.TokenStrategy`][] or [`None`][] is passed for
         `token`.
-    rest_url : str
+    rest_url
         The HTTP API base URL. This can contain format-string specifiers to
         interpolate information such as API version in use.
 

--- a/hikari/impl/rest_bot.py
+++ b/hikari/impl/rest_bot.py
@@ -72,9 +72,9 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
 
     Parameters
     ----------
-    token : typing.Union[str, hikari.api.rest.TokenStrategy]
+    token
         The bot or bearer token.
-    token_type : typing.Union[str, hikari.applications.TokenType, None]
+    token_type
         The type of token in use. This should only be passed when [`str`][]
         is passed for `token`, can be `"Bot"` or `"Bearer"` and defaults
         to `"Bot".
@@ -84,7 +84,7 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
 
     Other Parameters
     ----------------
-    allow_color : bool
+    allow_color
         Whether to enable coloured console logs on any platform that is a TTY.
         Setting a `"CLICOLOR"` environment variable to any **non `0`** value
         will override this setting.
@@ -94,15 +94,15 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
         awkward or not support features in a standard way, the option to
         explicitly disable this is provided. See `force_color` for an
         alternative.
-    banner : typing.Optional[str]
+    banner
         The package to search for a `banner.txt` in.
 
         Setting this to [`None`][] will disable the banner being shown.
-    suppress_optimization_warning : bool
+    suppress_optimization_warning
         By default, Hikari warns you if you are not running your bot using
         optimizations (`-O` or `-OO`). If this is [`True`][], you won't receive
         these warnings, even if you are not running using optimizations.
-    executor : typing.Optional[concurrent.futures.Executor]
+    executor
         If non-[`None`][], then this executor is used instead of the
         [`concurrent.futures.ThreadPoolExecutor`][] attached to the
         [`asyncio.AbstractEventLoop`][] that the bot will run on. This
@@ -114,19 +114,19 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
         relies on all objects used in IPC to be pickleable. Many third-party
         libraries will not support this fully though, so your mileage may vary
         on using ProcessPoolExecutor implementations with this parameter.
-    force_color : bool
+    force_color
         If [`True`][], then this application will __force__ colour to be
         used in console-based output. Specifying a `"CLICOLOR_FORCE"`
         environment variable with a non-`"0"` value will
         override this setting.
 
         This will take precedence over `allow_color` if both are specified.
-    http_settings : typing.Optional[hikari.config.HTTPSettings]
+    http_settings
         Optional custom HTTP configuration settings to use. Allows you to
         customise functionality such as whether SSL-verification is enabled,
         what timeouts [`aiohttp`][] should expect to use for requests, and behavior
         regarding HTTP-redirects.
-    logs : typing.Union[None, int, str, typing.Dict[str, typing.Any], os.PathLike[str]]
+    logs
         The flavour to set the logging to.
 
         This can be [`None`][] to not enable logging automatically.
@@ -147,7 +147,7 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
 
         Note that `"TRACE_HIKARI"` is a library-specific logging level
         which is expected to be more verbose than `"DEBUG"`.
-    max_rate_limit : float
+    max_rate_limit
         The max number of seconds to backoff for when rate limited. Anything
         greater than this will instead raise an error.
 
@@ -160,20 +160,20 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
         Note that this only applies to the REST API component that communicates
         with Discord, and will not affect sharding or third party HTTP endpoints
         that may be in use.
-    max_retries : typing.Optional[int]
+    max_retries
         Maximum number of times a request will be retried if
         it fails with a `5xx` status.
 
         Defaults to 3 if set to [`None`][].
-    proxy_settings : typing.Optional[hikari.impl.config.ProxySettings]
+    proxy_settings
         Custom proxy settings to use with network-layer logic
         in your application to get through an HTTP-proxy.
-    public_key : typing.Union[str, bytes, None]
+    public_key
         The public key to use to verify received interaction requests.
         This may be a hex encoded [`str`][] or the raw [`bytes`][].
         If left as [`None`][] then the client will try to work this value
         out based on [`token`][].
-    rest_url : typing.Optional[str]
+    rest_url
         Defaults to the Discord REST API URL if [`None`][]. Can be
         overridden if you are attempting to point to an unofficial endpoint, or
         if you are attempting to mock/stub the Discord API for any reason.
@@ -391,19 +391,19 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
 
         Parameters
         ----------
-        banner : typing.Optional[str]
+        banner
             The package to find a `banner.txt` in.
-        allow_color : bool
+        allow_color
             A flag that allows advising whether to allow color if supported or
             not. Can be overridden by setting a `CLICOLOR` environment
             variable to a non-`"0"` string.
-        force_color : bool
+        force_color
             A flag that allows forcing color to always be output, even if the
             terminal device may not support it. Setting the `CLICOLOR_FORCE`
             environment variable to a non-`"0"` string will override this.
 
             This will take precedence over `allow_color` if both are specified.
-        extra_args : typing.Optional[typing.Dict[str, str]]
+        extra_args
             If provided, extra $-substitutions to use when printing the banner.
             Default substitutions can not be overwritten.
 
@@ -491,15 +491,15 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
 
         Other Parameters
         ----------------
-        asyncio_debug : bool
+        asyncio_debug
             If [`True`][], then debugging is enabled for the asyncio event loop in use.
-        backlog : int
+        backlog
             The number of unaccepted connections that the system will allow before
             refusing new connections.
-        check_for_updates : bool
+        check_for_updates
             If [`True`][], will check for newer versions of hikari on
             PyPI and notify if available.
-        close_loop : bool
+        close_loop
             If [`True`][], then once the bot enters a state where all components
             have shut down permanently during application shut down, then all
             asyncgens and background tasks will be destroyed, and the event
@@ -509,19 +509,19 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
             had time to attempt to shut down correctly (around 250ms), and on
             Python 3.9 and newer, will also shut down the default event loop
             executor too.
-        close_passed_executor : bool
+        close_passed_executor
             If [`True`][], any custom [`concurrent.futures.Executor`][] passed
             to the constructor will be shut down when the application
             terminates. This does not affect the default executor associated
             with the event loop, and will not do anything if you do not
             provide a custom executor to the constructor.
-        coroutine_tracking_depth : typing.Optional[int]
+        coroutine_tracking_depth
             If an integer value and supported by the interpreter, then this
             many nested coroutine calls will be tracked with their call
             origin state. This allows you to determine where non-awaited
             coroutines may originate from, but generally you
             do not want to leave this enabled for performance reasons.
-        enable_signal_handlers : typing.Optional[bool]
+        enable_signal_handlers
             Defaults to [`True`][] if this is called in the main thread.
 
             If on a non-Windows OS with builtin support for kernel-level
@@ -531,24 +531,24 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
             rather than just killing the process in a dirty state immediately.
             You should leave this enabled unless you plan to implement your own
             signal handling yourself.
-        host : typing.Optional[typing.Union[str, aiohttp.web.HostSequence]]
+        host
             TCP/IP host or a sequence of hosts for the HTTP server.
-        port : typing.Optional[int]
+        port
             TCP/IP port for the HTTP server.
-        path : typing.Optional[str]
+        path
             File system path for HTTP server unix domain socket.
-        reuse_address : typing.Optional[bool]
+        reuse_address
             Tells the kernel to reuse a local socket in TIME_WAIT state, without
             waiting for its natural timeout to expire.
-        reuse_port : typing.Optional[bool]
+        reuse_port
             Tells the kernel to allow this endpoint to be bound to the same port
             as other existing endpoints are also bound to.
-        socket : typing.Optional[socket.socket]
+        socket
             A pre-existing socket object to accept connections on.
-        shutdown_timeout : float
+        shutdown_timeout
             A delay, in seconds, to wait for graceful server shut down before forcefully
             disconnecting all open client sockets.
-        ssl_context : typing.Optional[ssl.SSLContext]
+        ssl_context
             SSL context for HTTPS servers.
         """
         if self.is_alive:
@@ -628,30 +628,30 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
 
         Other Parameters
         ----------------
-        backlog : int
+        backlog
             The number of unaccepted connections that the system will allow before
             refusing new connections.
-        check_for_updates : bool
+        check_for_updates
             If [`True`][], will check for newer versions of hikari on PyPI
             and notify if available.
-        host : typing.Optional[typing.Union[str, aiohttp.web.HostSequence]]
+        host
             TCP/IP host or a sequence of hosts for the HTTP server.
-        port : typing.Optional[int]
+        port
             TCP/IP port for the HTTP server.
-        path : typing.Optional[str]
+        path
             File system path for HTTP server unix domain socket.
-        reuse_address : typing.Optional[bool]
+        reuse_address
             Tells the kernel to reuse a local socket in TIME_WAIT state, without
             waiting for its natural timeout to expire.
-        reuse_port : typing.Optional[bool]
+        reuse_port
             Tells the kernel to allow this endpoint to be bound to the same port
             as other existing endpoints are also bound to.
-        socket : typing.Optional[socket.socket]
+        socket
             A pre-existing socket object to accept connections on.
-        shutdown_timeout : float
+        shutdown_timeout
             A delay, in seconds, to wait for graceful server shut down before forcefully
             disconnecting all open client sockets.
-        ssl_context : typing.Optional[ssl.SSLContext]
+        ssl_context
             SSL context for HTTPS servers.
         """
         if self.is_alive:

--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -386,49 +386,49 @@ class GatewayShardImpl(shard.GatewayShard):
 
     Parameters
     ----------
-    token : str
+    token
         The bot token to use.
-    url : str
+    url
         The gateway URL to use. This should not contain a query-string or
         fragments.
-    event_manager : hikari.api.event_manager.EventManager
+    event_manager
         The event manager this shard should make calls to.
-    event_factory : hikari.api.event_factory.EventFactory
+    event_factory
         The event factory this shard should use.
 
     Other Parameters
     ----------------
-    compression : typing.Optional[str]
+    compression
         Compression format to use for the shard. Only supported values are
         `"transport_zlib_stream"` or [`None`][] to disable it.
-    dumps : hikari.internal.data_binding.JSONEncoder
+    dumps
         The JSON encoder this application should use.
-    loads : hikari.internal.data_binding.JSONDecoder
+    loads
         The JSON decoder this application should use.
-    initial_activity : typing.Optional[hikari.presences.Activity]
+    initial_activity
         The initial activity to appear to have for this shard, or
         [`None`][] if no activity should be set initially. This is the
         default.
-    initial_idle_since : typing.Optional[datetime.datetime]
+    initial_idle_since
         The datetime to appear to be idle since, or [`None`][] if the
         shard should not provide this. The default is [`None`][].
-    initial_is_afk : bool
+    initial_is_afk
         Whether to appear to be AFK or not on login.
-    initial_status : hikari.presences.Status
+    initial_status
         The initial status to set on login for the shard.
-    intents : hikari.intents.Intents
+    intents
         Collection of intents to use.
-    large_threshold : int
+    large_threshold
         The number of members to have in a guild for it to be considered large.
-    shard_id : int
+    shard_id
         The shard ID.
-    shard_count : int
+    shard_count
         The shard count.
-    http_settings : hikari.impl.config.HTTPSettings
+    http_settings
         The HTTP-related settings to use while negotiating a websocket.
-    proxy_settings : hikari.impl.config.ProxySettings
+    proxy_settings
         The proxy settings to use while negotiating a websocket.
-    data_format : str
+    data_format
         Data format to use for inbound data. Only supported format is `"json"`.
     """
 

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -1470,7 +1470,7 @@ def _build_emoji(
 
     Parameters
     ----------
-    emoji : typing.Union[hikari.snowflakes.Snowflakeish, hikari.emojis.Emoji, str, hikari.undefined.UndefinedType]
+    emoji
         The ID, object or raw string of an emoji to set on a component.
 
     Returns

--- a/hikari/interactions/base_interactions.py
+++ b/hikari/interactions/base_interactions.py
@@ -312,12 +312,12 @@ class MessageResponseMixin(PartialInteraction, typing.Generic[_CommandResponseTy
 
         Parameters
         ----------
-        response_type : typing.Union[int, CommandResponseTypesT]
+        response_type
             The type of interaction response this is.
 
         Other Parameters
         ----------------
-        content : hikari.undefined.UndefinedOr[typing.Any]
+        content
             If provided, the message contents. If
             [`hikari.undefined.UNDEFINED`][], then nothing will be sent
             in the content. Any other value here will be cast to a
@@ -326,34 +326,35 @@ class MessageResponseMixin(PartialInteraction, typing.Generic[_CommandResponseTy
             If this is a [`hikari.embeds.Embed`][] and no `embed` nor `embeds` kwarg
             is provided, then this will instead update the embed. This allows
             for simpler syntax when sending an embed alone.
-        attachment : hikari.undefined.UndefinedNoneOr[typing.Union[hikari.files.Resourceish, hikari.messages.Attachment]]
+        attachment
             If provided, the message attachment. This can be a resource,
             or string of a path on your computer or a URL.
-        attachments : hikari.undefined.UndefinedNoneOr[typing.Sequence[typing.Union[hikari.files.Resourceish, hikari.messages.Attachment]]]
+        attachments
             If provided, the message attachments. These can be resources, or
             strings consisting of paths on your computer or URLs.
-        component : hikari.undefined.UndefinedNoneOr[hikari.api.special_endpoints.ComponentBuilder]
+        component
             If provided, builder object of the component to include in this message.
-        components : hikari.undefined.UndefinedNoneOr[typing.Sequence[hikari.api.special_endpoints.ComponentBuilder]]
+        components
             If provided, a sequence of the component builder objects to include
             in this message.
-        embed : hikari.undefined.UndefinedNoneOr[hikari.embeds.Embed]
+        embed
             If provided, the message embed.
-        embeds : hikari.undefined.UndefinedNoneOr[typing.Sequence[hikari.embeds.Embed]]
+        embeds
             If provided, the message embeds.
-        flags : typing.Union[int, hikari.messages.MessageFlag, hikari.undefined.UndefinedType]
+        flags
             If provided, the message flags this response should have.
 
             As of writing the only message flags which can be set here are
-            [`hikari.messages.MessageFlag.EPHEMERAL`][], [`hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`][]
+            [`hikari.messages.MessageFlag.EPHEMERAL`][],
+            [`hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`][]
             and [`hikari.messages.MessageFlag.SUPPRESS_EMBEDS`][].
-        tts : hikari.undefined.UndefinedOr[bool]
+        tts
             If provided, whether the message will be read out by a screen
             reader using Discord's TTS (text-to-speech) system.
-        mentions_everyone : hikari.undefined.UndefinedOr[bool]
+        mentions_everyone
             If provided, whether the message should parse @everyone/@here
             mentions.
-        user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], bool]]
+        user_mentions
             If provided, and [`True`][], all user mentions will be detected.
             If provided, and [`False`][], all user mentions will be ignored
             if appearing in the message body.
@@ -361,7 +362,7 @@ class MessageResponseMixin(PartialInteraction, typing.Generic[_CommandResponseTy
             [`hikari.snowflakes.Snowflake`][], or
             [`hikari.users.PartialUser`][] derivatives to enforce mentioning
             specific users.
-        role_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole], bool]]
+        role_mentions
             If provided, and [`True`][], all role mentions will be detected.
             If provided, and [`False`][], all role mentions will be ignored
             if appearing in the message body.
@@ -392,7 +393,7 @@ class MessageResponseMixin(PartialInteraction, typing.Generic[_CommandResponseTy
             longer than `max_rate_limit` when making a request.
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
-        """  # noqa: E501 - Line too long
+        """
         await self.app.rest.create_interaction_response(
             self.id,
             self.token,
@@ -454,7 +455,7 @@ class MessageResponseMixin(PartialInteraction, typing.Generic[_CommandResponseTy
 
         Other Parameters
         ----------------
-        content : hikari.undefined.UndefinedNoneOr[typing.Any]
+        content
             If provided, the message contents. If
             [`hikari.undefined.UNDEFINED`][], then nothing will be sent
             in the content. Any other value here will be cast to a
@@ -470,43 +471,43 @@ class MessageResponseMixin(PartialInteraction, typing.Generic[_CommandResponseTy
             Likewise, if this is a [`hikari.files.Resource`][], then the
             content is instead treated as an attachment if no `attachment` and
             no `attachments` kwargs are provided.
-        attachment : hikari.undefined.UndefinedNoneOr[typing.Union[hikari.files.Resourceish, hikari.messages.Attachment]]
+        attachment
             If provided, the attachment to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous attachment, if
             present, is not changed. If this is [`None`][], then the
             attachment is removed, if present. Otherwise, the new attachment
             that was provided will be attached.
-        attachments : hikari.undefined.UndefinedNoneOr[typing.Sequence[typing.Union[hikari.files.Resourceish, hikari.messages.Attachment]]]
+        attachments
             If provided, the attachments to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous attachments, if
             present, are not changed. If this is [`None`][], then the
             attachments is removed, if present. Otherwise, the new attachments
             that were provided will be attached.
-        component : hikari.undefined.UndefinedNoneOr[hikari.api.special_endpoints.ComponentBuilder]
+        component
             If provided, builder object of the component to set for this message.
             This component will replace any previously set components and passing
             [`None`][] will remove all components.
-        components : hikari.undefined.UndefinedNoneOr[typing.Sequence[hikari.api.special_endpoints.ComponentBuilder]]
+        components
             If provided, a sequence of the component builder objects set for
             this message. These components will replace any previously set
             components and passing [`None`][] or an empty sequence will
             remove all components.
-        embed : hikari.undefined.UndefinedNoneOr[hikari.embeds.Embed]
+        embed
             If provided, the embed to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous embed(s) are not changed.
             If this is [`None`][] then any present embeds are removed.
             Otherwise, the new embed that was provided will be used as the
             replacement.
-        embeds : hikari.undefined.UndefinedNoneOr[typing.Sequence[hikari.embeds.Embed]]
+        embeds
             If provided, the embeds to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous embed(s) are not changed.
             If this is [`None`][] then any present embeds are removed.
             Otherwise, the new embeds that were provided will be used as the
             replacement.
-        mentions_everyone : hikari.undefined.UndefinedOr[bool]
+        mentions_everyone
             If provided, whether the message should parse @everyone/@here
             mentions.
-        user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], bool]]
+        user_mentions
             If provided, and [`True`][], all user mentions will be detected.
             If provided, and [`False`][], all user mentions will be ignored
             if appearing in the message body.
@@ -514,7 +515,7 @@ class MessageResponseMixin(PartialInteraction, typing.Generic[_CommandResponseTy
             [`hikari.snowflakes.Snowflake`][], or
             [`hikari.users.PartialUser`][] derivatives to enforce mentioning
             specific users.
-        role_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole], bool]]
+        role_mentions
             If provided, and [`True`][], all role mentions will be detected.
             If provided, and [`False`][], all role mentions will be ignored
             if appearing in the message body.
@@ -550,7 +551,7 @@ class MessageResponseMixin(PartialInteraction, typing.Generic[_CommandResponseTy
             longer than `max_rate_limit` when making a request.
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
-        """  # noqa: E501 - Line too long
+        """
         return await self.app.rest.edit_interaction_response(
             self.application_id,
             self.token,
@@ -600,16 +601,16 @@ class ModalResponseMixin(PartialInteraction):
 
         Parameters
         ----------
-        title : str
+        title
             The title that will show up in the modal.
-        custom_id : str
+        custom_id
             Developer set custom ID used for identifying interactions with this modal.
 
         Other Parameters
         ----------------
-        component : hikari.undefined.UndefinedOr[typing.Sequence[hikari.api.special_endpoints.ComponentBuilder]]
+        component
             A component builder to send in this modal.
-        components : hikari.undefined.UndefinedOr[typing.Sequence[hikari.api.special_endpoints.ComponentBuilder]]
+        components
             A sequence of component builders to send in this modal.
 
         Raises
@@ -626,9 +627,9 @@ class ModalResponseMixin(PartialInteraction):
 
         Parameters
         ----------
-        title : str
+        title
             The title that will show up in the modal.
-        custom_id : str
+        custom_id
             Developer set custom ID used for identifying interactions with this modal.
 
         Returns

--- a/hikari/interactions/command_interactions.py
+++ b/hikari/interactions/command_interactions.py
@@ -401,7 +401,7 @@ class AutocompleteInteraction(BaseCommandInteraction):
 
         Parameters
         ----------
-        choices : typing.Sequence[hikari.api.special_endpoints.AutocompleteChoiceBuilder]
+        choices
             The choices for the autocomplete.
 
         Examples
@@ -432,7 +432,7 @@ class AutocompleteInteraction(BaseCommandInteraction):
 
         Parameters
         ----------
-        choices : typing.Sequence[hikari.api.special_endpoints.AutocompleteChoiceBuilder]
+        choices
             The choices for the autocomplete.
         """
         await self.app.rest.create_autocomplete_response(self.id, self.token, choices)

--- a/hikari/interactions/component_interactions.py
+++ b/hikari/interactions/component_interactions.py
@@ -163,7 +163,7 @@ class ComponentInteraction(
 
         Parameters
         ----------
-        type_ : typing.Union[int, hikari.interactions.base_interactions.ResponseType]
+        type_
             The type of immediate response this should be.
 
             This may be one of the following:
@@ -208,7 +208,7 @@ class ComponentInteraction(
 
         Parameters
         ----------
-        type_ : typing.Union[int, hikari.interactions.base_interactions.ResponseType]
+        type_
             The type of deferred response this should be.
 
             This may be one of the following:

--- a/hikari/internal/aio.py
+++ b/hikari/internal/aio.py
@@ -55,15 +55,15 @@ def completed_future(result: typing.Optional[T_inv] = None, /) -> asyncio.Future
 
     Parameters
     ----------
-    result : T
+    result
         The value to set for the result of the future.
-        [`T`][] is a generic type placeholder for the type that
-        the future will have set as the result. `T` may be [`None`][], in
-        which case, this will return [`asyncio.Future`][][[`None`][]].
+        [`T_inv`][] is a generic type placeholder for the type that
+        the future will have set as the result. `T_inv` may be [`None`][],
+        in which case, this will return [`asyncio.Future`][][[`None`][]].
 
     Returns
     -------
-    asyncio.Future[T]
+    asyncio.Future[T_inv]
         The completed future.
 
     Raises
@@ -122,9 +122,9 @@ async def first_completed(*aws: typing.Awaitable[typing.Any], timeout: typing.Op
 
     Parameters
     ----------
-    *aws : typing.Awaitable[typing.Any]
+    *aws
         Awaitables to wait for.
-    timeout : typing.Optional[float]
+    timeout
         Optional timeout to wait for, or [`None`][] to not use one.
         If the timeout is reached, all awaitables are cancelled immediately.
     """
@@ -155,9 +155,9 @@ async def all_of(*aws: typing.Awaitable[T_co], timeout: typing.Optional[float] =
 
     Parameters
     ----------
-    *aws : typing.Awaitable[T_co]
+    *aws
         Awaitables to wait for.
-    timeout : typing.Optional[float]
+    timeout
         Optional timeout to wait for, or [`None`][] to not use one.
         If the timeout is reached, all awaitables are cancelled immediately.
 
@@ -231,9 +231,9 @@ def destroy_loop(loop: asyncio.AbstractEventLoop, logger: logging.Logger) -> Non
 
     Parameters
     ----------
-    loop : asyncio.AbstractEventLoop
+    loop
         The loop to destroy
-    logger : logging.Logger
+    logger
         The logger to use for logging
     """
 

--- a/hikari/internal/attrs_extensions.py
+++ b/hikari/internal/attrs_extensions.py
@@ -68,7 +68,7 @@ def get_fields_definition(
 
     Parameters
     ----------
-    cls : typing.Type[attrs.AttrsInstance]
+    cls
         The attrs class to get the fields definition for.
 
     Returns
@@ -95,7 +95,7 @@ def generate_shallow_copier(cls: typing.Type[ModelT]) -> typing.Callable[[ModelT
 
     Parameters
     ----------
-    cls : typing.Type[ModelT]
+    cls
         The attrs class to generate a shallow copying function for.
 
     Returns
@@ -121,7 +121,7 @@ def get_or_generate_shallow_copier(cls: typing.Type[ModelT]) -> typing.Callable[
 
     Parameters
     ----------
-    cls : typing.Type[ModelT]
+    cls
         The class to get or generate and cache a shallow copying function for.
 
     Returns
@@ -142,7 +142,7 @@ def copy_attrs(model: ModelT) -> ModelT:
 
     Parameters
     ----------
-    model : ModelT
+    model
         The attrs model to shallow copy.
 
     Returns
@@ -170,7 +170,7 @@ def generate_deep_copier(
 
     Parameters
     ----------
-    cls : typing.Type[ModelT]
+    cls
         The attrs class to generate a deep copying function for.
 
     Returns
@@ -204,7 +204,7 @@ def get_or_generate_deep_copier(
 
     Parameters
     ----------
-    cls : typing.Type[ModelT]
+    cls
         The class to get or generate and cache a shallow copying function for.
 
     Returns
@@ -229,9 +229,9 @@ def deep_copy_attrs(model: ModelT, memo: typing.Optional[typing.MutableMapping[i
 
     Parameters
     ----------
-    model : ModelT
+    model
         The attrs model to deep copy.
-    memo : typing.Optional[typing.MutableMapping[int, typing.Any]]
+    memo
         A memo dictionary of objects already copied during the current copying
         pass, see <https://docs.python.org/3/library/copy.html> for more details.
 

--- a/hikari/internal/cache.py
+++ b/hikari/internal/cache.py
@@ -90,10 +90,10 @@ class CacheMappingView(cache.CacheView[KeyT, ValueT]):
 
     Parameters
     ----------
-    items : typing.Union[typing.Mapping[KeyT, ValueT], typing.Mapping[KeyT, DataT]]
+    items
         A mapping of keys to the values in their raw forms, wrapped by a ref
         wrapper or in a data form.
-    builder : typing.Optional[typing.Callable[[DataT], ValueT]]
+    builder
         The callable used to build entities before they're returned by the
         mapping. This is used to cover the case when items stores [`DataT`][] objects.
     """
@@ -290,7 +290,7 @@ class BaseData(abc.ABC, typing.Generic[ValueT]):
 
         Parameters
         ----------
-        app : hikari.traits.RESTAware
+        app
             The hikari application the built object should be bound to.
 
         Returns
@@ -306,7 +306,7 @@ class BaseData(abc.ABC, typing.Generic[ValueT]):
 
         Parameters
         ----------
-        entity : ValueT
+        entity
             The entity object to build a data class from.
 
         Returns
@@ -993,7 +993,7 @@ def unwrap_ref_cell(cell: RefCell[ValueT]) -> ValueT:
 
     Parameters
     ----------
-    cell : RefCell[ValueT]
+    cell
         The reference cell instance to unwrap.
 
     Returns

--- a/hikari/internal/collections.py
+++ b/hikari/internal/collections.py
@@ -143,12 +143,12 @@ class LimitedCapacityCacheMap(ExtendedMutableMapping[KeyT, ValueT]):
 
     Parameters
     ----------
-    source : typing.Optional[typing.Dict[KeyT, ValueT]]
+    source
         A source dictionary of keys to values to create this from.
-    limit : int
+    limit
         The limit for how many objects should be stored by this mapping before
         it starts removing the oldest entries.
-    on_expire : typing.Optional[typing.Callable[[ValueT], None]]
+    on_expire
         A function to call each time an item is garbage collected from this
         map. This should take one positional argument of the same type stored
         in this mapping as the value and should return [`None`][].
@@ -235,7 +235,7 @@ class SnowflakeSet(typing.MutableSet[snowflakes.Snowflake]):
 
     Other Parameters
     ----------------
-    *ids : int
+    *ids
         The IDs to fill this table with.
     """
 
@@ -320,9 +320,9 @@ def get_index_or_slice(
 
     Parameters
     ----------
-    mapping : typing.Mapping[KeyT, ValueT]
+    mapping
         The mapping of entries to treat as a sequence.
-    index_or_slice : typing.Sequence[KeyT, ValueT]
+    index_or_slice
         The index to get an entry to get or slice of multiple entries to get.
 
     Returns

--- a/hikari/internal/data_binding.py
+++ b/hikari/internal/data_binding.py
@@ -214,14 +214,14 @@ class StringMapBuilder(multidict.MultiDict[str]):
 
         Parameters
         ----------
-        key : str
+        key
             The string key.
-        value : hikari.undefined.UndefinedOr[typing.Any]
+        value
             The value to set.
 
         Other Parameters
         ----------------
-        conversion : typing.Optional[typing.Callable[[typing.Any], typing.Any]]
+        conversion
             An optional conversion to perform.
         """
         if value is undefined.UNDEFINED:
@@ -291,16 +291,16 @@ class JSONObjectBuilder(typing.Dict[str, JSONish]):
 
         Parameters
         ----------
-        key : str
+        key
             The key to give the element.
-        value : hikari.undefined.UndefinedOr[typing.Any]
+        value
             The JSON type to put. This may be a non-JSON type if a conversion
             is also specified. This may alternatively be undefined. In the latter
             case, nothing is performed.
 
         Other Parameters
         ----------------
-        conversion : typing.Optional[typing.Callable[[typing.Any], JSONish]]
+        conversion
             The optional conversion to apply.
         """
         if value is undefined.UNDEFINED:
@@ -340,16 +340,16 @@ class JSONObjectBuilder(typing.Dict[str, JSONish]):
 
         Parameters
         ----------
-        key : str
+        key
             The key to give the element.
-        values : hikari.undefined.UndefinedOr[typing.Iterable[T_co]]
+        values
             The JSON types to put. This may be an iterable of non-JSON types if
             a conversion is also specified. This may alternatively be undefined.
             In the latter case, nothing is performed.
 
         Other Parameters
         ----------------
-        conversion : typing.Optional[typing.Callable[[typing.Any], JSONType]]
+        conversion
             The optional conversion to apply.
         """
         if values is not undefined.UNDEFINED:
@@ -367,9 +367,9 @@ class JSONObjectBuilder(typing.Dict[str, JSONish]):
 
         Parameters
         ----------
-        key : str
+        key
             The key to give the element.
-        value : hikari.undefined.UndefinedNoneOr[hikari.snowflakes.SnowflakeishOr[hikari.snowflakes.Unique]]
+        value
             The JSON type to put. This may alternatively be undefined, in this
             case, nothing is performed. This may also be [`None`][], in this
             case the value isn't cast.
@@ -390,9 +390,9 @@ class JSONObjectBuilder(typing.Dict[str, JSONish]):
 
         Parameters
         ----------
-        key : str
+        key
             The key to give the element.
-        values : hikari.undefined.UndefinedOr[typing.Iterable[hikari.snowflakes.SnowflakeishOr[hikari.snowflakes.Unique]]]
+        values
             The JSON snowflakes to put. This may alternatively be undefined.
             In the latter case, nothing is performed.
         """
@@ -405,12 +405,12 @@ def cast_variants_array(cast: typing.Callable[[T_co], T], raw_values: typing.Ite
 
     Parameters
     ----------
-    cast : typing.Callable[[T_co], T]
+    cast
         Callback to cast each variant to.
 
         This will ignore any variants which raises
         [`hikari.errors.UnrecognisedEntityError`][] on cast.
-    raw_values : typing.Iterable[T_co]
+    raw_values
         Iterable of the raw values to cast.
 
     Returns

--- a/hikari/internal/deprecation.py
+++ b/hikari/internal/deprecation.py
@@ -38,12 +38,12 @@ def check_if_past_removal(what: str, /, *, removal_version: str) -> None:
 
     Parameters
     ----------
-    what : str
+    what
         What is being deprecated.
 
     Other Parameters
     ----------------
-    removal_version : str
+    removal_version
         The version it will be removed in.
 
     Raises
@@ -64,18 +64,18 @@ def warn_deprecated(
 
     Parameters
     ----------
-    what : str
+    what
         What is being deprecated.
 
     Other Parameters
     ----------------
-    removal_version : str
+    removal_version
         The version it will be removed in.
-    additional_info : str
+    additional_info
         Additional information on the deprecation for the user.
-    stack_level : int
+    stack_level
         The stack level to issue the warning in.
-    quote : bool
+    quote
         Whether to quote [`what`][] when displaying the deprecation
 
     Raises

--- a/hikari/internal/mentions.py
+++ b/hikari/internal/mentions.py
@@ -46,17 +46,17 @@ def generate_allowed_mentions(
 
     Parameters
     ----------
-    mentions_everyone : hikari.undefined.UndefinedOr[bool]
+    mentions_everyone
         Whether @everyone and @here mentions are enabled. If
         [`hikari.undefined.UNDEFINED`][] or [`False`][] then this will be disabled.
-    mentions_reply : hikari.undefined.UndefinedOr[bool]
+    mentions_reply
         Whether the reply mention should be enabled. If [`hikari.undefined.UNDEFINED`][]
         or [`False`][] then this will be disabled.
-    user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], bool]]
+    user_mentions
         Either a sequence of objects/IDs of the users to enabled mentions for,
         [`True`][] to allow all mentions or [`False`][]/[`hikari.undefined.UNDEFINED`][]
         to disable all user mentions.
-    role_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole], bool]]
+    role_mentions
         Either a sequence of objects/IDs of the roles to enabled mentions for,
         [`True`][] to allow all mentions or [`False`][]/[`hikari.undefined.UNDEFINED`][]
         to disable all user mentions.
@@ -65,7 +65,7 @@ def generate_allowed_mentions(
     -------
     hikari.internal.data_binding.JSONObject
         The allowed mentions JSON Object.
-    """  # noqa: E501 - Line too long
+    """
     parsed_mentions: typing.List[str] = []
     allowed_mentions: typing.Dict[str, typing.Any] = {"parse": parsed_mentions}
 

--- a/hikari/internal/net.py
+++ b/hikari/internal/net.py
@@ -83,17 +83,17 @@ def create_tcp_connector(
 
     Parameters
     ----------
-    http_settings : config.HTTPSettings
+    http_settings
         HTTP settings to use for the connector.
 
     Optional Parameters
     -------------------
-    dns_cache : typing.Union[None, bool, int]
+    dns_cache
         If [`True`][], DNS caching is used with a default TTL of 10 seconds.
         If [`False`][], DNS caching is disabled. If an [`int`][] is
         given, then DNS caching is enabled with an explicit TTL set. If
         [`None`][], the cache will be enabled and never invalidate.
-    limit : int
+    limit
         Number of connections to allow in the pool at any given time.
 
     Returns
@@ -131,16 +131,16 @@ def create_client_session(
 
     Parameters
     ----------
-    connector : aiohttp.BaseConnector
+    connector
         The connector to use.
-    connector_owner : bool
+    connector_owner
         If [`True`][], then the client session will close the
         connector on shutdown. Otherwise, you must do it manually.
-    http_settings : hikari.impl.config.HTTPSettings
+    http_settings
         HTTP settings to use.
-    raise_for_status : bool
+    raise_for_status
         Whether to raise an exception when a request fails
-    trust_env : bool
+    trust_env
         Whether to trust anything in environment variables
         and the `netrc` file.
 

--- a/hikari/internal/reflect.py
+++ b/hikari/internal/reflect.py
@@ -48,7 +48,7 @@ def resolve_signature(func: typing.Callable[..., typing.Any]) -> inspect.Signatu
 
     Parameters
     ----------
-    func : typing.Callable[..., typing.Any]
+    func
         The function to get the resolved annotations from.
 
     Returns

--- a/hikari/internal/routes.py
+++ b/hikari/internal/routes.py
@@ -78,7 +78,7 @@ class CompiledRoute:
 
         Parameters
         ----------
-        base_url : str
+        base_url
             The base of the URL to prepend to the compiled path.
 
         Returns
@@ -96,10 +96,10 @@ class CompiledRoute:
 
         Parameters
         ----------
-        initial_bucket_hash : str
+        initial_bucket_hash
             The initial bucket hash provided by Discord in the HTTP headers
             for a given response.
-        authentication_hash : str
+        authentication_hash
             The token hash.
 
         Returns
@@ -125,9 +125,9 @@ class Route:
 
     Parameters
     ----------
-    method : str
+    method
         The HTTP method.
-    path_template : str
+    path_template
         The template string for the path to use.
     """
 
@@ -167,7 +167,7 @@ class Route:
 
         Parameters
         ----------
-        **kwargs : typing.Any
+        **kwargs
             Any parameters to interpolate into the route path.
 
         Returns
@@ -222,15 +222,15 @@ class CDNRoute:
 
         Parameters
         ----------
-        base_url : str
+        base_url
             The base URL for the CDN. The generated route is concatenated onto
             this.
-        file_format : str
+        file_format
             The file format to use for the asset.
-        size : typing.Optional[int]
+        size
             The custom size query parameter to set. If [`None`][],
             it is not passed.
-        **kwargs : typing.Any
+        **kwargs
             Parameters to interpolate into the path template.
 
         Returns

--- a/hikari/internal/signals.py
+++ b/hikari/internal/signals.py
@@ -84,14 +84,14 @@ def handle_interrupts(
 
     Parameters
     ----------
-    enabled : typing.Optional[bool]
+    enabled
         Whether to enable the signal interrupts.
 
         If set to [`None`][], then it will be enabled or not based on whether the running
         thread is the main one or not.
-    loop : asyncio.AbstractEventLoop
+    loop
         The event loop the interrupt will be raised in.
-    propagate_interrupts : bool
+    propagate_interrupts
         Whether to propagate interrupts.
     """
     if enabled is None:

--- a/hikari/internal/time.py
+++ b/hikari/internal/time.py
@@ -71,7 +71,7 @@ def slow_iso8601_datetime_string_to_datetime(datetime_str: str) -> datetime.date
 
     Parameters
     ----------
-    datetime_str : str
+    datetime_str
         The date string to parse.
 
     Returns
@@ -110,7 +110,7 @@ def discord_epoch_to_datetime(epoch: int, /) -> datetime.datetime:
 
     Parameters
     ----------
-    epoch : int
+    epoch
         Number of milliseconds since [1/1/2015 00:00:00 UTC][].
 
     Returns
@@ -126,7 +126,7 @@ def datetime_to_discord_epoch(timestamp: datetime.datetime) -> int:
 
     Parameters
     ----------
-    timestamp : datetime.datetime
+    timestamp
         Number of seconds since `1/1/1970 00:00:00 UTC`.
 
     Returns
@@ -147,9 +147,9 @@ def unix_epoch_to_datetime(epoch: typing.Union[int, float], /, *, is_millis: boo
 
     Parameters
     ----------
-    epoch : typing.Union[int, float]
+    epoch
         Number of seconds/milliseconds since [1/1/1970 00:00:00 UTC][].
-    is_millis : bool
+    is_millis
         [`True`][] by default, indicates the input timestamp is measured in
         milliseconds rather than seconds.
 
@@ -175,7 +175,7 @@ def timespan_to_int(value: Intervalish, /) -> int:
 
     Parameters
     ----------
-    value : Intervalish
+    value
         The number of seconds.
 
     Returns

--- a/hikari/internal/ux.py
+++ b/hikari/internal/ux.py
@@ -86,7 +86,7 @@ def init_logging(
 
     Parameters
     ----------
-    flavor : typing.Optional[None, str, int, typing.Dict[str, typing.Any], os.PathLike[str]]
+    flavor
         The hint for configuring logging.
 
         This can be [`None`][] to not enable logging automatically.
@@ -107,10 +107,10 @@ def init_logging(
 
         Note that `"TRACE_HIKARI"` is a library-specific logging level
         which is expected to be more verbose than `"DEBUG"`.
-    allow_color : bool
+    allow_color
         If [`False`][], no colour is allowed. If [`True`][], the
         output device must be supported for colour to be enabled.
-    force_color : bool
+    force_color
         If [`True`][], always force colour.
 
     Examples
@@ -266,15 +266,15 @@ def print_banner(
 
     Parameters
     ----------
-    package : typing.Optional[str]
+    package
         The package to find the `banner.txt` in, or [`None`][] if no
         banner should be shown.
-    allow_color : bool
+    allow_color
         If [`False`][], no colour is allowed. If [`True`][], the
         output device must be supported for colour to be enabled.
-    force_color : bool
+    force_color
         If [`True`][], always force colour.
-    extra_args : typing.Optional[typing.Dict[str, str]]
+    extra_args
         If provided, extra $-substitutions to use when printing the banner.
         Default substitutions can not be overwritten.
 
@@ -340,10 +340,10 @@ def supports_color(allow_color: bool, force_color: bool) -> bool:
 
     Parameters
     ----------
-    allow_color : bool
+    allow_color
         If [`False`][], no color is allowed. If [`True`][], the
         output device must be supported for this to return [`True`][].
-    force_color : bool
+    force_color
         If [`True`][], return [`True`][] always, otherwise only
         return [`True`][] if the device supports color output and the
         `allow_color` flag is not [`False`][].

--- a/hikari/invites.py
+++ b/hikari/invites.py
@@ -136,10 +136,10 @@ class InviteGuild(guilds.PartialGuild):
 
         Parameters
         ----------
-        ext : str
+        ext
             The extension to use for this URL.
             supports `png`, `jpeg`, `jpg` and `webp`.
-        size : int
+        size
             The size to set for the URL.
             Can be any power of two between `16` and `4096`.
 
@@ -170,14 +170,14 @@ class InviteGuild(guilds.PartialGuild):
 
         Parameters
         ----------
-        ext : typing.Optional[str]
+        ext
             The ext to use for this URL.
             Supports `png`, `jpeg`, `jpg`, `webp` and `gif` (when
             animated).
 
             If [`None`][], then the correct default extension is
             determined based on whether the banner is animated or not.
-        size : int
+        size
             The size to set for the URL.
             Can be any power of two between `16` and `4096`.
 

--- a/hikari/iterators.py
+++ b/hikari/iterators.py
@@ -88,7 +88,7 @@ class All(typing.Generic[ValueT]):
 
     Parameters
     ----------
-    conditions : typing.Callable[[ValueT], bool]
+    conditions
         The predicates to wrap.
     """
 
@@ -123,14 +123,14 @@ class AttrComparator(typing.Generic[ValueT]):
 
     Parameters
     ----------
-    attr_name : str
+    attr_name
         The attribute name. Can be prepended with a `.` optionally.
         If the attribute name ends with a `()`, then the call is invoked
         rather than treated as a property (useful for methods like
         [`str.isupper`][], for example).
-    expected_value : typing.Any
+    expected_value
         The expected value.
-    cast : typing.Optional[typing.Callable[[ValueT], typing.Any]]
+    cast
         Optional cast to perform on the input value when being called before
         comparing it to the expected value but after accessing the attribute.
     """
@@ -217,7 +217,7 @@ class LazyIterator(typing.Generic[ValueT], abc.ABC):
 
         Parameters
         ----------
-        chunk_size : int
+        chunk_size
             The limit for how many results should be returned in each chunk.
 
         Returns
@@ -234,7 +234,7 @@ class LazyIterator(typing.Generic[ValueT], abc.ABC):
 
         Parameters
         ----------
-        transformation : typing.Union[typing.Callable[[ValueT], bool], str]
+        transformation
             The function to use to map the attribute. This may alternatively
             be a string attribute name to replace the input value with. You
             can provide nested attributes using the ``.`` operator.
@@ -274,7 +274,7 @@ class LazyIterator(typing.Generic[ValueT], abc.ABC):
 
         Parameters
         ----------
-        *predicates : typing.Union[typing.Callable[[ValueT], bool], typing.Tuple[str, typing.Any]]
+        *predicates
             Predicates to invoke. These are functions that take a value and
             return [`True`][] if it is of interest, or [`False`][]
             otherwise. These may instead include 2-[`tuple`][] objects
@@ -282,7 +282,7 @@ class LazyIterator(typing.Generic[ValueT], abc.ABC):
             are referred to using the ``.`` operator), and values to compare for
             equality. This allows you to specify conditions such as
             `members.filter(("user.bot", True))`.
-        **attrs : typing.Any
+        **attrs
             Alternative to passing 2-tuples. Cannot specify nested attributes
             using this method.
 
@@ -304,7 +304,7 @@ class LazyIterator(typing.Generic[ValueT], abc.ABC):
 
         Parameters
         ----------
-        *predicates : typing.Union[typing.Callable[[ValueT], bool], typing.Tuple[str, typing.Any]]
+        *predicates
             Predicates to invoke. These are functions that take a value and
             return [`True`][] if it is of interest, or [`False`][]
             otherwise. These may instead include 2-[`tuple`][] objects
@@ -312,7 +312,7 @@ class LazyIterator(typing.Generic[ValueT], abc.ABC):
             are referred to using the ``.`` operator), and values to compare for
             equality. This allows you to specify conditions such as
             `members.take_while(("user.bot", True))`.
-        **attrs : typing.Any
+        **attrs
             Alternative to passing 2-tuples. Cannot specify nested attributes
             using this method.
 
@@ -334,7 +334,7 @@ class LazyIterator(typing.Generic[ValueT], abc.ABC):
 
         Parameters
         ----------
-        *predicates : typing.Union[typing.Callable[[ValueT], bool], typing.Tuple[str, typing.Any]]
+        *predicates
             Predicates to invoke. These are functions that take a value and
             return [`True`][] if it is of interest, or [`False`][]
             otherwise. These may instead include 2-[`tuple`][] objects
@@ -342,7 +342,7 @@ class LazyIterator(typing.Generic[ValueT], abc.ABC):
             referred to using the ``.`` operator), and values to compare for
             equality. This allows you to specify conditions such as
             `members.take_until(("user.bot", True))`.
-        **attrs : typing.Any
+        **attrs
             Alternative to passing 2-tuples. Cannot specify nested attributes
             using this method.
 
@@ -366,7 +366,7 @@ class LazyIterator(typing.Generic[ValueT], abc.ABC):
 
         Parameters
         ----------
-        *predicates : typing.Union[typing.Callable[[ValueT], bool], typing.Tuple[str, typing.Any]]
+        *predicates
             Predicates to invoke. These are functions that take a value and
             return [`True`][] if it is of interest, or [`False`][]
             otherwise. These may instead include 2-[`tuple`][] objects
@@ -374,7 +374,7 @@ class LazyIterator(typing.Generic[ValueT], abc.ABC):
             are referred to using the ``.`` operator), and values to compare for
             equality. This allows you to specify conditions such as
             `members.skip_while(("user.bot", True))`.
-        **attrs : typing.Any
+        **attrs
             Alternative to passing 2-tuples. Cannot specify nested attributes
             using this method.
 
@@ -398,7 +398,7 @@ class LazyIterator(typing.Generic[ValueT], abc.ABC):
 
         Parameters
         ----------
-        *predicates : typing.Union[typing.Callable[[ValueT], bool], typing.Tuple[str, typing.Any]]
+        *predicates
             Predicates to invoke. These are functions that take a value and
             return [`True`][] if it is of interest, or [`False`][]
             otherwise. These may instead include 2-[`tuple`][] objects
@@ -406,7 +406,7 @@ class LazyIterator(typing.Generic[ValueT], abc.ABC):
             referred to using the ``.`` operator), and values to compare for
             equality. This allows you to specify conditions such as
             `members.skip_until(("user.bot", True))`.
-        **attrs : typing.Any
+        **attrs
             Alternative to passing 2-tuples. Cannot specify nested attributes
             using this method.
 
@@ -428,7 +428,7 @@ class LazyIterator(typing.Generic[ValueT], abc.ABC):
 
         Parameters
         ----------
-        start : int
+        start
             Optional int to start at. If omitted, this is `0`.
 
         Examples
@@ -470,7 +470,7 @@ class LazyIterator(typing.Generic[ValueT], abc.ABC):
 
         Parameters
         ----------
-        limit : int
+        limit
             The number of items to get. This must be greater than zero.
 
         Examples
@@ -493,7 +493,7 @@ class LazyIterator(typing.Generic[ValueT], abc.ABC):
 
         Parameters
         ----------
-        number : int
+        number
             The max number of items to drop before any items are yielded.
 
         Returns
@@ -657,7 +657,7 @@ class LazyIterator(typing.Generic[ValueT], abc.ABC):
 
         Parameters
         ----------
-        window_size : int
+        window_size
             The window size of how many tasks to await at once. You can set this
             to `0` to await everything at once, but see the below warning.
 

--- a/hikari/messages.py
+++ b/hikari/messages.py
@@ -350,10 +350,10 @@ class MessageApplication(guilds.PartialApplication):
 
         Parameters
         ----------
-        ext : str
+        ext
             The extension to use for this URL.
             supports `png`, `jpeg`, `jpg` and `webp`.
-        size : int
+        size
             The size to set for the URL.
             Can be any power of two between `16` and `4096`.
 
@@ -698,7 +698,7 @@ class PartialMessage(snowflakes.Unique):
 
         Other Parameters
         ----------------
-        guild : typing.Optional[hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]]
+        guild
             Object or ID of the guild this message is in or [`None`][]
             to generate a DM message link.
 
@@ -789,7 +789,7 @@ class PartialMessage(snowflakes.Unique):
 
         Parameters
         ----------
-        content : hikari.undefined.UndefinedOr[typing.Any]
+        content
             If provided, the message content to update with. If
             [`hikari.undefined.UNDEFINED`][], then the content will not
             be changed. If [`None`][], then the content will be removed.
@@ -805,51 +805,51 @@ class PartialMessage(snowflakes.Unique):
 
         Other Parameters
         ----------------
-        attachment : hikari.undefined.UndefinedNoneOr[typing.Union[hikari.files.Resourceish, hikari.messages.Attachment]]
+        attachment
             If provided, the attachment to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous attachment, if
             present, is not changed. If this is [`None`][], then the
             attachment is removed, if present. Otherwise, the new attachment
             that was provided will be attached.
-        attachments : hikari.undefined.UndefinedNoneOr[typing.Sequence[typing.Union[hikari.files.Resourceish, hikari.messages.Attachment]]]
+        attachments
             If provided, the attachments to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous attachments, if
             present, are not changed. If this is [`None`][], then the
             attachments is removed, if present. Otherwise, the new attachments
             that were provided will be attached.
-        component : hikari.undefined.UndefinedNoneOr[hikari.api.special_endpoints.ComponentBuilder]
+        component
             If provided, builder object of the component to set for this message.
             This component will replace any previously set components and passing
             [`None`][] will remove all components.
-        components : hikari.undefined.UndefinedNoneOr[typing.Sequence[hikari.api.special_endpoints.ComponentBuilder]]
+        components
             If provided, a sequence of the component builder objects set for
             this message. These components will replace any previously set
             components and passing [`None`][] or an empty sequence will
             remove all components.
-        embed : hikari.undefined.UndefinedNoneOr[hikari.embeds.Embed]
+        embed
             If provided, the embed to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous embed(s) are not changed.
             If this is [`None`][] then any present embeds are removed.
             Otherwise, the new embed that was provided will be used as the
             replacement.
-        embeds : hikari.undefined.UndefinedNoneOr[typing.Sequence[hikari.embeds.Embed]]
+        embeds
             If provided, the embeds to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous embed(s) are not changed.
             If this is [`None`][] then any present embeds are removed.
             Otherwise, the new embeds that were provided will be used as the
             replacement.
-        mentions_everyone : hikari.undefined.UndefinedOr[bool]
+        mentions_everyone
             Sanitation for `@everyone` mentions. If
             [`hikari.undefined.UNDEFINED`][], then the previous setting is
             not changed. If [`True`][], then `@everyone`/`@here` mentions
             in the message content will show up as mentioning everyone that can
             view the chat.
-        mentions_reply : hikari.undefined.UndefinedOr[bool]
+        mentions_reply
             If provided, whether to mention the author of the message
             that is being replied to.
 
             This will not do anything if this is not a reply message.
-        user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], bool]]
+        user_mentions
             Sanitation for user mentions. If
             [`hikari.undefined.UNDEFINED`][], then the previous setting is
             not changed. If [`True`][], all valid user mentions will behave
@@ -859,7 +859,7 @@ class PartialMessage(snowflakes.Unique):
             You may alternatively pass a collection of
             [`hikari.snowflakes.Snowflake`][] user IDs, or
             [`hikari.users.PartialUser`][]-derived objects.
-        role_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole], bool]]
+        role_mentions
             Sanitation for role mentions. If
             [`hikari.undefined.UNDEFINED`][], then the previous setting is
             not changed. If [`True`][], all valid role mentions will behave
@@ -869,14 +869,15 @@ class PartialMessage(snowflakes.Unique):
             You may alternatively pass a collection of
             [`hikari.snowflakes.Snowflake`][] role IDs, or
             [`hikari.guilds.PartialRole`][]-derived objects.
-        flags : hikari.undefined.UndefinedOr[hikari.messages.MessageFlag]
+        flags
             Optional flags to set on the message. If
             [`hikari.undefined.UNDEFINED`][], then nothing is changed.
 
             Note that some flags may not be able to be set. Currently the only
-            flags that can be set are [`hikari.messages.MessageFlag.NONE`][] and [`hikari.messages.MessageFlag.SUPPRESS_EMBEDS`][]. If you
-            have [`hikari.permissions.Permissions.MANAGE_MESSAGES`][] permissions, you can use this call to
-            suppress embeds on another user's message.
+            flags that can be set are [`hikari.messages.MessageFlag.NONE`][] and
+            [`hikari.messages.MessageFlag.SUPPRESS_EMBEDS`][]. If you have
+            [`hikari.permissions.Permissions.MANAGE_MESSAGES`][] permissions,
+            you can use this call to suppress embeds on another user's message.
 
         Returns
         -------
@@ -901,7 +902,7 @@ class PartialMessage(snowflakes.Unique):
             If the channel or message is not found.
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
-        """  # noqa: E501 - Line too long
+        """
         return await self.app.rest.edit_message(
             message=self.id,
             channel=self.channel_id,
@@ -952,7 +953,7 @@ class PartialMessage(snowflakes.Unique):
 
         Parameters
         ----------
-        content : hikari.undefined.UndefinedOr[typing.Any]
+        content
             If provided, the message contents. If
             [`hikari.undefined.UNDEFINED`][], then nothing will be sent
             in the content. Any other value here will be cast to a
@@ -968,7 +969,7 @@ class PartialMessage(snowflakes.Unique):
 
         Other Parameters
         ----------------
-        attachment : hikari.undefined.UndefinedOr[hikari.files.Resourceish],
+        attachment
             If provided, the message attachment. This can be a resource,
             or string of a path on your computer or a URL.
 
@@ -997,63 +998,64 @@ class PartialMessage(snowflakes.Unique):
                 type of [`concurrent.futures.Executor`][] that is being used for
                 the application (default is a thread pool which supports this
                 behaviour).
-        attachments : hikari.undefined.UndefinedOr[typing.Sequence[hikari.files.Resourceish]],
+        attachments
             If provided, the message attachments. These can be resources, or
             strings consisting of paths on your computer or URLs.
-        component : hikari.undefined.UndefinedOr[hikari.api.special_endpoints.ComponentBuilder]
+        component
             If provided, builder object of the component to include in this message.
-        components : hikari.undefined.UndefinedOr[typing.Sequence[hikari.api.special_endpoints.ComponentBuilder]]
+        components
             If provided, a sequence of the component builder objects to include
             in this message.
-        embed : hikari.undefined.UndefinedOr[hikari.embeds.Embed]
+        embed
             If provided, the message embed.
-        embeds : hikari.undefined.UndefinedOr[typing.Sequence[hikari.embeds.Embed]]
+        embeds
             If provided, the message embeds.
-        sticker : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.stickers.PartialSticker]]
+        sticker
             If provided, object or ID of a sticker to send on the message.
 
             As of writing, bots can only send custom stickers from the current guild.
-        stickers : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishSequence[hikari.stickers.PartialSticker]]
+        stickers
             If provided, object or ID of up to 3 stickers to send on the message.
 
             As of writing, bots can only send custom stickers from the current guild.
-        tts : hikari.undefined.UndefinedOr[bool]
+        tts
             If provided, whether the message will be TTS (Text To Speech).
-        reply : typing.Union[hikari.undefined.UndefinedType, hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage], bool]
+        reply
             If provided and [`True`][], reply to this message.
             If provided and not [`bool`][], the message to reply to.
-        reply_must_exist : hikari.undefined.UndefinedOr[bool]
+        reply_must_exist
             If provided, whether to error if the message being replied to does
             not exist instead of sending as a normal (non-reply) message.
 
             This will not do anything if not being used with `reply`.
-        mentions_everyone : hikari.undefined.UndefinedOr[bool]
+        mentions_everyone
             If provided, whether the message should parse @everyone/@here
             mentions.
-        mentions_reply : hikari.undefined.UndefinedOr[bool]
+        mentions_reply
             If provided, whether to mention the author of the message
             that is being replied to.
 
             This will not do anything if not being used with `reply`.
-        user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], bool]]
+        user_mentions
             If provided, and [`True`][], all mentions will be parsed.
             If provided, and [`False`][], no mentions will be parsed.
             Alternatively this may be a collection of
             [`hikari.snowflakes.Snowflake`][], or [`hikari.users.PartialUser`][]
             derivatives to enforce mentioning specific users.
-        role_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole], bool]]
+        role_mentions
             If provided, and [`True`][], all mentions will be parsed.
             If provided, and [`False`][], no mentions will be parsed.
             Alternatively this may be a collection of
             [`hikari.snowflakes.Snowflake`][], or
             [`hikari.guilds.PartialRole`][] derivatives to enforce mentioning
             specific roles.
-        flags : hikari.undefined.UndefinedOr[hikari.messages.MessageFlag]
+        flags
             If provided, optional flags to set on the message. If
             [`hikari.undefined.UNDEFINED`][], then nothing is changed.
 
             Note that some flags may not be able to be set. Currently the only
-            flags that can be set are [`hikari.messages.MessageFlag.NONE`][] and [`hikari.messages.MessageFlag.SUPPRESS_EMBEDS`][].
+            flags that can be set are [`hikari.messages.MessageFlag.NONE`][] and
+            [`hikari.messages.MessageFlag.SUPPRESS_EMBEDS`][].
 
         Returns
         -------
@@ -1082,7 +1084,7 @@ class PartialMessage(snowflakes.Unique):
             `role_mentions` or `user_mentions`.
         TypeError
             If both `attachment` and `attachments` are specified.
-        """  # noqa: E501 - Line too long
+        """
         if reply is True:
             reply = self
 
@@ -1138,7 +1140,7 @@ class PartialMessage(snowflakes.Unique):
 
         Parameters
         ----------
-        emoji : typing.Union[str, hikari.emojis.Emoji]
+        emoji
             Object or name of the emoji to react with.
 
             Note that if the emoji is an [`hikari.emojis.CustomEmoji`][]
@@ -1146,7 +1148,7 @@ class PartialMessage(snowflakes.Unique):
 
         Other Parameters
         ----------------
-        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]]
+        emoji_id
             ID of the custom emoji to react with.
             This should only be provided when a custom emoji's name is passed
             for `emoji`.
@@ -1216,16 +1218,16 @@ class PartialMessage(snowflakes.Unique):
 
         Parameters
         ----------
-        emoji : typing.Union[str, hikari.emojis.Emoji]
+        emoji
             Object or name of the emoji to remove the reaction for.
 
         Other Parameters
         ----------------
-        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]]
+        emoji_id
             ID of the custom emoji to remove the reaction for.
             This should only be provided when a custom emoji's name is passed
             for `emoji`.
-        user : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.users.PartialUser]]
+        user
             The user of the reaction to remove. If unspecified, then the bot's
             reaction is removed instead.
 
@@ -1297,10 +1299,10 @@ class PartialMessage(snowflakes.Unique):
 
         Other Parameters
         ----------------
-        emoji : hikari.undefined.UndefinedOr[typing.Union[str, hikari.emojis.Emoji]]
+        emoji
             Object or name of the emoji to get the reactions for. If not specified
             then all reactions are removed.
-        emoji_id : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.emojis.CustomEmoji]]
+        emoji_id
             ID of the custom emoji to react with.
             This should only be provided when a custom emoji's name is passed
             for `emoji`.

--- a/hikari/presences.py
+++ b/hikari/presences.py
@@ -180,10 +180,10 @@ class ActivityAssets:
 
         Parameters
         ----------
-        ext : str
+        ext
             The extension to use for this URL.
             Supports `png`, `jpeg`, `jpg` and `webp`.
-        size : int
+        size
             The size to set for the URL.
             Can be any power of two between `16` and `4096`.
 
@@ -221,10 +221,10 @@ class ActivityAssets:
 
         Parameters
         ----------
-        ext : str
+        ext
             The extension to use for this URL.
             Supports `png`, `jpeg`, `jpg` and `webp`.
-        size : int
+        size
             The size to set for the URL.
             Can be any power of two between `16` and `4096`.
 

--- a/hikari/scheduled_events.py
+++ b/hikari/scheduled_events.py
@@ -161,10 +161,10 @@ class ScheduledEvent(snowflakes.Unique):
 
         Parameters
         ----------
-        ext : str
+        ext
             The extension to use for this URL.
             supports `png`, `jpeg`, `jpg` and `webp`.
-        size : int
+        size
             The size to set for the URL.
             Can be any power of two between `16` and `4096`.
 

--- a/hikari/snowflakes.py
+++ b/hikari/snowflakes.py
@@ -138,10 +138,10 @@ def calculate_shard_id(
 
     Parameters
     ----------
-    app_or_count : typing.Union[hikari.traits.ShardAware, int]
+    app_or_count
         The shard aware app of the current application or the integer count of
         the current app's shards.
-    guild : SnowflakeishOr[hikari.guilds.PartialGuild]
+    guild
         The object or ID of the guild to get the shard ID of.
 
     Returns

--- a/hikari/stickers.py
+++ b/hikari/stickers.py
@@ -120,10 +120,10 @@ class StickerPack(snowflakes.Unique):
 
         Parameters
         ----------
-        ext : str
+        ext
             The extension to use for this URL.
             Supports `png`, `jpeg`, `jpg` and `webp`.
-        size : int
+        size
             The size to set for the URL.
             Can be any power of two between `16` and `4096`.
 

--- a/hikari/templates.py
+++ b/hikari/templates.py
@@ -213,9 +213,9 @@ class Template:
 
         Parameters
         ----------
-        name : hikari.undefined.UndefinedOr[str]
+        name
             The name to set for this template.
-        description : hikari.undefined.UndefinedNoneOr[str]
+        description
             The description to set for the template.
 
         Returns
@@ -287,12 +287,12 @@ class Template:
 
         Parameters
         ----------
-        name : str
+        name
             The new guilds name.
 
         Other Parameters
         ----------------
-        icon : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
+        icon
             If provided, the guild icon to set.
             Must be a 1024x1024 image or can be an animated gif when the guild has the ANIMATED_ICON feature.
 

--- a/hikari/traits.py
+++ b/hikari/traits.py
@@ -304,16 +304,16 @@ class ShardAware(
 
         Other Parameters
         ----------------
-        idle_since : hikari.undefined.UndefinedNoneOr[datetime.datetime]
+        idle_since
             The datetime that the user started being idle. If undefined, this
             will not be changed.
-        afk : hikari.undefined.UndefinedOr[bool]
+        afk
             Whether to be marked as AFK. If undefined, this will not be
             changed.
-        activity : hikari.undefined.UndefinedNoneOr[hikari.presences.Activity]
+        activity
             The activity to appear to be playing. If undefined, this will not be
             changed.
-        status : hikari.undefined.UndefinedOr[hikari.presences.Status]
+        status
             The web status to show. If undefined, this will not be changed.
         """
         raise NotImplementedError
@@ -331,16 +331,16 @@ class ShardAware(
 
         Parameters
         ----------
-        guild : hikari.snowflakes.SnowflakeishOr[hikari.guilds.PartialGuild]
+        guild
             The guild or guild ID to update the voice state for.
-        channel : typing.Optional[hikari.snowflakes.SnowflakeishOr[hikari.channels.GuildVoiceChannel]]
+        channel
             The channel or channel ID to update the voice state for. If [`None`][]
             then the bot will leave the voice channel that it is in for the
             given guild.
-        self_mute : bool
+        self_mute
             If specified and [`True`][], the bot will mute itself in that
             voice channel. If [`False`][], then it will unmute itself.
-        self_deaf : bool
+        self_deaf
             If specified and [`True`][], the bot will deafen itself in that
             voice channel. If [`False`][], then it will undeafen itself.
 
@@ -370,20 +370,20 @@ class ShardAware(
 
         Parameters
         ----------
-        guild : hikari.guilds.Guild
+        guild
             The guild to request chunk for.
 
         Other Parameters
         ----------------
-        include_presences : hikari.undefined.UndefinedOr[bool]
+        include_presences
             If provided, whether to request presences.
-        query : str
+        query
             If not `""`, request the members which username starts with the string.
-        limit : int
+        limit
             Maximum number of members to send matching the query.
-        users : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishSequence[hikari.users.User]]
+        users
             If provided, the users to request for.
-        nonce : hikari.undefined.UndefinedOr[str]
+        nonce
             If provided, the nonce to be sent with guild chunks.
 
         Raises
@@ -513,7 +513,7 @@ class RESTBotAware(InteractionServerAware, Runnable, fast_protocol.FastProtocolC
 
         Parameters
         ----------
-        callback : typing.Callable[[RESTBotAware], typing.Coroutine[typing.Any, typing.Any, None]]
+        callback
             The asynchronous shutdown callback to add.
         """
         raise NotImplementedError
@@ -526,7 +526,7 @@ class RESTBotAware(InteractionServerAware, Runnable, fast_protocol.FastProtocolC
 
         Parameters
         ----------
-        callback : typing.Callable[[RESTBotAware], typing.Coroutine[typing.Any, typing.Any, None]]
+        callback
             The shutdown callback to remove.
 
         Raises
@@ -544,7 +544,7 @@ class RESTBotAware(InteractionServerAware, Runnable, fast_protocol.FastProtocolC
 
         Parameters
         ----------
-        callback : typing.Callable[[RESTBotAware], typing.Coroutine[typing.Any, typing.Any, None]]
+        callback
             The asynchronous startup callback to add.
         """
         raise NotImplementedError
@@ -557,7 +557,7 @@ class RESTBotAware(InteractionServerAware, Runnable, fast_protocol.FastProtocolC
 
         Parameters
         ----------
-        callback : typing.Callable[[RESTBotAware], typing.Coroutine[typing.Any, typing.Any, None]]
+        callback
             The asynchronous startup callback to remove.
 
         Raises

--- a/hikari/users.py
+++ b/hikari/users.py
@@ -281,7 +281,7 @@ class PartialUser(snowflakes.Unique, abc.ABC):
 
         Parameters
         ----------
-        content : hikari.undefined.UndefinedOr[typing.Any]
+        content
             If provided, the message contents. If
             [`hikari.undefined.UNDEFINED`][], then nothing will be sent
             in the content. Any other value here will be cast to a
@@ -297,7 +297,7 @@ class PartialUser(snowflakes.Unique, abc.ABC):
 
         Other Parameters
         ----------------
-        attachment : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
+        attachment
             If provided, the message attachment. This can be a resource,
             or string of a path on your computer or a URL.
 
@@ -326,37 +326,37 @@ class PartialUser(snowflakes.Unique, abc.ABC):
                 type of [`concurrent.futures.Executor`][] that is being used for
                 the application (default is a thread pool which supports this
                 behaviour).
-        attachments : hikari.undefined.UndefinedOr[typing.Sequence[hikari.files.Resourceish]]
+        attachments
             If provided, the message attachments. These can be resources, or
             strings consisting of paths on your computer or URLs.
-        component : hikari.undefined.UndefinedOr[hikari.api.special_endpoints.ComponentBuilder]
+        component
             If provided, builder object of the component to include in this message.
-        components : hikari.undefined.UndefinedOr[typing.Sequence[hikari.api.special_endpoints.ComponentBuilder]]
+        components
             If provided, a sequence of the component builder objects to include
             in this message.
-        embed : hikari.undefined.UndefinedOr[hikari.embeds.Embed]
+        embed
             If provided, the message embed.
-        embeds : hikari.undefined.UndefinedOr[typing.Sequence[hikari.embeds.Embed]]
+        embeds
             If provided, the message embeds.
-        tts : hikari.undefined.UndefinedOr[bool]
+        tts
             If provided, whether the message will be read out by a screen
             reader using Discord's TTS (text-to-speech) system.
-        reply : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]]
+        reply
             If provided, the message to reply to.
-        reply_must_exist : hikari.undefined.UndefinedOr[bool]
+        reply_must_exist
             If provided, whether to error if the message being replied to does
             not exist instead of sending as a normal (non-reply) message.
 
             This will not do anything if not being used with `reply`.
-        mentions_everyone : hikari.undefined.UndefinedOr[bool]
+        mentions_everyone
             If provided, whether the message should parse @everyone/@here
             mentions.
-        mentions_reply : hikari.undefined.UndefinedOr[bool]
+        mentions_reply
             If provided, whether to mention the author of the message
             that is being replied to.
 
             This will not do anything if not being used with `reply`.
-        user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], bool]]
+        user_mentions
             If provided, and [`True`][], all user mentions will be detected.
             If provided, and [`False`][], all user mentions will be ignored
             if appearing in the message body.
@@ -364,7 +364,7 @@ class PartialUser(snowflakes.Unique, abc.ABC):
             [`hikari.snowflakes.Snowflake`][], or
             [`hikari.users.PartialUser`][] derivatives to enforce mentioning
             specific users.
-        role_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole], bool]]
+        role_mentions
             If provided, and [`True`][], all role mentions will be detected.
             If provided, and [`False`][], all role mentions will be ignored
             if appearing in the message body.
@@ -372,12 +372,13 @@ class PartialUser(snowflakes.Unique, abc.ABC):
             [`hikari.snowflakes.Snowflake`][], or
             [`hikari.guilds.PartialRole`][] derivatives to enforce mentioning
             specific roles.
-        flags : hikari.undefined.UndefinedOr[hikari.messages.MessageFlag]
+        flags
             If provided, optional flags to set on the message. If
             [`hikari.undefined.UNDEFINED`][], then nothing is changed.
 
             Note that some flags may not be able to be set. Currently the only
-            flags that can be set are [`hikari.messages.MessageFlag.NONE`][] and [`hikari.messages.MessageFlag.SUPPRESS_EMBEDS`][].
+            flags that can be set are [`hikari.messages.MessageFlag.NONE`][]
+            and [`hikari.messages.MessageFlag.SUPPRESS_EMBEDS`][].
 
         Returns
         -------
@@ -401,8 +402,8 @@ class PartialUser(snowflakes.Unique, abc.ABC):
         hikari.errors.UnauthorizedError
             If you are unauthorized to make the request (invalid/missing token).
         hikari.errors.ForbiddenError
-            If you are missing the [`hikari.permissions.Permissions.SEND_MESSAGES`][] in the channel or the
-            person you are trying to message has the DM's disabled.
+            If you are missing the [`hikari.permissions.Permissions.SEND_MESSAGES`][] in
+            the channel or the person you are trying to message has the DM's disabled.
         hikari.errors.NotFoundError
             If the user is not found.
         hikari.errors.RateLimitTooLongError
@@ -410,7 +411,7 @@ class PartialUser(snowflakes.Unique, abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
-        """  # noqa: E501 - Line too long
+        """
         channel_id = None
         if isinstance(self.app, traits.CacheAware):
             channel_id = self.app.cache.get_dm_channel_id(self.id)
@@ -566,7 +567,7 @@ class User(PartialUser, abc.ABC):
 
         Parameters
         ----------
-        ext : typing.Optional[str]
+        ext
             The ext to use for this URL.
             Supports `png`, `jpeg`, `jpg`, `webp` and `gif` (when
             animated). Will be ignored for default avatars which can only be
@@ -574,7 +575,7 @@ class User(PartialUser, abc.ABC):
 
             If [`None`][], then the correct default extension is
             determined based on whether the icon is animated or not.
-        size : int
+        size
             The size to set for the URL.
             Can be any power of two between `16` and `4096`.
             Will be ignored for default avatars.
@@ -609,14 +610,14 @@ class User(PartialUser, abc.ABC):
 
         Parameters
         ----------
-        ext : typing.Optional[str]
+        ext
             The ext to use for this URL.
             Supports `png`, `jpeg`, `jpg`, `webp` and `gif` (when
             animated).
 
             If [`None`][], then the correct default extension is
             determined based on whether the banner is animated or not.
-        size : int
+        size
             The size to set for the URL.
             Can be any power of two between `16` and `4096`.
 

--- a/hikari/webhooks.py
+++ b/hikari/webhooks.py
@@ -125,13 +125,15 @@ class ExecutableWebhook(abc.ABC):
             At the time of writing, `username` and `avatar_url` are ignored for
             interaction webhooks.
 
-            Additionally, [`hikari.messages.MessageFlag.SUPPRESS_EMBEDS`][], [`hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`][] and [`hikari.messages.MessageFlag.EPHEMERAL`][]
-            are the only flags that can be set, with [`hikari.messages.MessageFlag.EPHEMERAL`][] being limited to
+            Additionally, [`hikari.messages.MessageFlag.SUPPRESS_EMBEDS`][],
+            [`hikari.messages.MessageFlag.SUPPRESS_NOTIFICATIONS`][] and
+            [`hikari.messages.MessageFlag.EPHEMERAL`][] are the only flags that can
+            be set, with [`hikari.messages.MessageFlag.EPHEMERAL`][] being limited to
             interaction webhooks.
 
         Parameters
         ----------
-        content : hikari.undefined.UndefinedOr[typing.Any]
+        content
             If provided, the message contents. If
             [`hikari.undefined.UNDEFINED`][], then nothing will be sent
             in the content. Any other value here will be cast to a
@@ -147,47 +149,47 @@ class ExecutableWebhook(abc.ABC):
 
         Other Parameters
         ----------------
-        username : hikari.undefined.UndefinedOr[str]
+        username
             If provided, the username to override the webhook's username
             for this request.
-        avatar_url : typing.Union[hikari.undefined.UndefinedType, hikari.files.URL, str]
+        avatar_url
             If provided, the url of an image to override the webhook's
             avatar with for this request.
-        tts : hikari.undefined.UndefinedOr[bool]
+        tts
             If provided, whether the message will be sent as a TTS message.
-        attachment : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
+        attachment
             If provided, the message attachment. This can be a resource,
             or string of a path on your computer or a URL.
-        attachments : hikari.undefined.UndefinedOr[typing.Sequence[hikari.files.Resourceish]]
+        attachments
             If provided, the message attachments. These can be resources, or
             strings consisting of paths on your computer or URLs.
-        component : hikari.undefined.UndefinedOr[hikari.api.special_endpoints.ComponentBuilder]
+        component
             If provided, builder object of the component to include in this message.
-        components : hikari.undefined.UndefinedOr[typing.Sequence[hikari.api.special_endpoints.ComponentBuilder]]
+        components
             If provided, a sequence of the component builder objects to include
             in this message.
-        embed : hikari.undefined.UndefinedOr[hikari.embeds.Embed]
+        embed
             If provided, the message embed.
-        embeds : hikari.undefined.UndefinedOr[typing.Sequence[hikari.embeds.Embed]]
+        embeds
             If provided, the message embeds.
-        mentions_everyone : hikari.undefined.UndefinedOr[bool]
+        mentions_everyone
             If provided, whether the message should parse @everyone/@here
             mentions.
-        user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], bool]]
+        user_mentions
             If provided, and [`True`][], all mentions will be parsed.
             If provided, and [`False`][], no mentions will be parsed.
             Alternatively this may be a collection of
             [`hikari.snowflakes.Snowflake`][], or
             [`hikari.users.PartialUser`][] derivatives to enforce mentioning
             specific users.
-        role_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole], bool]]
+        role_mentions
             If provided, and [`True`][], all mentions will be parsed.
             If provided, and [`False`][], no mentions will be parsed.
             Alternatively this may be a collection of
             [`hikari.snowflakes.Snowflake`][], or
             [`hikari.guilds.PartialRole`][] derivatives to enforce mentioning
             specific roles.
-        flags : typing.Union[hikari.undefined.UndefinedType, int, hikari.messages.MessageFlag]
+        flags
             The flags to set for this webhook message.
 
         Returns
@@ -213,7 +215,7 @@ class ExecutableWebhook(abc.ABC):
         TypeError
             If both `attachment` and `attachments`, `component` and `components`
             or `embed` and `embeds` are specified.
-        """  # noqa: E501 - Line too long
+        """
         if not self.token:
             raise ValueError("Cannot send a message using a webhook where we don't know the token")
 
@@ -241,7 +243,7 @@ class ExecutableWebhook(abc.ABC):
 
         Parameters
         ----------
-        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        message
             The message to fetch. This may be the object or the ID of an
             existing channel.
 
@@ -313,10 +315,10 @@ class ExecutableWebhook(abc.ABC):
 
         Parameters
         ----------
-        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        message
             The message to delete. This may be the object or the ID of
             an existing message.
-        content : hikari.undefined.UndefinedNoneOr[typing.Any]
+        content
             If provided, the message contents. If
             [`hikari.undefined.UNDEFINED`][], then nothing will be sent
             in the content. Any other value here will be cast to a
@@ -333,46 +335,46 @@ class ExecutableWebhook(abc.ABC):
 
         Other Parameters
         ----------------
-        attachment : hikari.undefined.UndefinedNoneOr[typing.Union[hikari.files.Resourceish, hikari.messages.Attachment]]
+        attachment
             If provided, the attachment to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous attachment, if
             present, is not changed. If this is [`None`][], then the
             attachment is removed, if present. Otherwise, the new attachment
             that was provided will be attached.
-        attachments : hikari.undefined.UndefinedNoneOr[typing.Sequence[typing.Union[hikari.files.Resourceish, hikari.messages.Attachment]]]
+        attachments
             If provided, the attachments to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous attachments, if
             present, are not changed. If this is [`None`][], then the
             attachments is removed, if present. Otherwise, the new attachments
             that were provided will be attached.
-        component : hikari.undefined.UndefinedNoneOr[hikari.api.special_endpoints.ComponentBuilder]
+        component
             If provided, builder object of the component to set for this message.
             This component will replace any previously set components and passing
             [`None`][] will remove all components.
-        components : hikari.undefined.UndefinedNoneOr[typing.Sequence[hikari.api.special_endpoints.ComponentBuilder]]
+        components
             If provided, a sequence of the component builder objects set for
             this message. These components will replace any previously set
             components and passing [`None`][] or an empty sequence will
             remove all components.
-        embed : hikari.undefined.UndefinedNoneOr[hikari.embeds.Embed]
+        embed
             If provided, the embed to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous embed(s) are not changed.
             If this is [`None`][] then any present embeds are removed.
             Otherwise, the new embed that was provided will be used as the
             replacement.
-        embeds : hikari.undefined.UndefinedNoneOr[typing.Sequence[hikari.embeds.Embed]]
+        embeds
             If provided, the embeds to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous embed(s) are not changed.
             If this is [`None`][] then any present embeds are removed.
             Otherwise, the new embeds that were provided will be used as the
             replacement.
-        mentions_everyone : hikari.undefined.UndefinedOr[bool]
+        mentions_everyone
             If provided, sanitation for `@everyone` mentions. If
             [`hikari.undefined.UNDEFINED`][], then the previous setting is
             not changed. If [`True`][], then `@everyone`/`@here` mentions
             in the message content will show up as mentioning everyone that can
             view the chat.
-        user_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.users.PartialUser], bool]]
+        user_mentions
             If provided, and [`True`][], all user mentions will be detected.
             If provided, and [`False`][], all user mentions will be ignored
             if appearing in the message body.
@@ -380,7 +382,7 @@ class ExecutableWebhook(abc.ABC):
             [`hikari.snowflakes.Snowflake`][], or
             [`hikari.users.PartialUser`][] derivatives to enforce mentioning
             specific users.
-        role_mentions : hikari.undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.guilds.PartialRole], bool]]
+        role_mentions
             If provided, and [`True`][], all role mentions will be detected.
             If provided, and [`False`][], all role mentions will be ignored
             if appearing in the message body.
@@ -417,7 +419,7 @@ class ExecutableWebhook(abc.ABC):
             longer than `max_rate_limit` when making a request.
         hikari.errors.InternalServerError
             If an internal error occurs on Discord while handling the request.
-        """  # noqa: E501 - Line too long
+        """
         if self.token is None:
             raise ValueError("Cannot edit a message using a webhook where we don't know the token")
 
@@ -442,7 +444,7 @@ class ExecutableWebhook(abc.ABC):
 
         Parameters
         ----------
-        message : hikari.snowflakes.SnowflakeishOr[hikari.messages.PartialMessage]
+        message
             The message to delete. This may be the object or the ID of
             an existing message.
 
@@ -534,10 +536,10 @@ class PartialWebhook(snowflakes.Unique):
 
         Parameters
         ----------
-        ext : str
+        ext
             The extension to use for this URL.
             Supports `png`, `jpeg`, `jpg` and `webp`.
-        size : int
+        size
             The size to set for the URL.
             Can be any power of two between `16` and `4096`.
             Will be ignored for default avatars.
@@ -602,7 +604,7 @@ class IncomingWebhook(PartialWebhook, ExecutableWebhook):
 
         Other Parameters
         ----------------
-        use_token : hikari.undefined.UndefinedOr[bool]
+        use_token
             If set to [`True`][] then the webhook's token will be used for
             this request; if set to [`False`][] then bot authorization will
             be used; if not specified then the webhook's token will be used for
@@ -643,19 +645,19 @@ class IncomingWebhook(PartialWebhook, ExecutableWebhook):
 
         Other Parameters
         ----------------
-        name : hikari.undefined.UndefinedOr[str]
+        name
             If provided, the new name string.
-        avatar : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
+        avatar
             If provided, the new avatar image. If [`None`][], then
             it is removed. If not specified, nothing is changed.
-        channel : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.WebhookChannelT]]
+        channel
             If provided, the object or ID of the new channel the given
             webhook should be moved to.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the audit log reason explaining why the operation
             was performed. This field will be used when using the webhook's
             token rather than bot authorization.
-        use_token : hikari.undefined.UndefinedOr[bool]
+        use_token
             If set to [`True`][] then the webhook's token will be used for
             this request; if set to [`False`][] then bot authorization will
             be used; if not specified then the webhook's token will be used for
@@ -732,7 +734,7 @@ class IncomingWebhook(PartialWebhook, ExecutableWebhook):
 
         Other Parameters
         ----------------
-        use_token : hikari.undefined.UndefinedOr[bool]
+        use_token
             If set to [`True`][] then the webhook's token will be used for
             this request; if set to [`False`][] then bot authorization will
             be used; if not specified then the webhook's token will be used for
@@ -831,15 +833,15 @@ class ChannelFollowerWebhook(PartialWebhook):
 
         Other Parameters
         ----------------
-        name : hikari.undefined.UndefinedOr[str]
+        name
             If provided, the new name string.
-        avatar : hikari.undefined.UndefinedOr[hikari.files.Resourceish]
+        avatar
             If provided, the new avatar image. If [`None`][], then
             it is removed. If not specified, nothing is changed.
-        channel : hikari.undefined.UndefinedOr[hikari.snowflakes.SnowflakeishOr[hikari.channels.WebhookChannelT]]
+        channel
             If provided, the object or ID of the new channel the given
             webhook should be moved to.
-        reason : hikari.undefined.UndefinedOr[str]
+        reason
             If provided, the audit log reason explaining why the operation
             was performed. This field will be used when using the webhook's
             token rather than bot authorization.


### PR DESCRIPTION
These are no-longer needed as Mkdocstrings python will extract these from the actual type-hints.

Removing the redundant type-hints also did fix some broken doc types and likely also fixed some out dated ones.
