### PR TITLE
Implement `interaction.data.guild_id` for command interactions

### DIFF
--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -2579,6 +2579,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             resolved=resolved,
             target_id=target_id,
             app_permissions=permission_models.Permissions(app_perms) if app_perms else None,
+            registered_guild_id=snowflakes.Snowflake(data_payload["guild_id"]) if "guild_id" in data_payload else None,
             entitlements=entitlements,
         )
 
@@ -2621,6 +2622,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             options=options,
             locale=locales.Locale(payload["locale"]),
             guild_locale=locales.Locale(payload["guild_locale"]) if "guild_locale" in payload else None,
+            registered_guild_id=snowflakes.Snowflake(data_payload["guild_id"]) if "guild_id" in data_payload else None,
             entitlements=[self.deserialize_entitlement(entitlement) for entitlement in payload.get("entitlements", ())],
         )
 

--- a/hikari/interactions/command_interactions.py
+++ b/hikari/interactions/command_interactions.py
@@ -181,6 +181,9 @@ class BaseCommandInteraction(base_interactions.PartialInteraction):
     command_type: typing.Union[commands.CommandType, int] = attrs.field(eq=False, hash=False, repr=True)
     """The type of the command."""
 
+    registered_guild_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=True)
+    """ID of the guild the command is registered to."""
+
     entitlements: typing.Sequence[monetization.Entitlement] = attrs.field(eq=False, hash=False, repr=True)
     """For monetized apps, any entitlements for the invoking user, represents access to SKUs."""
 

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -4388,6 +4388,7 @@ class TestEntityFactoryImpl:
                         ],
                     }
                 ],
+                "guild_id": "12345678",
                 "resolved": interaction_resolved_data_payload,
             },
             "channel_id": "49949494",
@@ -4447,6 +4448,7 @@ class TestEntityFactoryImpl:
         assert interaction.app_permissions == 54123
         assert len(interaction.entitlements) == 1
         assert interaction.entitlements[0].id == 696969696969696
+        assert interaction.registered_guild_id == 12345678
 
         # CommandInteractionOption
         assert len(interaction.options) == 1
@@ -4486,6 +4488,7 @@ class TestEntityFactoryImpl:
                 "type": 2,
                 "target_id": "115590097100865541",
                 "resolved": {"users": {"115590097100865541": user_payload}},
+                "guild_id": 12345678,
             },
             "channel_id": "49949494",
             "member": interaction_member_payload,
@@ -4528,6 +4531,7 @@ class TestEntityFactoryImpl:
         del command_interaction_payload["data"]["options"]
         del command_interaction_payload["guild_locale"]
         del command_interaction_payload["app_permissions"]
+        del command_interaction_payload["data"]["guild_id"]
 
         interaction = entity_factory_impl.deserialize_command_interaction(command_interaction_payload)
 
@@ -4538,6 +4542,7 @@ class TestEntityFactoryImpl:
         assert interaction.resolved is None
         assert interaction.guild_locale is None
         assert interaction.app_permissions is None
+        assert interaction.registered_guild_id is None
 
     @pytest.fixture
     def autocomplete_interaction_payload(self, member_payload, user_payload, interaction_resolved_data_payload):
@@ -4560,6 +4565,7 @@ class TestEntityFactoryImpl:
                         ],
                     }
                 ],
+                "guild_id": 12345678,
             },
             "channel_id": "49949494",
             "user": user_payload,
@@ -4608,6 +4614,7 @@ class TestEntityFactoryImpl:
         entity_factory_impl._deserialize_interaction_member.assert_called_once_with(member_payload, guild_id=43123123)
         assert interaction.locale is locales.Locale.ES_ES
         assert interaction.guild_locale is locales.Locale.EN_US
+        assert interaction.registered_guild_id == 12345678
 
         # AutocompleteInteractionOption
         assert len(interaction.options) == 1

--- a/tests/hikari/interactions/test_command_interactions.py
+++ b/tests/hikari/interactions/test_command_interactions.py
@@ -58,6 +58,7 @@ class TestCommandInteraction:
             locale="es-ES",
             guild_locale="en-US",
             app_permissions=543123,
+            registered_guild_id=snowflakes.Snowflake(12345678),
             entitlements=[
                 monetization.Entitlement(
                     id=snowflakes.Snowflake(123123),
@@ -135,6 +136,7 @@ class TestAutocompleteInteraction:
             command_name="OKOKOK",
             command_type=1,
             options=[],
+            registered_guild_id=snowflakes.Snowflake(12345678),
             entitlements=[
                 monetization.Entitlement(
                     id=snowflakes.Snowflake(123123),


### PR DESCRIPTION
### Summary
The `BaseCommandInteraction` was previously missing a field for `interaction.data.guild_id` as documented [here](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data). This PR adds the `BaseCommandInteraction.registered_guild_id` field and updates unit tests accordingly.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
