### PR TITLE
Fix uploading files when using aiohttp 3.10.6 and onwards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,6 @@ prof/
 # Logs
 *.log
 
+# Misc
 Pipfile*
+pyrightconfig.json

--- a/changes/2059.bugfix.md
+++ b/changes/2059.bugfix.md
@@ -1,0 +1,1 @@
+Fix uploading files when using aiohttp 3.10.6 and onwards

--- a/hikari/impl/interaction_server.py
+++ b/hikari/impl/interaction_server.py
@@ -159,6 +159,9 @@ class _FilePayload(aiohttp.Payload):
         super().__init__(value=value, headers=headers, content_type=content_type)
         self._executor = executor
 
+    def decode(self, encoding: str = "utf-8", errors: str = "strict") -> str:
+        raise RuntimeError("Impossible to decode a _FilePayload. If you see this, please file a bug report with hikari")
+
     async def write(self, writer: aiohttp.abc.AbstractStreamWriter) -> None:
         async with self._value.stream(executor=self._executor) as data:
             async for chunk in data:


### PR DESCRIPTION
In aiohttp 3.10.6, a new abstract method was added to `aiohttp.Payload`, so trying to instantiate our `_FilePayload`, would cause issues.

It is impossible to implement `.decode` in a sync context, so, for now, just error pointing them to raise an issue with us if this ever becomes an issue in the future, in which case we will have to revisit this and look for an alternative and better solution