### PR TITLE
Remove FasterSpeeding from authors section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ readme = "README.md"
 authors = [
     { name = "Nekokatt" },
     { name = "davfsa" },
-    { name = "FasterSpeeding" },
 ]
 maintainers = [{ name = "davfsa", email = "davfsa@hikari-py.dev" }]
 classifiers = [


### PR DESCRIPTION
### Summary
the old state of this isn't accurate, it's misleading/wrong to say someone who isn't associated with the project is an author

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
