### PR TITLE
feat: no-content responses when interaction handlers return None

### DIFF
--- a/changes/2280.feature.md
+++ b/changes/2280.feature.md
@@ -1,0 +1,1 @@
+HTTP interaction handlers can return `None` to indicate a response was/will be sent using REST instead.

--- a/hikari/api/interaction_server.py
+++ b/hikari/api/interaction_server.py
@@ -46,8 +46,8 @@ if typing.TYPE_CHECKING:
 
 
 ListenerT = typing.Union[
-    typing.Callable[["_InteractionT_co"], typing.Awaitable["_ResponseT_co"]],
-    typing.Callable[["_InteractionT_co"], typing.AsyncGenerator["_ResponseT_co", None]],
+    typing.Callable[["_InteractionT_co"], typing.Awaitable[typing.Union["_ResponseT_co", None]]],
+    typing.Callable[["_InteractionT_co"], typing.AsyncGenerator[typing.Union["_ResponseT_co", None], None]],
 ]
 """Type hint of a Interaction server's listener callback.
 
@@ -56,6 +56,9 @@ subclasses [`hikari.interactions.base_interactions.PartialInteraction`][] and ma
 instance of the relevant [`hikari.api.special_endpoints.InteractionResponseBuilder`][]
 subclass for the provided interaction type which will instruct the server on how
 to respond.
+
+If the callback returns [`None`][], an HTTP no-content response will be returned. In this case
+you should respond to the interaction using the appropriate REST method instead.
 
 !!! note
     For the standard implementations of

--- a/hikari/impl/interaction_server.py
+++ b/hikari/impl/interaction_server.py
@@ -78,6 +78,7 @@ _PONG_RESPONSE_TYPE: typing.Final[int] = 1
 
 # HTTP status codes.
 _OK_STATUS: typing.Final[int] = 200
+_NO_CONTENT_STATUS: typing.Final[int] = 204
 _BAD_REQUEST_STATUS: typing.Final[int] = 400
 _PAYLOAD_TOO_LARGE_STATUS: typing.Final[int] = 413
 _UNSUPPORTED_MEDIA_TYPE_STATUS: typing.Final[int] = 415
@@ -487,6 +488,9 @@ class InteractionServer(interaction_server.InteractionServer):
 
                 else:
                     result = await call
+
+                if result is None:
+                    return _Response(_NO_CONTENT_STATUS)
 
                 raw_payload, files = result.build(self._entity_factory)
                 payload = self._dumps(raw_payload)

--- a/tests/hikari/impl/test_interaction_server.py
+++ b/tests/hikari/impl/test_interaction_server.py
@@ -251,7 +251,7 @@ class TestInteractionServer:
 
     @pytest.fixture
     def mock_interaction_server(
-        self, mock_entity_factory: interaction_server_impl.InteractionServer, mock_rest_client: rest_impl.RESTClientImpl
+        self, mock_entity_factory: entity_factory_impl.EntityFactoryImpl, mock_rest_client: rest_impl.RESTClientImpl
     ):
         cls = hikari_test_helpers.mock_class_namespace(interaction_server_impl.InteractionServer, slots_=False)
         stack = contextlib.ExitStack()
@@ -764,6 +764,45 @@ class TestInteractionServer:
 
         assert g_complete is True
         assert len(mock_interaction_server._running_generator_listeners) == 0
+
+    @pytest.mark.asyncio
+    async def test_on_interaction_returns_no_content(
+        self,
+        mock_interaction_server: interaction_server_impl.InteractionServer,
+        mock_entity_factory: entity_factory_impl.EntityFactoryImpl,
+        public_key: bytes,
+        valid_edd25519: bytes,
+        valid_payload: bytes,
+    ):
+        mock_interaction_server._public_key = nacl.signing.VerifyKey(public_key)
+        mock_file_1 = mock.Mock()
+        mock_file_2 = mock.Mock()
+        mock_entity_factory.deserialize_interaction.return_value = base_interactions.PartialInteraction(
+            app=None,
+            id=123,
+            application_id=541324,
+            type=2,
+            token="ok",
+            version=1,
+            authorizing_integration_owners={},
+            context=applications.ApplicationContextType.GUILD,
+            app_permissions=123123123,
+            user=mock.Mock(),
+            member=mock.Mock(),
+            channel=mock.Mock(),
+            guild_id=123123,
+            guild_locale="en-GB",
+            locale="es-ES",
+            entitlements=[],
+        )
+
+        mock_listener = mock.AsyncMock(return_value=None)
+        mock_interaction_server.set_listener(base_interactions.PartialInteraction, mock_listener)
+
+        result = await mock_interaction_server.on_interaction(*valid_edd25519)
+        assert result.payload is None
+        assert len(result.files) == 0
+        assert result.status_code == 204
 
     @pytest.mark.asyncio
     async def test_on_interaction_calls__fetch_public_key(


### PR DESCRIPTION
### Summary
This PR allows REST interaction handlers to return None instead of a response builder - indicating that the interaction was responded to manually using an HTTP request. [Relevant documentation](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback)

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
