### PR TITLE
Fix dumping JSON with enum values as dict keys

### DIFF
--- a/changes/1957.bugfix.md
+++ b/changes/1957.bugfix.md
@@ -1,0 +1,3 @@
+Fix serializing JSON dicts with enum values as keys.
+
+See https://github.com/hikari-py/hikari/issues/1955

--- a/hikari/internal/data_binding.py
+++ b/hikari/internal/data_binding.py
@@ -99,15 +99,18 @@ _JSON_CONTENT_TYPE: typing.Final[str] = "application/json"
 _UTF_8: typing.Final[str] = "utf-8"
 
 default_json_dumps: JSONEncoder
-"""Default json encoder to use."""
+"""Default JSON encoder to use."""
 
 default_json_loads: JSONDecoder
-"""Default json decoder to use."""
+"""Default JSON decoder to use."""
 
 try:
     import orjson
 
-    default_json_dumps = orjson.dumps
+    def default_json_dumps(obj: typing.Union[JSONArray, JSONObject]) -> bytes:
+        """Encode a JSON object to [`bytes`][]."""
+        return orjson.dumps(obj, option=orjson.OPT_NON_STR_KEYS)
+
     default_json_loads = orjson.loads
 except ModuleNotFoundError:
     import json
@@ -115,7 +118,7 @@ except ModuleNotFoundError:
     _json_separators = (",", ":")
 
     def default_json_dumps(obj: typing.Union[JSONArray, JSONObject]) -> bytes:
-        """Encode a JSON object to a [`str`][]."""
+        """Encode a JSON object to [`bytes`][]."""
         return json.dumps(obj, separators=_json_separators).encode(_UTF_8)
 
     default_json_loads = json.loads


### PR DESCRIPTION
### Summary
Not the ideal way I would like to fix it, but it looks like `orjson` doesn't want to add support for enums because "would be too confusing" (even tho the fact that it doesn't work is more confusing)

See all the issues opened through the years https://github.com/ijl/orjson/issues?q=str+enum

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Closes #1955 
