### PR TITLE
Switch from safety to pip-audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,10 +129,10 @@ jobs:
             exit 1
           fi
 
-      - name: Safety
+      - name: Audit
         if: always()
         run: |
-          nox -s safety
+          nox -s audit
 
       - name: Mypy
         if: always()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ This includes:
   - `test`
     - Run tests and installation of the package on different OS's and python versions.
   - `linting`
-    - Linting (`flake8`), type checking (`mypy`), safety (`safety`) and spelling (`codespell`).
+    - Linting (`flake8`), type checking (`mypy`), audit (`pip-audit`) and spelling (`codespell`).
   - `twemoji`
     - Force test all discord emojis.
   - `pages`

--- a/dev-requirements/audit.txt
+++ b/dev-requirements/audit.txt
@@ -1,0 +1,1 @@
+pip-audit

--- a/dev-requirements/safety.txt
+++ b/dev-requirements/safety.txt
@@ -1,4 +1,0 @@
-safety~=3.2
-
-# Temporary addition to avoid safety erroring due to https://github.com/pypa/pip/pull/9827
-pip>=21.1

--- a/pipelines/audit.nox.py
+++ b/pipelines/audit.nox.py
@@ -25,7 +25,17 @@ from pipelines import nox
 
 
 @nox.session()
-def safety(session: nox.Session) -> None:
+def audit(session: nox.Session) -> None:
     """Perform dependency scanning."""
-    session.install("-r", "requirements.txt", *nox.dev_requirements("safety"))
-    session.run("safety", "check", "--full-report")
+    session.install(*nox.dev_requirements("audit"))
+    session.run(
+        "pip-audit",
+        "-r",
+        "requirements.txt",
+        "-r",
+        "server-requirements.txt",
+        "-r",
+        "speedup-requirements.txt",
+        "--aliases",
+        "on",
+    )


### PR DESCRIPTION
### Summary
A lot more up to date than safety (safety is 30 days behind).

Us running audits of the packages with the loose bounds we have is not really useful, as it should be more in the end developer to do with their environments. Nevertheless, this will help us catch the odd case were a security vulnerability is fixed in version bump we do not allow

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

