### PR TITLE
Properly solve documenting inherited members

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,7 @@ repo_url: https://github.com/hikari-py/hikari/
 repo_name: hikari-py/hikari
 edit_uri: blob/master/docs/
 
-watch: [ hikari, README.md, CHANGELOG.md ]
+watch: [ hikari, README.md, CHANGELOG.md, scripts/docs ]
 copyright: © 2021-present davfsa
 
 #strict: true

--- a/scripts/docs/gen_ref_pages.py
+++ b/scripts/docs/gen_ref_pages.py
@@ -46,6 +46,11 @@ for path in sorted(pathlib.Path("hikari").rglob("*.py")):
             f"::: {full_name}\n"
         )
 
+        # As of this commit b327b908 in griffe the idea of "exported" members has changed
+        # when it comes to `__init__` files, but we can work around it by explicitly
+        # removing all members from the init renders, leaving only the docstrings
+        # see: https://github.com/mkdocstrings/griffe/commit/d9546c8eb8f4ce5d3a216309937a6552
+        # see: https://github.com/mkdocstrings/python/issues/39
         if index:
             fd.write("    options:\n")
             fd.write("      members: false\n")


### PR DESCRIPTION
It seems like, for some reason, `mkdocs serve` respects `inherited_members` but `mkdocs build` doesn't

This is a bit of a hacky alternative solution until the root cause is found
