### PR TITLE
Fix docstring typos pointing to incorrect events

### DIFF
--- a/hikari/events/lifetime_events.py
+++ b/hikari/events/lifetime_events.py
@@ -56,7 +56,7 @@ class StartingEvent(base_events.Event):
         to try to access a database that has not yet connected fully).
 
     If you want to do something _after_ the application has initialized, you
-    should consider using [`hikari.events.lifetime_events.StartingEvent`][] instead.
+    should consider using [`hikari.events.lifetime_events.StartedEvent`][] instead.
     """
 
     app: traits.RESTAware = attrs.field(metadata={attrs_extensions.SKIP_DEEP_COPY: True})
@@ -98,7 +98,7 @@ class StoppingEvent(base_events.Event):
         on a connection still being available to complete.
 
     If you want to do something _after_ the disconnection has occurred, you
-    should consider using [`hikari.events.lifetime_events.StoppingEvent`][] instead.
+    should consider using [`hikari.events.lifetime_events.StoppedEvent`][] instead.
     """
 
     app: traits.RESTAware = attrs.field(metadata={attrs_extensions.SKIP_DEEP_COPY: True})


### PR DESCRIPTION
### Summary
Corrected the docstrings for StartingEvent and StoppingEvent, both of which suggest the use of themselves over StartedEvent and StoppedEvent respectively.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted. (N / A)

### Related issues
None
