### PR TITLE
Add payload to deserialization error to make it easier to diagnose

### DIFF
--- a/changes/1943.feature.md
+++ b/changes/1943.feature.md
@@ -1,0 +1,1 @@
+Add payload to deserialization error to make it easier to diagnose

--- a/hikari/impl/event_manager_base.py
+++ b/hikari/impl/event_manager_base.py
@@ -614,6 +614,7 @@ class EventManagerBase(event_manager_.EventManager):
             asyncio.get_running_loop().call_exception_handler(
                 {
                     "message": "Exception occurred in raw event dispatch conduit",
+                    "payload": payload,
                     "exception": ex,
                     "task": asyncio.current_task(),
                 }

--- a/hikari/impl/interaction_server.py
+++ b/hikari/impl/interaction_server.py
@@ -453,7 +453,11 @@ class InteractionServer(interaction_server.InteractionServer):
 
         except Exception as exc:
             asyncio.get_running_loop().call_exception_handler(
-                {"message": "Exception occurred during interaction deserialization", "exception": exc}
+                {
+                    "message": "Exception occurred during interaction deserialization",
+                    "payload": payload,
+                    "exception": exc,
+                }
             )
             return _Response(_INTERNAL_SERVER_ERROR_STATUS, b"Exception occurred during interaction deserialization")
 

--- a/tests/hikari/impl/test_event_manager_base.py
+++ b/tests/hikari/impl/test_event_manager_base.py
@@ -592,7 +592,12 @@ class TestEventManagerBase:
 
         error_handler.assert_called_once_with(
             event_loop,
-            {"exception": exc, "message": "Exception occurred in raw event dispatch conduit", "task": mock_task},
+            {
+                "exception": exc,
+                "message": "Exception occurred in raw event dispatch conduit",
+                "payload": pl,
+                "task": mock_task,
+            },
         )
 
     @pytest.mark.asyncio

--- a/tests/hikari/impl/test_interaction_server.py
+++ b/tests/hikari/impl/test_interaction_server.py
@@ -848,7 +848,11 @@ class TestInteractionServer:
             result = await mock_interaction_server.on_interaction(b'{"type": 2}', b"signature", b"timestamp")
 
             get_running_loop.return_value.call_exception_handler.assert_called_once_with(
-                {"message": "Exception occurred during interaction deserialization", "exception": mock_exception}
+                {
+                    "message": "Exception occurred during interaction deserialization",
+                    "payload": {"type": 2},
+                    "exception": mock_exception,
+                }
             )
 
         assert result.content_type == "text/plain"


### PR DESCRIPTION
### Summary
Add payload to deserialization error to make it easier to diagnose

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
None