### PR TITLE
Merge the Parameters and Other Parameters doc sections

### DIFF
--- a/hikari/api/entity_factory.py
+++ b/hikari/api/entity_factory.py
@@ -323,9 +323,6 @@ class EntityFactory(abc.ABC):
         ----------
         payload
             The JSON payload to deserialize.
-
-        Other Parameters
-        ----------------
         guild_id
             The ID of the guild this entry belongs to. If passed then this
             will be prioritised over `"guild_id"` in the payload.
@@ -449,9 +446,6 @@ class EntityFactory(abc.ABC):
         ----------
         payload
             The JSON payload to deserialize.
-
-        Other Parameters
-        ----------------
         guild_id
             The ID of the guild this channel belongs to. If passed then this
             will be prioritised over `"guild_id"` in the payload.
@@ -484,9 +478,6 @@ class EntityFactory(abc.ABC):
         ----------
         payload
             The JSON payload to deserialize.
-
-        Other Parameters
-        ----------------
         guild_id
             The ID of the guild this channel belongs to. If passed then this
             will be prioritised over `"guild_id"` in the payload.
@@ -519,9 +510,6 @@ class EntityFactory(abc.ABC):
         ----------
         payload
             The JSON payload to deserialize.
-
-        Other Parameters
-        ----------------
         guild_id
             The ID of the guild this channel belongs to. If passed then this
             will be prioritised over `"guild_id"` in the payload.
@@ -554,9 +542,6 @@ class EntityFactory(abc.ABC):
         ----------
         payload
             The JSON payload to deserialize.
-
-        Other Parameters
-        ----------------
         guild_id
             The ID of the guild this channel belongs to. If passed then this
             will be prioritised over `"guild_id"` in the payload.
@@ -589,9 +574,6 @@ class EntityFactory(abc.ABC):
         ----------
         payload
             The JSON payload to deserialize.
-
-        Other Parameters
-        ----------------
         guild_id
             The ID of the guild this channel belongs to. If passed then this
             will be prioritised over `"guild_id"` in the payload.
@@ -624,9 +606,6 @@ class EntityFactory(abc.ABC):
         ----------
         payload
             The JSON payload to deserialize.
-
-        Other Parameters
-        ----------------
         guild_id
             The ID of the guild this channel belongs to. If passed then this
             will be prioritised over `"guild_id"` in the payload.
@@ -674,9 +653,6 @@ class EntityFactory(abc.ABC):
         ----------
         payload
             The JSON payload to deserialize.
-
-        Other Parameters
-        ----------------
         thread_id
             ID of the thread this member belongs to. This will be
             prioritised over `"id"` in the payload when passed.
@@ -746,9 +722,6 @@ class EntityFactory(abc.ABC):
         ----------
         payload
             The JSON payload to deserialize.
-
-        Other Parameters
-        ----------------
         guild_id
             The ID of the guild this channel belongs to. This will be
             prioritised over `"guild_id"` in the payload when passed.
@@ -786,9 +759,6 @@ class EntityFactory(abc.ABC):
         ----------
         payload
             The JSON payload to deserialize.
-
-        Other Parameters
-        ----------------
         guild_id
             The ID of the guild this channel belongs to. This will be
             prioritised over `"guild_id"` in the payload when passed.
@@ -826,9 +796,6 @@ class EntityFactory(abc.ABC):
         ----------
         payload
             The JSON payload to deserialize.
-
-        Other Parameters
-        ----------------
         guild_id
             The ID of the guild this channel belongs to. This will be
             prioritised over `"guild_id"` in the payload when passed.
@@ -868,9 +835,6 @@ class EntityFactory(abc.ABC):
         ----------
         payload
             The JSON payload to deserialize.
-
-        Other Parameters
-        ----------------
         guild_id
             The ID of the guild this channel belongs to. This will be ignored
             for DM and group DM channels and will be prioritised over
@@ -1091,9 +1055,6 @@ class EntityFactory(abc.ABC):
         ----------
         payload
             The JSON payload to deserialize.
-
-        Other Parameters
-        ----------------
         user
             The user to attach to this member, should only be passed in
             situations where "user" is not included in the payload.
@@ -1162,9 +1123,6 @@ class EntityFactory(abc.ABC):
         ----------
         payload
             The JSON payload to deserialize.
-
-        Other Parameters
-        ----------------
         guild_id
             The ID of the guild this integration belongs to. If this is specified
             then this will be prioritised over `"guild_id"` in the payload.
@@ -1273,9 +1231,6 @@ class EntityFactory(abc.ABC):
         ----------
         payload
             The JSON payload to deserialize.
-
-        Other Parameters
-        ----------------
         guild_id
             The ID of the guild this command belongs to. If this is specified
             then this will be prioritised over `"guild_id"` in the payload.
@@ -1306,9 +1261,6 @@ class EntityFactory(abc.ABC):
         ----------
         payload
             The JSON payload to deserialize.
-
-        Other Parameters
-        ----------------
         guild_id
             The ID of the guild this command belongs to. If this is specified
             then this will be prioritised over `"guild_id"` in the payload.
@@ -1339,9 +1291,6 @@ class EntityFactory(abc.ABC):
         ----------
         payload
             The JSON payload to deserialize.
-
-        Other Parameters
-        ----------------
         guild_id
             The ID of the guild this command belongs to. If this is specified
             then this will be prioritised over `"guild_id"` in the payload.
@@ -1684,9 +1633,6 @@ class EntityFactory(abc.ABC):
         ----------
         payload
             The JSON payload to deserialize.
-
-        Other Parameters
-        ----------------
         guild_id
             The ID of the guild the presence belongs to. If this is specified
             then it is prioritised over `guild_id` in the payload.
@@ -1791,9 +1737,6 @@ class EntityFactory(abc.ABC):
         ----------
         payload
             The JSON payload to deserialize.
-
-        Other Parameters
-        ----------------
         guild_id
             The ID of the guild the user belongs to. If this is specified
             then it is prioritised over `guild_id` in the payload.
@@ -1881,9 +1824,6 @@ class EntityFactory(abc.ABC):
         ----------
         payload
             The JSON payload to deserialize.
-
-        Other Parameters
-        ----------------
         guild_id
             The ID of the guild this voice state belongs to. If this is specified
             then this will be prioritised over `"guild_id"` in the payload.

--- a/hikari/api/event_factory.py
+++ b/hikari/api/event_factory.py
@@ -126,9 +126,6 @@ class EventFactory(abc.ABC):
             The shard that emitted this event.
         payload
             The dict payload to parse.
-
-        Other Parameters
-        ----------------
         old_channel
             The guild channel object or [`None`][].
 
@@ -344,9 +341,6 @@ class EventFactory(abc.ABC):
             The shard that emitted this event.
         payload
             The dict payload to parse.
-
-        Other Parameters
-        ----------------
         old_invite
             The invite object or [`None`][].
 
@@ -437,9 +431,6 @@ class EventFactory(abc.ABC):
             The shard that emitted this event.
         payload
             The dict payload to parse.
-
-        Other Parameters
-        ----------------
         old_guild
             The guild object or [`None`][].
 
@@ -465,9 +456,6 @@ class EventFactory(abc.ABC):
             The shard that emitted this event.
         payload
             The dict payload to parse.
-
-        Other Parameters
-        ----------------
         old_guild
             The guild object or [`None`][].
 
@@ -550,9 +538,6 @@ class EventFactory(abc.ABC):
             The shard that emitted this event.
         payload
             The dict payload to parse.
-
-        Other Parameters
-        ----------------
         old_emojis
             The sequence of emojis or [`None`][].
 
@@ -578,9 +563,6 @@ class EventFactory(abc.ABC):
             The shard that emitted this event.
         payload
             The dict payload to parse.
-
-        Other Parameters
-        ----------------
         old_stickers
             The sequence of stickers or [`None`][].
 
@@ -663,9 +645,6 @@ class EventFactory(abc.ABC):
             The shard that emitted this event.
         payload
             The dict payload to parse.
-
-        Other Parameters
-        ----------------
         old_presence
             The presence object or [`None`][].
 
@@ -756,9 +735,6 @@ class EventFactory(abc.ABC):
             The shard that emitted this event.
         payload
             The dict payload to parse.
-
-        Other Parameters
-        ----------------
         old_member
             The member object or [`None`][].
 
@@ -784,9 +760,6 @@ class EventFactory(abc.ABC):
             The shard that emitted this event.
         payload
             The dict payload to parse.
-
-        Other Parameters
-        ----------------
         old_member
             The member object or [`None`][].
 
@@ -835,9 +808,6 @@ class EventFactory(abc.ABC):
             The shard that emitted this event.
         payload
             The dict payload to parse.
-
-        Other Parameters
-        ----------------
         old_role
             The role object or [`None`][].
 
@@ -863,9 +833,6 @@ class EventFactory(abc.ABC):
             The shard that emitted this event.
         payload
             The dict payload to parse.
-
-        Other Parameters
-        ----------------
         old_role
             The role object or [`None`][].
 
@@ -1057,9 +1024,6 @@ class EventFactory(abc.ABC):
             The shard that emitted this event.
         payload
             The dict payload to parse.
-
-        Other Parameters
-        ----------------
         old_message
             The message object or [`None`][].
 
@@ -1085,9 +1049,6 @@ class EventFactory(abc.ABC):
             The shard that emitted this event.
         payload
             The dict payload to parse.
-
-        Other Parameters
-        ----------------
         old_message
             The old message object.
 
@@ -1113,9 +1074,6 @@ class EventFactory(abc.ABC):
             The shard that emitted this event.
         payload
             The dict payload to parse.
-
-        Other Parameters
-        ----------------
         old_messages
             A mapping of the old message objects.
 
@@ -1333,9 +1291,6 @@ class EventFactory(abc.ABC):
             The shard that emitted this event.
         payload
             The dict payload to parse.
-
-        Other Parameters
-        ----------------
         old_user
             The OwnUser object or [`None`][].
 
@@ -1365,9 +1320,6 @@ class EventFactory(abc.ABC):
             The shard that emitted this event.
         payload
             The dict payload to parse.
-
-        Other Parameters
-        ----------------
         old_state
             The VoiceState object or [`None`][].
 

--- a/hikari/api/interaction_server.py
+++ b/hikari/api/interaction_server.py
@@ -253,9 +253,6 @@ class InteractionServer(abc.ABC):
             async generator which should yield exactly once. This allows
             sending an initial response to the request, while still
             later executing further logic.
-
-        Other Parameters
-        ----------------
         replace
             Whether this call should replace the previously set listener or not.
 

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -229,9 +229,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         channel
             The channel to edit. This may be the object or the ID of an
             existing channel.
-
-        Other Parameters
-        ----------------
         name
             If provided, the new name for the channel.
         flags
@@ -429,9 +426,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             Object or Id of the guild to edit a voice state in.
         channel
             Object or Id of the channel to edit a voice state in.
-
-        Other Parameters
-        ----------------
         suppress
             If specified, whether the user should be allowed to become a speaker
             in the target stage channel with [`True`][] suppressing them from
@@ -485,9 +479,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             Object or ID of the channel to edit a voice state in.
         user
             Object or ID of the user to edit the voice state of.
-
-        Other Parameters
-        ----------------
         suppress
             If defined, whether the user should be allowed to become a speaker
             in the target stage channel.
@@ -559,9 +550,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         target
             The channel overwrite to edit. This may be the object or the ID of an
             existing overwrite.
-
-        Other Parameters
-        ----------------
         target_type
             If provided, the type of the target to update. If unset, will attempt to get
             the type from `target`.
@@ -684,9 +672,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         channel
             The channel to create a invite for. This may be the object
             or the ID of an existing channel.
-
-        Other Parameters
-        ----------------
         max_age
             If provided, the duration of the invite before expiry.
         max_uses
@@ -911,9 +896,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         channel
             The channel to fetch messages in. This may be the object or
             the ID of an existing channel.
-
-        Other Parameters
-        ----------------
         before
             If provided, fetch messages before this snowflake. If you provide
             a datetime object, it will be transformed into a snowflake. This
@@ -1038,9 +1020,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             Likewise, if this is a [`hikari.files.Resource`][], then the
             content is instead treated as an attachment if no `attachment` and
             no `attachments` kwargs are provided.
-
-        Other Parameters
-        ----------------
         attachment
             If provided, the message attachment. This can be a resource,
             or string of a path on your computer or a URL.
@@ -1280,9 +1259,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             `attachment` or `attachments` kwargs are provided, the values will
             be overwritten. This allows for simpler syntax when sending an
             embed or an attachment alone.
-
-        Other Parameters
-        ----------------
         attachment
             If provided, the attachment to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous attachment, if
@@ -1464,9 +1440,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         messages
             Either the object/ID of an existing message to delete or an iterable
             (sync or async) of the objects and/or IDs of existing messages to delete.
-
-        Other Parameters
-        ----------------
         *other_messages
             The objects and/or IDs of other existing messages to delete.
 
@@ -1500,9 +1473,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             object or the ID of an existing message.
         emoji
             Object or name of the emoji to react with.
-
-        Other Parameters
-        ----------------
         emoji_id
             ID of the custom emoji to react with.
             This should only be provided when a custom emoji's name is passed
@@ -1547,9 +1517,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             object or the ID of an existing message.
         emoji
             Object or name of the emoji to remove your reaction for.
-
-        Other Parameters
-        ----------------
         emoji_id
             ID of the custom emoji to remove your reaction for.
             This should only be provided when a custom emoji's name is passed
@@ -1591,9 +1558,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             object or the ID of an existing message.
         emoji
             Object or name of the emoji to remove all the reactions for.
-
-        Other Parameters
-        ----------------
         emoji_id
             ID of the custom emoji to remove all the reactions for.
             This should only be provided when a custom emoji's name is passed
@@ -1643,9 +1607,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             Object or ID of the user to remove the reaction of.
         emoji
             Object or name of the emoji to react with.
-
-        Other Parameters
-        ----------------
         emoji_id
             ID of the custom emoji to react with.
             This should only be provided when a custom emoji's name is passed
@@ -1731,9 +1692,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             object or the ID of an existing message.
         emoji
             Object or name of the emoji to get the reactions for.
-
-        Other Parameters
-        ----------------
         emoji_id
             ID of the custom emoji to get the reactions for.
             This should only be provided when a custom emoji's name is passed
@@ -1778,9 +1736,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             the object or the ID of an existing channel.
         name
             The name for the webhook. This cannot be `clyde`.
-
-        Other Parameters
-        ----------------
         avatar
             If provided, the avatar for the webhook.
         reason
@@ -1823,9 +1778,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         webhook
             The webhook to fetch. This may be the object or the ID
             of an existing webhook.
-
-        Other Parameters
-        ----------------
         token
             If provided, the webhook token that will be used to fetch
             the webhook instead of the token the client was initialized with.
@@ -1934,9 +1886,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         webhook
             The webhook to edit. This may be the object or the
             ID of an existing webhook.
-
-        Other Parameters
-        ----------------
         token
             If provided, the webhook token that will be used to edit
             the webhook instead of the token the client was initialized with.
@@ -1986,9 +1935,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         webhook
             The webhook to delete. This may be the object or the
             ID of an existing webhook.
-
-        Other Parameters
-        ----------------
         token
             If provided, the webhook token that will be used to delete
             the webhook instead of the token the client was initialized with.
@@ -2071,9 +2017,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             Likewise, if this is a [`hikari.files.Resource`][], then the
             content is instead treated as an attachment if no `attachment` and
             no `attachments` kwargs are provided.
-
-        Other Parameters
-        ----------------
         thread
             If provided then the message will be created in the target thread
             within the webhook's channel, otherwise it will be created in
@@ -2204,9 +2147,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         message
             The message to fetch. This may be the object or the ID of an
             existing channel.
-
-        Other Parameters
-        ----------------
         thread
             If provided then the message will be fetched from the target thread
             within the webhook's channel, otherwise it will be fetched from
@@ -2303,9 +2243,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             `attachments` kwargs are provided, the values will be overwritten.
             This allows for simpler syntax when sending an embed or an
             attachment alone.
-
-        Other Parameters
-        ----------------
         thread
             If provided then the message will be edited in the target thread
             within the webhook's channel, otherwise it will be edited in
@@ -2419,9 +2356,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         message
             The message to delete. This may be the object or the ID of
             an existing message.
-
-        Other Parameters
-        ----------------
         thread
             If provided then the message will be deleted from the target thread
             within the webhook's channel, otherwise it will be deleted from
@@ -2574,8 +2508,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     ) -> users.OwnUser:
         """Edit the token's associated user.
 
-        Other Parameters
-        ----------------
+        Parameters
+        ----------
         username
             If provided, the new username.
         avatar
@@ -2639,8 +2573,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
             See [`hikari.iterators`][] for the full API for this iterator type.
 
-        Other Parameters
-        ----------------
+        Parameters
+        ----------
         newest_first
             Whether to fetch the newest first or the oldest first.
         start_at
@@ -2743,9 +2677,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------
         application
             The application to set the application role connections for.
-
-        Other Parameters
-        ----------------
         platform_name
             If provided, the name of the platform that will be connected.
         platform_username
@@ -3034,9 +2965,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             Secret of the application to authorize with.
         refresh_token
             The refresh token to use.
-
-        Other Parameters
-        ----------------
         scopes
             The scope of the access request.
 
@@ -3118,9 +3046,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         user
             The user to add to the guild. This may be the object
             or the ID of an existing user.
-
-        Other Parameters
-        ----------------
         nickname
             If provided, the nick to add to the user when he joins the guild.
 
@@ -3237,9 +3162,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         guild
             The guild to fetch the audit logs from. This can be a
             guild object or the ID of an existing guild.
-
-        Other Parameters
-        ----------------
         before
             If provided, filter to only actions before this snowflake. If you provide
             a datetime object, it will be transformed into a snowflake. This
@@ -3357,9 +3279,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         image
             The 128x128 image for the emoji. Maximum upload size is 256kb.
             This can be a still or an animated image.
-
-        Other Parameters
-        ----------------
         roles
             If provided, a collection of the roles that will be able to
             use this emoji. This can be a [`hikari.guilds.PartialRole`][] or
@@ -3412,9 +3331,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         emoji
             The emoji to edit. This can be a [`hikari.emojis.CustomEmoji`][]
             or the ID of an existing emoji.
-
-        Other Parameters
-        ----------------
         name
             If provided, the new name for the emoji.
         roles
@@ -3466,9 +3382,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         emoji
             The emoji to delete. This can be a [`hikari.emojis.CustomEmoji`][]
             or the ID of an existing emoji.
-
-        Other Parameters
-        ----------------
         reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
@@ -3635,9 +3548,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             !!! note
                 Lottie support is only available for verified and partnered
                 servers.
-
-        Other Parameters
-        ----------------
         description
             If provided, the description of the sticker.
         reason
@@ -3689,9 +3599,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         sticker
             The sticker to edit. This can be a sticker object or the ID of an
             existing sticker.
-
-        Other Parameters
-        ----------------
         name
             If provided, the new name for the sticker.
         description
@@ -3743,9 +3650,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         sticker
             The sticker to delete. This can be a sticker object or the ID
             of an existing sticker.
-
-        Other Parameters
-        ----------------
         reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
@@ -3911,9 +3815,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         guild
             The guild to edit. This may be the object
             or the ID of an existing guild.
-
-        Other Parameters
-        ----------------
         name
             If provided, the new name for the guild.
         verification_level
@@ -4067,9 +3968,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             object or the ID of an existing guild.
         name
             The channels name. Must be between 2 and 1000 characters.
-
-        Other Parameters
-        ----------------
         position
             If provided, the position of the channel (relative to the
             category, if any).
@@ -4145,9 +4043,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             object or the ID of an existing guild.
         name
             The channels name. Must be between 2 and 1000 characters.
-
-        Other Parameters
-        ----------------
         position
             If provided, the position of the channel (relative to the
             category, if any).
@@ -4232,9 +4127,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             object or the ID of an existing guild.
         name
             The channels name. Must be between 2 and 1000 characters.
-
-        Other Parameters
-        ----------------
         position
             If provided, the position of the category.
         category
@@ -4320,9 +4212,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             object or the ID of an existing guild.
         name
             The channels name. Must be between 2 and 1000 characters.
-
-        Other Parameters
-        ----------------
         position
             If provided, the position of the channel (relative to the
             category, if any).
@@ -4396,9 +4285,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             object or the ID of an existing guild.
         name
             The channel's name. Must be between 2 and 1000 characters.
-
-        Other Parameters
-        ----------------
         position
             If provided, the position of the channel (relative to the
             category, if any).
@@ -4466,9 +4352,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             object or the ID of an existing guild.
         name
             The channels name. Must be between 2 and 1000 characters.
-
-        Other Parameters
-        ----------------
         position
             If provided, the position of the category.
         permission_overwrites
@@ -4527,9 +4410,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             Object or ID of the message to attach the created thread to.
         name
             Name of the thread channel.
-
-        Other Parameters
-        ----------------
         auto_archive_duration
             If provided, how long the thread should remain inactive until it's archived.
 
@@ -4594,9 +4474,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             The thread type to create.
         name
             Name of the thread channel.
-
-        Other Parameters
-        ----------------
         auto_archive_duration
             If provided, how long the thread should remain inactive until it's archived.
 
@@ -4692,9 +4569,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             Likewise, if this is a [`hikari.files.Resource`][], then the
             content is instead treated as an attachment if no `attachment` and
             no `attachments` kwargs are provided.
-
-        Other Parameters
-        ----------------
         attachment
             If provided, the message attachment. This can be a resource,
             or string of a path on your computer or a URL.
@@ -5055,9 +4929,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------
         channel
             Object or ID of the channel to fetch the archived threads of.
-
-        Other Parameters
-        ----------------
         before
             The date to fetch threads before.
 
@@ -5107,9 +4978,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------
         channel
             Object or ID of the channel to fetch the private archived threads of.
-
-        Other Parameters
-        ----------------
         before
             The date to fetch threads before.
 
@@ -5161,9 +5029,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------
         channel
             Object or ID of the channel to fetch the private archived threads of.
-
-        Other Parameters
-        ----------------
         before
             If provided, fetch joined threads before this snowflake. If you
             provide a datetime object, it will be transformed into a snowflake.
@@ -5390,9 +5255,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         user
             The user to edit. This may be the object
             or the ID of an existing user.
-
-        Other Parameters
-        ----------------
         nickname
             If provided, the new nick for the member. If [`None`][],
             will remove the members nick.
@@ -5469,9 +5331,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         guild
             The guild to edit the member in. This may be the object
             or the ID of an existing guild.
-
-        Other Parameters
-        ----------------
         nickname
             If provided, the new nickname for the member. If
             [`None`][], will remove the members nickname.
@@ -5527,9 +5386,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         role
             The role to add. This may be the object or the
             ID of an existing role.
-
-        Other Parameters
-        ----------------
         reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
@@ -5571,9 +5427,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         role
             The role to remove. This may be the object or the
             ID of an existing role.
-
-        Other Parameters
-        ----------------
         reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
@@ -5611,9 +5464,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         user
             The user to kick. This may be the object
             or the ID of an existing user.
-
-        Other Parameters
-        ----------------
         reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
@@ -5662,9 +5512,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         user
             The user to kick. This may be the object
             or the ID of an existing user.
-
-        Other Parameters
-        ----------------
         delete_message_seconds
             If provided, the number of seconds to delete messages for.
             This can be represented as either an int/float between 0 and 604800 (7 days), or
@@ -5719,9 +5566,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         user
             The user to unban. This may be the object
             or the ID of an existing user.
-
-        Other Parameters
-        ----------------
         reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
@@ -5808,9 +5652,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         guild
             The guild to fetch the bans from. This may be the
             object or the ID of an existing guild.
-
-        Other Parameters
-        ----------------
         newest_first
             Whether to fetch the newest first or the oldest first.
         start_at
@@ -5889,9 +5730,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         guild
             The guild to create the role in. This may be the
             object or the ID of an existing guild.
-
-        Other Parameters
-        ----------------
         name
             If provided, the name for the role.
         permissions
@@ -5997,9 +5835,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         role
             The role to edit. This may be the object or the
             ID of an existing role.
-
-        Other Parameters
-        ----------------
         name
             If provided, the new name for the role.
         permissions
@@ -6091,9 +5926,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         guild
             The guild to estimate the guild prune count for. This may be the object
             or the ID of an existing guild.
-
-        Other Parameters
-        ----------------
         days
             If provided, number of days to count prune for.
         include_roles
@@ -6141,9 +5973,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         guild
             The guild to begin the guild prune in. This may be the object
             or the ID of an existing guild.
-
-        Other Parameters
-        ----------------
         days
             If provided, number of days to count prune for.
         compute_prune_count
@@ -6321,9 +6150,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         guild
             The guild to edit the widget in. This can be the object
             or the ID of an existing guild.
-
-        Other Parameters
-        ----------------
         channel
             If provided, the channel to set the widget to. If [`None`][],
             will not set to any.
@@ -6397,9 +6223,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------
         guild
             ID or object of the guild to edit the welcome screen for.
-
-        Other Parameters
-        ----------------
         description
             If provided, the description to set for the guild's welcome screen.
             This may be [`None`][] to unset the description.
@@ -6487,9 +6310,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             The guild to create a template from.
         name
             The name to use for the created template.
-
-        Other Parameters
-        ----------------
         description
             The description to set for the template.
 
@@ -6533,9 +6353,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             The object or string code of the template to create a guild based on.
         name
             The new guilds name.
-
-        Other Parameters
-        ----------------
         icon
             If provided, the guild icon to set. Must be a 1024x1024 image or can
             be an animated gif when the guild has the [`hikari.guilds.GuildFeature.ANIMATED_ICON`][] feature.
@@ -6610,9 +6427,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             The guild to edit a template in.
         template
             Object or string code of the template to modify.
-
-        Other Parameters
-        ----------------
         name
             The name to set for this template.
         description
@@ -6785,9 +6599,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             Object or ID of the application to fetch a command for.
         command
             Object or ID of the command to fetch.
-
-        Other Parameters
-        ----------------
         guild
             Object or ID of the guild to fetch the command for. If left as
             [`hikari.undefined.UNDEFINED`][] then this will return a global command,
@@ -6825,9 +6636,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------
         application
             Object or ID of the application to fetch the commands for.
-
-        Other Parameters
-        ----------------
         guild
             Object or ID of the guild to fetch the commands for. If left as
             [`hikari.undefined.UNDEFINED`][] then this will only return the global
@@ -6890,9 +6698,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         description
             The description to set for the command.
             This should be inclusively between 1-100 characters in length.
-
-        Other Parameters
-        ----------------
         guild
             Object or ID of the specific guild this should be made for.
             If left as [`hikari.undefined.UNDEFINED`][] then this call will create
@@ -6966,9 +6771,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             Only USER and MESSAGE are valid here.
         name
             The command's name.
-
-        Other Parameters
-        ----------------
         guild
             Object or ID of the specific guild this should be made for.
             If left as [`hikari.undefined.UNDEFINED`][] then this call will create
@@ -7029,9 +6831,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         commands
             A sequence of up to 100 initialised command builder objects of the
             commands to set for this the application.
-
-        Other Parameters
-        ----------------
         guild
             Object or ID of the specific guild to set the commands for.
             If left as [`hikari.undefined.UNDEFINED`][] then this set the global
@@ -7082,9 +6881,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             Object or ID of the application to edit a command for.
         command
             Object or ID of the command to modify.
-
-        Other Parameters
-        ----------------
         guild
             Object or ID of the guild to edit a command for if this is a guild
             specific command. Leave this as [`hikari.undefined.UNDEFINED`][] to delete
@@ -7145,9 +6941,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             Object or ID of the application to delete a command for.
         command
             Object or ID of the command to delete.
-
-        Other Parameters
-        ----------------
         guild
             Object or ID of the guild to delete a command for if this is a guild
             specific command. Leave this as [`hikari.undefined.UNDEFINED`][] to
@@ -7446,9 +7239,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             The interaction's token.
         response_type
             The type of interaction response this is.
-
-        Other Parameters
-        ----------------
         content
             If provided, the message contents. If
             [`hikari.undefined.UNDEFINED`][], then nothing will be sent
@@ -7577,9 +7367,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             Object or ID of the application to edit a command response for.
         token
             The interaction's token.
-
-        Other Parameters
-        ----------------
         content
             If provided, the message content to update with. If
             [`hikari.undefined.UNDEFINED`][], then the content will not
@@ -7754,9 +7541,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             The title that will show up in the modal.
         custom_id
             Developer set custom ID used for identifying interactions with this modal.
-
-        Other Parameters
-        ----------------
         component
             A component builders to send in this modal.
         components
@@ -7907,9 +7691,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             The name of the event.
         start_time
             When the event is scheduled to start.
-
-        Other Parameters
-        ----------------
         description
             The event's description.
         end_time
@@ -7980,9 +7761,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             The name of the event.
         start_time
             When the event is scheduled to start.
-
-        Other Parameters
-        ----------------
         description
             The event's description.
         end_time
@@ -8055,9 +7833,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             When the event is scheduled to start.
         end_time
             When the event is scheduled to end.
-
-        Other Parameters
-        ----------------
         description
             The event's description.
         image
@@ -8123,9 +7898,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             The guild to edit the event in.
         event
             The scheduled event to edit.
-
-        Other Parameters
-        ----------------
         channel
             The channel a `VOICE` or `STAGE` event should be associated with.
         description
@@ -8244,9 +8016,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             The guild to fetch the scheduled event users from.
         event
             The scheduled event to fetch the subscribed users for.
-
-        Other Parameters
-        ----------------
         newest_first
             Whether to fetch the newest first or the oldest first.
         start_at
@@ -8327,9 +8096,6 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ----------
         application
             The application to fetch entitlements for.
-
-        Other Parameters
-        ----------------
         user
             The user to look up entitlements for.
         guild

--- a/hikari/api/shard.py
+++ b/hikari/api/shard.py
@@ -145,8 +145,8 @@ class GatewayShard(abc.ABC):
         the new presence settings will be remembered for when the shard
         does connect.
 
-        Other Parameters
-        ----------------
+        Parameters
+        ----------
         idle_since
             The datetime that the user started being idle. If undefined, this
             will not be changed.
@@ -208,9 +208,6 @@ class GatewayShard(abc.ABC):
         ----------
         guild
             The guild to request chunk for.
-
-        Other Parameters
-        ----------------
         include_presences
             If provided, whether to request presences.
         query

--- a/hikari/api/special_endpoints.py
+++ b/hikari/api/special_endpoints.py
@@ -282,9 +282,6 @@ class GuildBuilder(abc.ABC):
         ----------
         name
             The role's name.
-
-        Other Parameters
-        ----------------
         permissions
             If provided, the permissions for the role.
         color
@@ -334,9 +331,6 @@ class GuildBuilder(abc.ABC):
         ----------
         name
             The channels name. Must be between 2 and 1000 characters.
-
-        Other Parameters
-        ----------------
         position
             If provided, the position of the category.
         permission_overwrites
@@ -373,9 +367,6 @@ class GuildBuilder(abc.ABC):
         ----------
         name
             The channels name. Must be between 2 and 1000 characters.
-
-        Other Parameters
-        ----------------
         position
             If provided, the position of the channel (relative to the
             category, if any).
@@ -424,9 +415,6 @@ class GuildBuilder(abc.ABC):
         ----------
         name
             The channels name. Must be between 2 and 1000 characters.
-
-        Other Parameters
-        ----------------
         position
             If provided, the position of the channel (relative to the
             category, if any).
@@ -480,9 +468,6 @@ class GuildBuilder(abc.ABC):
         ----------
         name
             The channels name. Must be between 2 and 1000 characters.
-
-        Other Parameters
-        ----------------
         position
             If provided, the position of the channel (relative to the
             category, if any).
@@ -1171,9 +1156,6 @@ class CommandBuilder(abc.ABC):
             The REST client to use to make this request.
         application
             The application to create this command for.
-
-        Other Parameters
-        ----------------
         guild
             The guild to create this command for.
 
@@ -1280,9 +1262,6 @@ class SlashCommandBuilder(CommandBuilder):
             The REST client to use to make this request.
         application
             The application to create this command for.
-
-        Other Parameters
-        ----------------
         guild
             The guild to create this command for.
 
@@ -1321,9 +1300,6 @@ class ContextMenuCommandBuilder(CommandBuilder):
             The REST client to use to make this request.
         application
             The application to create this command for.
-
-        Other Parameters
-        ----------------
         guild
             The guild to create this command for.
 

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -418,8 +418,8 @@ class TextableChannel(PartialChannel):
             thus any errors documented below will happen then.
             See [`hikari.iterators`][] for the full API for this iterator type.
 
-        Other Parameters
-        ----------------
+        Parameters
+        ----------
         before
             If provided, fetch messages before this snowflakes. If you provide
             a datetime object, it will be transformed into a snowflakes. This
@@ -532,9 +532,6 @@ class TextableChannel(PartialChannel):
             Likewise, if this is a [`hikari.files.Resource`][], then the
             content is instead treated as an attachment if no `attachment` and
             no `attachments` kwargs are provided.
-
-        Other Parameters
-        ----------------
         attachment
             If provided, the message attachment. This can be a resource,
             or string of a path on your computer or a URL.
@@ -814,9 +811,6 @@ class TextableChannel(PartialChannel):
         messages
             Either the object/ID of an existing message to delete or an iterable
             (sync or async) of the objects and/or IDs of existing messages to delete.
-
-        Other Parameters
-        ----------------
         *other_messages
             The objects and/or IDs of other existing messages to delete.
 
@@ -1020,8 +1014,8 @@ class GuildChannel(PartialChannel):
     ) -> PartialChannel:
         """Edit the text channel.
 
-        Other Parameters
-        ----------------
+        Parameters
+        ----------
         name
             If provided, the new name for the channel.
         position
@@ -1170,9 +1164,6 @@ class PermissibleGuildChannel(GuildChannel):
         target
             The channel overwrite to edit. This may be the object or the ID of an
             existing overwrite.
-
-        Other Parameters
-        ----------------
         target_type
             If provided, the type of the target to update. If unset, will attempt to get
             the type from `target`.

--- a/hikari/commands.py
+++ b/hikari/commands.py
@@ -301,8 +301,8 @@ class PartialCommand(snowflakes.Unique):
     ) -> PartialCommand:
         """Edit this command.
 
-        Other Parameters
-        ----------------
+        Parameters
+        ----------
         name
             The name to set for the command. Leave as [`hikari.undefined.UNDEFINED`][]
             to not change.

--- a/hikari/embeds.py
+++ b/hikari/embeds.py
@@ -800,9 +800,6 @@ class Embed:
         value
             The mandatory non-empty field value. This must contain at least one
             non-whitespace character to be valid.
-
-        Other Parameters
-        ----------------
         inline
             If [`True`][], the embed field may be shown "inline" on some
             Discord clients with other fields. If [`False`][], it is always placed
@@ -833,9 +830,6 @@ class Embed:
         ----------
         index
             The index of the field to edit.
-
-        Other Parameters
-        ----------------
         name
             The new field name to use. If left to the default ([`hikari.undefined.UNDEFINED`][]),
             then it will not be changed.

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -698,8 +698,8 @@ class Member(users.User):
     ) -> None:
         """Ban this member from this guild.
 
-        Other Parameters
-        ----------------
+        Parameters
+        ----------
         delete_message_seconds
             If provided, the number of seconds to delete messages for.
             This can be represented as either an int/float between 0 and 604800 (7 days), or
@@ -731,8 +731,8 @@ class Member(users.User):
     async def unban(self, *, reason: undefined.UndefinedOr[str] = undefined.UNDEFINED) -> None:
         """Unban this member from the guild.
 
-        Other Parameters
-        ----------------
+        Parameters
+        ----------
         reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
@@ -758,8 +758,8 @@ class Member(users.User):
     async def kick(self, *, reason: undefined.UndefinedOr[str] = undefined.UNDEFINED) -> None:
         """Kick this member from this guild.
 
-        Other Parameters
-        ----------------
+        Parameters
+        ----------
         reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
@@ -792,9 +792,6 @@ class Member(users.User):
         role
             The role to add. This may be the object or the
             ID of an existing role.
-
-        Other Parameters
-        ----------------
         reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
@@ -825,9 +822,6 @@ class Member(users.User):
         role
             The role to remove. This may be the object or the
             ID of an existing role.
-
-        Other Parameters
-        ----------------
         reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
@@ -863,8 +857,8 @@ class Member(users.User):
     ) -> Member:
         """Edit the member.
 
-        Other Parameters
-        ----------------
+        Parameters
+        ----------
         nickname
             If provided, the new nick for the member. If [`None`][],
             will remove the members nick.
@@ -1425,9 +1419,6 @@ class PartialGuild(snowflakes.Unique):
         ----------
         user
             The user to ban from the guild.
-
-        Other Parameters
-        ----------------
         delete_message_seconds
             If provided, the number of seconds to delete messages for.
             This can be represented as either an int/float between 0 and 604800 (7 days), or
@@ -1466,9 +1457,6 @@ class PartialGuild(snowflakes.Unique):
         ----------
         user
             The user to unban from the guild.
-
-        Other Parameters
-        ----------------
         reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
@@ -1503,9 +1491,6 @@ class PartialGuild(snowflakes.Unique):
         ----------
         user
             The user to kick from the guild.
-
-        Other Parameters
-        ----------------
         reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
@@ -1772,9 +1757,6 @@ class PartialGuild(snowflakes.Unique):
         image
             The 320x320 image for the sticker. Maximum upload size is 500kb.
             This can be a still PNG, an animated PNG, a Lottie, or a GIF.
-
-        Other Parameters
-        ----------------
         description
             If provided, the description of the sticker.
         reason
@@ -1822,9 +1804,6 @@ class PartialGuild(snowflakes.Unique):
         sticker
             The sticker to edit. This can be a sticker object or the ID of an
             existing sticker.
-
-        Other Parameters
-        ----------------
         name
             If provided, the new name for the sticker.
         description
@@ -1874,9 +1853,6 @@ class PartialGuild(snowflakes.Unique):
         sticker
             The sticker to delete. This can be a sticker object or the ID
             of an existing sticker.
-
-        Other Parameters
-        ----------------
         reason
             If provided, the reason that will be recorded in the audit logs.
             Maximum of 512 characters.
@@ -1914,9 +1890,6 @@ class PartialGuild(snowflakes.Unique):
         ----------
         name
             The channels name. Must be between 2 and 1000 characters.
-
-        Other Parameters
-        ----------------
         position
             If provided, the position of the category.
         permission_overwrites
@@ -1970,9 +1943,6 @@ class PartialGuild(snowflakes.Unique):
         ----------
         name
             The channels name. Must be between 2 and 1000 characters.
-
-        Other Parameters
-        ----------------
         position
             If provided, the position of the channel (relative to the
             category, if any).
@@ -2046,9 +2016,6 @@ class PartialGuild(snowflakes.Unique):
         ----------
         name
             The channels name. Must be between 2 and 1000 characters.
-
-        Other Parameters
-        ----------------
         position
             If provided, the position of the channel (relative to the
             category, if any).
@@ -2132,9 +2099,6 @@ class PartialGuild(snowflakes.Unique):
         ----------
         name
             The channels name. Must be between 2 and 1000 characters.
-
-        Other Parameters
-        ----------------
         position
             If provided, the position of the category.
         category
@@ -2232,9 +2196,6 @@ class PartialGuild(snowflakes.Unique):
         ----------
         name
             The channels name. Must be between 2 and 1000 characters.
-
-        Other Parameters
-        ----------------
         position
             If provided, the position of the channel (relative to the
             category, if any).
@@ -2315,9 +2276,6 @@ class PartialGuild(snowflakes.Unique):
         ----------
         name
             The channel's name. Must be between 2 and 1000 characters.
-
-        Other Parameters
-        ----------------
         position
             If provided, the position of the channel (relative to the
             category, if any).

--- a/hikari/impl/event_manager_base.py
+++ b/hikari/impl/event_manager_base.py
@@ -272,9 +272,6 @@ def filtered(
     event_types
         Types of the events this raw consumer method may dispatch.
         This may either be a singular type of a sequence of types.
-
-    Other Parameters
-    ----------------
     cache_components
         Bitfield of the cache components this event may make altering calls to.
     """

--- a/hikari/impl/gateway_bot.py
+++ b/hikari/impl/gateway_bot.py
@@ -120,9 +120,6 @@ class GatewayBot(traits.GatewayBotAware):
     ----------
     token
         The bot token to sign in with.
-
-    Other Parameters
-    ----------------
     allow_color
         Whether enable coloured console logs will be enabled on any platform that is a TTY.
         Setting a `"CLICOLOR"` environment variable to any **non `0`** value
@@ -698,8 +695,8 @@ class GatewayBot(traits.GatewayBotAware):
     ) -> None:
         """Start the application and block until it's finished running.
 
-        Other Parameters
-        ----------------
+        Parameters
+        ----------
         activity
             The initial activity to display in the bot user presence, or
             [`None`][] (default) to not show any.
@@ -864,8 +861,8 @@ class GatewayBot(traits.GatewayBotAware):
     ) -> None:
         """Start the bot, wait for all shards to become ready, and then return.
 
-        Other Parameters
-        ----------------
+        Parameters
+        ----------
         activity
             The initial activity to display in the bot user presence, or
             [`None`][] (default) to not show any.

--- a/hikari/impl/interaction_server.py
+++ b/hikari/impl/interaction_server.py
@@ -188,9 +188,6 @@ class InteractionServer(interaction_server.InteractionServer):
     ----------
     entity_factory
         The entity factory instance this server should use.
-
-    Other Parameters
-    ----------------
     dumps
         The JSON encoder this server should use.
     loads
@@ -508,8 +505,8 @@ class InteractionServer(interaction_server.InteractionServer):
             For more information on the other parameters such as defaults see
             AIOHTTP's documentation.
 
-        Other Parameters
-        ----------------
+        Parameters
+        ----------
         backlog
             The number of unaccepted connections that the system will allow before
             refusing new connections.

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -127,9 +127,6 @@ class ClientCredentialsStrategy(rest_api.TokenStrategy):
         authorize as.
     client_secret
         Client secret to use when authorizing.
-
-    Other Parameters
-    ----------------
     scopes
         The scopes to authorize for.
     """

--- a/hikari/impl/rest_bot.py
+++ b/hikari/impl/rest_bot.py
@@ -81,9 +81,6 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
 
         This should be left as [`None`][] when [`hikari.api.rest.TokenStrategy`][]
         is passed for [`token`][].
-
-    Other Parameters
-    ----------------
     allow_color
         Whether to enable coloured console logs on any platform that is a TTY.
         Setting a `"CLICOLOR"` environment variable to any **non `0`** value
@@ -489,8 +486,8 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
     ) -> None:
         """Open this REST server and block until it closes.
 
-        Other Parameters
-        ----------------
+        Parameters
+        ----------
         asyncio_debug
             If [`True`][], then debugging is enabled for the asyncio event loop in use.
         backlog
@@ -626,8 +623,8 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
             For more information on the other parameters such as defaults see
             AIOHTTP's documentation.
 
-        Other Parameters
-        ----------------
+        Parameters
+        ----------
         backlog
             The number of unaccepted connections that the system will allow before
             refusing new connections.

--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -395,9 +395,6 @@ class GatewayShardImpl(shard.GatewayShard):
         The event manager this shard should make calls to.
     event_factory
         The event factory this shard should use.
-
-    Other Parameters
-    ----------------
     compression
         Compression format to use for the shard. Only supported values are
         `"transport_zlib_stream"` or [`None`][] to disable it.

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -994,9 +994,6 @@ class InteractionMessageBuilder(special_endpoints.InteractionMessageBuilder):
     ----------
     type : hikari.interactions.base_interactions.MessageResponseTypesT
         The type of interaction response this is.
-
-    Other Parameters
-    ----------------
     content : hikari.undefined.UndefinedOr[str]
         The content of this response, if supplied. This follows the same rules
         as "content" on create message.

--- a/hikari/interactions/base_interactions.py
+++ b/hikari/interactions/base_interactions.py
@@ -314,9 +314,6 @@ class MessageResponseMixin(PartialInteraction, typing.Generic[_CommandResponseTy
         ----------
         response_type
             The type of interaction response this is.
-
-        Other Parameters
-        ----------------
         content
             If provided, the message contents. If
             [`hikari.undefined.UNDEFINED`][], then nothing will be sent
@@ -453,8 +450,8 @@ class MessageResponseMixin(PartialInteraction, typing.Generic[_CommandResponseTy
             This is a limitation of Discord's design. If in doubt, specify all
             four of them each time.
 
-        Other Parameters
-        ----------------
+        Parameters
+        ----------
         content
             If provided, the message contents. If
             [`hikari.undefined.UNDEFINED`][], then nothing will be sent
@@ -605,9 +602,6 @@ class ModalResponseMixin(PartialInteraction):
             The title that will show up in the modal.
         custom_id
             Developer set custom ID used for identifying interactions with this modal.
-
-        Other Parameters
-        ----------------
         component
             A component builder to send in this modal.
         components

--- a/hikari/internal/collections.py
+++ b/hikari/internal/collections.py
@@ -233,8 +233,8 @@ class SnowflakeSet(typing.MutableSet[snowflakes.Snowflake]):
         This is not thread-safe and must not be iterated across whilst being
         concurrently modified.
 
-    Other Parameters
-    ----------------
+    Parameters
+    ----------
     *ids
         The IDs to fill this table with.
     """

--- a/hikari/internal/data_binding.py
+++ b/hikari/internal/data_binding.py
@@ -218,9 +218,6 @@ class StringMapBuilder(multidict.MultiDict[str]):
             The string key.
         value
             The value to set.
-
-        Other Parameters
-        ----------------
         conversion
             An optional conversion to perform.
         """
@@ -297,9 +294,6 @@ class JSONObjectBuilder(typing.Dict[str, JSONish]):
             The JSON type to put. This may be a non-JSON type if a conversion
             is also specified. This may alternatively be undefined. In the latter
             case, nothing is performed.
-
-        Other Parameters
-        ----------------
         conversion
             The optional conversion to apply.
         """
@@ -346,9 +340,6 @@ class JSONObjectBuilder(typing.Dict[str, JSONish]):
             The JSON types to put. This may be an iterable of non-JSON types if
             a conversion is also specified. This may alternatively be undefined.
             In the latter case, nothing is performed.
-
-        Other Parameters
-        ----------------
         conversion
             The optional conversion to apply.
         """

--- a/hikari/internal/deprecation.py
+++ b/hikari/internal/deprecation.py
@@ -40,9 +40,6 @@ def check_if_past_removal(what: str, /, *, removal_version: str) -> None:
     ----------
     what
         What is being deprecated.
-
-    Other Parameters
-    ----------------
     removal_version
         The version it will be removed in.
 
@@ -66,9 +63,6 @@ def warn_deprecated(
     ----------
     what
         What is being deprecated.
-
-    Other Parameters
-    ----------------
     removal_version
         The version it will be removed in.
     additional_info

--- a/hikari/messages.py
+++ b/hikari/messages.py
@@ -696,8 +696,8 @@ class PartialMessage(snowflakes.Unique):
     def make_link(self, guild: typing.Optional[snowflakes.SnowflakeishOr[guilds.PartialGuild]]) -> str:
         """Generate a jump link to this message.
 
-        Other Parameters
-        ----------------
+        Parameters
+        ----------
         guild
             Object or ID of the guild this message is in or [`None`][]
             to generate a DM message link.
@@ -802,9 +802,6 @@ class PartialMessage(snowflakes.Unique):
             `attachment` or `attachments` kwargs are provided, the values will
             be overwritten. This allows for simpler syntax when sending an
             embed or an attachment alone.
-
-        Other Parameters
-        ----------------
         attachment
             If provided, the attachment to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous attachment, if
@@ -966,9 +963,6 @@ class PartialMessage(snowflakes.Unique):
             Likewise, if this is a [`hikari.files.Resource`][], then the
             content is instead treated as an attachment if no `attachment` and
             no `attachments` kwargs are provided.
-
-        Other Parameters
-        ----------------
         attachment
             If provided, the message attachment. This can be a resource,
             or string of a path on your computer or a URL.
@@ -1145,9 +1139,6 @@ class PartialMessage(snowflakes.Unique):
 
             Note that if the emoji is an [`hikari.emojis.CustomEmoji`][]
             and is not from a guild the bot user is in, then this will fail.
-
-        Other Parameters
-        ----------------
         emoji_id
             ID of the custom emoji to react with.
             This should only be provided when a custom emoji's name is passed
@@ -1220,9 +1211,6 @@ class PartialMessage(snowflakes.Unique):
         ----------
         emoji
             Object or name of the emoji to remove the reaction for.
-
-        Other Parameters
-        ----------------
         emoji_id
             ID of the custom emoji to remove the reaction for.
             This should only be provided when a custom emoji's name is passed
@@ -1297,8 +1285,8 @@ class PartialMessage(snowflakes.Unique):
     ) -> None:
         r"""Remove all users' reactions for a specific emoji from the message.
 
-        Other Parameters
-        ----------------
+        Parameters
+        ----------
         emoji
             Object or name of the emoji to get the reactions for. If not specified
             then all reactions are removed.

--- a/hikari/templates.py
+++ b/hikari/templates.py
@@ -289,9 +289,6 @@ class Template:
         ----------
         name
             The new guilds name.
-
-        Other Parameters
-        ----------------
         icon
             If provided, the guild icon to set.
             Must be a 1024x1024 image or can be an animated gif when the guild has the ANIMATED_ICON feature.

--- a/hikari/traits.py
+++ b/hikari/traits.py
@@ -302,8 +302,8 @@ class ShardAware(
             This method is simply a facade to make performing this in bulk
             simpler.
 
-        Other Parameters
-        ----------------
+        Parameters
+        ----------
         idle_since
             The datetime that the user started being idle. If undefined, this
             will not be changed.
@@ -372,9 +372,6 @@ class ShardAware(
         ----------
         guild
             The guild to request chunk for.
-
-        Other Parameters
-        ----------------
         include_presences
             If provided, whether to request presences.
         query

--- a/hikari/users.py
+++ b/hikari/users.py
@@ -294,9 +294,6 @@ class PartialUser(snowflakes.Unique, abc.ABC):
             Likewise, if this is a [`hikari.files.Resource`][], then the
             content is instead treated as an attachment if no `attachment` and
             no `attachments` kwargs are provided.
-
-        Other Parameters
-        ----------------
         attachment
             If provided, the message attachment. This can be a resource,
             or string of a path on your computer or a URL.

--- a/hikari/webhooks.py
+++ b/hikari/webhooks.py
@@ -146,9 +146,6 @@ class ExecutableWebhook(abc.ABC):
             Likewise, if this is a [`hikari.files.Resource`][], then the
             content is instead treated as an attachment if no `attachment` and
             no `attachments` kwargs are provided.
-
-        Other Parameters
-        ----------------
         username
             If provided, the username to override the webhook's username
             for this request.
@@ -332,9 +329,6 @@ class ExecutableWebhook(abc.ABC):
             Likewise, if this is a [`hikari.files.Resource`][], then the
             content is instead treated as an attachment if no `attachment` nor
             `attachments` kwargs are provided.
-
-        Other Parameters
-        ----------------
         attachment
             If provided, the attachment to set on the message. If
             [`hikari.undefined.UNDEFINED`][], the previous attachment, if
@@ -602,8 +596,8 @@ class IncomingWebhook(PartialWebhook, ExecutableWebhook):
     async def delete(self, *, use_token: undefined.UndefinedOr[bool] = undefined.UNDEFINED) -> None:
         """Delete this webhook.
 
-        Other Parameters
-        ----------------
+        Parameters
+        ----------
         use_token
             If set to [`True`][] then the webhook's token will be used for
             this request; if set to [`False`][] then bot authorization will
@@ -643,8 +637,8 @@ class IncomingWebhook(PartialWebhook, ExecutableWebhook):
     ) -> IncomingWebhook:
         """Edit this webhook.
 
-        Other Parameters
-        ----------------
+        Parameters
+        ----------
         name
             If provided, the new name string.
         avatar
@@ -732,8 +726,8 @@ class IncomingWebhook(PartialWebhook, ExecutableWebhook):
     async def fetch_self(self, *, use_token: undefined.UndefinedOr[bool] = undefined.UNDEFINED) -> IncomingWebhook:
         """Fetch this webhook.
 
-        Other Parameters
-        ----------------
+        Parameters
+        ----------
         use_token
             If set to [`True`][] then the webhook's token will be used for
             this request; if set to [`False`][] then bot authorization will
@@ -831,8 +825,8 @@ class ChannelFollowerWebhook(PartialWebhook):
     ) -> ChannelFollowerWebhook:
         """Edit this webhook.
 
-        Other Parameters
-        ----------------
+        Parameters
+        ----------
         name
             If provided, the new name string.
         avatar


### PR DESCRIPTION
This distinction no-longer serves a purpose and prevents field defaults from being show in the parameters table.

In the old doc gen system this distinction was done as a way to document fields as being optional since the parameter defaults weren't actually included in the generated docs. But mkdocstrings-python includes them so this is now redundant and prob even a bit confusing (since it doesn't actually distinguish between the two different tqables).

