### PR TITLE
Use uv as package manager in the contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,10 @@ You will need to install `towncrier` and `hikari` from source before making chan
 pip install --group towncrier -e .
 ```
 <details>
-    <summary>Test</summary>
-    Test command
+    <summary>Equivilant `pip`command</summary>
+    ```bash
+    pip install --group towncrier -e .
+    ```
 </details>
 
 For every pull request made to this project, there should be a short explanation of the change under `changes/`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ and enter it (`source .venv/bin/activate` on
 Linux, or for Windows use one of `.venv\Scripts\activate.ps1`, `.venv\Scripts\activate.bat`,
 `source .venv/Scripts/activate`).
 
-Then you should continue by installing [nox](#nox)
+Then you should continue by installing [nox](#nox).
 
 # Nox
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,8 @@ You will need to install `towncrier` and `hikari` from source before making chan
 pip install --group towncrier -e .
 ```
 <details>
-    <summary>Equivilant `pip`command</summary>
+    <summary>Equivilant pip command</summary>
+    
     ```bash
     pip install --group towncrier -e .
     ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,13 +46,13 @@ To aid with the generation of `CHANGELOG.md` as well as the releases changelog w
 You will need to install `towncrier` and `hikari` from source before making changelog additions.
 
 ```bash
-pip install --group towncrier -e .
+uv sync --group towncrier -e .
 ```
 <details>
     <summary>Equivilant pip command</summary>
     
 ```bash
-pip install --group towncrier -e .
+pip install towncrier
 ```
 </details>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,13 +33,13 @@ match that of the versioning scheme. There are utilities under `hikari.internal.
 
 # UV Package Manager
 
-We use the `uv` package manager as a faster drop-in replacement for pip. While it's not required to use in order to
+We use the `uv` package manager as a faster drop-in replacement for `pip`. While it's not required to use in order to
 contribute to hikari, it's highly recommended! From here on we will use `uv` instead of `pip`.
+
+Installing `uv` is explained [here](https://docs.astral.sh/uv/getting-started/installation/)
 
 If you still want to use `pip` as your package manager, you can see the equivalent `pip` command by clicking on
 the dropdowns below every command.
-
-Installing `uv` is explained [here](https://docs.astral.sh/uv/getting-started/installation/)
 
 # Getting Started
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ uv sync --group nox
     <summary>Equivalent pip command</summary>
     
 ```bash
-pip install nox[uv]
+pip install 'nox[uv]'
 ```
 </details>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,71 @@ contribute to hikari, it's highly recommended! From here on we will use `uv` ins
 If you still want to use `pip` as your package manager, you can take a look at equivalent `pip`command by clicking on
 the dropdowns.
 
+# Getting Started
+
+First of all you should start by cloning the repository.
+In the repository, make a virtual environment 
+```bash
+uv venv
+```
+<details>
+    <summary>Equivalent pip command</summary>
+    
+```bash
+python -m venv .venv
+```
+</details>
+
+and enter it (`source .venv/bin/activate` on
+Linux, or for Windows use one of `.venv\Scripts\activate.ps1`, `.venv\Scripts\activate.bat`,
+`source .venv/Scripts/activate`).
+
+Then you should continue by installing [nox](#nox)
+
+# Nox
+
+We have nox to help out with running pipelines locally and provides some helpful functionality.
+
+You will need to install `nox` locally before running any pipelines.
+
+```bash
+uv sync --group nox
+```
+<details>
+    <summary>Equivalent pip command</summary>
+    
+```bash
+pip install nox[uv]
+```
+</details>
+
+Nox is similar to tox, but uses a pure Python configuration instead of an INI based configuration. Nox and tox are
+both tools for generating virtual environments and running commands in those environments. Examples of usage include
+installing, configuring, and running flake8, running pytest, etc.
+
+You can check all the available nox commands by running `nox -l`.
+
+Before committing we recommend you to run `nox` to run all important pipelines and make sure the pipelines won't fail.
+
+You may run a single pipeline with `nox -s name` or multiple pipelines with `nox -s name1 name3 name9`.
+
+# Pipelines
+
+We have several jobs to ensure that the code is at its best that in can be.
+
+This includes:
+
+- `test`
+    - Run tests and installation of the package on different OS's and python versions.
+- `linting`
+    - Linting (`flake8`), type checking (`mypy`), audit (`pip-audit`) and spelling (`codespell`).
+- `twemoji`
+    - Force test all discord emojis.
+- `pages`
+    - Generate webpage + documentation.
+
+All jobs will need to succeed before anything gets merged.
+
 # Towncrier
 
 To aid with the generation of `CHANGELOG.md` as well as the releases changelog we use `towncrier`.
@@ -89,47 +154,3 @@ To push branches directly to the remote, you will have to name them like this:
 
 `issue-number` is optional (only use if issue exists) and can be left out. `small-info-on-branch` should be replaced
 with a small description of the branch.
-
-# Nox
-
-We have nox to help out with running pipelines locally and provides some helpful functionality.
-
-You will need to install `nox` locally before running any pipelines.
-
-```bash
-uv sync --group nox
-```
-<details>
-    <summary>Equivalent pip command</summary>
-    
-```bash
-pip install nox[uv]
-```
-</details>
-
-Nox is similar to tox, but uses a pure Python configuration instead of an INI based configuration. Nox and tox are
-both tools for generating virtual environments and running commands in those environments. Examples of usage include
-installing, configuring, and running flake8, running pytest, etc.
-
-You can check all the available nox commands by running `nox -l`.
-
-Before committing we recommend you to run `nox` to run all important pipelines and make sure the pipelines won't fail.
-
-You may run a single pipeline with `nox -s name` or multiple pipelines with `nox -s name1 name3 name9`.
-
-# Pipelines
-
-We have several jobs to ensure that the code is at its best that in can be.
-
-This includes:
-
-- `test`
-    - Run tests and installation of the package on different OS's and python versions.
-- `linting`
-    - Linting (`flake8`), type checking (`mypy`), audit (`pip-audit`) and spelling (`codespell`).
-- `twemoji`
-    - Force test all discord emojis.
-- `pages`
-    - Generate webpage + documentation.
-
-All jobs will need to succeed before anything gets merged.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,9 +56,9 @@ python -m venv .venv
 ```
 </details>
 
-and enter it (`source .venv/bin/activate` on
-Linux, or for Windows use one of `.venv\Scripts\activate.ps1`, `.venv\Scripts\activate.bat`,
-`source .venv/Scripts/activate`).
+and enter it:
+- On Linux/macOS: `source .venv/bin/activate`
+- On Windows: one of `.\.venv\Scripts\activate.ps1`, `.\.venv\Scripts\activate.bat`, or `.\.venv\Scripts\activate`
 
 Then you should continue by installing [nox](#nox).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,9 +51,9 @@ pip install --group towncrier -e .
 <details>
     <summary>Equivilant pip command</summary>
     
-    ```bash
-    pip install --group towncrier -e .
-    ```
+```bash
+pip install --group towncrier -e .
+```
 </details>
 
 For every pull request made to this project, there should be a short explanation of the change under `changes/`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ match that of the versioning scheme. There are utilities under `hikari.internal.
 We use the `uv` package manager as a faster drop-in replacement for pip. While it's not required to use in order to
 contribute to hikari, it's highly recommended! From here on we will use `uv` instead of `pip`.
 
-If you still want to use `pip` as your package manager, you can take a look at equivalent `pip`command by clicking on
+If you still want to use `pip` as your package manager, you can see the equivalent `pip` command by clicking on
 the dropdowns below every command.
 
 Installing `uv` is explained [here](https://docs.astral.sh/uv/getting-started/installation/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ To aid with the generation of `CHANGELOG.md` as well as the releases changelog w
 You will need to install `towncrier` and `hikari` from source before making changelog additions.
 
 ```bash
-uv sync --group towncrier -e .
+uv sync --group towncrier
 ```
 <details>
     <summary>Equivilant pip command</summary>
@@ -97,8 +97,15 @@ We have nox to help out with running pipelines locally and provides some helpful
 You will need to install `nox` locally before running any pipelines.
 
 ```bash
-pip install --group nox
+uv sync --group nox
 ```
+<details>
+    <summary>Equivilant pip command</summary>
+    
+```bash
+pip install nox[uv]
+```
+</details>
 
 Nox is similar to tox, but uses a pure Python configuration instead of an INI based configuration. Nox and tox are
 both tools for generating virtual environments and running commands in those environments. Examples of usage include

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,14 @@ More specifically:
 The removal or renaming of anything facing the public facing API must go through a deprecation process, which should
 match that of the versioning scheme. There are utilities under `hikari.internal.deprecation` to aid with it.
 
+# UV Package Manager
+
+We use the `uv` package manager as a faster drop-in replacement for pip. While it's not required to use in order to
+contribute to hikari, it's highly recommended! From here on we will use `uv` instead of `pip`.
+
+If you still want to use `pip` as your package manager, you can take a look at equivelant `pip`command by clicking on
+the dropdowns.
+
 # Towncrier
 
 To aid with the generation of `CHANGELOG.md` as well as the releases changelog we use `towncrier`.
@@ -40,6 +48,10 @@ You will need to install `towncrier` and `hikari` from source before making chan
 ```bash
 pip install --group towncrier -e .
 ```
+<details>
+    <summary>Test</summary>
+    Test command
+</details>
 
 For every pull request made to this project, there should be a short explanation of the change under `changes/`
 with the following format: `{pull_request_number}.{type}.md`,
@@ -80,10 +92,6 @@ with a small description of the branch.
 We have nox to help out with running pipelines locally and provides some helpful functionality.
 
 You will need to install `nox` locally before running any pipelines.
-
-> [!TIP]
-> We use the `uv` package manager as a faster drop-in replacement for pip. While it's not required to use in order to
-> contribute to hikari, it's highly recommended! If you use it, replace `pip` commands below with `uv pip`.
 
 ```bash
 pip install --group nox

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,9 @@ We use the `uv` package manager as a faster drop-in replacement for pip. While i
 contribute to hikari, it's highly recommended! From here on we will use `uv` instead of `pip`.
 
 If you still want to use `pip` as your package manager, you can take a look at equivalent `pip`command by clicking on
-the dropdowns.
+the dropdowns below every command.
+
+Installing `uv` is explained [here](https://docs.astral.sh/uv/getting-started/installation/)
 
 # Getting Started
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ match that of the versioning scheme. There are utilities under `hikari.internal.
 We use the `uv` package manager as a faster drop-in replacement for pip. While it's not required to use in order to
 contribute to hikari, it's highly recommended! From here on we will use `uv` instead of `pip`.
 
-If you still want to use `pip` as your package manager, you can take a look at equivelant `pip`command by clicking on
+If you still want to use `pip` as your package manager, you can take a look at equivalent `pip`command by clicking on
 the dropdowns.
 
 # Towncrier
@@ -49,7 +49,7 @@ You will need to install `towncrier` and `hikari` from source before making chan
 uv sync --group towncrier
 ```
 <details>
-    <summary>Equivilant pip command</summary>
+    <summary>Equivalent pip command</summary>
     
 ```bash
 pip install towncrier
@@ -100,7 +100,7 @@ You will need to install `nox` locally before running any pipelines.
 uv sync --group nox
 ```
 <details>
-    <summary>Equivilant pip command</summary>
+    <summary>Equivalent pip command</summary>
     
 ```bash
 pip install nox[uv]

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ In the repository, make a virtual environment (`python -m venv .venv`) and enter
 Linux, or for Windows use one of `.venv\Scripts\activate.ps1`, `.venv\Scripts\activate.bat`,
 `source .venv/Scripts/activate`).
 
-The first thing you should run is `pip install nox` to install nox.
+The first thing you should run is `pip install nox uv` to install nox.
 This handles running predefined tasks and pipelines.
 
 Once this is complete, you can run `nox` without any arguments to ensure everything builds and is correct.

--- a/README.md
+++ b/README.md
@@ -323,12 +323,12 @@ To familiarize yourself with the project, you should read our
 
 If you wish to contribute something, you should first start by cloning the repository.
 
-In the repository, make a virtual environment (`uv venv`) and enter it (`source .venv/bin/activate` on
-Linux or macOS, or for Windows use one of `.venv\Scripts\activate.ps1`, `.venv\Scripts\activate.bat`,
-`source .venv/Scripts/activate`).
 > [!NOTE]
 > We are using the package manager `uv` here. If you don't know how to use `uv`, we have a more detailed
 > section about that in the [contributing manual](https://github.com/hikari-py/hikari/blob/master/CONTRIBUTING.md).
+In the repository, make a virtual environment (`uv venv`) and enter it (`source .venv/bin/activate` on
+Linux or macOS, or for Windows use one of `.venv\Scripts\activate.ps1`, `.venv\Scripts\activate.bat`,
+`source .venv/Scripts/activate`).
 
 The first thing you should run is `uv sync --group nox` to install nox.
 This handles running predefined tasks and pipelines.

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ To familiarize yourself with the project, you should read our
 If you wish to contribute something, you should first start by cloning the repository.
 
 In the repository, make a virtual environment (`uv venv`) and enter it (`source .venv/bin/activate` on
-Linux, or for Windows use one of `.venv\Scripts\activate.ps1`, `.venv\Scripts\activate.bat`,
+Linux or macOS, or for Windows use one of `.venv\Scripts\activate.ps1`, `.venv\Scripts\activate.bat`,
 `source .venv/Scripts/activate`).
 > [!NOTE]
 > We are using the package manager `uv` here. If you don't know how to use `uv`, we have a more detailed

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Currently, this functionality does not yet exist.
 
 ## Developing hikari
 
-To familiarize yourself a bit with the project, we recommend reading our
+To familiarize yourself with the project, we recommend reading our
 [contributing manual](https://github.com/hikari-py/hikari/blob/master/CONTRIBUTING.md).
 
 If you wish to contribute something, you should first start by cloning the repository.

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ In the repository, make a virtual environment (`python -m venv .venv`) and enter
 Linux, or for Windows use one of `.venv\Scripts\activate.ps1`, `.venv\Scripts\activate.bat`,
 `source .venv/Scripts/activate`).
 
-The first thing you should run is `pip install --group nox` to install nox.
+The first thing you should run is `pip install nox` to install nox.
 This handles running predefined tasks and pipelines.
 
 Once this is complete, you can run `nox` without any arguments to ensure everything builds and is correct.

--- a/README.md
+++ b/README.md
@@ -318,16 +318,19 @@ Currently, this functionality does not yet exist.
 
 ## Developing hikari
 
-To familiarize yourself with the project, we recommend reading our
+To familiarize yourself with the project, you should read our
 [contributing manual](https://github.com/hikari-py/hikari/blob/master/CONTRIBUTING.md).
 
 If you wish to contribute something, you should first start by cloning the repository.
 
-In the repository, make a virtual environment (`python -m venv .venv`) and enter it (`source .venv/bin/activate` on
+In the repository, make a virtual environment (`uv venv`) and enter it (`source .venv/bin/activate` on
 Linux, or for Windows use one of `.venv\Scripts\activate.ps1`, `.venv\Scripts\activate.bat`,
 `source .venv/Scripts/activate`).
+> [!NOTE]
+> We are using the package manager `uv` here. If you don't know how to use `uv`, we have a more detailed
+> section about that in the [contributing manual](https://github.com/hikari-py/hikari/blob/master/CONTRIBUTING.md).
 
-The first thing you should run is `pip install nox uv` to install nox.
+The first thing you should run is `uv sync --group nox` to install nox.
 This handles running predefined tasks and pipelines.
 
 Once this is complete, you can run `nox` without any arguments to ensure everything builds and is correct.


### PR DESCRIPTION
### Summary
In the contributing guide was a small mistake for installing nox.
I know that the `--group` was already merged into master but it isn't released yet and that is prob. a bit confusing for beginners.
Also you needed to install uv using pip `pip install uv` for nox to work properly. Ofc this is something that a lot of people who want to contribute would figure out in a second but idk I feel like it could still be fixed.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed. 
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
