### PR TITLE
Use bash in windows CI to allow failfast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Test Installation
+        shell: bash
         run: |
           pip install -r dev-requirements/build.txt
 
@@ -41,8 +42,10 @@ jobs:
           pip uninstall -y hikari
 
       - name: Run tests
+        shell: bash
         run: |
           pip install -r dev-requirements.txt
+
           nox -s pytest
           nox -s pytest-all-features -- --cov-append
 


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/6668