### PR TITLE
Adding application emojis

### DIFF
--- a/hikari/api/entity_factory.py
+++ b/hikari/api/entity_factory.py
@@ -952,6 +952,27 @@ class EntityFactory(abc.ABC):
         """
 
     @abc.abstractmethod
+    def deserialize_application_emoji(
+        self, payload: data_binding.JSONObject, *, application_id: snowflakes.Snowflake
+    ) -> emoji_models.ApplicationEmoji:
+        """Parse a raw payload from Discord into a application emoji object.
+
+        Parameters
+        ----------
+        payload
+            The JSON payload to deserialize.
+        application_id
+            The ID of the guild this emoji belongs to. This is used to ensure
+            that the guild a known custom emoji belongs to is remembered by
+            allowing for a context based artificial `guild_id` attribute.
+
+        Returns
+        -------
+        hikari.emojis.ApplicationEmoji
+            The deserialized "known custom emoji" object.
+        """
+
+    @abc.abstractmethod
     def deserialize_emoji(
         self, payload: data_binding.JSONObject
     ) -> typing.Union[emoji_models.UnicodeEmoji, emoji_models.CustomEmoji]:

--- a/hikari/api/entity_factory.py
+++ b/hikari/api/entity_factory.py
@@ -955,21 +955,21 @@ class EntityFactory(abc.ABC):
     def deserialize_application_emoji(
         self, payload: data_binding.JSONObject, *, application_id: snowflakes.Snowflake
     ) -> emoji_models.ApplicationEmoji:
-        """Parse a raw payload from Discord into a application emoji object.
+        """Parse a raw payload from Discord into an application emoji object.
 
         Parameters
         ----------
         payload
             The JSON payload to deserialize.
         application_id
-            The ID of the guild this emoji belongs to. This is used to ensure
-            that the guild a known custom emoji belongs to is remembered by
-            allowing for a context based artificial `guild_id` attribute.
+            The ID of the application this emoji belongs to. This is used to ensure
+            that the application an application emoji belongs to is remembered by
+            allowing for a context based artificial `application_id` attribute.
 
         Returns
         -------
         hikari.emojis.ApplicationEmoji
-            The deserialized "known custom emoji" object.
+            The deserialized "application emoji" object.
         """
 
     @abc.abstractmethod

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -3407,7 +3407,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         self,
         application: snowflakes.SnowflakeishOr[guilds.PartialApplication],
         emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji],
-    ) -> emojis.CustomEmoji:
+    ) -> emojis.ApplicationEmoji:
         """Fetch an application emoji.
 
         Parameters
@@ -3422,7 +3422,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Returns
         -------
-        hikari.emojis.CustomEmoji
+        hikari.emojis.ApplicationEmoji
             The requested application emoji.
 
         Raises
@@ -3443,7 +3443,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def fetch_application_emojis(
         self, application: snowflakes.SnowflakeishOr[guilds.PartialApplication]
-    ) -> typing.Sequence[emojis.CustomEmoji]:
+    ) -> typing.Sequence[emojis.ApplicationEmoji]:
         """Fetch the emojis of an application.
 
         Parameters
@@ -3454,7 +3454,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Returns
         -------
-        typing.Sequence[hikari.emojis.CustomEmoji]
+        typing.Sequence[hikari.emojis.ApplicationEmoji]
             The requested emojis.
 
         Raises
@@ -3475,7 +3475,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def create_application_emoji(
         self, application: snowflakes.SnowflakeishOr[guilds.PartialApplication], name: str, image: files.Resourceish
-    ) -> emojis.CustomEmoji:
+    ) -> emojis.ApplicationEmoji:
         """Create an emoji for an application.
 
         Parameters
@@ -3491,7 +3491,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Returns
         -------
-        hikari.emojis.CustomEmoji
+        hikari.emojis.ApplicationEmoji
             The created emoji.
 
         Raises
@@ -3519,7 +3519,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         application: snowflakes.SnowflakeishOr[guilds.PartialApplication],
         emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji],
         name: str,
-    ) -> emojis.CustomEmoji:
+    ) -> emojis.ApplicationEmoji:
         """Edit an emoji in a guild.
 
         Parameters
@@ -3535,7 +3535,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Returns
         -------
-        hikari.emojis.CustomEmoji
+        hikari.emojis.ApplicationEmoji
             The edited emoji.
 
         Raises

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -3403,6 +3403,196 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         """
 
     @abc.abstractmethod
+    async def fetch_application_emoji(
+        self,
+        application: snowflakes.SnowflakeishOr[guilds.PartialApplication],
+        emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji]
+    ) -> emojis.CustomEmoji:
+        """Fetch an application emoji.
+
+        Parameters
+        ----------
+        application
+            The application to fetch the emoji from. This can be a [`hikari.guilds.PartialApplication`][]
+            or the ID of an application.
+        emoji
+            The emoji to fetch. This can be a [`hikari.emojis.CustomEmoji`][]
+            or the ID of an existing application emoji.
+
+
+        Returns
+        -------
+        hikari.emojis.CustomEmoji
+            The requested application emoji.
+
+        Raises
+        ------
+        hikari.errors.NotFoundError
+            If the emoji is not found.
+        hikari.errors.UnauthorizedError
+            If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
+        hikari.errors.InternalServerError
+            If an internal error occurs on Discord while handling the request.
+        hikari.errors.ForbiddenError
+            If you are not allowed to access the emoji from this application.
+        """
+
+    @abc.abstractmethod
+    async def fetch_application_emojis(
+        self, application: snowflakes.SnowflakeishOr[guilds.PartialApplication]
+    ) -> typing.Sequence[emojis.CustomEmoji]:
+        """Fetch the emojis of an application.
+
+        Parameters
+        ----------
+        application
+            The application to fetch the emojis from. This can be a [`hikari.guilds.PartialApplication`][]
+            or the ID of an application.
+
+        Returns
+        -------
+        typing.Sequence[hikari.emojis.CustomEmoji]
+            The requested emojis.
+
+        Raises
+        ------
+        hikari.errors.NotFoundError
+            If the application is not found.
+        hikari.errors.UnauthorizedError
+            If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
+        hikari.errors.InternalServerError
+            If an internal error occurs on Discord while handling the request.
+        hikari.errors.ForbiddenError
+            If you are not allowed to access emojis from this application.
+        """
+
+    @abc.abstractmethod
+    async def create_application_emoji(
+        self,
+        application: snowflakes.SnowflakeishOr[guilds.PartialApplication],
+        name: str,
+        image: files.Resourceish,
+    ) -> emojis.CustomEmoji:
+        """Create an emoji for an application.
+
+        Parameters
+        ----------
+        application
+            The application to create the emoji for. This can be an
+            application object or the ID of an existing application.
+        name
+            The name for the emoji.
+        image
+            The 128x128 image for the emoji. Maximum upload size is 256kb.
+            This can be a still or an animated image.
+
+        Returns
+        -------
+        hikari.emojis.CustomEmoji
+            The created emoji.
+
+        Raises
+        ------
+        hikari.errors.BadRequestError
+            If any of the fields that are passed have an invalid value or
+            if there are no more spaces for the emoji in the application.
+        hikari.errors.ForbiddenError
+            If you are trying to create an emoji for an application
+            that is not yours.
+        hikari.errors.NotFoundError
+            If the application is not found.
+        hikari.errors.UnauthorizedError
+            If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
+        hikari.errors.InternalServerError
+            If an internal error occurs on Discord while handling the request.
+        """
+
+    @abc.abstractmethod
+    async def edit_application_emoji(
+        self,
+        application: snowflakes.SnowflakeishOr[guilds.PartialApplication],
+        emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji],
+        name: str
+    ) -> emojis.CustomEmoji:
+        """Edit an emoji in a guild.
+
+        Parameters
+        ----------
+        application
+            The application to edit the emoji on. This can be a [`hikari.guilds.PartialApplication`][]
+            or the ID of an application.
+        emoji
+            The emoji to edit. This can be a [`hikari.emojis.CustomEmoji`][]
+            or the ID of an existing emoji.
+        name
+            The new name for the emoji.
+
+        Returns
+        -------
+        hikari.emojis.CustomEmoji
+            The edited emoji.
+
+        Raises
+        ------
+        hikari.errors.BadRequestError
+            If any of the fields that are passed have an invalid value.
+        hikari.errors.ForbiddenError
+            If you are trying to edit an emoji for an application
+            that is not yours.
+        hikari.errors.NotFoundError
+            If the application or the emoji are not found.
+        hikari.errors.UnauthorizedError
+            If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
+        hikari.errors.InternalServerError
+            If an internal error occurs on Discord while handling the request.
+        """
+
+    @abc.abstractmethod
+    async def delete_application_emoji(
+        self,
+        application: snowflakes.SnowflakeishOr[guilds.PartialApplication],
+        emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji]
+    ) -> None:
+        """Delete an emoji in a guild.
+
+        Parameters
+        ----------
+        application
+            The guild to delete the emoji on. This can be a guild object or the
+            ID of an existing guild.
+        emoji
+            The emoji to delete. This can be a [`hikari.emojis.CustomEmoji`][]
+            or the ID of an existing emoji.
+
+        Raises
+        ------
+        hikari.errors.ForbiddenError
+            If you are trying to edit an emoji for an application
+            that is not yours.
+        hikari.errors.NotFoundError
+            If the application or the emoji are not found.
+        hikari.errors.UnauthorizedError
+            If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
+        hikari.errors.InternalServerError
+            If an internal error occurs on Discord while handling the request.
+        """
+
+    @abc.abstractmethod
     async def fetch_available_sticker_packs(self) -> typing.Sequence[stickers_.StickerPack]:
         """Fetch the available sticker packs.
 

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -3406,7 +3406,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     async def fetch_application_emoji(
         self,
         application: snowflakes.SnowflakeishOr[guilds.PartialApplication],
-        emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji]
+        emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji],
     ) -> emojis.CustomEmoji:
         """Fetch an application emoji.
 
@@ -3474,10 +3474,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     @abc.abstractmethod
     async def create_application_emoji(
-        self,
-        application: snowflakes.SnowflakeishOr[guilds.PartialApplication],
-        name: str,
-        image: files.Resourceish,
+        self, application: snowflakes.SnowflakeishOr[guilds.PartialApplication], name: str, image: files.Resourceish
     ) -> emojis.CustomEmoji:
         """Create an emoji for an application.
 
@@ -3521,7 +3518,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         self,
         application: snowflakes.SnowflakeishOr[guilds.PartialApplication],
         emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji],
-        name: str
+        name: str,
     ) -> emojis.CustomEmoji:
         """Edit an emoji in a guild.
 
@@ -3563,7 +3560,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     async def delete_application_emoji(
         self,
         application: snowflakes.SnowflakeishOr[guilds.PartialApplication],
-        emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji]
+        emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji],
     ) -> None:
         """Delete an emoji in a guild.
 

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -3498,7 +3498,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ------
         hikari.errors.BadRequestError
             If any of the fields that are passed have an invalid value or
-            if there are no more spaces for the emoji in the application.
+            if there is no more spaces for the emoji in the application.
         hikari.errors.ForbiddenError
             If you are trying to create an emoji for an application
             that is not yours.
@@ -3520,7 +3520,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji],
         name: str,
     ) -> emojis.ApplicationEmoji:
-        """Edit an emoji in a guild.
+        """Edit an emoji in an application.
 
         Parameters
         ----------
@@ -3562,13 +3562,13 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         application: snowflakes.SnowflakeishOr[guilds.PartialApplication],
         emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji],
     ) -> None:
-        """Delete an emoji in a guild.
+        """Delete an emoji in an application.
 
         Parameters
         ----------
         application
-            The guild to delete the emoji on. This can be a guild object or the
-            ID of an existing guild.
+            The application to delete the emoji from. This can be a [`hikari.guilds.PartialApplication`][]
+            or the ID of an application.
         emoji
             The emoji to delete. This can be a [`hikari.emojis.CustomEmoji`][]
             or the ID of an existing emoji.

--- a/hikari/emojis.py
+++ b/hikari/emojis.py
@@ -366,3 +366,38 @@ class KnownCustomEmoji(CustomEmoji):
 
     May be [`False`][] due to a loss of Sever Boosts on the emoji's guild.
     """
+
+
+@attrs.define(hash=True, kw_only=True, weakref_slot=False)
+class ApplicationEmoji(CustomEmoji):
+    """Represents an emoji that is known from a guild the bot is in.
+
+    This is a specialization of [`hikari.emojis.CustomEmoji`][] that is from a guild that you
+    _are_ part of. As a result, it contains a lot more information with it.
+    """
+
+    app: traits.RESTAware = attrs.field(
+        repr=False, eq=False, hash=False, metadata={attrs_extensions.SKIP_DEEP_COPY: True}
+    )
+    """Client application that models may use for procedures."""
+
+    application_id: snowflakes.Snowflake = attrs.field(eq=False, hash=False, repr=False)
+    """The ID of the application this emoji belongs to."""
+
+    role_ids: typing.Sequence[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    """The IDs of the roles that are whitelisted to use this emoji.
+
+    If this is empty then any user can use this emoji regardless of their roles.
+    """
+
+    user: typing.Optional[users.User] = attrs.field(eq=False, hash=False, repr=False)
+    """The user that created the emoji."""
+
+    is_colons_required: bool = attrs.field(eq=False, hash=False, repr=False)
+    """Whether this emoji must be wrapped in colons."""
+
+    is_managed: bool = attrs.field(eq=False, hash=False, repr=False)
+    """Whether the emoji is managed by an integration."""
+
+    is_available: bool = attrs.field(eq=False, hash=False, repr=False)
+    """Whether this emoji can currently be used."""

--- a/hikari/emojis.py
+++ b/hikari/emojis.py
@@ -370,10 +370,10 @@ class KnownCustomEmoji(CustomEmoji):
 
 @attrs.define(hash=True, kw_only=True, weakref_slot=False)
 class ApplicationEmoji(CustomEmoji):
-    """Represents an emoji that is known from a guild the bot is in.
+    """Represents an application emoji.
 
-    This is a specialization of [`hikari.emojis.CustomEmoji`][] that is from a guild that you
-    _are_ part of. As a result, it contains a lot more information with it.
+    This is a specialization of [`hikari.emojis.CustomEmoji`][] that is from an application.
+    As a result, it contains a lot more information with it.
     """
 
     app: traits.RESTAware = attrs.field(

--- a/hikari/emojis.py
+++ b/hikari/emojis.py
@@ -242,8 +242,7 @@ class UnicodeEmoji(str, Emoji):
 class CustomEmoji(snowflakes.Unique, Emoji):
     """Represents a custom emoji.
 
-    This is a custom emoji which could be an application emoji or
-    a normal custom emoji from a guild you might not be part of.
+    This is a custom emoji that is from a guild you might not be part of.
 
     All CustomEmoji objects and their derivatives act as valid
     [`hikari.files.Resource`][] objects. This means you can use them as a

--- a/hikari/emojis.py
+++ b/hikari/emojis.py
@@ -242,7 +242,8 @@ class UnicodeEmoji(str, Emoji):
 class CustomEmoji(snowflakes.Unique, Emoji):
     """Represents a custom emoji.
 
-    This is a custom emoji that is from a guild you might not be part of.
+    This is a custom emoji which could be an application emoji or
+    a normal custom emoji from a guild you might not be part of.
 
     All CustomEmoji objects and their derivatives act as valid
     [`hikari.files.Resource`][] objects. This means you can use them as a

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -1719,6 +1719,28 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             is_available=payload["available"],
         )
 
+    def deserialize_application_emoji(
+        self, payload: data_binding.JSONObject, *, application_id: snowflakes.Snowflake
+    ) -> emoji_models.ApplicationEmoji:
+        role_ids = [snowflakes.Snowflake(role_id) for role_id in payload["roles"]] if "roles" in payload else []
+
+        user: typing.Optional[user_models.User] = None
+        if (raw_user := payload.get("user")) is not None:
+            user = self.deserialize_user(raw_user)
+
+        return emoji_models.ApplicationEmoji(
+            app=self._app,
+            id=snowflakes.Snowflake(payload["id"]),
+            name=payload["name"],
+            is_animated=payload.get("animated", False),
+            application_id=application_id,
+            role_ids=role_ids,
+            user=user,
+            is_colons_required=payload["require_colons"],
+            is_managed=payload["managed"],
+            is_available=payload["available"],
+        )
+
     def deserialize_emoji(
         self, payload: data_binding.JSONObject
     ) -> typing.Union[emoji_models.UnicodeEmoji, emoji_models.CustomEmoji]:

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -2417,7 +2417,7 @@ class RESTClientImpl(rest_api.RESTClient):
     async def fetch_application_emoji(
         self,
         application: snowflakes.SnowflakeishOr[guilds.PartialApplication],
-        emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji]
+        emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji],
     ) -> emojis.CustomEmoji:
         route = routes.GET_APPLICATION_EMOJI.compile(application=application, emoji=emoji)
         response = await self._request(route)
@@ -2430,16 +2430,10 @@ class RESTClientImpl(rest_api.RESTClient):
         route = routes.GET_APPLICATION_EMOJIS.compile(application=application)
         response = await self._request(route)
         assert isinstance(response, list)
-        return [
-            self._entity_factory.deserialize_custom_emoji(emoji_payload)
-            for emoji_payload in response
-        ]
+        return [self._entity_factory.deserialize_custom_emoji(emoji_payload) for emoji_payload in response]
 
     async def create_application_emoji(
-        self,
-        application: snowflakes.SnowflakeishOr[guilds.PartialApplication],
-        name: str,
-        image: files.Resourceish,
+        self, application: snowflakes.SnowflakeishOr[guilds.PartialApplication], name: str, image: files.Resourceish
     ) -> emojis.CustomEmoji:
         route = routes.POST_APPLICATION_EMOJIS.compile(application=application)
         body = data_binding.JSONObjectBuilder()
@@ -2456,7 +2450,7 @@ class RESTClientImpl(rest_api.RESTClient):
         self,
         application: snowflakes.SnowflakeishOr[guilds.PartialApplication],
         emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji],
-        name: str
+        name: str,
     ) -> emojis.CustomEmoji:
         route = routes.PATCH_APPLICATION_EMOJI.compile(application=application, emoji=emoji)
         body = data_binding.JSONObjectBuilder()
@@ -2469,7 +2463,7 @@ class RESTClientImpl(rest_api.RESTClient):
     async def delete_application_emoji(
         self,
         application: snowflakes.SnowflakeishOr[guilds.PartialApplication],
-        emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji]
+        emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji],
     ) -> None:
         route = routes.DELETE_APPLICATION_EMOJI.compile(application=application, emoji=emoji)
         await self._request(route)

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -2418,23 +2418,29 @@ class RESTClientImpl(rest_api.RESTClient):
         self,
         application: snowflakes.SnowflakeishOr[guilds.PartialApplication],
         emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji],
-    ) -> emojis.CustomEmoji:
+    ) -> emojis.ApplicationEmoji:
         route = routes.GET_APPLICATION_EMOJI.compile(application=application, emoji=emoji)
         response = await self._request(route)
         assert isinstance(response, dict)
-        return self._entity_factory.deserialize_custom_emoji(response)
+        return self._entity_factory.deserialize_application_emoji(
+            response, application_id=snowflakes.Snowflake(application)
+        )
 
     async def fetch_application_emojis(
         self, application: snowflakes.SnowflakeishOr[guilds.PartialApplication]
-    ) -> typing.Sequence[emojis.CustomEmoji]:
+    ) -> typing.Sequence[emojis.ApplicationEmoji]:
         route = routes.GET_APPLICATION_EMOJIS.compile(application=application)
         response = await self._request(route)
         assert isinstance(response, list)
-        return [self._entity_factory.deserialize_custom_emoji(emoji_payload) for emoji_payload in response]
+        application_id = snowflakes.Snowflake(application)
+        return [
+            self._entity_factory.deserialize_application_emoji(emoji_payload, application_id=application_id)
+            for emoji_payload in response
+        ]
 
     async def create_application_emoji(
         self, application: snowflakes.SnowflakeishOr[guilds.PartialApplication], name: str, image: files.Resourceish
-    ) -> emojis.CustomEmoji:
+    ) -> emojis.ApplicationEmoji:
         route = routes.POST_APPLICATION_EMOJIS.compile(application=application)
         body = data_binding.JSONObjectBuilder()
         body.put("name", name)
@@ -2444,21 +2450,25 @@ class RESTClientImpl(rest_api.RESTClient):
 
         response = await self._request(route, json=body)
         assert isinstance(response, dict)
-        return self._entity_factory.deserialize_custom_emoji(response)
+        return self._entity_factory.deserialize_application_emoji(
+            response, application_id=snowflakes.Snowflake(application)
+        )
 
     async def edit_application_emoji(
         self,
         application: snowflakes.SnowflakeishOr[guilds.PartialApplication],
         emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji],
         name: str,
-    ) -> emojis.CustomEmoji:
+    ) -> emojis.ApplicationEmoji:
         route = routes.PATCH_APPLICATION_EMOJI.compile(application=application, emoji=emoji)
         body = data_binding.JSONObjectBuilder()
         body.put("name", name)
 
         response = await self._request(route, json=body)
         assert isinstance(response, dict)
-        return self._entity_factory.deserialize_custom_emoji(response)
+        return self._entity_factory.deserialize_application_emoji(
+            response, application_id=snowflakes.Snowflake(application)
+        )
 
     async def delete_application_emoji(
         self,

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -2414,6 +2414,66 @@ class RESTClientImpl(rest_api.RESTClient):
         route = routes.DELETE_GUILD_EMOJI.compile(guild=guild, emoji=emoji)
         await self._request(route, reason=reason)
 
+    async def fetch_application_emoji(
+        self,
+        application: snowflakes.SnowflakeishOr[guilds.PartialApplication],
+        emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji]
+    ) -> emojis.CustomEmoji:
+        route = routes.GET_APPLICATION_EMOJI.compile(application=application, emoji=emoji)
+        response = await self._request(route)
+        assert isinstance(response, dict)
+        return self._entity_factory.deserialize_custom_emoji(response)
+
+    async def fetch_application_emojis(
+        self, application: snowflakes.SnowflakeishOr[guilds.PartialApplication]
+    ) -> typing.Sequence[emojis.CustomEmoji]:
+        route = routes.GET_APPLICATION_EMOJIS.compile(application=application)
+        response = await self._request(route)
+        assert isinstance(response, list)
+        return [
+            self._entity_factory.deserialize_custom_emoji(emoji_payload)
+            for emoji_payload in response
+        ]
+
+    async def create_application_emoji(
+        self,
+        application: snowflakes.SnowflakeishOr[guilds.PartialApplication],
+        name: str,
+        image: files.Resourceish,
+    ) -> emojis.CustomEmoji:
+        route = routes.POST_APPLICATION_EMOJIS.compile(application=application)
+        body = data_binding.JSONObjectBuilder()
+        body.put("name", name)
+        image_resource = files.ensure_resource(image)
+        async with image_resource.stream(executor=self._executor) as stream:
+            body.put("image", await stream.data_uri())
+
+        response = await self._request(route, json=body)
+        assert isinstance(response, dict)
+        return self._entity_factory.deserialize_custom_emoji(response)
+
+    async def edit_application_emoji(
+        self,
+        application: snowflakes.SnowflakeishOr[guilds.PartialApplication],
+        emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji],
+        name: str
+    ) -> emojis.CustomEmoji:
+        route = routes.PATCH_APPLICATION_EMOJI.compile(application=application, emoji=emoji)
+        body = data_binding.JSONObjectBuilder()
+        body.put("name", name)
+
+        response = await self._request(route, json=body)
+        assert isinstance(response, dict)
+        return self._entity_factory.deserialize_custom_emoji(response)
+
+    async def delete_application_emoji(
+        self,
+        application: snowflakes.SnowflakeishOr[guilds.PartialApplication],
+        emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji]
+    ) -> None:
+        route = routes.DELETE_APPLICATION_EMOJI.compile(application=application, emoji=emoji)
+        await self._request(route)
+
     async def fetch_available_sticker_packs(self) -> typing.Sequence[stickers_.StickerPack]:
         route = routes.GET_STICKER_PACKS.compile()
         response = await self._request(route, auth=None)

--- a/hikari/internal/routes.py
+++ b/hikari/internal/routes.py
@@ -382,6 +382,14 @@ DELETE_GUILD_EMOJI: typing.Final[Route] = Route(DELETE, "/guilds/{guild}/emojis/
 GET_GUILD_EMOJIS: typing.Final[Route] = Route(GET, "/guilds/{guild}/emojis")
 POST_GUILD_EMOJIS: typing.Final[Route] = Route(POST, "/guilds/{guild}/emojis")
 
+GET_APPLICATION_EMOJI: typing.Final[Route] = Route(GET, "/applications/{application}/emojis/{emoji}")
+PATCH_APPLICATION_EMOJI: typing.Final[Route] = Route(PATCH, "/applications/{application}/emojis/{emoji}")
+DELETE_APPLICATION_EMOJI: typing.Final[Route] = Route(DELETE, "/applications/{application}/emojis/{emoji}")
+
+GET_APPLICATION_EMOJIS: typing.Final[Route] = Route(GET, "/applications/{application}/emojis")
+POST_APPLICATION_EMOJIS: typing.Final[Route] = Route(POST, "/applications/{application}/emojis")
+
+
 GET_GUILD_SCHEDULED_EVENT: typing.Final[Route] = Route(GET, "/guilds/{guild}/scheduled-events/{scheduled_event}")
 GET_GUILD_SCHEDULED_EVENTS: typing.Final[Route] = Route(GET, "/guilds/{guild}/scheduled-events")
 GET_GUILD_SCHEDULED_EVENT_USERS: typing.Final[Route] = Route(


### PR DESCRIPTION
### Summary
I've added the needed rest functions for handling application emojis and created an `ApplicationEmoji `class.

I didn't want to either `CustomEmoji` or `KnownCustomEmoji `because `CustomEmoji `is missing the `user `field and `KnownCustomEmoji` has a `guild_id` field which i didn't want to mess with because `KnownCustomEmoji` is used for the `CacheImpl` and i didn't want to mess up the caching somehow which uses the `guild_id`. 

It's my first time contributing to a big project and my first time using Github not only for personal use, so I'm open to critic or any tips

### Checklist
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
