### PR TITLE
Add proper ChannelOverwriteEntryInfo deserialization for field "type"

### DIFF
--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -777,7 +777,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         return audit_log_models.ChannelOverwriteEntryInfo(
             app=self._app,
             id=snowflakes.Snowflake(payload["id"]),
-            type=channel_models.PermissionOverwriteType(payload["type"]),
+            type=channel_models.PermissionOverwriteType(int(payload["type"])),
             role_name=payload.get("role_name"),
         )
 


### PR DESCRIPTION
### Summary
field "type" of ChannelOverwriteEntryInfo does not get deserialized properly. I've added a conversion from a str to an int to deserialize into the PermissionOverwriteType Enum.

### Checklist
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Fix #1992
