### PR TITLE
Do not run pytest with coverage by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,8 @@ jobs:
         run: |
           uv sync --frozen --only-group nox
 
-          nox -s pytest
-          nox -s pytest-all-features -- --cov-append
+          nox -s pytest -- --coverage
+          nox -s pytest-all-features -- --coverage --cov-append
 
           python scripts/ci/normalize_coverage.py
 

--- a/pipelines/pytest.nox.py
+++ b/pipelines/pytest.nox.py
@@ -67,10 +67,10 @@ def _pytest(
 ) -> None:
     nox.sync(session, self=True, extras=extras_install, groups=["pytest"])
 
-    if "--skip-coverage" in session.posargs:
-        session.posargs.remove("--skip-coverage")
-        flags = RUN_FLAGS
-    else:
-        flags = [*RUN_FLAGS, *COVERAGE_FLAGS]
+    flags = RUN_FLAGS
+
+    if "--coverage" in session.posargs:
+        session.posargs.remove("--coverage")
+        flags.extend(COVERAGE_FLAGS)
 
     session.run("python", *python_flags, "-m", "pytest", *flags, *session.posargs, config.TEST_PACKAGE)


### PR DESCRIPTION
Coverage can now be enabled by providing `--coverage` as an argument like so: `nox -s pytest -- --coverage`
