### PR TITLE
Upgrade typing to use `X | Y` notation

### DIFF
--- a/hikari/api/cache.py
+++ b/hikari/api/cache.py
@@ -61,7 +61,7 @@ class CacheView(typing.Mapping[_KeyT, _ValueT], abc.ABC):
     def get_item_at(self, index: slice, /) -> typing.Sequence[_ValueT]: ...
 
     @abc.abstractmethod
-    def get_item_at(self, index: typing.Union[slice, int], /) -> typing.Union[_ValueT, typing.Sequence[_ValueT]]:
+    def get_item_at(self, index: slice | int, /) -> _ValueT | typing.Sequence[_ValueT]:
         """Get an item at a specific position or slice."""
 
 
@@ -87,9 +87,7 @@ class Cache(abc.ABC):
         """Get the configured settings for this cache."""
 
     @abc.abstractmethod
-    def get_dm_channel_id(
-        self, user: snowflakes.SnowflakeishOr[users.PartialUser], /
-    ) -> typing.Optional[snowflakes.Snowflake]:
+    def get_dm_channel_id(self, user: snowflakes.SnowflakeishOr[users.PartialUser], /) -> snowflakes.Snowflake | None:
         """Get the DM channel ID for a user.
 
         Parameters
@@ -115,9 +113,7 @@ class Cache(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_emoji(
-        self, emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji], /
-    ) -> typing.Optional[emojis.KnownCustomEmoji]:
+    def get_emoji(self, emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji], /) -> emojis.KnownCustomEmoji | None:
         """Get a known custom emoji from the cache.
 
         Parameters
@@ -161,9 +157,7 @@ class Cache(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_sticker(
-        self, sticker: snowflakes.SnowflakeishOr[stickers.GuildSticker], /
-    ) -> typing.Optional[stickers.GuildSticker]:
+    def get_sticker(self, sticker: snowflakes.SnowflakeishOr[stickers.GuildSticker], /) -> stickers.GuildSticker | None:
         """Get a sticker from the cache.
 
         Parameters
@@ -206,9 +200,7 @@ class Cache(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_guild(
-        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
-    ) -> typing.Optional[guilds.GatewayGuild]:
+    def get_guild(self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /) -> guilds.GatewayGuild | None:
         """Get a guild from the cache.
 
         !!! warning
@@ -231,7 +223,7 @@ class Cache(abc.ABC):
     @abc.abstractmethod
     def get_available_guild(
         self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
-    ) -> typing.Optional[guilds.GatewayGuild]:
+    ) -> guilds.GatewayGuild | None:
         """Get the object of an available guild from the cache.
 
         Parameters
@@ -248,7 +240,7 @@ class Cache(abc.ABC):
     @abc.abstractmethod
     def get_unavailable_guild(
         self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
-    ) -> typing.Optional[guilds.GatewayGuild]:
+    ) -> guilds.GatewayGuild | None:
         """Get the object of an unavailable guild from the cache.
 
         !!! note
@@ -307,7 +299,7 @@ class Cache(abc.ABC):
     @abc.abstractmethod
     def get_guild_channel(
         self, channel: snowflakes.SnowflakeishOr[channels.PartialChannel], /
-    ) -> typing.Optional[channels.PermissibleGuildChannel]:
+    ) -> channels.PermissibleGuildChannel | None:
         """Get a guild channel from the cache.
 
         Parameters
@@ -354,7 +346,7 @@ class Cache(abc.ABC):
     @abc.abstractmethod
     def get_thread(
         self, thread: snowflakes.SnowflakeishOr[channels.PartialChannel], /
-    ) -> typing.Optional[channels.GuildThreadChannel]:
+    ) -> channels.GuildThreadChannel | None:
         """Get a thread channel from the cache.
 
         Parameters
@@ -422,7 +414,7 @@ class Cache(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_invite(self, code: typing.Union[invites.InviteCode, str], /) -> typing.Optional[invites.InviteWithMetadata]:
+    def get_invite(self, code: invites.InviteCode | str, /) -> invites.InviteWithMetadata | None:
         """Get an invite object from the cache.
 
         Parameters
@@ -489,7 +481,7 @@ class Cache(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_me(self) -> typing.Optional[users.OwnUser]:
+    def get_me(self) -> users.OwnUser | None:
         """Get the own user object from the cache.
 
         Returns
@@ -504,7 +496,7 @@ class Cache(abc.ABC):
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
         user: snowflakes.SnowflakeishOr[users.PartialUser],
         /,
-    ) -> typing.Optional[guilds.Member]:
+    ) -> guilds.Member | None:
         """Get a member object from the cache.
 
         Parameters
@@ -549,9 +541,7 @@ class Cache(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_message(
-        self, message: snowflakes.SnowflakeishOr[messages.PartialMessage], /
-    ) -> typing.Optional[messages.Message]:
+    def get_message(self, message: snowflakes.SnowflakeishOr[messages.PartialMessage], /) -> messages.Message | None:
         """Get a message object from the cache.
 
         Parameters
@@ -581,7 +571,7 @@ class Cache(abc.ABC):
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
         user: snowflakes.SnowflakeishOr[users.PartialUser],
         /,
-    ) -> typing.Optional[presences.MemberPresence]:
+    ) -> presences.MemberPresence | None:
         """Get a presence object from the cache.
 
         Parameters
@@ -630,7 +620,7 @@ class Cache(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_role(self, role: snowflakes.SnowflakeishOr[guilds.PartialRole], /) -> typing.Optional[guilds.Role]:
+    def get_role(self, role: snowflakes.SnowflakeishOr[guilds.PartialRole], /) -> guilds.Role | None:
         """Get a role object from the cache.
 
         Parameters
@@ -673,7 +663,7 @@ class Cache(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_user(self, user: snowflakes.SnowflakeishOr[users.PartialUser], /) -> typing.Optional[users.User]:
+    def get_user(self, user: snowflakes.SnowflakeishOr[users.PartialUser], /) -> users.User | None:
         """Get a user object from the cache.
 
         Parameters
@@ -704,7 +694,7 @@ class Cache(abc.ABC):
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
         user: snowflakes.SnowflakeishOr[users.PartialUser],
         /,
-    ) -> typing.Optional[voices.VoiceState]:
+    ) -> voices.VoiceState | None:
         """Get a voice state object from the cache.
 
         Parameters
@@ -803,7 +793,7 @@ class MutableCache(Cache, abc.ABC):
     @abc.abstractmethod
     def delete_dm_channel_id(
         self, user: snowflakes.SnowflakeishOr[users.PartialUser], /
-    ) -> typing.Optional[snowflakes.Snowflake]:
+    ) -> snowflakes.Snowflake | None:
         """Remove a DM channel ID from the cache.
 
         Parameters
@@ -873,9 +863,7 @@ class MutableCache(Cache, abc.ABC):
         """
 
     @abc.abstractmethod
-    def delete_emoji(
-        self, emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji], /
-    ) -> typing.Optional[emojis.KnownCustomEmoji]:
+    def delete_emoji(self, emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji], /) -> emojis.KnownCustomEmoji | None:
         """Remove a known custom emoji from the cache.
 
         !!! note
@@ -907,7 +895,7 @@ class MutableCache(Cache, abc.ABC):
     @abc.abstractmethod
     def update_emoji(
         self, emoji: emojis.KnownCustomEmoji, /
-    ) -> tuple[typing.Optional[emojis.KnownCustomEmoji], typing.Optional[emojis.KnownCustomEmoji]]:
+    ) -> tuple[emojis.KnownCustomEmoji | None, emojis.KnownCustomEmoji | None]:
         """Update an emoji object in the cache.
 
         Parameters
@@ -961,7 +949,7 @@ class MutableCache(Cache, abc.ABC):
     @abc.abstractmethod
     def delete_sticker(
         self, sticker: snowflakes.SnowflakeishOr[stickers.GuildSticker], /
-    ) -> typing.Optional[stickers.GuildSticker]:
+    ) -> stickers.GuildSticker | None:
         """Remove a sticker from the cache.
 
         !!! note
@@ -1001,9 +989,7 @@ class MutableCache(Cache, abc.ABC):
         """
 
     @abc.abstractmethod
-    def delete_guild(
-        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
-    ) -> typing.Optional[guilds.GatewayGuild]:
+    def delete_guild(self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /) -> guilds.GatewayGuild | None:
         """Remove a guild object from the cache.
 
         Parameters
@@ -1048,7 +1034,7 @@ class MutableCache(Cache, abc.ABC):
     @abc.abstractmethod
     def update_guild(
         self, guild: guilds.GatewayGuild, /
-    ) -> tuple[typing.Optional[guilds.GatewayGuild], typing.Optional[guilds.GatewayGuild]]:
+    ) -> tuple[guilds.GatewayGuild | None, guilds.GatewayGuild | None]:
         """Update a guild in the cache.
 
         Parameters
@@ -1096,7 +1082,7 @@ class MutableCache(Cache, abc.ABC):
     @abc.abstractmethod
     def delete_guild_channel(
         self, channel: snowflakes.SnowflakeishOr[channels.PartialChannel], /
-    ) -> typing.Optional[channels.PermissibleGuildChannel]:
+    ) -> channels.PermissibleGuildChannel | None:
         """Remove a guild channel from the cache.
 
         Parameters
@@ -1124,7 +1110,7 @@ class MutableCache(Cache, abc.ABC):
     @abc.abstractmethod
     def update_guild_channel(
         self, channel: channels.PermissibleGuildChannel, /
-    ) -> tuple[typing.Optional[channels.PermissibleGuildChannel], typing.Optional[channels.PermissibleGuildChannel]]:
+    ) -> tuple[channels.PermissibleGuildChannel | None, channels.PermissibleGuildChannel | None]:
         """Update a guild channel in the cache.
 
         Parameters
@@ -1195,7 +1181,7 @@ class MutableCache(Cache, abc.ABC):
     @abc.abstractmethod
     def delete_thread(
         self, thread: snowflakes.SnowflakeishOr[channels.PartialChannel], /
-    ) -> typing.Optional[channels.GuildThreadChannel]:
+    ) -> channels.GuildThreadChannel | None:
         """Remove a thread channel from the cache.
 
         Parameters
@@ -1223,7 +1209,7 @@ class MutableCache(Cache, abc.ABC):
     @abc.abstractmethod
     def update_thread(
         self, thread: channels.GuildThreadChannel, /
-    ) -> tuple[typing.Optional[channels.GuildThreadChannel], typing.Optional[channels.GuildThreadChannel]]:
+    ) -> tuple[channels.GuildThreadChannel | None, channels.GuildThreadChannel | None]:
         """Update a thread channel in the cache.
 
         Parameters
@@ -1292,9 +1278,7 @@ class MutableCache(Cache, abc.ABC):
         """
 
     @abc.abstractmethod
-    def delete_invite(
-        self, code: typing.Union[invites.InviteCode, str], /
-    ) -> typing.Optional[invites.InviteWithMetadata]:
+    def delete_invite(self, code: invites.InviteCode | str, /) -> invites.InviteWithMetadata | None:
         """Remove an invite object from the cache.
 
         Parameters
@@ -1322,7 +1306,7 @@ class MutableCache(Cache, abc.ABC):
     @abc.abstractmethod
     def update_invite(
         self, invite: invites.InviteWithMetadata, /
-    ) -> tuple[typing.Optional[invites.InviteWithMetadata], typing.Optional[invites.InviteWithMetadata]]:
+    ) -> tuple[invites.InviteWithMetadata | None, invites.InviteWithMetadata | None]:
         """Update an invite in the cache.
 
         Parameters
@@ -1339,7 +1323,7 @@ class MutableCache(Cache, abc.ABC):
         """  # noqa: E501
 
     @abc.abstractmethod
-    def delete_me(self) -> typing.Optional[users.OwnUser]:
+    def delete_me(self) -> users.OwnUser | None:
         """Remove the own user object from the cache.
 
         Returns
@@ -1360,9 +1344,7 @@ class MutableCache(Cache, abc.ABC):
         """
 
     @abc.abstractmethod
-    def update_me(
-        self, user: users.OwnUser, /
-    ) -> tuple[typing.Optional[users.OwnUser], typing.Optional[users.OwnUser]]:
+    def update_me(self, user: users.OwnUser, /) -> tuple[users.OwnUser | None, users.OwnUser | None]:
         """Update the own user entry in the cache.
 
         Parameters
@@ -1417,7 +1399,7 @@ class MutableCache(Cache, abc.ABC):
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
         user: snowflakes.SnowflakeishOr[users.PartialUser],
         /,
-    ) -> typing.Optional[guilds.Member]:
+    ) -> guilds.Member | None:
         """Remove a member object from the cache.
 
         !!! note
@@ -1450,9 +1432,7 @@ class MutableCache(Cache, abc.ABC):
         """
 
     @abc.abstractmethod
-    def update_member(
-        self, member: guilds.Member, /
-    ) -> tuple[typing.Optional[guilds.Member], typing.Optional[guilds.Member]]:
+    def update_member(self, member: guilds.Member, /) -> tuple[guilds.Member | None, guilds.Member | None]:
         """Update a member in the cache.
 
         Parameters
@@ -1505,7 +1485,7 @@ class MutableCache(Cache, abc.ABC):
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
         user: snowflakes.SnowflakeishOr[users.PartialUser],
         /,
-    ) -> typing.Optional[presences.MemberPresence]:
+    ) -> presences.MemberPresence | None:
         """Remove a presence from the cache.
 
         Parameters
@@ -1535,7 +1515,7 @@ class MutableCache(Cache, abc.ABC):
     @abc.abstractmethod
     def update_presence(
         self, presence: presences.MemberPresence, /
-    ) -> tuple[typing.Optional[presences.MemberPresence], typing.Optional[presences.MemberPresence]]:
+    ) -> tuple[presences.MemberPresence | None, presences.MemberPresence | None]:
         """Update a presence object in the cache.
 
         Parameters
@@ -1581,7 +1561,7 @@ class MutableCache(Cache, abc.ABC):
         """
 
     @abc.abstractmethod
-    def delete_role(self, role: snowflakes.SnowflakeishOr[guilds.PartialRole], /) -> typing.Optional[guilds.Role]:
+    def delete_role(self, role: snowflakes.SnowflakeishOr[guilds.PartialRole], /) -> guilds.Role | None:
         """Remove a role object form the cache.
 
         Parameters
@@ -1607,7 +1587,7 @@ class MutableCache(Cache, abc.ABC):
         """
 
     @abc.abstractmethod
-    def update_role(self, role: guilds.Role, /) -> tuple[typing.Optional[guilds.Role], typing.Optional[guilds.Role]]:
+    def update_role(self, role: guilds.Role, /) -> tuple[guilds.Role | None, guilds.Role | None]:
         """Update a role in the cache.
 
         Parameters
@@ -1681,7 +1661,7 @@ class MutableCache(Cache, abc.ABC):
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
         user: snowflakes.SnowflakeishOr[users.PartialUser],
         /,
-    ) -> typing.Optional[voices.VoiceState]:
+    ) -> voices.VoiceState | None:
         """Remove a voice state object from the cache.
 
         Parameters
@@ -1711,7 +1691,7 @@ class MutableCache(Cache, abc.ABC):
     @abc.abstractmethod
     def update_voice_state(
         self, voice_state: voices.VoiceState, /
-    ) -> tuple[typing.Optional[voices.VoiceState], typing.Optional[voices.VoiceState]]:
+    ) -> tuple[voices.VoiceState | None, voices.VoiceState | None]:
         """Update a voice state object in the cache.
 
         Parameters
@@ -1738,9 +1718,7 @@ class MutableCache(Cache, abc.ABC):
         """
 
     @abc.abstractmethod
-    def delete_message(
-        self, message: snowflakes.SnowflakeishOr[messages.PartialMessage], /
-    ) -> typing.Optional[messages.Message]:
+    def delete_message(self, message: snowflakes.SnowflakeishOr[messages.PartialMessage], /) -> messages.Message | None:
         """Remove a message object from the cache.
 
         Parameters
@@ -1767,8 +1745,8 @@ class MutableCache(Cache, abc.ABC):
 
     @abc.abstractmethod
     def update_message(
-        self, message: typing.Union[messages.PartialMessage, messages.Message], /
-    ) -> tuple[typing.Optional[messages.Message], typing.Optional[messages.Message]]:
+        self, message: messages.PartialMessage | messages.Message, /
+    ) -> tuple[messages.Message | None, messages.Message | None]:
         """Update a message in the cache.
 
         Parameters

--- a/hikari/api/config.py
+++ b/hikari/api/config.py
@@ -103,7 +103,7 @@ class ProxySettings(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def url(self) -> typing.Union[None, str]:
+    def url(self) -> None | str:
         """Proxy URL to use.
 
         If this is [`None`][] then no explicit proxy is being used.
@@ -133,7 +133,7 @@ class HTTPSettings(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def max_redirects(self) -> typing.Optional[int]:
+    def max_redirects(self) -> int | None:
         """Behavior for handling redirect HTTP responses.
 
         If a [`int`][], allow following redirects from `3xx` HTTP responses

--- a/hikari/api/entity_factory.py
+++ b/hikari/api/entity_factory.py
@@ -962,7 +962,7 @@ class EntityFactory(abc.ABC):
     @abc.abstractmethod
     def deserialize_emoji(
         self, payload: data_binding.JSONObject
-    ) -> typing.Union[emoji_models.UnicodeEmoji, emoji_models.CustomEmoji]:
+    ) -> emoji_models.UnicodeEmoji | emoji_models.CustomEmoji:
         """Parse a raw payload from Discord into an emoji object.
 
         Parameters

--- a/hikari/api/event_factory.py
+++ b/hikari/api/event_factory.py
@@ -116,7 +116,7 @@ class EventFactory(abc.ABC):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_channel: typing.Optional[channel_models.PermissibleGuildChannel] = None,
+        old_channel: channel_models.PermissibleGuildChannel | None = None,
     ) -> channel_events.GuildChannelUpdateEvent:
         """Parse a raw payload from Discord into a channel update event object.
 
@@ -331,7 +331,7 @@ class EventFactory(abc.ABC):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_invite: typing.Optional[invite_models.InviteWithMetadata] = None,
+        old_invite: invite_models.InviteWithMetadata | None = None,
     ) -> channel_events.InviteDeleteEvent:
         """Parse a raw payload from Discord into an invite delete event object.
 
@@ -421,7 +421,7 @@ class EventFactory(abc.ABC):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_guild: typing.Optional[guild_models.GatewayGuild] = None,
+        old_guild: guild_models.GatewayGuild | None = None,
     ) -> guild_events.GuildUpdateEvent:
         """Parse a raw payload from Discord into a guild update event object.
 
@@ -446,7 +446,7 @@ class EventFactory(abc.ABC):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_guild: typing.Optional[guild_models.GatewayGuild] = None,
+        old_guild: guild_models.GatewayGuild | None = None,
     ) -> guild_events.GuildLeaveEvent:
         """Parse a raw payload from Discord into a guild leave event object.
 
@@ -528,7 +528,7 @@ class EventFactory(abc.ABC):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_emojis: typing.Optional[typing.Sequence[emojis_models.KnownCustomEmoji]] = None,
+        old_emojis: typing.Sequence[emojis_models.KnownCustomEmoji] | None = None,
     ) -> guild_events.EmojisUpdateEvent:
         """Parse a raw payload from Discord into a guild emojis update event object.
 
@@ -553,7 +553,7 @@ class EventFactory(abc.ABC):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_stickers: typing.Optional[typing.Sequence[sticker_models.GuildSticker]] = None,
+        old_stickers: typing.Sequence[sticker_models.GuildSticker] | None = None,
     ) -> guild_events.StickersUpdateEvent:
         """Parse a raw payload from Discord into a guild stickers update event object.
 
@@ -635,7 +635,7 @@ class EventFactory(abc.ABC):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_presence: typing.Optional[presences_models.MemberPresence] = None,
+        old_presence: presences_models.MemberPresence | None = None,
     ) -> guild_events.PresenceUpdateEvent:
         """Parse a raw payload from Discord into a presence update event object.
 
@@ -725,7 +725,7 @@ class EventFactory(abc.ABC):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_member: typing.Optional[guild_models.Member] = None,
+        old_member: guild_models.Member | None = None,
     ) -> member_events.MemberUpdateEvent:
         """Parse a raw payload from Discord into a guild member update event object.
 
@@ -750,7 +750,7 @@ class EventFactory(abc.ABC):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_member: typing.Optional[guild_models.Member] = None,
+        old_member: guild_models.Member | None = None,
     ) -> member_events.MemberDeleteEvent:
         """Parse a raw payload from Discord into a guild member remove event object.
 
@@ -798,7 +798,7 @@ class EventFactory(abc.ABC):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_role: typing.Optional[guild_models.Role] = None,
+        old_role: guild_models.Role | None = None,
     ) -> role_events.RoleUpdateEvent:
         """Parse a raw payload from Discord into a guild role update event object.
 
@@ -823,7 +823,7 @@ class EventFactory(abc.ABC):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_role: typing.Optional[guild_models.Role] = None,
+        old_role: guild_models.Role | None = None,
     ) -> role_events.RoleDeleteEvent:
         """Parse a raw payload from Discord into a guild role delete event object.
 
@@ -1014,7 +1014,7 @@ class EventFactory(abc.ABC):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_message: typing.Optional[messages_models.PartialMessage] = None,
+        old_message: messages_models.PartialMessage | None = None,
     ) -> message_events.MessageUpdateEvent:
         """Parse a raw payload from Discord into a message update event object.
 
@@ -1039,7 +1039,7 @@ class EventFactory(abc.ABC):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_message: typing.Optional[messages_models.Message] = None,
+        old_message: messages_models.Message | None = None,
     ) -> message_events.MessageDeleteEvent:
         """Parse a raw payload from Discord into a message delete event object.
 
@@ -1064,7 +1064,7 @@ class EventFactory(abc.ABC):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_messages: typing.Optional[typing.Mapping[snowflakes.Snowflake, messages_models.Message]] = None,
+        old_messages: typing.Mapping[snowflakes.Snowflake, messages_models.Message] | None = None,
     ) -> message_events.GuildBulkMessageDeleteEvent:
         """Parse a raw payload from Discord into a guild message delete bulk event object.
 
@@ -1281,7 +1281,7 @@ class EventFactory(abc.ABC):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_user: typing.Optional[user_models.OwnUser] = None,
+        old_user: user_models.OwnUser | None = None,
     ) -> user_events.OwnUserUpdateEvent:
         """Parse a raw payload from Discord into a own user update event object.
 
@@ -1310,7 +1310,7 @@ class EventFactory(abc.ABC):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_state: typing.Optional[voices_models.VoiceState] = None,
+        old_state: voices_models.VoiceState | None = None,
     ) -> voice_events.VoiceStateUpdateEvent:
         """Parse a raw payload from Discord into a voice state update event object.
 

--- a/hikari/api/event_manager.py
+++ b/hikari/api/event_manager.py
@@ -111,9 +111,7 @@ class EventStream(iterators.LazyIterator[base_events.EventT], abc.ABC):
     @abc.abstractmethod
     @typing_extensions.override
     def filter(
-        self,
-        *predicates: typing.Union[tuple[str, typing.Any], typing.Callable[[base_events.EventT], bool]],
-        **attrs: object,
+        self, *predicates: tuple[str, typing.Any] | typing.Callable[[base_events.EventT], bool], **attrs: object
     ) -> Self:
         """Filter the items by one or more conditions.
 
@@ -150,10 +148,7 @@ class EventStream(iterators.LazyIterator[base_events.EventT], abc.ABC):
 
     @abc.abstractmethod
     def __exit__(
-        self,
-        exc_type: typing.Optional[type[BaseException]],
-        exc: typing.Optional[BaseException],
-        exc_tb: typing.Optional[types.TracebackType],
+        self, exc_type: type[BaseException] | None, exc: BaseException | None, exc_tb: types.TracebackType | None
     ) -> None:
         raise NotImplementedError
 
@@ -416,11 +411,7 @@ class EventManager(abc.ABC):
 
     @abc.abstractmethod
     def stream(
-        self,
-        event_type: type[base_events.EventT],
-        /,
-        timeout: typing.Union[float, None],
-        limit: typing.Optional[int] = None,
+        self, event_type: type[base_events.EventT], /, timeout: float | None, limit: int | None = None
     ) -> EventStream[base_events.EventT]:
         """Return a stream iterator for the given event and sub-events.
 
@@ -486,8 +477,8 @@ class EventManager(abc.ABC):
         self,
         event_type: type[base_events.EventT],
         /,
-        timeout: typing.Union[float, None],
-        predicate: typing.Optional[PredicateT[base_events.EventT]] = None,
+        timeout: float | None,
+        predicate: PredicateT[base_events.EventT] | None = None,
     ) -> base_events.EventT:
         """Wait for a given event to occur once, then return the event.
 

--- a/hikari/api/interaction_server.py
+++ b/hikari/api/interaction_server.py
@@ -77,12 +77,12 @@ class Response(typing.Protocol):
     __slots__: typing.Sequence[str] = ()
 
     @property
-    def content_type(self) -> typing.Optional[str]:
+    def content_type(self) -> str | None:
         """Content type of the response's payload, if applicable."""
         raise NotImplementedError
 
     @property
-    def charset(self) -> typing.Optional[str]:
+    def charset(self) -> str | None:
         """Charset of the response's payload, if applicable."""
         raise NotImplementedError
 
@@ -92,12 +92,12 @@ class Response(typing.Protocol):
         raise NotImplementedError
 
     @property
-    def headers(self) -> typing.Optional[typing.MutableMapping[str, str]]:
+    def headers(self) -> typing.MutableMapping[str, str] | None:
         """Headers that should be added to the response if applicable."""
         raise NotImplementedError
 
     @property
-    def payload(self) -> typing.Optional[bytes]:
+    def payload(self) -> bytes | None:
         """Payload to provide in the response."""
         raise NotImplementedError
 
@@ -138,7 +138,7 @@ class InteractionServer(abc.ABC):
     @abc.abstractmethod
     def get_listener(
         self, interaction_type: type[_InteractionT_co], /
-    ) -> typing.Optional[ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder]]:
+    ) -> ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder] | None:
         """Get the listener registered for an interaction.
 
         Parameters
@@ -158,7 +158,7 @@ class InteractionServer(abc.ABC):
     def set_listener(
         self,
         interaction_type: type[command_interactions.CommandInteraction],
-        listener: typing.Optional[ListenerT[command_interactions.CommandInteraction, _ModalOrMessageResponseBuilder]],
+        listener: ListenerT[command_interactions.CommandInteraction, _ModalOrMessageResponseBuilder] | None,
         /,
         *,
         replace: bool = False,
@@ -169,9 +169,7 @@ class InteractionServer(abc.ABC):
     def set_listener(
         self,
         interaction_type: type[component_interactions.ComponentInteraction],
-        listener: typing.Optional[
-            ListenerT[component_interactions.ComponentInteraction, _ModalOrMessageResponseBuilder]
-        ],
+        listener: ListenerT[component_interactions.ComponentInteraction, _ModalOrMessageResponseBuilder] | None,
         /,
         *,
         replace: bool = False,
@@ -182,9 +180,10 @@ class InteractionServer(abc.ABC):
     def set_listener(
         self,
         interaction_type: type[command_interactions.AutocompleteInteraction],
-        listener: typing.Optional[
-            ListenerT[command_interactions.AutocompleteInteraction, special_endpoints.InteractionAutocompleteBuilder]
-        ],
+        listener: ListenerT[
+            command_interactions.AutocompleteInteraction, special_endpoints.InteractionAutocompleteBuilder
+        ]
+        | None,
         /,
         *,
         replace: bool = False,
@@ -195,7 +194,7 @@ class InteractionServer(abc.ABC):
     def set_listener(
         self,
         interaction_type: type[modal_interactions.ModalInteraction],
-        listener: typing.Optional[ListenerT[modal_interactions.ModalInteraction, _MessageResponseBuilderT]],
+        listener: ListenerT[modal_interactions.ModalInteraction, _MessageResponseBuilderT] | None,
         /,
         *,
         replace: bool = False,
@@ -205,7 +204,7 @@ class InteractionServer(abc.ABC):
     def set_listener(
         self,
         interaction_type: type[_InteractionT_co],
-        listener: typing.Optional[ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder]],
+        listener: ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder] | None,
         /,
         *,
         replace: bool = False,

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -69,7 +69,7 @@ class TokenStrategy(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def token_type(self) -> typing.Union[applications.TokenType, str]:
+    def token_type(self) -> applications.TokenType | str:
         """Type of token this strategy returns."""
 
     @abc.abstractmethod
@@ -89,7 +89,7 @@ class TokenStrategy(abc.ABC):
         """
 
     @abc.abstractmethod
-    def invalidate(self, token: typing.Optional[str]) -> None:
+    def invalidate(self, token: str | None) -> None:
         """Invalidate the cached token in this handler.
 
         !!! note
@@ -123,7 +123,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     @property
     @abc.abstractmethod
-    def token_type(self) -> typing.Union[str, applications.TokenType, None]:
+    def token_type(self) -> str | applications.TokenType | None:
         """Type of token this client is using for most requests.
 
         If this is [`None`][] then this client will likely only work
@@ -195,10 +195,10 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         topic: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         nsfw: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         bitrate: undefined.UndefinedOr[int] = undefined.UNDEFINED,
-        video_quality_mode: undefined.UndefinedOr[typing.Union[channels_.VideoQualityMode, int]] = undefined.UNDEFINED,
+        video_quality_mode: undefined.UndefinedOr[channels_.VideoQualityMode | int] = undefined.UNDEFINED,
         user_limit: undefined.UndefinedOr[int] = undefined.UNDEFINED,
         rate_limit_per_user: undefined.UndefinedOr[time.Intervalish] = undefined.UNDEFINED,
-        region: undefined.UndefinedNoneOr[typing.Union[voices.VoiceRegion, str]] = undefined.UNDEFINED,
+        region: undefined.UndefinedNoneOr[voices.VoiceRegion | str] = undefined.UNDEFINED,
         permission_overwrites: undefined.UndefinedOr[
             typing.Sequence[channels_.PermissionOverwrite]
         ] = undefined.UNDEFINED,
@@ -207,14 +207,14 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         ] = undefined.UNDEFINED,
         default_auto_archive_duration: undefined.UndefinedOr[time.Intervalish] = undefined.UNDEFINED,
         default_thread_rate_limit_per_user: undefined.UndefinedOr[time.Intervalish] = undefined.UNDEFINED,
-        default_forum_layout: undefined.UndefinedOr[typing.Union[channels_.ForumLayoutType, int]] = undefined.UNDEFINED,
-        default_sort_order: undefined.UndefinedOr[
-            typing.Union[channels_.ForumSortOrderType, int]
-        ] = undefined.UNDEFINED,
+        default_forum_layout: undefined.UndefinedOr[channels_.ForumLayoutType | int] = undefined.UNDEFINED,
+        default_sort_order: undefined.UndefinedOr[channels_.ForumSortOrderType | int] = undefined.UNDEFINED,
         available_tags: undefined.UndefinedOr[typing.Sequence[channels_.ForumTag]] = undefined.UNDEFINED,
-        default_reaction_emoji: typing.Union[
-            str, emojis.Emoji, undefined.UndefinedType, snowflakes.Snowflake, None
-        ] = undefined.UNDEFINED,
+        default_reaction_emoji: str
+        | emojis.Emoji
+        | undefined.UndefinedType
+        | snowflakes.Snowflake
+        | None = undefined.UNDEFINED,
         archived: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         locked: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         invitable: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
@@ -475,7 +475,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         channel: snowflakes.SnowflakeishOr[channels_.GuildStageChannel],
         *,
         suppress: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-        request_to_speak: typing.Union[undefined.UndefinedType, bool, datetime.datetime] = undefined.UNDEFINED,
+        request_to_speak: undefined.UndefinedType | bool | datetime.datetime = undefined.UNDEFINED,
     ) -> None:
         """Edit the current user's voice state in a stage channel.
 
@@ -568,7 +568,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     async def edit_permission_overwrite(
         self,
         channel: snowflakes.SnowflakeishOr[channels_.GuildChannel],
-        target: typing.Union[channels_.PermissionOverwrite, users.PartialUser, guilds.PartialRole],
+        target: channels_.PermissionOverwrite | users.PartialUser | guilds.PartialRole,
         *,
         allow: undefined.UndefinedOr[permissions_.Permissions] = undefined.UNDEFINED,
         deny: undefined.UndefinedOr[permissions_.Permissions] = undefined.UNDEFINED,
@@ -584,7 +584,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         channel: snowflakes.SnowflakeishOr[channels_.GuildChannel],
         target: snowflakes.Snowflakeish,
         *,
-        target_type: typing.Union[channels_.PermissionOverwriteType, int],
+        target_type: channels_.PermissionOverwriteType | int,
         allow: undefined.UndefinedOr[permissions_.Permissions] = undefined.UNDEFINED,
         deny: undefined.UndefinedOr[permissions_.Permissions] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
@@ -596,11 +596,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     async def edit_permission_overwrite(
         self,
         channel: snowflakes.SnowflakeishOr[channels_.GuildChannel],
-        target: typing.Union[
-            snowflakes.Snowflakeish, users.PartialUser, guilds.PartialRole, channels_.PermissionOverwrite
-        ],
+        target: snowflakes.Snowflakeish | users.PartialUser | guilds.PartialRole | channels_.PermissionOverwrite,
         *,
-        target_type: undefined.UndefinedOr[typing.Union[channels_.PermissionOverwriteType, int]] = undefined.UNDEFINED,
+        target_type: undefined.UndefinedOr[channels_.PermissionOverwriteType | int] = undefined.UNDEFINED,
         allow: undefined.UndefinedOr[permissions_.Permissions] = undefined.UNDEFINED,
         deny: undefined.UndefinedOr[permissions_.Permissions] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
@@ -652,9 +650,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     async def delete_permission_overwrite(
         self,
         channel: snowflakes.SnowflakeishOr[channels_.GuildChannel],
-        target: typing.Union[
-            channels_.PermissionOverwrite, guilds.PartialRole, users.PartialUser, snowflakes.Snowflakeish
-        ],
+        target: channels_.PermissionOverwrite | guilds.PartialRole | users.PartialUser | snowflakes.Snowflakeish,
     ) -> None:
         """Delete a custom permission for an entity in a given guild channel.
 
@@ -1060,12 +1056,12 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[users.PartialUser], bool]
+            snowflakes.SnowflakeishSequence[users.PartialUser] | bool
         ] = undefined.UNDEFINED,
         role_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
+            snowflakes.SnowflakeishSequence[guilds.PartialRole] | bool
         ] = undefined.UNDEFINED,
-        flags: typing.Union[undefined.UndefinedType, int, messages_.MessageFlag] = undefined.UNDEFINED,
+        flags: undefined.UndefinedType | int | messages_.MessageFlag = undefined.UNDEFINED,
     ) -> messages_.Message:
         """Create a message in the given channel.
 
@@ -1263,11 +1259,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         content: undefined.UndefinedOr[typing.Any] = undefined.UNDEFINED,
         *,
-        attachment: undefined.UndefinedNoneOr[
-            typing.Union[files.Resourceish, messages_.Attachment]
-        ] = undefined.UNDEFINED,
+        attachment: undefined.UndefinedNoneOr[files.Resourceish | messages_.Attachment] = undefined.UNDEFINED,
         attachments: undefined.UndefinedNoneOr[
-            typing.Sequence[typing.Union[files.Resourceish, messages_.Attachment]]
+            typing.Sequence[files.Resourceish | messages_.Attachment]
         ] = undefined.UNDEFINED,
         component: undefined.UndefinedNoneOr[special_endpoints.ComponentBuilder] = undefined.UNDEFINED,
         components: undefined.UndefinedNoneOr[
@@ -1278,10 +1272,10 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[users.PartialUser], bool]
+            snowflakes.SnowflakeishSequence[users.PartialUser] | bool
         ] = undefined.UNDEFINED,
         role_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
+            snowflakes.SnowflakeishSequence[guilds.PartialRole] | bool
         ] = undefined.UNDEFINED,
         flags: undefined.UndefinedOr[messages_.MessageFlag] = undefined.UNDEFINED,
     ) -> messages_.Message:
@@ -1474,11 +1468,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     async def delete_messages(
         self,
         channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
-        messages: typing.Union[
-            snowflakes.SnowflakeishOr[messages_.PartialMessage],
-            typing.Iterable[snowflakes.SnowflakeishOr[messages_.PartialMessage]],
-            typing.AsyncIterable[snowflakes.SnowflakeishOr[messages_.PartialMessage]],
-        ],
+        messages: snowflakes.SnowflakeishOr[messages_.PartialMessage]
+        | typing.Iterable[snowflakes.SnowflakeishOr[messages_.PartialMessage]]
+        | typing.AsyncIterable[snowflakes.SnowflakeishOr[messages_.PartialMessage]],
         /,
         *other_messages: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
@@ -1534,7 +1526,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         self,
         channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
-        emoji: typing.Union[str, emojis.Emoji],
+        emoji: str | emojis.Emoji,
         emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.CustomEmoji]] = undefined.UNDEFINED,
     ) -> None:
         """Add a reaction emoji to a message in a given channel.
@@ -1579,7 +1571,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         self,
         channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
-        emoji: typing.Union[str, emojis.Emoji],
+        emoji: str | emojis.Emoji,
         emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.CustomEmoji]] = undefined.UNDEFINED,
     ) -> None:
         """Delete a reaction that your application user created.
@@ -1620,7 +1612,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         self,
         channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
-        emoji: typing.Union[str, emojis.Emoji],
+        emoji: str | emojis.Emoji,
         emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.CustomEmoji]] = undefined.UNDEFINED,
     ) -> None:
         """Delete all reactions for a single emoji on a given message.
@@ -1664,7 +1656,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         user: snowflakes.SnowflakeishOr[users.PartialUser],
-        emoji: typing.Union[str, emojis.Emoji],
+        emoji: str | emojis.Emoji,
         emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.CustomEmoji]] = undefined.UNDEFINED,
     ) -> None:
         """Delete a reaction from a message.
@@ -1747,7 +1739,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         self,
         channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
-        emoji: typing.Union[str, emojis.Emoji],
+        emoji: str | emojis.Emoji,
         emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis.CustomEmoji]] = undefined.UNDEFINED,
     ) -> iterators.LazyIterator[users.User]:
         """Fetch reactions for an emoji from a message.
@@ -2036,15 +2028,13 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     async def execute_webhook(
         self,
         # MyPy might not say this but SnowflakeishOr[ExecutableWebhook] isn't valid as ExecutableWebhook isn't Unique
-        webhook: typing.Union[webhooks.ExecutableWebhook, snowflakes.Snowflakeish],
+        webhook: webhooks.ExecutableWebhook | snowflakes.Snowflakeish,
         token: str,
         content: undefined.UndefinedOr[typing.Any] = undefined.UNDEFINED,
         *,
-        thread: typing.Union[
-            undefined.UndefinedType, snowflakes.SnowflakeishOr[channels_.GuildThreadChannel]
-        ] = undefined.UNDEFINED,
+        thread: undefined.UndefinedType | snowflakes.SnowflakeishOr[channels_.GuildThreadChannel] = undefined.UNDEFINED,
         username: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-        avatar_url: typing.Union[undefined.UndefinedType, str, files.URL] = undefined.UNDEFINED,
+        avatar_url: undefined.UndefinedType | str | files.URL = undefined.UNDEFINED,
         attachment: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
         attachments: undefined.UndefinedOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
         component: undefined.UndefinedOr[special_endpoints.ComponentBuilder] = undefined.UNDEFINED,
@@ -2055,12 +2045,12 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[users.PartialUser], bool]
+            snowflakes.SnowflakeishSequence[users.PartialUser] | bool
         ] = undefined.UNDEFINED,
         role_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
+            snowflakes.SnowflakeishSequence[guilds.PartialRole] | bool
         ] = undefined.UNDEFINED,
-        flags: typing.Union[undefined.UndefinedType, int, messages_.MessageFlag] = undefined.UNDEFINED,
+        flags: undefined.UndefinedType | int | messages_.MessageFlag = undefined.UNDEFINED,
     ) -> messages_.Message:
         """Execute a webhook.
 
@@ -2207,13 +2197,11 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     async def fetch_webhook_message(
         self,
         # MyPy might not say this but SnowflakeishOr[ExecutableWebhook] isn't valid as ExecutableWebhook isn't Unique
-        webhook: typing.Union[webhooks.ExecutableWebhook, snowflakes.Snowflakeish],
+        webhook: webhooks.ExecutableWebhook | snowflakes.Snowflakeish,
         token: str,
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         *,
-        thread: typing.Union[
-            undefined.UndefinedType, snowflakes.SnowflakeishOr[channels_.GuildThreadChannel]
-        ] = undefined.UNDEFINED,
+        thread: undefined.UndefinedType | snowflakes.SnowflakeishOr[channels_.GuildThreadChannel] = undefined.UNDEFINED,
     ) -> messages_.Message:
         """Fetch an old message sent by the webhook.
 
@@ -2256,19 +2244,15 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     async def edit_webhook_message(
         self,
         # MyPy might not say this but SnowflakeishOr[ExecutableWebhook] isn't valid as ExecutableWebhook isn't Unique
-        webhook: typing.Union[webhooks.ExecutableWebhook, snowflakes.Snowflakeish],
+        webhook: webhooks.ExecutableWebhook | snowflakes.Snowflakeish,
         token: str,
         message: snowflakes.SnowflakeishOr[messages_.Message],
         content: undefined.UndefinedNoneOr[typing.Any] = undefined.UNDEFINED,
         *,
-        thread: typing.Union[
-            undefined.UndefinedType, snowflakes.SnowflakeishOr[channels_.GuildThreadChannel]
-        ] = undefined.UNDEFINED,
-        attachment: undefined.UndefinedNoneOr[
-            typing.Union[files.Resourceish, messages_.Attachment]
-        ] = undefined.UNDEFINED,
+        thread: undefined.UndefinedType | snowflakes.SnowflakeishOr[channels_.GuildThreadChannel] = undefined.UNDEFINED,
+        attachment: undefined.UndefinedNoneOr[files.Resourceish | messages_.Attachment] = undefined.UNDEFINED,
         attachments: undefined.UndefinedNoneOr[
-            typing.Sequence[typing.Union[files.Resourceish, messages_.Attachment]]
+            typing.Sequence[files.Resourceish | messages_.Attachment]
         ] = undefined.UNDEFINED,
         component: undefined.UndefinedNoneOr[special_endpoints.ComponentBuilder] = undefined.UNDEFINED,
         components: undefined.UndefinedNoneOr[
@@ -2278,10 +2262,10 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         embeds: undefined.UndefinedNoneOr[typing.Sequence[embeds_.Embed]] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[users.PartialUser], bool]
+            snowflakes.SnowflakeishSequence[users.PartialUser] | bool
         ] = undefined.UNDEFINED,
         role_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
+            snowflakes.SnowflakeishSequence[guilds.PartialRole] | bool
         ] = undefined.UNDEFINED,
     ) -> messages_.Message:
         """Edit a message sent by a webhook.
@@ -2416,13 +2400,11 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     async def delete_webhook_message(
         self,
         # MyPy might not say this but SnowflakeishOr[ExecutableWebhook] isn't valid as ExecutableWebhook isn't Unique
-        webhook: typing.Union[webhooks.ExecutableWebhook, snowflakes.Snowflakeish],
+        webhook: webhooks.ExecutableWebhook | snowflakes.Snowflakeish,
         token: str,
         message: snowflakes.SnowflakeishOr[messages_.Message],
         *,
-        thread: typing.Union[
-            undefined.UndefinedType, snowflakes.SnowflakeishOr[channels_.GuildThreadChannel]
-        ] = undefined.UNDEFINED,
+        thread: undefined.UndefinedType | snowflakes.SnowflakeishOr[channels_.GuildThreadChannel] = undefined.UNDEFINED,
     ) -> None:
         """Delete a given message in a given channel.
 
@@ -2493,9 +2475,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         """
 
     @abc.abstractmethod
-    async def fetch_invite(
-        self, invite: typing.Union[invites.InviteCode, str], *, with_counts: bool = True
-    ) -> invites.Invite:
+    async def fetch_invite(self, invite: invites.InviteCode | str, *, with_counts: bool = True) -> invites.Invite:
         """Fetch an existing invite.
 
         Parameters
@@ -2525,7 +2505,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         """
 
     @abc.abstractmethod
-    async def delete_invite(self, invite: typing.Union[invites.InviteCode, str]) -> invites.Invite:
+    async def delete_invite(self, invite: invites.InviteCode | str) -> invites.Invite:
         """Delete an existing invite.
 
         Parameters
@@ -2742,7 +2722,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         platform_name: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         platform_username: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         metadata: undefined.UndefinedOr[
-            typing.Mapping[str, typing.Union[str, int, bool, datetime.datetime]]
+            typing.Mapping[str, str | int | bool | datetime.datetime]
         ] = undefined.UNDEFINED,
     ) -> applications.OwnApplicationRoleConnection:
         """Set the token's associated role connections.
@@ -2946,7 +2926,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         client: snowflakes.SnowflakeishOr[guilds.PartialApplication],
         client_secret: str,
         # While according to the spec scopes are optional here, Discord requires that "valid" scopes are passed.
-        scopes: typing.Sequence[typing.Union[applications.OAuth2Scope, str]],
+        scopes: typing.Sequence[applications.OAuth2Scope | str],
     ) -> applications.PartialOAuth2Token:
         """Authorize a client credentials token for an application.
 
@@ -3023,9 +3003,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         client_secret: str,
         refresh_token: str,
         *,
-        scopes: undefined.UndefinedOr[
-            typing.Sequence[typing.Union[applications.OAuth2Scope, str]]
-        ] = undefined.UNDEFINED,
+        scopes: undefined.UndefinedOr[typing.Sequence[applications.OAuth2Scope | str]] = undefined.UNDEFINED,
     ) -> applications.OAuth2AuthorizationToken:
         """Refresh an access token.
 
@@ -3069,7 +3047,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         self,
         client: snowflakes.SnowflakeishOr[guilds.PartialApplication],
         client_secret: str,
-        token: typing.Union[str, applications.PartialOAuth2Token],
+        token: str | applications.PartialOAuth2Token,
     ) -> None:
         """Revoke an OAuth2 token.
 
@@ -3097,7 +3075,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def add_user_to_guild(
         self,
-        access_token: typing.Union[str, applications.PartialOAuth2Token],
+        access_token: str | applications.PartialOAuth2Token,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
         user: snowflakes.SnowflakeishOr[users.PartialUser],
         *,
@@ -3105,7 +3083,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         roles: undefined.UndefinedOr[snowflakes.SnowflakeishSequence[guilds.PartialRole]] = undefined.UNDEFINED,
         mute: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         deaf: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-    ) -> typing.Optional[guilds.Member]:
+    ) -> guilds.Member | None:
         """Add a user to a guild.
 
         !!! note
@@ -3224,7 +3202,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         *,
         before: undefined.UndefinedOr[snowflakes.SearchableSnowflakeishOr[snowflakes.Unique]] = undefined.UNDEFINED,
         user: undefined.UndefinedOr[snowflakes.SnowflakeishOr[users.PartialUser]] = undefined.UNDEFINED,
-        event_type: undefined.UndefinedOr[typing.Union[audit_logs.AuditLogEventType, int]] = undefined.UNDEFINED,
+        event_type: undefined.UndefinedOr[audit_logs.AuditLogEventType | int] = undefined.UNDEFINED,
     ) -> iterators.LazyIterator[audit_logs.AuditLog]:
         """Fetch pages of the guild's audit log.
 
@@ -3688,7 +3666,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def fetch_sticker(
         self, sticker: snowflakes.SnowflakeishOr[stickers_.PartialSticker]
-    ) -> typing.Union[stickers_.GuildSticker, stickers_.StandardSticker]:
+    ) -> stickers_.GuildSticker | stickers_.StandardSticker:
         """Fetch a sticker.
 
         Parameters
@@ -4069,7 +4047,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         public_updates_channel: undefined.UndefinedNoneOr[
             snowflakes.SnowflakeishOr[channels_.GuildTextChannel]
         ] = undefined.UNDEFINED,
-        preferred_locale: undefined.UndefinedOr[typing.Union[str, locales.Locale]] = undefined.UNDEFINED,
+        preferred_locale: undefined.UndefinedOr[str | locales.Locale] = undefined.UNDEFINED,
         features: undefined.UndefinedOr[typing.Sequence[guilds.GuildFeature]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> guilds.RESTGuild:
@@ -4373,14 +4351,13 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         rate_limit_per_user: undefined.UndefinedOr[time.Intervalish] = undefined.UNDEFINED,
         default_auto_archive_duration: undefined.UndefinedOr[time.Intervalish] = undefined.UNDEFINED,
         default_thread_rate_limit_per_user: undefined.UndefinedOr[time.Intervalish] = undefined.UNDEFINED,
-        default_forum_layout: undefined.UndefinedOr[typing.Union[channels_.ForumLayoutType, int]] = undefined.UNDEFINED,
-        default_sort_order: undefined.UndefinedOr[
-            typing.Union[channels_.ForumSortOrderType, int]
-        ] = undefined.UNDEFINED,
+        default_forum_layout: undefined.UndefinedOr[channels_.ForumLayoutType | int] = undefined.UNDEFINED,
+        default_sort_order: undefined.UndefinedOr[channels_.ForumSortOrderType | int] = undefined.UNDEFINED,
         available_tags: undefined.UndefinedOr[typing.Sequence[channels_.ForumTag]] = undefined.UNDEFINED,
-        default_reaction_emoji: typing.Union[
-            str, emojis.Emoji, undefined.UndefinedType, snowflakes.Snowflake
-        ] = undefined.UNDEFINED,
+        default_reaction_emoji: str
+        | emojis.Emoji
+        | undefined.UndefinedType
+        | snowflakes.Snowflake = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> channels_.GuildForumChannel:
         """Create a forum channel in a guild.
@@ -4460,11 +4437,11 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         position: undefined.UndefinedOr[int] = undefined.UNDEFINED,
         user_limit: undefined.UndefinedOr[int] = undefined.UNDEFINED,
         bitrate: undefined.UndefinedOr[int] = undefined.UNDEFINED,
-        video_quality_mode: undefined.UndefinedOr[typing.Union[channels_.VideoQualityMode, int]] = undefined.UNDEFINED,
+        video_quality_mode: undefined.UndefinedOr[channels_.VideoQualityMode | int] = undefined.UNDEFINED,
         permission_overwrites: undefined.UndefinedOr[
             typing.Sequence[channels_.PermissionOverwrite]
         ] = undefined.UNDEFINED,
-        region: undefined.UndefinedOr[typing.Union[voices.VoiceRegion, str]] = undefined.UNDEFINED,
+        region: undefined.UndefinedOr[voices.VoiceRegion | str] = undefined.UNDEFINED,
         category: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.GuildCategory]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> channels_.GuildVoiceChannel:
@@ -4537,7 +4514,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         permission_overwrites: undefined.UndefinedOr[
             typing.Sequence[channels_.PermissionOverwrite]
         ] = undefined.UNDEFINED,
-        region: undefined.UndefinedOr[typing.Union[voices.VoiceRegion, str]] = undefined.UNDEFINED,
+        region: undefined.UndefinedOr[voices.VoiceRegion | str] = undefined.UNDEFINED,
         category: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.GuildCategory]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> channels_.GuildStageChannel:
@@ -4660,7 +4637,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         auto_archive_duration: undefined.UndefinedOr[time.Intervalish] = datetime.timedelta(days=1),
         rate_limit_per_user: undefined.UndefinedOr[time.Intervalish] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-    ) -> typing.Union[channels_.GuildPublicThread, channels_.GuildNewsThread]:
+    ) -> channels_.GuildPublicThread | channels_.GuildNewsThread:
         """Create a public or news thread on a message in a guild channel.
 
         !!! note
@@ -4714,7 +4691,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     async def create_thread(
         self,
         channel: snowflakes.SnowflakeishOr[channels_.PermissibleGuildChannel],
-        type: typing.Union[channels_.ChannelType, int],
+        type: channels_.ChannelType | int,
         name: str,
         /,
         *,
@@ -4802,12 +4779,12 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[users.PartialUser], bool]
+            snowflakes.SnowflakeishSequence[users.PartialUser] | bool
         ] = undefined.UNDEFINED,
         role_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
+            snowflakes.SnowflakeishSequence[guilds.PartialRole] | bool
         ] = undefined.UNDEFINED,
-        flags: typing.Union[undefined.UndefinedType, int, messages_.MessageFlag] = undefined.UNDEFINED,
+        flags: undefined.UndefinedType | int | messages_.MessageFlag = undefined.UNDEFINED,
         # Channel arguments
         auto_archive_duration: undefined.UndefinedOr[time.Intervalish] = datetime.timedelta(days=1),
         rate_limit_per_user: undefined.UndefinedOr[time.Intervalish] = undefined.UNDEFINED,
@@ -5185,7 +5162,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         /,
         *,
         before: undefined.UndefinedOr[datetime.datetime] = undefined.UNDEFINED,
-    ) -> iterators.LazyIterator[typing.Union[channels_.GuildNewsThread, channels_.GuildPublicThread]]:
+    ) -> iterators.LazyIterator[channels_.GuildNewsThread | channels_.GuildPublicThread]:
         """Fetch a channel's public archived threads.
 
         !!! note
@@ -6266,7 +6243,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         compute_prune_count: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         include_roles: undefined.UndefinedOr[snowflakes.SnowflakeishSequence[guilds.PartialRole]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-    ) -> typing.Optional[int]:
+    ) -> int | None:
         """Begin the guild prune.
 
         Parameters
@@ -6638,7 +6615,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     @abc.abstractmethod
     async def create_guild_from_template(
         self,
-        template: typing.Union[str, templates.Template],
+        template: str | templates.Template,
         name: str,
         *,
         icon: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
@@ -6679,7 +6656,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     @abc.abstractmethod
     async def delete_template(
-        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], template: typing.Union[str, templates.Template]
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], template: str | templates.Template
     ) -> templates.Template:
         """Delete a guild template.
 
@@ -6715,7 +6692,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     async def edit_template(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        template: typing.Union[templates.Template, str],
+        template: templates.Template | str,
         *,
         name: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         description: undefined.UndefinedNoneOr[str] = undefined.UNDEFINED,
@@ -6755,7 +6732,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         """
 
     @abc.abstractmethod
-    async def fetch_template(self, template: typing.Union[str, templates.Template]) -> templates.Template:
+    async def fetch_template(self, template: str | templates.Template) -> templates.Template:
         """Fetch a guild template.
 
         Parameters
@@ -6815,7 +6792,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     @abc.abstractmethod
     async def sync_guild_template(
-        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], template: typing.Union[str, templates.Template]
+        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], template: str | templates.Template
     ) -> templates.Template:
         """Create a guild template.
 
@@ -6868,7 +6845,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     @abc.abstractmethod
     def context_menu_command_builder(
-        self, type: typing.Union[commands.CommandType, int], name: str
+        self, type: commands.CommandType | int, name: str
     ) -> special_endpoints.ContextMenuCommandBuilder:
         """Create a command builder to use in [`hikari.api.rest.RESTClient.set_application_commands`][].
 
@@ -6974,15 +6951,11 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         *,
         guild: undefined.UndefinedOr[snowflakes.SnowflakeishOr[guilds.PartialGuild]] = undefined.UNDEFINED,
         options: undefined.UndefinedOr[typing.Sequence[commands.CommandOption]] = undefined.UNDEFINED,
-        name_localizations: undefined.UndefinedOr[
-            typing.Mapping[typing.Union[locales.Locale, str], str]
-        ] = undefined.UNDEFINED,
+        name_localizations: undefined.UndefinedOr[typing.Mapping[locales.Locale | str, str]] = undefined.UNDEFINED,
         description_localizations: undefined.UndefinedOr[
-            typing.Mapping[typing.Union[locales.Locale, str], str]
+            typing.Mapping[locales.Locale | str, str]
         ] = undefined.UNDEFINED,
-        default_member_permissions: typing.Union[
-            undefined.UndefinedType, int, permissions_.Permissions
-        ] = undefined.UNDEFINED,
+        default_member_permissions: undefined.UndefinedType | int | permissions_.Permissions = undefined.UNDEFINED,
         nsfw: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
     ) -> commands.SlashCommand:
         r"""Create an application slash command.
@@ -7042,16 +7015,12 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
     async def create_context_menu_command(
         self,
         application: snowflakes.SnowflakeishOr[guilds.PartialApplication],
-        type: typing.Union[commands.CommandType, int],
+        type: commands.CommandType | int,
         name: str,
         *,
         guild: undefined.UndefinedOr[snowflakes.SnowflakeishOr[guilds.PartialGuild]] = undefined.UNDEFINED,
-        name_localizations: undefined.UndefinedOr[
-            typing.Mapping[typing.Union[locales.Locale, str], str]
-        ] = undefined.UNDEFINED,
-        default_member_permissions: typing.Union[
-            undefined.UndefinedType, int, permissions_.Permissions
-        ] = undefined.UNDEFINED,
+        name_localizations: undefined.UndefinedOr[typing.Mapping[locales.Locale | str, str]] = undefined.UNDEFINED,
+        default_member_permissions: undefined.UndefinedType | int | permissions_.Permissions = undefined.UNDEFINED,
         nsfw: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
     ) -> commands.ContextMenuCommand:
         r"""Create an application context menu command.
@@ -7159,9 +7128,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         name: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         description: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         options: undefined.UndefinedOr[typing.Sequence[commands.CommandOption]] = undefined.UNDEFINED,
-        default_member_permissions: typing.Union[
-            undefined.UndefinedType, int, permissions_.Permissions
-        ] = undefined.UNDEFINED,
+        default_member_permissions: undefined.UndefinedType | int | permissions_.Permissions = undefined.UNDEFINED,
     ) -> commands.PartialCommand:
         """Edit a registered application command.
 
@@ -7374,7 +7341,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     @abc.abstractmethod
     def interaction_deferred_builder(
-        self, type: typing.Union[base_interactions.ResponseType, int], /
+        self, type: base_interactions.ResponseType | int, /
     ) -> special_endpoints.InteractionDeferredBuilder:
         """Create a builder for a deferred message interaction response.
 
@@ -7408,7 +7375,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
     @abc.abstractmethod
     def interaction_message_builder(
-        self, type: typing.Union[base_interactions.ResponseType, int], /
+        self, type: base_interactions.ResponseType | int, /
     ) -> special_endpoints.InteractionMessageBuilder:
         """Create a builder for a message interaction response.
 
@@ -7488,10 +7455,10 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         self,
         interaction: snowflakes.SnowflakeishOr[base_interactions.PartialInteraction],
         token: str,
-        response_type: typing.Union[int, base_interactions.ResponseType],
+        response_type: int | base_interactions.ResponseType,
         content: undefined.UndefinedOr[typing.Any] = undefined.UNDEFINED,
         *,
-        flags: typing.Union[int, messages_.MessageFlag, undefined.UndefinedType] = undefined.UNDEFINED,
+        flags: int | messages_.MessageFlag | undefined.UndefinedType = undefined.UNDEFINED,
         tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         attachment: undefined.UndefinedNoneOr[files.Resourceish] = undefined.UNDEFINED,
         attachments: undefined.UndefinedNoneOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
@@ -7504,10 +7471,10 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         poll: undefined.UndefinedOr[special_endpoints.PollBuilder] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[users.PartialUser], bool]
+            snowflakes.SnowflakeishSequence[users.PartialUser] | bool
         ] = undefined.UNDEFINED,
         role_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
+            snowflakes.SnowflakeishSequence[guilds.PartialRole] | bool
         ] = undefined.UNDEFINED,
     ) -> None:
         """Create the initial response for a interaction.
@@ -7614,11 +7581,9 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         token: str,
         content: undefined.UndefinedNoneOr[typing.Any] = undefined.UNDEFINED,
         *,
-        attachment: undefined.UndefinedNoneOr[
-            typing.Union[files.Resourceish, messages_.Attachment]
-        ] = undefined.UNDEFINED,
+        attachment: undefined.UndefinedNoneOr[files.Resourceish | messages_.Attachment] = undefined.UNDEFINED,
         attachments: undefined.UndefinedNoneOr[
-            typing.Sequence[typing.Union[files.Resourceish, messages_.Attachment]]
+            typing.Sequence[files.Resourceish | messages_.Attachment]
         ] = undefined.UNDEFINED,
         component: undefined.UndefinedNoneOr[special_endpoints.ComponentBuilder] = undefined.UNDEFINED,
         components: undefined.UndefinedNoneOr[
@@ -7628,10 +7593,10 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         embeds: undefined.UndefinedNoneOr[typing.Sequence[embeds_.Embed]] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[users.PartialUser], bool]
+            snowflakes.SnowflakeishSequence[users.PartialUser] | bool
         ] = undefined.UNDEFINED,
         role_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
+            snowflakes.SnowflakeishSequence[guilds.PartialRole] | bool
         ] = undefined.UNDEFINED,
     ) -> messages_.Message:
         """Edit the initial response to a command interaction.
@@ -7965,9 +7930,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         description: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         end_time: undefined.UndefinedOr[datetime.datetime] = undefined.UNDEFINED,
         image: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
-        privacy_level: typing.Union[
-            int, scheduled_events.EventPrivacyLevel
-        ] = scheduled_events.EventPrivacyLevel.GUILD_ONLY,
+        privacy_level: int | scheduled_events.EventPrivacyLevel = scheduled_events.EventPrivacyLevel.GUILD_ONLY,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> scheduled_events.ScheduledStageEvent:
         """Create a scheduled stage event.
@@ -8035,9 +7998,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         description: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         end_time: undefined.UndefinedOr[datetime.datetime] = undefined.UNDEFINED,
         image: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
-        privacy_level: typing.Union[
-            int, scheduled_events.EventPrivacyLevel
-        ] = scheduled_events.EventPrivacyLevel.GUILD_ONLY,
+        privacy_level: int | scheduled_events.EventPrivacyLevel = scheduled_events.EventPrivacyLevel.GUILD_ONLY,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> scheduled_events.ScheduledVoiceEvent:
         """Create a scheduled voice event.
@@ -8105,9 +8066,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         *,
         description: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         image: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
-        privacy_level: typing.Union[
-            int, scheduled_events.EventPrivacyLevel
-        ] = scheduled_events.EventPrivacyLevel.GUILD_ONLY,
+        privacy_level: int | scheduled_events.EventPrivacyLevel = scheduled_events.EventPrivacyLevel.GUILD_ONLY,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> scheduled_events.ScheduledExternalEvent:
         """Create a scheduled external event.
@@ -8167,18 +8126,14 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         *,
         channel: undefined.UndefinedNoneOr[snowflakes.SnowflakeishOr[channels_.PartialChannel]] = undefined.UNDEFINED,
         description: undefined.UndefinedNoneOr[str] = undefined.UNDEFINED,
-        entity_type: undefined.UndefinedOr[
-            typing.Union[int, scheduled_events.ScheduledEventType]
-        ] = undefined.UNDEFINED,
+        entity_type: undefined.UndefinedOr[int | scheduled_events.ScheduledEventType] = undefined.UNDEFINED,
         image: undefined.UndefinedOr[files.Resourceish] = undefined.UNDEFINED,
         location: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         name: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-        privacy_level: undefined.UndefinedOr[
-            typing.Union[int, scheduled_events.EventPrivacyLevel]
-        ] = undefined.UNDEFINED,
+        privacy_level: undefined.UndefinedOr[int | scheduled_events.EventPrivacyLevel] = undefined.UNDEFINED,
         start_time: undefined.UndefinedOr[datetime.datetime] = undefined.UNDEFINED,
         end_time: undefined.UndefinedNoneOr[datetime.datetime] = undefined.UNDEFINED,
-        status: undefined.UndefinedOr[typing.Union[int, scheduled_events.ScheduledEventStatus]] = undefined.UNDEFINED,
+        status: undefined.UndefinedOr[int | scheduled_events.ScheduledEventStatus] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> scheduled_events.ScheduledEvent:
         """Edit a scheduled event.
@@ -8541,7 +8496,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         channel: snowflakes.SnowflakeishOr[channels_.GuildStageChannel],
         *,
         topic: str,
-        privacy_level: undefined.UndefinedOr[typing.Union[int, stage_instances.StageInstancePrivacyLevel]],
+        privacy_level: undefined.UndefinedOr[int | stage_instances.StageInstancePrivacyLevel],
         send_start_notification: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         scheduled_event_id: undefined.UndefinedOr[
             snowflakes.SnowflakeishOr[scheduled_events.ScheduledEvent]
@@ -8595,9 +8550,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         channel: snowflakes.SnowflakeishOr[channels_.GuildStageChannel],
         *,
         topic: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-        privacy_level: undefined.UndefinedOr[
-            typing.Union[int, stage_instances.StageInstancePrivacyLevel]
-        ] = undefined.UNDEFINED,
+        privacy_level: undefined.UndefinedOr[int | stage_instances.StageInstancePrivacyLevel] = undefined.UNDEFINED,
     ) -> stage_instances.StageInstance:
         """Edit the stage instance in a guild stage channel.
 

--- a/hikari/api/shard.py
+++ b/hikari/api/shard.py
@@ -173,7 +173,7 @@ class GatewayShard(abc.ABC):
     async def update_voice_state(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        channel: typing.Optional[snowflakes.SnowflakeishOr[channels.GuildVoiceChannel]],
+        channel: snowflakes.SnowflakeishOr[channels.GuildVoiceChannel] | None,
         *,
         self_mute: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         self_deaf: undefined.UndefinedOr[bool] = undefined.UNDEFINED,

--- a/hikari/api/special_endpoints.py
+++ b/hikari/api/special_endpoints.py
@@ -108,9 +108,9 @@ class TypingIndicator(abc.ABC):
     @abc.abstractmethod
     async def __aexit__(
         self,
-        exception_type: typing.Optional[type[BaseException]],
-        exception: typing.Optional[BaseException],
-        exception_traceback: typing.Optional[types.TracebackType],
+        exception_type: type[BaseException] | None,
+        exception: BaseException | None,
+        exception_traceback: types.TracebackType | None,
     ) -> None: ...
 
 
@@ -231,12 +231,12 @@ class GuildBuilder(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def verification_level(self) -> undefined.UndefinedOr[typing.Union[guilds.GuildVerificationLevel, int]]:
+    def verification_level(self) -> undefined.UndefinedOr[guilds.GuildVerificationLevel | int]:
         """Verification level required to join the guild."""
 
     @verification_level.setter
     def verification_level(
-        self, verification_level: undefined.UndefinedOr[typing.Union[guilds.GuildVerificationLevel, int]], /
+        self, verification_level: undefined.UndefinedOr[guilds.GuildVerificationLevel | int], /
     ) -> None:
         raise NotImplementedError
 
@@ -407,12 +407,12 @@ class GuildBuilder(abc.ABC):
         *,
         parent_id: undefined.UndefinedOr[snowflakes.Snowflake] = undefined.UNDEFINED,
         bitrate: undefined.UndefinedOr[int] = undefined.UNDEFINED,
-        video_quality_mode: undefined.UndefinedOr[typing.Union[channels.VideoQualityMode, int]] = undefined.UNDEFINED,
+        video_quality_mode: undefined.UndefinedOr[channels.VideoQualityMode | int] = undefined.UNDEFINED,
         position: undefined.UndefinedOr[int] = undefined.UNDEFINED,
         permission_overwrites: undefined.UndefinedOr[
             typing.Collection[channels.PermissionOverwrite]
         ] = undefined.UNDEFINED,
-        region: undefined.UndefinedNoneOr[typing.Union[voices.VoiceRegion, str]],
+        region: undefined.UndefinedNoneOr[voices.VoiceRegion | str],
         user_limit: undefined.UndefinedOr[int] = undefined.UNDEFINED,
     ) -> snowflakes.Snowflake:
         """Create a voice channel.
@@ -465,7 +465,7 @@ class GuildBuilder(abc.ABC):
         permission_overwrites: undefined.UndefinedOr[
             typing.Collection[channels.PermissionOverwrite]
         ] = undefined.UNDEFINED,
-        region: undefined.UndefinedNoneOr[typing.Union[voices.VoiceRegion, str]],
+        region: undefined.UndefinedNoneOr[voices.VoiceRegion | str],
         user_limit: undefined.UndefinedOr[int] = undefined.UNDEFINED,
     ) -> snowflakes.Snowflake:
         """Create a stage channel.
@@ -512,7 +512,7 @@ class InteractionResponseBuilder(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def type(self) -> typing.Union[int, base_interactions.ResponseType]:
+    def type(self) -> int | base_interactions.ResponseType:
         """Type of this response."""
 
     @abc.abstractmethod
@@ -547,7 +547,7 @@ class InteractionDeferredBuilder(InteractionResponseBuilder, abc.ABC):
 
     @property
     @abc.abstractmethod
-    def flags(self) -> typing.Union[undefined.UndefinedType, int, messages.MessageFlag]:
+    def flags(self) -> undefined.UndefinedType | int | messages.MessageFlag:
         """Message flags this response should have.
 
         !!! note
@@ -557,7 +557,7 @@ class InteractionDeferredBuilder(InteractionResponseBuilder, abc.ABC):
         """
 
     @abc.abstractmethod
-    def set_flags(self, flags: typing.Union[undefined.UndefinedType, int, messages.MessageFlag], /) -> Self:
+    def set_flags(self, flags: undefined.UndefinedType | int | messages.MessageFlag, /) -> Self:
         """Set message flags for this response.
 
         !!! note
@@ -589,7 +589,7 @@ class AutocompleteChoiceBuilder(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def value(self) -> typing.Union[int, str, float]:
+    def value(self) -> int | str | float:
         """The choice's value."""
 
     @abc.abstractmethod
@@ -603,7 +603,7 @@ class AutocompleteChoiceBuilder(abc.ABC):
         """
 
     @abc.abstractmethod
-    def set_value(self, value: typing.Union[float, str], /) -> Self:
+    def set_value(self, value: float | str, /) -> Self:
         """Set this choice's value.
 
         Returns
@@ -693,7 +693,7 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
 
     @property
     @abc.abstractmethod
-    def flags(self) -> typing.Union[undefined.UndefinedType, int, messages.MessageFlag]:
+    def flags(self) -> undefined.UndefinedType | int | messages.MessageFlag:
         """Message flags this response should have.
 
         !!! note
@@ -715,9 +715,7 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
 
     @property
     @abc.abstractmethod
-    def role_mentions(
-        self,
-    ) -> undefined.UndefinedOr[typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]]:
+    def role_mentions(self) -> undefined.UndefinedOr[snowflakes.SnowflakeishSequence[guilds.PartialRole] | bool]:
         """Whether and what role mentions should be enabled for this response.
 
         Either a sequence of object/IDs of the roles mentions should be enabled
@@ -727,9 +725,7 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
 
     @property
     @abc.abstractmethod
-    def user_mentions(
-        self,
-    ) -> undefined.UndefinedOr[typing.Union[snowflakes.SnowflakeishSequence[users.PartialUser], bool]]:
+    def user_mentions(self) -> undefined.UndefinedOr[snowflakes.SnowflakeishSequence[users.PartialUser] | bool]:
         """Whether and what user mentions should be enabled for this response.
 
         Either a sequence of object/IDs of the users mentions should be enabled
@@ -836,7 +832,7 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
         """
 
     @abc.abstractmethod
-    def set_flags(self, flags: typing.Union[undefined.UndefinedType, int, messages.MessageFlag], /) -> Self:
+    def set_flags(self, flags: undefined.UndefinedType | int | messages.MessageFlag, /) -> Self:
         """Set message flags for this response.
 
         !!! note
@@ -888,7 +884,7 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
     def set_role_mentions(
         self,
         mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
+            snowflakes.SnowflakeishSequence[guilds.PartialRole] | bool
         ] = undefined.UNDEFINED,
         /,
     ) -> Self:
@@ -911,7 +907,7 @@ class InteractionMessageBuilder(InteractionResponseBuilder, abc.ABC):
     def set_user_mentions(
         self,
         mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[users.PartialUser], bool]
+            snowflakes.SnowflakeishSequence[users.PartialUser] | bool
         ] = undefined.UNDEFINED,
         /,
     ) -> Self:
@@ -1053,7 +1049,7 @@ class CommandBuilder(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def default_member_permissions(self) -> typing.Union[undefined.UndefinedType, permissions_.Permissions, int]:
+    def default_member_permissions(self) -> undefined.UndefinedType | permissions_.Permissions | int:
         """Member permissions necessary to utilize this command by default.
 
         If `0`, then it will be available for all members. Note that this doesn't affect
@@ -1067,7 +1063,7 @@ class CommandBuilder(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def name_localizations(self) -> typing.Mapping[typing.Union[locales.Locale, str], str]:
+    def name_localizations(self) -> typing.Mapping[locales.Locale | str, str]:
         """Name localizations set for this command."""
 
     @property
@@ -1112,7 +1108,7 @@ class CommandBuilder(abc.ABC):
 
     @abc.abstractmethod
     def set_default_member_permissions(
-        self, default_member_permissions: typing.Union[undefined.UndefinedType, int, permissions_.Permissions], /
+        self, default_member_permissions: undefined.UndefinedType | int | permissions_.Permissions, /
     ) -> Self:
         """Set the member permissions necessary to utilize this command by default.
 
@@ -1146,9 +1142,7 @@ class CommandBuilder(abc.ABC):
         """
 
     @abc.abstractmethod
-    def set_name_localizations(
-        self, name_localizations: typing.Mapping[typing.Union[locales.Locale, str], str], /
-    ) -> Self:
+    def set_name_localizations(self, name_localizations: typing.Mapping[locales.Locale | str, str], /) -> Self:
         """Set the name localizations for this command.
 
         Parameters
@@ -1256,7 +1250,7 @@ class SlashCommandBuilder(CommandBuilder):
 
     @property
     @abc.abstractmethod
-    def description_localizations(self) -> typing.Mapping[typing.Union[locales.Locale, str], str]:
+    def description_localizations(self) -> typing.Mapping[locales.Locale | str, str]:
         """Command's localised descriptions."""
 
     @property
@@ -1281,7 +1275,7 @@ class SlashCommandBuilder(CommandBuilder):
 
     @abc.abstractmethod
     def set_description_localizations(
-        self, description_localizations: typing.Mapping[typing.Union[locales.Locale, str], str], /
+        self, description_localizations: typing.Mapping[locales.Locale | str, str], /
     ) -> Self:
         """Set the localised descriptions for this command.
 
@@ -1393,7 +1387,7 @@ class ComponentBuilder(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def type(self) -> typing.Union[int, components_.ComponentType]:
+    def type(self) -> int | components_.ComponentType:
         """Type of component this builder represents."""
 
     @abc.abstractmethod
@@ -1420,12 +1414,12 @@ class ButtonBuilder(ComponentBuilder, abc.ABC):
 
     @property
     @abc.abstractmethod
-    def style(self) -> typing.Union[components_.ButtonStyle, int]:
+    def style(self) -> components_.ButtonStyle | int:
         """Button's style."""
 
     @property
     @abc.abstractmethod
-    def emoji(self) -> typing.Union[snowflakes.Snowflakeish, emojis.Emoji, str, undefined.UndefinedType]:
+    def emoji(self) -> snowflakes.Snowflakeish | emojis.Emoji | str | undefined.UndefinedType:
         """Emoji which should appear on this button."""
 
     @property
@@ -1444,9 +1438,7 @@ class ButtonBuilder(ComponentBuilder, abc.ABC):
         """Whether the button should be marked as disabled."""
 
     @abc.abstractmethod
-    def set_emoji(
-        self, emoji: typing.Union[snowflakes.Snowflakeish, emojis.Emoji, str, undefined.UndefinedType], /
-    ) -> Self:
+    def set_emoji(self, emoji: snowflakes.Snowflakeish | emojis.Emoji | str | undefined.UndefinedType, /) -> Self:
         """Set the emoji to display on this button.
 
         Parameters
@@ -1553,7 +1545,7 @@ class SelectOptionBuilder(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def emoji(self) -> typing.Union[snowflakes.Snowflakeish, emojis.Emoji, str, undefined.UndefinedType]:
+    def emoji(self) -> snowflakes.Snowflakeish | emojis.Emoji | str | undefined.UndefinedType:
         """Emoji which should appear on this option."""
 
     @property
@@ -1610,9 +1602,7 @@ class SelectOptionBuilder(abc.ABC):
         """
 
     @abc.abstractmethod
-    def set_emoji(
-        self, emoji: typing.Union[snowflakes.Snowflakeish, emojis.Emoji, str, undefined.UndefinedType], /
-    ) -> Self:
+    def set_emoji(self, emoji: snowflakes.Snowflakeish | emojis.Emoji | str | undefined.UndefinedType, /) -> Self:
         """Set the emoji to display on this option.
 
         Parameters
@@ -1801,7 +1791,7 @@ class TextSelectMenuBuilder(SelectMenuBuilder, abc.ABC, typing.Generic[_ParentT]
         /,
         *,
         description: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-        emoji: typing.Union[snowflakes.Snowflakeish, emojis.Emoji, str, undefined.UndefinedType] = undefined.UNDEFINED,
+        emoji: snowflakes.Snowflakeish | emojis.Emoji | str | undefined.UndefinedType = undefined.UNDEFINED,
         is_default: bool = False,
     ) -> Self:
         """Add an option to this menu.
@@ -1911,7 +1901,7 @@ class TextInputBuilder(ComponentBuilder, abc.ABC):
         """Maximum length the text should have."""
 
     @abc.abstractmethod
-    def set_style(self, style: typing.Union[components_.TextInputStyle, int], /) -> Self:
+    def set_style(self, style: components_.TextInputStyle | int, /) -> Self:
         """Set the style to use for the text input.
 
         Parameters
@@ -2075,7 +2065,7 @@ class MessageActionRowBuilder(ComponentBuilder, abc.ABC):
         custom_id: str,
         /,
         *,
-        emoji: typing.Union[snowflakes.Snowflakeish, emojis.Emoji, str, undefined.UndefinedType] = undefined.UNDEFINED,
+        emoji: snowflakes.Snowflakeish | emojis.Emoji | str | undefined.UndefinedType = undefined.UNDEFINED,
         label: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         is_disabled: bool = False,
     ) -> Self:
@@ -2110,7 +2100,7 @@ class MessageActionRowBuilder(ComponentBuilder, abc.ABC):
         url: str,
         /,
         *,
-        emoji: typing.Union[snowflakes.Snowflakeish, emojis.Emoji, str, undefined.UndefinedType] = undefined.UNDEFINED,
+        emoji: snowflakes.Snowflakeish | emojis.Emoji | str | undefined.UndefinedType = undefined.UNDEFINED,
         label: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         is_disabled: bool = False,
     ) -> Self:
@@ -2139,7 +2129,7 @@ class MessageActionRowBuilder(ComponentBuilder, abc.ABC):
     @abc.abstractmethod
     def add_select_menu(
         self,
-        type_: typing.Union[components_.ComponentType, int],
+        type_: components_.ComponentType | int,
         custom_id: str,
         /,
         *,

--- a/hikari/api/voice.py
+++ b/hikari/api/voice.py
@@ -86,7 +86,7 @@ class VoiceComponent(abc.ABC):
         *,
         deaf: bool = False,
         mute: bool = False,
-        timeout: typing.Optional[int] = 5,
+        timeout: int | None = 5,
         **kwargs: object,
     ) -> _VoiceConnectionT:
         """Connect to a given voice channel.

--- a/hikari/applications.py
+++ b/hikari/applications.py
@@ -294,7 +294,7 @@ class OwnConnection:
     is_activity_visible: bool = attrs.field(eq=False, hash=False, repr=False)
     """[`True`][] if this connection's activities are shown in the user's presence."""
 
-    visibility: typing.Union[ConnectionVisibility, int] = attrs.field(eq=False, hash=False, repr=True)
+    visibility: ConnectionVisibility | int = attrs.field(eq=False, hash=False, repr=True)
     """The visibility of the connection."""
 
 
@@ -302,7 +302,7 @@ class OwnConnection:
 class OwnGuild(guilds.PartialGuild):
     """Represents a user bound partial guild object."""
 
-    features: typing.Sequence[typing.Union[str, guilds.GuildFeature]] = attrs.field(eq=False, hash=False, repr=False)
+    features: typing.Sequence[str | guilds.GuildFeature] = attrs.field(eq=False, hash=False, repr=False)
     """A list of the features in this guild."""
 
     is_owner: bool = attrs.field(eq=False, hash=False, repr=True)
@@ -322,10 +322,10 @@ class OwnGuild(guilds.PartialGuild):
 class OwnApplicationRoleConnection:
     """Represents an own application role connection."""
 
-    platform_name: typing.Optional[str] = attrs.field(eq=True, hash=True, repr=True)
+    platform_name: str | None = attrs.field(eq=True, hash=True, repr=True)
     """The name of the platform."""
 
-    platform_username: typing.Optional[str] = attrs.field(eq=True, hash=True, repr=True)
+    platform_username: str | None = attrs.field(eq=True, hash=True, repr=True)
     """The users name in the platform."""
 
     metadata: typing.Mapping[str, str] = attrs.field(eq=False, hash=False, repr=False)
@@ -358,7 +358,7 @@ class TeamMembershipState(int, enums.Enum):
 class TeamMember(users.User):
     """Represents a member of a Team."""
 
-    membership_state: typing.Union[TeamMembershipState, int] = attrs.field(repr=False)
+    membership_state: TeamMembershipState | int = attrs.field(repr=False)
     """The state of this user's membership."""
 
     permissions: typing.Sequence[str] = attrs.field(repr=False)
@@ -382,12 +382,12 @@ class TeamMember(users.User):
 
     @property
     @typing_extensions.override
-    def avatar_hash(self) -> typing.Optional[str]:
+    def avatar_hash(self) -> str | None:
         return self.user.avatar_hash
 
     @property
     @typing_extensions.override
-    def avatar_url(self) -> typing.Optional[files.URL]:
+    def avatar_url(self) -> files.URL | None:
         return self.user.avatar_url
 
     @property
@@ -397,17 +397,17 @@ class TeamMember(users.User):
 
     @property
     @typing_extensions.override
-    def banner_hash(self) -> typing.Optional[str]:
+    def banner_hash(self) -> str | None:
         return self.user.banner_hash
 
     @property
     @typing_extensions.override
-    def banner_url(self) -> typing.Optional[files.URL]:
+    def banner_url(self) -> files.URL | None:
         return self.user.banner_url
 
     @property
     @typing_extensions.override
-    def accent_color(self) -> typing.Optional[colors.Color]:
+    def accent_color(self) -> colors.Color | None:
         return self.user.accent_color
 
     @property
@@ -447,7 +447,7 @@ class TeamMember(users.User):
 
     @property
     @typing_extensions.override
-    def global_name(self) -> typing.Optional[str]:
+    def global_name(self) -> str | None:
         return self.user.global_name
 
     @typing_extensions.override
@@ -479,7 +479,7 @@ class Team(snowflakes.Unique):
     name: str = attrs.field(hash=False, eq=False, repr=True)
     """The name of this team."""
 
-    icon_hash: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    icon_hash: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The CDN hash of this team's icon.
 
     If no icon is provided, this will be [`None`][].
@@ -500,11 +500,11 @@ class Team(snowflakes.Unique):
         return f"Team {self.name} ({self.id})"
 
     @property
-    def icon_url(self) -> typing.Optional[files.URL]:
+    def icon_url(self) -> files.URL | None:
         """Icon URL, or [`None`][] if no icon exists."""
         return self.make_icon_url()
 
-    def make_icon_url(self, *, ext: str = "png", size: int = 4096) -> typing.Optional[files.URL]:
+    def make_icon_url(self, *, ext: str = "png", size: int = 4096) -> files.URL | None:
         """Generate the icon URL for this team if set.
 
         Parameters
@@ -545,18 +545,18 @@ class InviteApplication(guilds.PartialApplication):
     )
     """Client application that models may use for procedures."""
 
-    cover_image_hash: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    cover_image_hash: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The CDN's hash of this application's default rich presence invite cover image."""
 
     public_key: bytes = attrs.field(eq=False, hash=False, repr=False)
     """The key used for verifying interaction and GameSDK payload signatures."""
 
     @property
-    def cover_image_url(self) -> typing.Optional[files.URL]:
+    def cover_image_url(self) -> files.URL | None:
         """Rich presence cover image URL for this application, if set."""
         return self.make_cover_image_url()
 
-    def make_cover_image_url(self, *, ext: str = "png", size: int = 4096) -> typing.Optional[files.URL]:
+    def make_cover_image_url(self, *, ext: str = "png", size: int = 4096) -> files.URL | None:
         """Generate the rich presence cover image URL for this application, if set.
 
         Parameters
@@ -618,7 +618,7 @@ class Application(guilds.PartialApplication):
     owner: users.User = attrs.field(eq=False, hash=False, repr=True)
     """The application's owner."""
 
-    rpc_origins: typing.Optional[typing.Sequence[str]] = attrs.field(eq=False, hash=False, repr=False)
+    rpc_origins: typing.Sequence[str] | None = attrs.field(eq=False, hash=False, repr=False)
     """A collection of this application's RPC origin URLs, if RPC is enabled."""
 
     flags: ApplicationFlags = attrs.field(eq=False, hash=False, repr=False)
@@ -627,31 +627,31 @@ class Application(guilds.PartialApplication):
     public_key: bytes = attrs.field(eq=False, hash=False, repr=False)
     """The key used for verifying interaction and GameSDK payload signatures."""
 
-    team: typing.Optional[Team] = attrs.field(eq=False, hash=False, repr=False)
+    team: Team | None = attrs.field(eq=False, hash=False, repr=False)
     """The team this application belongs to.
 
     If the application is not part of a team, this will be [`None`][].
     """
 
-    cover_image_hash: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    cover_image_hash: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The CDN's hash of this application's default rich presence invite cover image."""
 
-    terms_of_service_url: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    terms_of_service_url: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The URL of this application's terms of service."""
 
-    privacy_policy_url: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    privacy_policy_url: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The URL of this application's privacy policy."""
 
-    role_connections_verification_url: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    role_connections_verification_url: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The URL of this application's role connection verification entry point."""
 
-    custom_install_url: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    custom_install_url: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The URL of this application's custom authorization link."""
 
     tags: typing.Sequence[str] = attrs.field(eq=False, hash=False, repr=False)
     """A sequence of tags describing the content and functionality of the application."""
 
-    install_parameters: typing.Optional[ApplicationInstallParameters] = attrs.field(eq=False, hash=False, repr=False)
+    install_parameters: ApplicationInstallParameters | None = attrs.field(eq=False, hash=False, repr=False)
     """Settings for the application's default in-app authorization link, if enabled."""
 
     approximate_guild_count: int = attrs.field(eq=False, hash=False, repr=False)
@@ -663,11 +663,11 @@ class Application(guilds.PartialApplication):
     """The default scopes and permissions for each integration type."""
 
     @property
-    def cover_image_url(self) -> typing.Optional[files.URL]:
+    def cover_image_url(self) -> files.URL | None:
         """Rich presence cover image URL for this application, if set."""
         return self.make_cover_image_url()
 
-    def make_cover_image_url(self, *, ext: str = "png", size: int = 4096) -> typing.Optional[files.URL]:
+    def make_cover_image_url(self, *, ext: str = "png", size: int = 4096) -> files.URL | None:
         """Generate the rich presence cover image URL for this application, if set.
 
         Parameters
@@ -706,22 +706,22 @@ class AuthorizationApplication(guilds.PartialApplication):
     public_key: bytes = attrs.field(eq=False, hash=False, repr=False)
     """The key used for verifying interaction and GameSDK payload signatures."""
 
-    is_bot_public: typing.Optional[bool] = attrs.field(eq=False, hash=False, repr=True)
+    is_bot_public: bool | None = attrs.field(eq=False, hash=False, repr=True)
     """[`True`][] if the bot associated with this application is public.
 
     Will be [`None`][] if this application doesn't have an associated bot.
     """
 
-    is_bot_code_grant_required: typing.Optional[bool] = attrs.field(eq=False, hash=False, repr=False)
+    is_bot_code_grant_required: bool | None = attrs.field(eq=False, hash=False, repr=False)
     """[`True`][] if this application's bot is requiring code grant for invites.
 
     Will be [`None`][] if this application doesn't have a bot.
     """
 
-    terms_of_service_url: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    terms_of_service_url: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The URL of this application's terms of service."""
 
-    privacy_policy_url: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    privacy_policy_url: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The URL of this application's privacy policy."""
 
 
@@ -736,10 +736,10 @@ class AuthorizationInformation:
     expires_at: datetime.datetime = attrs.field(hash=False, repr=True)
     """When the access token this data was retrieved with expires."""
 
-    scopes: typing.Sequence[typing.Union[OAuth2Scope, str]] = attrs.field(hash=False, repr=True)
+    scopes: typing.Sequence[OAuth2Scope | str] = attrs.field(hash=False, repr=True)
     """A sequence of the scopes the current user has authorized the application for."""
 
-    user: typing.Optional[users.User] = attrs.field(hash=False, repr=True)
+    user: users.User | None = attrs.field(hash=False, repr=True)
     """The user who has authorized this token.
 
     This will only be included if the token is authorized for the
@@ -759,13 +759,13 @@ class PartialOAuth2Token:
     access_token: str = attrs.field(hash=True, repr=False)
     """Access token issued by the authorization server."""
 
-    token_type: typing.Union[TokenType, str] = attrs.field(eq=False, hash=False, repr=True)
+    token_type: TokenType | str = attrs.field(eq=False, hash=False, repr=True)
     """Type of token issued by the authorization server."""
 
     expires_in: datetime.timedelta = attrs.field(eq=False, hash=False, repr=True)
     """Lifetime of this access token."""
 
-    scopes: typing.Sequence[typing.Union[OAuth2Scope, str]] = attrs.field(eq=False, hash=False, repr=True)
+    scopes: typing.Sequence[OAuth2Scope | str] = attrs.field(eq=False, hash=False, repr=True)
     """Scopes the access token has access to."""
 
     @typing_extensions.override
@@ -781,14 +781,14 @@ class OAuth2AuthorizationToken(PartialOAuth2Token):
     refresh_token: int = attrs.field(eq=False, hash=False, repr=False)
     """Refresh token used to obtain new access tokens with the same grant."""
 
-    webhook: typing.Optional[webhooks.IncomingWebhook] = attrs.field(eq=False, hash=False, repr=True)
+    webhook: webhooks.IncomingWebhook | None = attrs.field(eq=False, hash=False, repr=True)
     """Object of the webhook that was created.
 
     This will only be present if this token was authorized with the
     [`hikari.applications.OAuth2Scope.WEBHOOK_INCOMING`][] scope, otherwise this will be [`None`][].
     """
 
-    guild: typing.Optional[guilds.RESTGuild] = attrs.field(eq=False, hash=False, repr=True)
+    guild: guilds.RESTGuild | None = attrs.field(eq=False, hash=False, repr=True)
     """Object of the guild the user was added to.
 
     This will only be present if this token was authorized with the
@@ -801,7 +801,7 @@ class OAuth2AuthorizationToken(PartialOAuth2Token):
 class OAuth2ImplicitToken(PartialOAuth2Token):
     """Model for the OAuth2 token data returned by the implicit grant flow."""
 
-    state: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    state: str | None = attrs.field(eq=False, hash=False, repr=False)
     """State parameter that was present in the authorization request if provided."""
 
 
@@ -852,7 +852,7 @@ class ApplicationRoleConnectionMetadataRecordType(int, enums.Enum):
 class ApplicationRoleConnectionMetadataRecord:
     """Represents a role connection metadata record."""
 
-    type: typing.Union[ApplicationRoleConnectionMetadataRecordType, int] = attrs.field(eq=False, hash=False, repr=False)
+    type: ApplicationRoleConnectionMetadataRecordType | int = attrs.field(eq=False, hash=False, repr=False)
     """The type of metadata value record."""
 
     key: str = attrs.field(eq=True, hash=True, repr=False)
@@ -864,12 +864,12 @@ class ApplicationRoleConnectionMetadataRecord:
     description: str = attrs.field(eq=False, hash=False, repr=True)
     """The metadata's field description."""
 
-    name_localizations: typing.Mapping[typing.Union[locales.Locale, str], str] = attrs.field(
+    name_localizations: typing.Mapping[locales.Locale | str, str] = attrs.field(
         eq=False, hash=False, repr=False, factory=dict
     )
     """A mapping of name localizations for this metadata field."""
 
-    description_localizations: typing.Mapping[typing.Union[locales.Locale, str], str] = attrs.field(
+    description_localizations: typing.Mapping[locales.Locale | str, str] = attrs.field(
         eq=False, hash=False, repr=False, factory=dict
     )
     """A mapping of description localizations for this metadata field."""
@@ -880,7 +880,7 @@ class ApplicationRoleConnectionMetadataRecord:
 class ApplicationIntegrationConfiguration:
     """The Application Integration Configuration for the related [ApplicationIntegrationType][]."""
 
-    oauth2_install_parameters: typing.Optional[OAuth2InstallParameters] = attrs.field(eq=False, hash=False, repr=True)
+    oauth2_install_parameters: OAuth2InstallParameters | None = attrs.field(eq=False, hash=False, repr=True)
     """The OAuth2 Install parameters for the Application Integration."""
 
 

--- a/hikari/audit_logs.py
+++ b/hikari/audit_logs.py
@@ -279,13 +279,13 @@ class AuditLogChangeKey(str, enums.Enum):
 class AuditLogChange:
     """Represents a change made to an audit log entry's target entity."""
 
-    new_value: typing.Optional[typing.Any] = attrs.field(repr=True)
+    new_value: typing.Any | None = attrs.field(repr=True)
     """The new value of the key, if something was added or changed."""
 
-    old_value: typing.Optional[typing.Any] = attrs.field(repr=True)
+    old_value: typing.Any | None = attrs.field(repr=True)
     """The old value of the key, if something was removed or changed."""
 
-    key: typing.Union[AuditLogChangeKey, str] = attrs.field(repr=True)
+    key: AuditLogChangeKey | str = attrs.field(repr=True)
     """The name of the audit log change's key."""
 
 
@@ -372,10 +372,10 @@ class ChannelOverwriteEntryInfo(BaseAuditLogEntryInfo, snowflakes.Unique):
     id: snowflakes.Snowflake = attrs.field(hash=True, repr=True)
     """The ID of this entity."""
 
-    type: typing.Union[channels.PermissionOverwriteType, int] = attrs.field(repr=True)
+    type: channels.PermissionOverwriteType | int = attrs.field(repr=True)
     """The type of entity this overwrite targets."""
 
-    role_name: typing.Optional[str] = attrs.field(repr=True)
+    role_name: str | None = attrs.field(repr=True)
     """The name of the role this overwrite targets, if it targets a role."""
 
 
@@ -561,25 +561,25 @@ class AuditLogEntry(snowflakes.Unique):
     guild_id: snowflakes.Snowflake = attrs.field(eq=False, hash=False, repr=True)
     """ID of the guild this audit log entry is for."""
 
-    target_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=True)
+    target_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=True)
     """The ID of the entity affected by this change, if applicable."""
 
     changes: typing.Sequence[AuditLogChange] = attrs.field(eq=False, hash=False, repr=False)
     """A sequence of the changes made to [`hikari.audit_logs.AuditLogEntry.target_id`][]."""
 
-    user_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=True)
+    user_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=True)
     """The ID of the user who made this change."""
 
-    action_type: typing.Union[AuditLogEventType, int] = attrs.field(eq=False, hash=False, repr=True)
+    action_type: AuditLogEventType | int = attrs.field(eq=False, hash=False, repr=True)
     """The type of action this entry represents."""
 
-    options: typing.Optional[BaseAuditLogEntryInfo] = attrs.field(eq=False, hash=False, repr=False)
+    options: BaseAuditLogEntryInfo | None = attrs.field(eq=False, hash=False, repr=False)
     """Extra information about this entry. Only be provided for certain `event_type`."""
 
-    reason: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    reason: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The reason for this change, if set (between 0-512 characters)."""
 
-    async def fetch_user(self) -> typing.Optional[users_.User]:
+    async def fetch_user(self) -> users_.User | None:
         """Fetch the user who made this change.
 
         Returns
@@ -631,9 +631,7 @@ class AuditLog(typing.Sequence[AuditLogEntry]):
     def __getitem__(self, slice_: slice, /) -> typing.Sequence[AuditLogEntry]: ...
 
     @typing_extensions.override
-    def __getitem__(
-        self, index_or_slice: typing.Union[int, slice], /
-    ) -> typing.Union[AuditLogEntry, typing.Sequence[AuditLogEntry]]:
+    def __getitem__(self, index_or_slice: int | slice, /) -> AuditLogEntry | typing.Sequence[AuditLogEntry]:
         return collections.get_index_or_slice(self.entries, index_or_slice)
 
     @typing_extensions.override

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -191,7 +191,7 @@ class ChannelFollow:
     webhook_id: snowflakes.Snowflake = attrs.field(hash=True, repr=True)
     """Return the ID of the webhook for this follow."""
 
-    async def fetch_channel(self) -> typing.Union[GuildNewsChannel, GuildTextChannel]:
+    async def fetch_channel(self) -> GuildNewsChannel | GuildTextChannel:
         """Fetch the object of the guild channel being followed.
 
         Returns
@@ -247,7 +247,7 @@ class ChannelFollow:
         assert isinstance(webhook, webhooks.ChannelFollowerWebhook)
         return webhook
 
-    def get_channel(self) -> typing.Union[GuildNewsChannel, GuildTextChannel, None]:
+    def get_channel(self) -> GuildNewsChannel | GuildTextChannel | None:
         """Get the channel being followed from the cache.
 
         !!! warning
@@ -310,7 +310,7 @@ class PermissionOverwrite(snowflakes.Unique):
     id: snowflakes.Snowflake = attrs.field(converter=snowflakes.Snowflake, repr=True)
     """The ID of this entity."""
 
-    type: typing.Union[PermissionOverwriteType, int] = attrs.field(converter=PermissionOverwriteType, repr=True)
+    type: PermissionOverwriteType | int = attrs.field(converter=PermissionOverwriteType, repr=True)
     """The type of entity this overwrite targets."""
 
     allow: permissions.Permissions = attrs.field(
@@ -346,10 +346,10 @@ class PartialChannel(snowflakes.Unique):
     id: snowflakes.Snowflake = attrs.field(hash=True, repr=True)
     """The ID of this entity."""
 
-    name: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=True)
+    name: str | None = attrs.field(eq=False, hash=False, repr=True)
     """The channel's name. This will be missing for DM channels."""
 
-    type: typing.Union[ChannelType, int] = attrs.field(eq=False, hash=False, repr=True)
+    type: ChannelType | int = attrs.field(eq=False, hash=False, repr=True)
     """The channel's type."""
 
     @property
@@ -513,12 +513,12 @@ class TextableChannel(PartialChannel):
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[users.PartialUser], bool]
+            snowflakes.SnowflakeishSequence[users.PartialUser] | bool
         ] = undefined.UNDEFINED,
         role_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
+            snowflakes.SnowflakeishSequence[guilds.PartialRole] | bool
         ] = undefined.UNDEFINED,
-        flags: typing.Union[undefined.UndefinedType, int, messages_.MessageFlag] = undefined.UNDEFINED,
+        flags: undefined.UndefinedType | int | messages_.MessageFlag = undefined.UNDEFINED,
     ) -> messages_.Message:
         """Create a message in this channel.
 
@@ -780,11 +780,9 @@ class TextableChannel(PartialChannel):
 
     async def delete_messages(
         self,
-        messages: typing.Union[
-            snowflakes.SnowflakeishOr[messages_.PartialMessage],
-            typing.Iterable[snowflakes.SnowflakeishOr[messages_.PartialMessage]],
-            typing.AsyncIterable[snowflakes.SnowflakeishOr[messages_.PartialMessage]],
-        ],
+        messages: snowflakes.SnowflakeishOr[messages_.PartialMessage]
+        | typing.Iterable[snowflakes.SnowflakeishOr[messages_.PartialMessage]]
+        | typing.AsyncIterable[snowflakes.SnowflakeishOr[messages_.PartialMessage]],
         /,
         *other_messages: snowflakes.SnowflakeishOr[messages_.PartialMessage],
     ) -> None:
@@ -834,7 +832,7 @@ class TextableChannel(PartialChannel):
 class PrivateChannel(PartialChannel):
     """The base for anything that is a private (non-guild bound) channel."""
 
-    last_message_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    last_message_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """The ID of the last message sent in this channel.
 
     !!! warning
@@ -873,7 +871,7 @@ class GroupDMChannel(PrivateChannel):
     owner_id: snowflakes.Snowflake = attrs.field(eq=False, hash=False, repr=True)
     """The ID of the owner of the group."""
 
-    icon_hash: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    icon_hash: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The CDN hash of the icon of the group, if an icon is set."""
 
     nicknames: typing.MutableMapping[snowflakes.Snowflake, str] = attrs.field(eq=False, hash=False, repr=False)
@@ -882,7 +880,7 @@ class GroupDMChannel(PrivateChannel):
     recipients: typing.Mapping[snowflakes.Snowflake, users.User] = attrs.field(eq=False, hash=False, repr=False)
     """The recipients of the group DM."""
 
-    application_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    application_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """The ID of the application that created the group DM.
 
     If the group DM was not created by a bot, this will be [`None`][].
@@ -896,11 +894,11 @@ class GroupDMChannel(PrivateChannel):
         return self.name
 
     @property
-    def icon_url(self) -> typing.Optional[files.URL]:
+    def icon_url(self) -> files.URL | None:
         """Icon for this group DM, if set."""
         return self.make_icon_url()
 
-    def make_icon_url(self, *, ext: str = "png", size: int = 4096) -> typing.Optional[files.URL]:
+    def make_icon_url(self, *, ext: str = "png", size: int = 4096) -> files.URL | None:
         """Generate the icon for this group, if set.
 
         Parameters
@@ -937,7 +935,7 @@ class GuildChannel(PartialChannel):
     guild_id: snowflakes.Snowflake = attrs.field(eq=False, hash=False, repr=True)
     """The ID of the guild the channel belongs to."""
 
-    parent_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=True)
+    parent_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=True)
     """The ID of the parent channel the channel belongs to.
 
     For thread channels this will refer to the parent textable guild channel.
@@ -947,7 +945,7 @@ class GuildChannel(PartialChannel):
     """
 
     @property
-    def shard_id(self) -> typing.Optional[int]:
+    def shard_id(self) -> int | None:
         """Return the shard ID for the shard.
 
         This may be [`None`][] if the shard count is not known.
@@ -957,7 +955,7 @@ class GuildChannel(PartialChannel):
 
         return None
 
-    def get_guild(self) -> typing.Optional[guilds.GatewayGuild]:
+    def get_guild(self) -> guilds.GatewayGuild | None:
         """Return the guild linked to this channel.
 
         Returns
@@ -1002,10 +1000,10 @@ class GuildChannel(PartialChannel):
         topic: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         nsfw: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         bitrate: undefined.UndefinedOr[int] = undefined.UNDEFINED,
-        video_quality_mode: undefined.UndefinedOr[typing.Union[VideoQualityMode, int]] = undefined.UNDEFINED,
+        video_quality_mode: undefined.UndefinedOr[VideoQualityMode | int] = undefined.UNDEFINED,
         user_limit: undefined.UndefinedOr[int] = undefined.UNDEFINED,
         rate_limit_per_user: undefined.UndefinedOr[time.Intervalish] = undefined.UNDEFINED,
-        region: undefined.UndefinedOr[typing.Union[voices.VoiceRegion, str]] = undefined.UNDEFINED,
+        region: undefined.UndefinedOr[voices.VoiceRegion | str] = undefined.UNDEFINED,
         permission_overwrites: undefined.UndefinedOr[typing.Sequence[PermissionOverwrite]] = undefined.UNDEFINED,
         parent_category: undefined.UndefinedOr[snowflakes.SnowflakeishOr[GuildCategory]] = undefined.UNDEFINED,
         default_auto_archive_duration: undefined.UndefinedOr[time.Intervalish] = undefined.UNDEFINED,
@@ -1155,9 +1153,9 @@ class PermissibleGuildChannel(GuildChannel):
 
     async def edit_overwrite(
         self,
-        target: typing.Union[snowflakes.Snowflakeish, users.PartialUser, guilds.PartialRole, PermissionOverwrite],
+        target: snowflakes.Snowflakeish | users.PartialUser | guilds.PartialRole | PermissionOverwrite,
         *,
-        target_type: undefined.UndefinedOr[typing.Union[PermissionOverwriteType, int]] = undefined.UNDEFINED,
+        target_type: undefined.UndefinedOr[PermissionOverwriteType | int] = undefined.UNDEFINED,
         allow: undefined.UndefinedOr[permissions.Permissions] = undefined.UNDEFINED,
         deny: undefined.UndefinedOr[permissions.Permissions] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
@@ -1214,7 +1212,7 @@ class PermissibleGuildChannel(GuildChannel):
         )
 
     async def remove_overwrite(
-        self, target: typing.Union[PermissionOverwrite, guilds.PartialRole, users.PartialUser, snowflakes.Snowflakeish]
+        self, target: PermissionOverwrite | guilds.PartialRole | users.PartialUser | snowflakes.Snowflakeish
     ) -> None:
         """Delete a custom permission for an entity in a given guild channel.
 
@@ -1267,10 +1265,10 @@ class GuildCategory(PermissibleGuildChannel):
 class GuildTextChannel(PermissibleGuildChannel, TextableGuildChannel):
     """Represents a guild text channel."""
 
-    topic: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    topic: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The topic of the channel."""
 
-    last_message_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    last_message_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """The ID of the last message sent in this channel.
 
     !!! warning
@@ -1290,7 +1288,7 @@ class GuildTextChannel(PermissibleGuildChannel, TextableGuildChannel):
         Likewise, bots will not be affected by this rate limit.
     """
 
-    last_pin_timestamp: typing.Optional[datetime.datetime] = attrs.field(eq=False, hash=False, repr=False)
+    last_pin_timestamp: datetime.datetime | None = attrs.field(eq=False, hash=False, repr=False)
     """The timestamp of the last-pinned message.
 
     !!! note
@@ -1309,10 +1307,10 @@ class GuildTextChannel(PermissibleGuildChannel, TextableGuildChannel):
 class GuildNewsChannel(PermissibleGuildChannel, TextableGuildChannel):
     """Represents an news channel."""
 
-    topic: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    topic: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The topic of the channel."""
 
-    last_message_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    last_message_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """The ID of the last message sent in this channel.
 
     !!! warning
@@ -1320,7 +1318,7 @@ class GuildNewsChannel(PermissibleGuildChannel, TextableGuildChannel):
         this will always be valid.
     """
 
-    last_pin_timestamp: typing.Optional[datetime.datetime] = attrs.field(eq=False, hash=False, repr=False)
+    last_pin_timestamp: datetime.datetime | None = attrs.field(eq=False, hash=False, repr=False)
     """The timestamp of the last-pinned message.
 
     !!! note
@@ -1342,7 +1340,7 @@ class GuildVoiceChannel(PermissibleGuildChannel, TextableGuildChannel):
     bitrate: int = attrs.field(eq=False, hash=False, repr=True)
     """The bitrate for the voice channel (in bits per second)."""
 
-    region: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    region: str | None = attrs.field(eq=False, hash=False, repr=False)
     """ID of the voice region for this voice channel.
 
     If set to [`None`][] then this is set to "auto" mode where the used
@@ -1356,10 +1354,10 @@ class GuildVoiceChannel(PermissibleGuildChannel, TextableGuildChannel):
     If this is `0`, then assume no limit.
     """
 
-    video_quality_mode: typing.Union[VideoQualityMode, int] = attrs.field(eq=False, hash=False, repr=False)
+    video_quality_mode: VideoQualityMode | int = attrs.field(eq=False, hash=False, repr=False)
     """The video quality mode for this channel."""
 
-    last_message_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    last_message_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """The ID of the last message sent in this channel.
 
     !!! warning
@@ -1375,7 +1373,7 @@ class GuildStageChannel(PermissibleGuildChannel, TextableGuildChannel):
     bitrate: int = attrs.field(eq=False, hash=False, repr=True)
     """The bitrate for the stage channel (in bits per second)."""
 
-    region: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    region: str | None = attrs.field(eq=False, hash=False, repr=False)
     """ID of the voice region for this stage channel.
 
     If set to [`None`][] then this is set to "auto" mode where the used
@@ -1389,10 +1387,10 @@ class GuildStageChannel(PermissibleGuildChannel, TextableGuildChannel):
     If this is `0`, then assume no limit.
     """
 
-    video_quality_mode: typing.Union[VideoQualityMode, int] = attrs.field(eq=False, hash=False, repr=False)
+    video_quality_mode: VideoQualityMode | int = attrs.field(eq=False, hash=False, repr=False)
     """The video quality mode for this channel."""
 
-    last_message_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    last_message_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """The ID of the last message sent in this channel.
 
     !!! warning
@@ -1448,13 +1446,13 @@ class ForumTag(snowflakes.Unique):
     or [`hikari.permissions.Permissions.ADMINISTRATOR`][] permissions.
     """
 
-    _emoji: typing.Union[str, int, emojis.Emoji, None] = attrs.field(alias="emoji", default=None)
+    _emoji: str | int | emojis.Emoji | None = attrs.field(alias="emoji", default=None)
     # Discord will send either emoji_id or emoji_name, never both.
     # Thus, we can take in a generic "emoji" argument when the user
     # creates the class and then demystify it later.
 
     @property
-    def unicode_emoji(self) -> typing.Optional[emojis.UnicodeEmoji]:
+    def unicode_emoji(self) -> emojis.UnicodeEmoji | None:
         """Unicode emoji of this tag."""
         if isinstance(self._emoji, str):
             return emojis.UnicodeEmoji(self._emoji)
@@ -1462,7 +1460,7 @@ class ForumTag(snowflakes.Unique):
         return None
 
     @property
-    def emoji_id(self) -> typing.Optional[snowflakes.Snowflake]:
+    def emoji_id(self) -> snowflakes.Snowflake | None:
         """ID of the emoji of this tag."""
         if isinstance(self._emoji, (int, emojis.CustomEmoji)):
             return snowflakes.Snowflake(self._emoji)
@@ -1474,10 +1472,10 @@ class ForumTag(snowflakes.Unique):
 class GuildForumChannel(PermissibleGuildChannel):
     """Represents a guild forum channel."""
 
-    topic: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    topic: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The guidelines for the channel."""
 
-    last_thread_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    last_thread_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """The ID of the last thread created in this channel.
 
     !!! warning
@@ -1531,12 +1529,10 @@ class GuildForumChannel(PermissibleGuildChannel):
     default_layout: ForumLayoutType = attrs.field(eq=False, hash=False, repr=False)
     """The default layout for the forum."""
 
-    default_reaction_emoji_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    default_reaction_emoji_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """The ID of the default reaction emoji."""
 
-    default_reaction_emoji_name: typing.Union[str, emojis.UnicodeEmoji, None] = attrs.field(
-        eq=False, hash=False, repr=False
-    )
+    default_reaction_emoji_name: str | emojis.UnicodeEmoji | None = attrs.field(eq=False, hash=False, repr=False)
     """Name of the default reaction emoji.
 
     Either the string name of the custom emoji, the object
@@ -1624,7 +1620,7 @@ class ThreadMetadata:
     can un-archive it.
     """
 
-    created_at: typing.Optional[datetime.datetime] = attrs.field(repr=True)
+    created_at: datetime.datetime | None = attrs.field(repr=True)
     """When the thread was created.
 
     Will be [`None`][] for threads created before 2022-01-09.
@@ -1635,7 +1631,7 @@ class ThreadMetadata:
 class GuildThreadChannel(TextableGuildChannel):
     """Base class for all guild thread channels."""
 
-    last_message_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    last_message_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """The ID of the last message sent in this channel.
 
     !!! warning
@@ -1643,7 +1639,7 @@ class GuildThreadChannel(TextableGuildChannel):
         this will always be valid.
     """
 
-    last_pin_timestamp: typing.Optional[datetime.datetime] = attrs.field(eq=False, hash=False, repr=False)
+    last_pin_timestamp: datetime.datetime | None = attrs.field(eq=False, hash=False, repr=False)
     """The timestamp of the last-pinned message.
 
     !!! note
@@ -1677,7 +1673,7 @@ class GuildThreadChannel(TextableGuildChannel):
         This stop counting at 50.
     """
 
-    member: typing.Optional[ThreadMember] = attrs.field(eq=False, hash=False, repr=True)
+    member: ThreadMember | None = attrs.field(eq=False, hash=False, repr=True)
     """Thread member object for the current user, if they are in the thread.
 
     !!! note
@@ -1727,7 +1723,7 @@ class GuildThreadChannel(TextableGuildChannel):
         return self.metadata.is_locked
 
     @property
-    def thread_created_at(self) -> typing.Optional[datetime.datetime]:
+    def thread_created_at(self) -> datetime.datetime | None:
         """When the thread was created.
 
         Will be [`None`][] for threads created before 2022-01-09.

--- a/hikari/commands.py
+++ b/hikari/commands.py
@@ -118,12 +118,12 @@ class CommandChoice:
     name: str = attrs.field(repr=True)
     """The choice's name (inclusively between 1-100 characters)."""
 
-    name_localizations: typing.Mapping[typing.Union[locales.Locale, str], str] = attrs.field(
+    name_localizations: typing.Mapping[locales.Locale | str, str] = attrs.field(
         eq=False, factory=dict, hash=False, repr=False
     )
     """A mapping of name localizations for this command choice."""
 
-    value: typing.Union[str, int, float] = attrs.field(repr=True)
+    value: str | int | float = attrs.field(repr=True)
     """Value of the choice (up to 100 characters if a string)."""
 
 
@@ -132,7 +132,7 @@ class CommandChoice:
 class CommandOption:
     """Represents an application command's argument."""
 
-    type: typing.Union[OptionType, int] = attrs.field(repr=True)
+    type: OptionType | int = attrs.field(repr=True)
     """The type of command option this is."""
 
     name: str = attrs.field(repr=True)
@@ -153,7 +153,7 @@ class CommandOption:
     is_required: bool = attrs.field(default=False, repr=False)
     """Whether this command option is required."""
 
-    choices: typing.Optional[typing.Sequence[CommandChoice]] = attrs.field(default=None, repr=False)
+    choices: typing.Sequence[CommandChoice] | None = attrs.field(default=None, repr=False)
     """A sequence of up to (and including) 25 choices for this command.
 
     This will be [`None`][] if the input values for this option aren't
@@ -161,12 +161,10 @@ class CommandOption:
     option.
     """
 
-    options: typing.Optional[typing.Sequence[CommandOption]] = attrs.field(default=None, repr=False)
+    options: typing.Sequence[CommandOption] | None = attrs.field(default=None, repr=False)
     """Sequence of up to (and including) 25 of the options for this command option."""
 
-    channel_types: typing.Optional[typing.Sequence[typing.Union[channels.ChannelType, int]]] = attrs.field(
-        default=None, repr=False
-    )
+    channel_types: typing.Sequence[channels.ChannelType | int] | None = attrs.field(default=None, repr=False)
     """The channel types that this option will accept.
 
     If [`None`][], then all channel types will be accepted.
@@ -175,38 +173,38 @@ class CommandOption:
     autocomplete: bool = attrs.field(default=False, repr=False)
     """Whether this option has autocomplete."""
 
-    min_value: typing.Union[int, float, None] = attrs.field(default=None, repr=False)
+    min_value: int | float | None = attrs.field(default=None, repr=False)
     """The minimum value permitted (inclusive).
 
     This will be [`int`][] if the type of the option is [`hikari.commands.OptionType.INTEGER`][]
     and [`float`][] if the type is [`hikari.commands.OptionType.FLOAT`][].
     """
 
-    max_value: typing.Union[int, float, None] = attrs.field(default=None, repr=False)
+    max_value: int | float | None = attrs.field(default=None, repr=False)
     """The maximum value permitted (inclusive).
 
     This will be [`int`][] if the type of the option is [`hikari.commands.OptionType.INTEGER`][]
     and [`float`][] if the type is [`hikari.commands.OptionType.FLOAT`][].
     """
 
-    name_localizations: typing.Mapping[typing.Union[locales.Locale, str], str] = attrs.field(
+    name_localizations: typing.Mapping[locales.Locale | str, str] = attrs.field(
         eq=False, factory=dict, hash=False, repr=False
     )
     """A mapping of name localizations for this option."""
 
-    description_localizations: typing.Mapping[typing.Union[locales.Locale, str], str] = attrs.field(
+    description_localizations: typing.Mapping[locales.Locale | str, str] = attrs.field(
         eq=False, factory=dict, hash=False, repr=False
     )
     """A mapping of description localizations for this option."""
 
-    min_length: typing.Optional[int] = attrs.field(default=None, repr=False)
+    min_length: int | None = attrs.field(default=None, repr=False)
     """The minimum length permitted (inclusive).
 
     This is only valid for [`hikari.commands.OptionType.STRING`][],
     otherwise it will be [`None`][].
     """
 
-    max_length: typing.Optional[int] = attrs.field(default=None, repr=False)
+    max_length: int | None = attrs.field(default=None, repr=False)
     """The maximum length permitted (inclusive).
 
     This is only valid for [`hikari.commands.OptionType.STRING`][],
@@ -248,7 +246,7 @@ class PartialCommand(snowflakes.Unique):
     is_nsfw: bool = attrs.field(eq=False, hash=False, repr=True)
     """Whether this command is age-restricted."""
 
-    guild_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    guild_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """ID of the guild this command is in.
 
     This will be [`None`][] if this is a global command.
@@ -257,9 +255,7 @@ class PartialCommand(snowflakes.Unique):
     version: snowflakes.Snowflake = attrs.field(eq=False, hash=False, repr=True)
     """Auto-incrementing version identifier updated during substantial record changes."""
 
-    name_localizations: typing.Mapping[typing.Union[locales.Locale, str], str] = attrs.field(
-        eq=False, hash=False, repr=False
-    )
+    name_localizations: typing.Mapping[locales.Locale | str, str] = attrs.field(eq=False, hash=False, repr=False)
     """A mapping of name localizations for this command."""
 
     integration_types: typing.Sequence[applications.ApplicationIntegrationType] = attrs.field(
@@ -454,12 +450,10 @@ class SlashCommand(PartialCommand):
         This will be inclusively between 1-100 characters in length.
     """
 
-    description_localizations: typing.Mapping[typing.Union[locales.Locale, str], str] = attrs.field(
-        eq=False, hash=False, repr=False
-    )
+    description_localizations: typing.Mapping[locales.Locale | str, str] = attrs.field(eq=False, hash=False, repr=False)
     """A set of description localizations for this command."""
 
-    options: typing.Optional[typing.Sequence[CommandOption]] = attrs.field(eq=False, hash=False, repr=False)
+    options: typing.Sequence[CommandOption] | None = attrs.field(eq=False, hash=False, repr=False)
     """Sequence of up to (and including) 25 of the options for this command."""
 
 
@@ -496,7 +490,7 @@ class CommandPermission:
     * If equals to (`guild_id` - 1), then it applies to all channels in a guild.
     """
 
-    type: typing.Union[CommandPermissionType, int] = attrs.field(converter=CommandPermissionType)
+    type: CommandPermissionType | int = attrs.field(converter=CommandPermissionType)
     """The entity this permission overrides the command's state for."""
 
     has_access: bool = attrs.field()

--- a/hikari/components.py
+++ b/hikari/components.py
@@ -172,7 +172,7 @@ class TextInputStyle(int, enums.Enum):
 class PartialComponent:
     """Base class for all component entities."""
 
-    type: typing.Union[ComponentType, int] = attrs.field()
+    type: ComponentType | int = attrs.field()
     """The type of component this is."""
 
 
@@ -192,9 +192,7 @@ class ActionRowComponent(typing.Generic[AllowedComponentsT], PartialComponent):
     @typing.overload
     def __getitem__(self, slice_: slice, /) -> typing.Sequence[AllowedComponentsT]: ...
 
-    def __getitem__(
-        self, index_or_slice: typing.Union[int, slice], /
-    ) -> typing.Union[PartialComponent, typing.Sequence[AllowedComponentsT]]:
+    def __getitem__(self, index_or_slice: int | slice, /) -> PartialComponent | typing.Sequence[AllowedComponentsT]:
         return self.components[index_or_slice]
 
     def __iter__(self) -> typing.Iterator[AllowedComponentsT]:
@@ -208,16 +206,16 @@ class ActionRowComponent(typing.Generic[AllowedComponentsT], PartialComponent):
 class ButtonComponent(PartialComponent):
     """Represents a button component."""
 
-    style: typing.Union[ButtonStyle, int] = attrs.field(eq=False)
+    style: ButtonStyle | int = attrs.field(eq=False)
     """The button's style."""
 
-    label: typing.Optional[str] = attrs.field(eq=False)
+    label: str | None = attrs.field(eq=False)
     """Text label which appears on the button."""
 
-    emoji: typing.Optional[emojis.Emoji] = attrs.field(eq=False)
+    emoji: emojis.Emoji | None = attrs.field(eq=False)
     """Custom or unicode emoji which appears on the button."""
 
-    custom_id: typing.Optional[str] = attrs.field(hash=True)
+    custom_id: str | None = attrs.field(hash=True)
     """Developer defined identifier for this button (will be <= 100 characters).
 
     !!! note
@@ -229,7 +227,7 @@ class ButtonComponent(PartialComponent):
         * [`hikari.components.ButtonStyle.DANGER`][]
     """
 
-    url: typing.Optional[str] = attrs.field(eq=False)
+    url: str | None = attrs.field(eq=False)
     """Url for [`hikari.components.ButtonStyle.LINK`][] style buttons."""
 
     is_disabled: bool = attrs.field(eq=False)
@@ -246,10 +244,10 @@ class SelectMenuOption:
     value: str = attrs.field()
     """Dev-defined value of the option, max 100 characters."""
 
-    description: typing.Optional[str] = attrs.field()
+    description: str | None = attrs.field()
     """Optional description of the option, max 100 characters."""
 
-    emoji: typing.Optional[emojis.Emoji] = attrs.field(eq=False)
+    emoji: emojis.Emoji | None = attrs.field(eq=False)
     """Custom or unicode emoji which appears on the button."""
 
     is_default: bool = attrs.field()
@@ -263,7 +261,7 @@ class SelectMenuComponent(PartialComponent):
     custom_id: str = attrs.field(hash=True)
     """Developer defined identifier for this menu (will be <= 100 characters)."""
 
-    placeholder: typing.Optional[str] = attrs.field(eq=False)
+    placeholder: str | None = attrs.field(eq=False)
     """Custom placeholder text shown if nothing is selected, max 100 characters."""
 
     min_values: int = attrs.field(eq=False)
@@ -296,7 +294,7 @@ class TextSelectMenuComponent(SelectMenuComponent):
 class ChannelSelectMenuComponent(SelectMenuComponent):
     """Represents a channel select menu component."""
 
-    channel_types: typing.Sequence[typing.Union[int, channels.ChannelType]] = attrs.field(eq=False)
+    channel_types: typing.Sequence[int | channels.ChannelType] = attrs.field(eq=False)
     """The valid channel types for this menu."""
 
 

--- a/hikari/embeds.py
+++ b/hikari/embeds.py
@@ -78,7 +78,7 @@ class EmbedResource(files.Resource[files.AsyncReader]):
 
     @typing_extensions.override
     def stream(
-        self, *, executor: typing.Optional[concurrent.futures.Executor] = None, head_only: bool = False
+        self, *, executor: concurrent.futures.Executor | None = None, head_only: bool = False
     ) -> files.AsyncReaderContextManager[files.AsyncReader]:
         """Produce a stream of data for the resource.
 
@@ -100,7 +100,7 @@ class EmbedResource(files.Resource[files.AsyncReader]):
 class EmbedResourceWithProxy(EmbedResource):
     """Resource with a corresponding proxied element."""
 
-    proxy_resource: typing.Optional[files.Resource[files.AsyncReader]] = attrs.field(default=None, repr=False)
+    proxy_resource: files.Resource[files.AsyncReader] | None = attrs.field(default=None, repr=False)
     """The proxied version of the resource, or [`None`][] if not present.
 
     !!! note
@@ -111,13 +111,13 @@ class EmbedResourceWithProxy(EmbedResource):
 
     @property
     @typing.final
-    def proxy_url(self) -> typing.Optional[str]:
+    def proxy_url(self) -> str | None:
         """Proxied URL of this embed resource if applicable, else [`None`][]."""
         return self.proxy_resource.url if self.proxy_resource else None
 
     @property
     @typing.final
-    def proxy_filename(self) -> typing.Optional[str]:
+    def proxy_filename(self) -> str | None:
         """File name of the proxied version of this embed resource if applicable, else [`None`][]."""
         return self.proxy_resource.filename if self.proxy_resource else None
 
@@ -129,10 +129,10 @@ class EmbedFooter:
 
     # Discord says this is never None. We know that is invalid because Discord.py
     # sets it to None. Seems like undocumented behaviour again.
-    text: typing.Optional[str] = attrs.field(default=None, repr=True)
+    text: str | None = attrs.field(default=None, repr=True)
     """The footer text, or [`None`][] if not present."""
 
-    icon: typing.Optional[EmbedResourceWithProxy] = attrs.field(default=None, repr=True)
+    icon: EmbedResourceWithProxy | None = attrs.field(default=None, repr=True)
     """The URL of the footer icon, or [`None`][] if not present."""
 
 
@@ -140,7 +140,7 @@ class EmbedFooter:
 class EmbedImage(EmbedResourceWithProxy):
     """Represents an embed image."""
 
-    height: typing.Optional[int] = attrs.field(default=None, repr=False)
+    height: int | None = attrs.field(default=None, repr=False)
     """The height of the image, if present and known, otherwise [`None`][].
 
     !!! note
@@ -149,7 +149,7 @@ class EmbedImage(EmbedResourceWithProxy):
         any received embed attached to a message event.
     """
 
-    width: typing.Optional[int] = attrs.field(default=None, repr=False)
+    width: int | None = attrs.field(default=None, repr=False)
     """The width of the image, if present and known, otherwise [`None`][].
 
     !!! note
@@ -172,10 +172,10 @@ class EmbedVideo(EmbedResourceWithProxy):
         class yourself.**
     """
 
-    height: typing.Optional[int] = attrs.field(default=None, repr=False)
+    height: int | None = attrs.field(default=None, repr=False)
     """The height of the video."""
 
-    width: typing.Optional[int] = attrs.field(default=None, repr=False)
+    width: int | None = attrs.field(default=None, repr=False)
     """The width of the video."""
 
 
@@ -194,10 +194,10 @@ class EmbedProvider:
         class yourself.**
     """
 
-    name: typing.Optional[str] = attrs.field(default=None, repr=True)
+    name: str | None = attrs.field(default=None, repr=True)
     """The name of the provider."""
 
-    url: typing.Optional[str] = attrs.field(default=None, repr=True)
+    url: str | None = attrs.field(default=None, repr=True)
     """The URL of the provider."""
 
 
@@ -206,16 +206,16 @@ class EmbedProvider:
 class EmbedAuthor:
     """Represents an author of an embed."""
 
-    name: typing.Optional[str] = attrs.field(default=None, repr=True)
+    name: str | None = attrs.field(default=None, repr=True)
     """The name of the author, or [`None`][] if not specified."""
 
-    url: typing.Optional[str] = attrs.field(default=None, repr=True)
+    url: str | None = attrs.field(default=None, repr=True)
     """The URL that the author's name should act as a hyperlink to.
 
     This may be [`None`][] if no hyperlink on the author's name is specified.
     """
 
-    icon: typing.Optional[EmbedResourceWithProxy] = attrs.field(default=None, repr=False)
+    icon: EmbedResourceWithProxy | None = attrs.field(default=None, repr=False)
     """The author's icon, or [`None`][] if not present."""
 
 
@@ -276,18 +276,18 @@ class Embed:
     def from_received_embed(
         cls,
         *,
-        title: typing.Optional[str],
-        description: typing.Optional[str],
-        url: typing.Optional[str],
-        color: typing.Optional[colors.Color],
-        timestamp: typing.Optional[datetime.datetime],
-        image: typing.Optional[EmbedImage],
-        thumbnail: typing.Optional[EmbedImage],
-        video: typing.Optional[EmbedVideo],
-        author: typing.Optional[EmbedAuthor],
-        provider: typing.Optional[EmbedProvider],
-        footer: typing.Optional[EmbedFooter],
-        fields: typing.Optional[typing.MutableSequence[EmbedField]],
+        title: str | None,
+        description: str | None,
+        url: str | None,
+        color: colors.Color | None,
+        timestamp: datetime.datetime | None,
+        image: EmbedImage | None,
+        thumbnail: EmbedImage | None,
+        video: EmbedVideo | None,
+        author: EmbedAuthor | None,
+        provider: EmbedProvider | None,
+        footer: EmbedFooter | None,
+        fields: typing.MutableSequence[EmbedField] | None,
     ) -> Embed:
         """Generate an embed from the given attributes.
 
@@ -314,12 +314,12 @@ class Embed:
     def __init__(
         self,
         *,
-        title: typing.Optional[str] = None,
-        description: typing.Optional[str] = None,
-        url: typing.Optional[str] = None,
-        color: typing.Optional[colors.Colorish] = None,
-        colour: typing.Optional[colors.Colorish] = None,
-        timestamp: typing.Optional[datetime.datetime] = None,
+        title: str | None = None,
+        description: str | None = None,
+        url: str | None = None,
+        color: colors.Colorish | None = None,
+        colour: colors.Colorish | None = None,
+        timestamp: datetime.datetime | None = None,
     ) -> None:
         if color is not None and colour is not None:
             msg = "Please provide one of color or colour to Embed(). Do not pass both."
@@ -339,19 +339,19 @@ class Embed:
         self._title = title
         self._description = description
         self._url = url
-        self._author: typing.Optional[EmbedAuthor] = None
-        self._image: typing.Optional[EmbedImage] = None
-        self._video: typing.Optional[EmbedVideo] = None
-        self._provider: typing.Optional[EmbedProvider] = None
-        self._thumbnail: typing.Optional[EmbedImage] = None
-        self._footer: typing.Optional[EmbedFooter] = None
+        self._author: EmbedAuthor | None = None
+        self._image: EmbedImage | None = None
+        self._video: EmbedVideo | None = None
+        self._provider: EmbedProvider | None = None
+        self._thumbnail: EmbedImage | None = None
+        self._footer: EmbedFooter | None = None
 
         # More boilerplate to allow this to be optional, but saves a useless list on every embed
         # when we don't always need it.
-        self._fields: typing.Optional[typing.MutableSequence[EmbedField]] = None
+        self._fields: typing.MutableSequence[EmbedField] | None = None
 
     @property
-    def title(self) -> typing.Optional[str]:
+    def title(self) -> str | None:
         """Return the title of the embed.
 
         This will be [`None`][] if not set.
@@ -359,11 +359,11 @@ class Embed:
         return self._title
 
     @title.setter
-    def title(self, value: typing.Optional[str]) -> None:
+    def title(self, value: str | None) -> None:
         self._title = value
 
     @property
-    def description(self) -> typing.Optional[str]:
+    def description(self) -> str | None:
         """Return the description of the embed.
 
         This will be [`None`][] if not set.
@@ -371,11 +371,11 @@ class Embed:
         return self._description
 
     @description.setter
-    def description(self, value: typing.Optional[str]) -> None:
+    def description(self, value: str | None) -> None:
         self._description = value
 
     @property
-    def url(self) -> typing.Optional[str]:
+    def url(self) -> str | None:
         """Return the URL of the embed title.
 
         This will be [`None`][] if not set.
@@ -383,11 +383,11 @@ class Embed:
         return self._url
 
     @url.setter
-    def url(self, value: typing.Optional[str]) -> None:
+    def url(self, value: str | None) -> None:
         self._url = value
 
     @property
-    def color(self) -> typing.Optional[colors.Color]:
+    def color(self) -> colors.Color | None:
         """Return the colour of the embed.
 
         This will be [`None`][] if not set.
@@ -397,12 +397,12 @@ class Embed:
     # As a note, MYPY currently complains about setting embed.color to a Colourish value which isn't explicitly Color.
     # see https://github.com/python/mypy/issues/3004
     @color.setter
-    def color(self, value: typing.Optional[colors.Colorish]) -> None:
+    def color(self, value: colors.Colorish | None) -> None:
         self._color = colors.Color.of(value) if value is not None else None
 
     # Alias.
     @property
-    def colour(self) -> typing.Optional[colors.Color]:
+    def colour(self) -> colors.Color | None:
         """Alias of [`hikari.colors.Color`][]."""
         return self._color
 
@@ -410,11 +410,11 @@ class Embed:
     # As a note, MYPY currently complains about setting embed.color to a Colourish value which isn't explicitly Color.
     # see https://github.com/python/mypy/issues/3004
     @colour.setter
-    def colour(self, value: typing.Optional[colors.Colorish]) -> None:
+    def colour(self, value: colors.Colorish | None) -> None:
         self._color = colors.Color.of(value) if value is not None else None
 
     @property
-    def timestamp(self) -> typing.Optional[datetime.datetime]:
+    def timestamp(self) -> datetime.datetime | None:
         """Return the timestamp of the embed.
 
         This will be [`None`][] if not set.
@@ -499,7 +499,7 @@ class Embed:
         return self._timestamp
 
     @timestamp.setter
-    def timestamp(self, value: typing.Optional[datetime.datetime]) -> None:
+    def timestamp(self, value: datetime.datetime | None) -> None:
         if value is not None and value.tzinfo is None:
             self.__warn_naive_datetime()
             value = value.astimezone()
@@ -536,7 +536,7 @@ class Embed:
         warnings.warn(message, category=errors.HikariWarning, stacklevel=3)
 
     @property
-    def footer(self) -> typing.Optional[EmbedFooter]:
+    def footer(self) -> EmbedFooter | None:
         """Return the footer of the embed.
 
         Will be [`None`][] if not set.
@@ -544,7 +544,7 @@ class Embed:
         return self._footer
 
     @property
-    def image(self) -> typing.Optional[EmbedImage]:
+    def image(self) -> EmbedImage | None:
         """Return the image set in the embed.
 
         Will be [`None`][] if not set.
@@ -555,7 +555,7 @@ class Embed:
         return self._image
 
     @property
-    def thumbnail(self) -> typing.Optional[EmbedImage]:
+    def thumbnail(self) -> EmbedImage | None:
         """Return the thumbnail set in the embed.
 
         Will be [`None`][] if not set.
@@ -566,7 +566,7 @@ class Embed:
         return self._thumbnail
 
     @property
-    def video(self) -> typing.Optional[EmbedVideo]:
+    def video(self) -> EmbedVideo | None:
         """Return the video to show in the embed.
 
         Will be [`None`][] if not set.
@@ -580,7 +580,7 @@ class Embed:
         return self._video
 
     @property
-    def provider(self) -> typing.Optional[EmbedProvider]:
+    def provider(self) -> EmbedProvider | None:
         """Return the provider to show in the embed.
 
         Will be [`None`][] if not set.
@@ -594,7 +594,7 @@ class Embed:
         return self._provider
 
     @property
-    def author(self) -> typing.Optional[EmbedAuthor]:
+    def author(self) -> EmbedAuthor | None:
         """Return the author to show in the embed.
 
         Will be [`None`][] if not set.
@@ -615,11 +615,7 @@ class Embed:
         return self._fields if self._fields else []
 
     def set_author(
-        self,
-        *,
-        name: typing.Optional[str] = None,
-        url: typing.Optional[str] = None,
-        icon: typing.Optional[files.Resourceish] = None,
+        self, *, name: str | None = None, url: str | None = None, icon: files.Resourceish | None = None
     ) -> Embed:
         """Set the author of this embed.
 
@@ -664,7 +660,7 @@ class Embed:
             self._author = EmbedAuthor(name=name, url=url, icon=real_icon)
         return self
 
-    def set_footer(self, text: typing.Optional[str], *, icon: typing.Optional[files.Resourceish] = None) -> Embed:
+    def set_footer(self, text: str | None, *, icon: files.Resourceish | None = None) -> Embed:
         """Set the footer of this embed.
 
         Parameters
@@ -714,7 +710,7 @@ class Embed:
             self._footer = EmbedFooter(icon=real_icon, text=text)
         return self
 
-    def set_image(self, image: typing.Optional[files.Resourceish] = None, /) -> Embed:
+    def set_image(self, image: files.Resourceish | None = None, /) -> Embed:
         """Set the image on this embed.
 
         Parameters
@@ -754,7 +750,7 @@ class Embed:
 
         return self
 
-    def set_thumbnail(self, image: typing.Optional[files.Resourceish] = None, /) -> Embed:
+    def set_thumbnail(self, image: files.Resourceish | None = None, /) -> Embed:
         """Set the image on this embed.
 
         Parameters

--- a/hikari/emojis.py
+++ b/hikari/emojis.py
@@ -78,7 +78,7 @@ class Emoji(files.WebResource, abc.ABC):
         """Mention string to use to mention the emoji with."""
 
     @classmethod
-    def parse(cls, string: str, /) -> typing.Union[UnicodeEmoji, CustomEmoji]:
+    def parse(cls, string: str, /) -> UnicodeEmoji | CustomEmoji:
         """Parse a given string into an emoji object.
 
         Parameters
@@ -345,7 +345,7 @@ class KnownCustomEmoji(CustomEmoji):
     )
     """Client application that models may use for procedures."""
 
-    guild_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    guild_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """The ID of the guild this emoji belongs to, if applicable.
 
     This will be [`None`][] if the emoji is an application emoji.
@@ -357,7 +357,7 @@ class KnownCustomEmoji(CustomEmoji):
     If this is empty then any user can use this emoji regardless of their roles.
     """
 
-    user: typing.Optional[users.User] = attrs.field(eq=False, hash=False, repr=False)
+    user: users.User | None = attrs.field(eq=False, hash=False, repr=False)
     """The user that created the emoji.
 
     !!! note

--- a/hikari/errors.py
+++ b/hikari/errors.py
@@ -202,7 +202,7 @@ class GatewayConnectionError(GatewayError):
 class GatewayServerClosedConnectionError(GatewayError):
     """An exception raised when the server closes the connection."""
 
-    code: typing.Union[ShardCloseCode, int, None] = attrs.field(default=None)
+    code: ShardCloseCode | int | None = attrs.field(default=None)
     """Return the close code that was received, if there is one."""
 
     can_reconnect: bool = attrs.field(default=False)
@@ -234,7 +234,7 @@ class HTTPResponseError(HTTPError):
     url: str = attrs.field()
     """The URL that produced this error message."""
 
-    status: typing.Union[http.HTTPStatus, int] = attrs.field()
+    status: http.HTTPStatus | int = attrs.field()
     """The HTTP status code for the response.
 
     This will be [`int`][] if it's outside the range of status codes in the HTTP
@@ -312,7 +312,7 @@ class BadRequestError(ClientHTTPResponseError):
     status: http.HTTPStatus = attrs.field(default=http.HTTPStatus.BAD_REQUEST, init=False)
     """The HTTP status code for the response."""
 
-    errors: typing.Optional[typing.Mapping[str, data_binding.JSONObject]] = attrs.field(default=None, kw_only=True)
+    errors: typing.Mapping[str, data_binding.JSONObject] | None = attrs.field(default=None, kw_only=True)
     """Dict of top level field names to field specific error paths.
 
     For more information, this error format is loosely defined at
@@ -398,10 +398,10 @@ class RateLimitTooLongError(HTTPError):
     reset_at: float = attrs.field()
     """UNIX timestamp of when this limit will be lifted."""
 
-    limit: typing.Optional[int] = attrs.field()
+    limit: int | None = attrs.field()
     """The maximum number of calls per window for this rate limit, if known."""
 
-    period: typing.Optional[float] = attrs.field()
+    period: float | None = attrs.field()
     """How long the rate limit window lasts for from start to end, if known."""
 
     message: str = attrs.field(init=False)

--- a/hikari/events/base_events.py
+++ b/hikari/events/base_events.py
@@ -170,7 +170,7 @@ def no_recursive_throw() -> typing.Callable[[_T], _T]:
     return decorator
 
 
-def is_no_recursive_throw_event(obj: typing.Union[_T, type[_T]]) -> bool:
+def is_no_recursive_throw_event(obj: _T | type[_T]) -> bool:
     """Whether the event is marked as `___norecursivethrow___`."""
     result = getattr(obj, NO_RECURSIVE_THROW_attrs, False)
     assert isinstance(result, bool)
@@ -211,7 +211,7 @@ class ExceptionEvent(Event, typing.Generic[EventT]):
         return self.failed_event.app
 
     @property
-    def shard(self) -> typing.Optional[gateway_shard.GatewayShard]:
+    def shard(self) -> gateway_shard.GatewayShard | None:
         """Shard that received the event, if there was one associated.
 
         This may be [`None`][] if no specific shard was the cause of this
@@ -223,7 +223,7 @@ class ExceptionEvent(Event, typing.Generic[EventT]):
         return None
 
     @property
-    def exc_info(self) -> tuple[type[Exception], Exception, typing.Optional[types.TracebackType]]:
+    def exc_info(self) -> tuple[type[Exception], Exception, types.TracebackType | None]:
         """Exception triplet that follows the same format as [`sys.exc_info`][].
 
         The [`sys.exc_info`][] triplet consists of the exception type, the exception

--- a/hikari/events/channel_events.py
+++ b/hikari/events/channel_events.py
@@ -125,7 +125,7 @@ class GuildChannelEvent(ChannelEvent, abc.ABC):
     def guild_id(self) -> snowflakes.Snowflake:
         """ID of the guild that this event relates to."""
 
-    def get_guild(self) -> typing.Optional[guilds.GatewayGuild]:
+    def get_guild(self) -> guilds.GatewayGuild | None:
         """Get the cached guild that this event relates to, if known.
 
         If not, return [`None`][].
@@ -165,7 +165,7 @@ class GuildChannelEvent(ChannelEvent, abc.ABC):
         """
         return await self.app.rest.fetch_guild(self.guild_id)
 
-    def get_channel(self) -> typing.Optional[channels.PermissibleGuildChannel]:
+    def get_channel(self) -> channels.PermissibleGuildChannel | None:
         """Get the cached channel that this event relates to, if known.
 
         If not, return [`None`][].
@@ -294,7 +294,7 @@ class GuildChannelUpdateEvent(GuildChannelEvent):
     shard: gateway_shard.GatewayShard = attrs.field(metadata={attrs_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>.
 
-    old_channel: typing.Optional[channels.PermissibleGuildChannel] = attrs.field(repr=True)
+    old_channel: channels.PermissibleGuildChannel | None = attrs.field(repr=True)
     """The old guild channel object.
 
     This will be [`None`][] if the channel missing from the cache.
@@ -366,7 +366,7 @@ class PinsUpdateEvent(ChannelEvent, abc.ABC):
 
     @property
     @abc.abstractmethod
-    def last_pin_timestamp(self) -> typing.Optional[datetime.datetime]:
+    def last_pin_timestamp(self) -> datetime.datetime | None:
         """Datetime of when the most recent message was pinned in the channel.
 
         Will be [`None`][] if nothing is pinned or the information is
@@ -415,11 +415,11 @@ class GuildPinsUpdateEvent(PinsUpdateEvent, GuildChannelEvent):
     guild_id: snowflakes.Snowflake = attrs.field()
     # <<inherited docstring from GuildChannelEvent>>.
 
-    last_pin_timestamp: typing.Optional[datetime.datetime] = attrs.field(repr=True)
+    last_pin_timestamp: datetime.datetime | None = attrs.field(repr=True)
     # <<inherited docstring from ChannelPinsUpdateEvent>>.
 
     @typing_extensions.override
-    def get_channel(self) -> typing.Optional[channels.PermissibleGuildChannel]:
+    def get_channel(self) -> channels.PermissibleGuildChannel | None:
         """Get the cached channel that this event relates to, if known.
 
         If not, return [`None`][].
@@ -479,7 +479,7 @@ class DMPinsUpdateEvent(PinsUpdateEvent, DMChannelEvent):
     channel_id: snowflakes.Snowflake = attrs.field()
     # <<inherited docstring from ChannelEvent>>.
 
-    last_pin_timestamp: typing.Optional[datetime.datetime] = attrs.field(repr=True)
+    last_pin_timestamp: datetime.datetime | None = attrs.field(repr=True)
     # <<inherited docstring from ChannelPinsUpdateEvent>>.
 
     @typing_extensions.override
@@ -602,7 +602,7 @@ class InviteDeleteEvent(InviteEvent):
     code: str = attrs.field()
     # <<inherited docstring from InviteEvent>>.
 
-    old_invite: typing.Optional[invites.InviteWithMetadata] = attrs.field()
+    old_invite: invites.InviteWithMetadata | None = attrs.field()
     """Object of the old cached invite.
 
     This will be [`None`][] if the invite is missing from the cache.
@@ -917,7 +917,7 @@ class ThreadListSyncEvent(shard_events.ShardEvent):
     guild_id: snowflakes.Snowflake = attrs.field()
     # <<inherited docstring from GuildThreadEvent>>.
 
-    channel_ids: typing.Optional[typing.Sequence[snowflakes.Snowflake]] = attrs.field()
+    channel_ids: typing.Sequence[snowflakes.Snowflake] | None = attrs.field()
     """IDs of the text channels threads are being synced for.
 
     If this is [`None`][] then threads are being synced for all text

--- a/hikari/events/guild_events.py
+++ b/hikari/events/guild_events.py
@@ -104,7 +104,7 @@ class GuildEvent(shard_events.ShardEvent, abc.ABC):
         """
         return await self.app.rest.fetch_guild_preview(self.guild_id)
 
-    def get_guild(self) -> typing.Optional[guilds.GatewayGuild]:
+    def get_guild(self) -> guilds.GatewayGuild | None:
         """Get the cached guild that this event relates to, if known.
 
         If not known, this will return [`None`][] instead.
@@ -177,7 +177,7 @@ class GuildAvailableEvent(GuildVisibilityEvent):
     voice_states: typing.Mapping[snowflakes.Snowflake, voices.VoiceState] = attrs.field(repr=False)
     """Mapping of user IDs to the voice states active in this guild."""
 
-    chunk_nonce: typing.Optional[str] = attrs.field(repr=False, default=None)
+    chunk_nonce: str | None = attrs.field(repr=False, default=None)
     """Nonce used to request the member chunks for this guild.
 
     This will be [`None`][] if no chunks were requested.
@@ -241,7 +241,7 @@ class GuildJoinEvent(GuildVisibilityEvent):
     voice_states: typing.Mapping[snowflakes.Snowflake, voices.VoiceState] = attrs.field(repr=False)
     """Mapping of user IDs to the voice states active in this guild."""
 
-    chunk_nonce: typing.Optional[str] = attrs.field(repr=False, default=None)
+    chunk_nonce: str | None = attrs.field(repr=False, default=None)
     """Nonce used to request the member chunks for this guild.
 
     This will be [`None`][] if no chunks were requested.
@@ -281,7 +281,7 @@ class GuildLeaveEvent(GuildVisibilityEvent):
     guild_id: snowflakes.Snowflake = attrs.field()
     # <<inherited docstring from GuildEvent>>.
 
-    old_guild: typing.Optional[guilds.GatewayGuild] = attrs.field()
+    old_guild: guilds.GatewayGuild | None = attrs.field()
     """The old guild object.
 
     This will be [`None`][] if the guild missing from the cache.
@@ -318,7 +318,7 @@ class GuildUpdateEvent(GuildEvent):
     shard: gateway_shard.GatewayShard = attrs.field(metadata={attrs_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>.
 
-    old_guild: typing.Optional[guilds.GatewayGuild] = attrs.field()
+    old_guild: guilds.GatewayGuild | None = attrs.field()
     """The old guild object.
 
     This will be [`None`][] if the guild missing from the cache.
@@ -442,7 +442,7 @@ class EmojisUpdateEvent(GuildEvent):
     guild_id: snowflakes.Snowflake = attrs.field()
     # <<inherited docstring from GuildEvent>>.
 
-    old_emojis: typing.Optional[typing.Sequence[emojis_.KnownCustomEmoji]] = attrs.field()
+    old_emojis: typing.Sequence[emojis_.KnownCustomEmoji] | None = attrs.field()
     """Sequence of all old emojis in this guild.
 
     This will be [`None`][] if it's missing from the cache.
@@ -477,7 +477,7 @@ class StickersUpdateEvent(GuildEvent):
     guild_id: snowflakes.Snowflake = attrs.field()
     # <<inherited docstring from GuildEvent>>.
 
-    old_stickers: typing.Optional[typing.Sequence[stickers_.GuildSticker]] = attrs.field()
+    old_stickers: typing.Sequence[stickers_.GuildSticker] | None = attrs.field()
     """Sequence of all old stickers in this guild.
 
     This will be [`None`][] if it's missing from the cache.
@@ -505,7 +505,7 @@ class IntegrationEvent(GuildEvent, abc.ABC):
 
     @property
     @abc.abstractmethod
-    def application_id(self) -> typing.Optional[snowflakes.Snowflake]:
+    def application_id(self) -> snowflakes.Snowflake | None:
         """ID of Discord bot application this integration is connected to."""
 
     @property
@@ -549,7 +549,7 @@ class IntegrationCreateEvent(IntegrationEvent):
 
     @property
     @typing_extensions.override
-    def application_id(self) -> typing.Optional[snowflakes.Snowflake]:
+    def application_id(self) -> snowflakes.Snowflake | None:
         # <<inherited docstring from IntegrationEvent>>.
         return self.integration.application.id if self.integration.application else None
 
@@ -578,7 +578,7 @@ class IntegrationDeleteEvent(IntegrationEvent):
     shard: gateway_shard.GatewayShard = attrs.field(metadata={attrs_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>.
 
-    application_id: typing.Optional[snowflakes.Snowflake] = attrs.field()
+    application_id: snowflakes.Snowflake | None = attrs.field()
     # <<inherited docstring from IntegrationEvent>>.
 
     guild_id: snowflakes.Snowflake = attrs.field()
@@ -605,7 +605,7 @@ class IntegrationUpdateEvent(IntegrationEvent):
 
     @property
     @typing_extensions.override
-    def application_id(self) -> typing.Optional[snowflakes.Snowflake]:
+    def application_id(self) -> snowflakes.Snowflake | None:
         # <<inherited docstring from IntegrationEvent>>.
         return self.integration.application.id if self.integration.application else None
 
@@ -642,7 +642,7 @@ class PresenceUpdateEvent(shard_events.ShardEvent):
     shard: gateway_shard.GatewayShard = attrs.field(metadata={attrs_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>.
 
-    old_presence: typing.Optional[presences_.MemberPresence] = attrs.field()
+    old_presence: presences_.MemberPresence | None = attrs.field()
     """The old member presence object.
 
     This will be [`None`][] if the member presence missing from the cache.
@@ -651,7 +651,7 @@ class PresenceUpdateEvent(shard_events.ShardEvent):
     presence: presences_.MemberPresence = attrs.field()
     """Member presence."""
 
-    user: typing.Optional[users.PartialUser] = attrs.field()
+    user: users.PartialUser | None = attrs.field()
     """User that was updated.
 
     This is a partial user object that only contains the fields that were
@@ -678,7 +678,7 @@ class PresenceUpdateEvent(shard_events.ShardEvent):
         """Guild ID that the presence was updated in."""
         return self.presence.guild_id
 
-    def get_user(self) -> typing.Optional[users.User]:
+    def get_user(self) -> users.User | None:
         """Get the full cached user, if it is available.
 
         Returns

--- a/hikari/events/member_events.py
+++ b/hikari/events/member_events.py
@@ -70,7 +70,7 @@ class MemberEvent(shard_events.ShardEvent, abc.ABC):
         """ID of the user that this event concerns."""
         return self.user.id
 
-    def get_guild(self) -> typing.Optional[guilds.GatewayGuild]:
+    def get_guild(self) -> guilds.GatewayGuild | None:
         """Get the cached view of the guild this member event occurred in.
 
         If the guild itself is not cached, this will return [`None`][].
@@ -124,7 +124,7 @@ class MemberUpdateEvent(MemberEvent):
     shard: gateway_shard.GatewayShard = attrs.field(metadata={attrs_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>.
 
-    old_member: typing.Optional[guilds.Member] = attrs.field()
+    old_member: guilds.Member | None = attrs.field()
     """The old member object.
 
     This will be [`None`][] if the member missing from the cache.
@@ -161,7 +161,7 @@ class MemberDeleteEvent(MemberEvent):
     user: users.User = attrs.field()
     # <<inherited docstring from MemberEvent>>.
 
-    old_member: typing.Optional[guilds.Member] = attrs.field()
+    old_member: guilds.Member | None = attrs.field()
     """The old member object.
 
     This will be [`None`][] if the member was missing from the cache.

--- a/hikari/events/message_events.py
+++ b/hikari/events/message_events.py
@@ -105,7 +105,7 @@ class MessageCreateEvent(MessageEvent, abc.ABC):
         return self.message.channel_id
 
     @property
-    def content(self) -> typing.Optional[str]:
+    def content(self) -> str | None:
         """Content of the message.
 
         The content of the message, if present. This will be [`None`][]
@@ -170,7 +170,7 @@ class GuildMessageCreateEvent(MessageCreateEvent):
         return self.message.author
 
     @property
-    def member(self) -> typing.Optional[guilds.Member]:
+    def member(self) -> guilds.Member | None:
         """Member object of the user that sent the message."""
         return self.message.member
 
@@ -182,7 +182,7 @@ class GuildMessageCreateEvent(MessageCreateEvent):
         assert isinstance(guild_id, snowflakes.Snowflake), "no guild_id attribute set"
         return guild_id
 
-    def get_channel(self) -> typing.Optional[channels.TextableGuildChannel]:
+    def get_channel(self) -> channels.TextableGuildChannel | None:
         """Channel that the message was sent in, if known.
 
         Returns
@@ -200,7 +200,7 @@ class GuildMessageCreateEvent(MessageCreateEvent):
         )
         return channel
 
-    def get_guild(self) -> typing.Optional[guilds.GatewayGuild]:
+    def get_guild(self) -> guilds.GatewayGuild | None:
         """Get the cached guild that this event occurred in, if known.
 
         !!! note
@@ -218,7 +218,7 @@ class GuildMessageCreateEvent(MessageCreateEvent):
 
         return self.app.cache.get_guild(self.guild_id)
 
-    def get_member(self) -> typing.Optional[guilds.Member]:
+    def get_member(self) -> guilds.Member | None:
         """Get the member that sent this message from the cache if available.
 
         Returns
@@ -379,7 +379,7 @@ class GuildMessageUpdateEvent(MessageUpdateEvent):
         due to Discord limitations.
     """
 
-    old_message: typing.Optional[messages.PartialMessage] = attrs.field()
+    old_message: messages.PartialMessage | None = attrs.field()
     """The old message object.
 
     This will be [`None`][] if the message missing from the cache.
@@ -402,7 +402,7 @@ class GuildMessageUpdateEvent(MessageUpdateEvent):
         """
         return self.message.member
 
-    def get_member(self) -> typing.Optional[guilds.Member]:
+    def get_member(self) -> guilds.Member | None:
         """Get the member that sent this message from the cache if available.
 
         Returns
@@ -423,7 +423,7 @@ class GuildMessageUpdateEvent(MessageUpdateEvent):
         assert isinstance(guild_id, snowflakes.Snowflake), f"expected guild_id, got {guild_id}"
         return guild_id
 
-    def get_channel(self) -> typing.Optional[channels.TextableGuildChannel]:
+    def get_channel(self) -> channels.TextableGuildChannel | None:
         """Channel that the message was sent in, if known.
 
         Returns
@@ -441,7 +441,7 @@ class GuildMessageUpdateEvent(MessageUpdateEvent):
         )
         return channel
 
-    def get_guild(self) -> typing.Optional[guilds.GatewayGuild]:
+    def get_guild(self) -> guilds.GatewayGuild | None:
         """Get the cached guild that this event occurred in, if known.
 
         !!! note
@@ -471,7 +471,7 @@ class DMMessageUpdateEvent(MessageUpdateEvent):
         due to Discord limitations.
     """
 
-    old_message: typing.Optional[messages.PartialMessage] = attrs.field()
+    old_message: messages.PartialMessage | None = attrs.field()
     """The old message object.
 
     This will be [`None`][] if the message missing from the cache.
@@ -503,7 +503,7 @@ class MessageDeleteEvent(MessageEvent, abc.ABC):
 
     @property
     @abc.abstractmethod
-    def old_message(self) -> typing.Optional[messages.Message]:
+    def old_message(self) -> messages.Message | None:
         """Object of the message that was deleted.
 
         Will be [`None`][] if the message was not found in the cache.
@@ -533,13 +533,13 @@ class GuildMessageDeleteEvent(MessageDeleteEvent):
     message_id: snowflakes.Snowflake = attrs.field()
     # <<inherited docstring from MessageDeleteEvent>>
 
-    old_message: typing.Optional[messages.Message] = attrs.field()
+    old_message: messages.Message | None = attrs.field()
     # <<inherited docstring from MessageDeleteEvent>>
 
     shard: shard_.GatewayShard = attrs.field(metadata={attrs_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>
 
-    def get_channel(self) -> typing.Optional[channels.TextableGuildChannel]:
+    def get_channel(self) -> channels.TextableGuildChannel | None:
         """Get the cached channel the message were sent in, if known.
 
         Returns
@@ -557,7 +557,7 @@ class GuildMessageDeleteEvent(MessageDeleteEvent):
         )
         return channel
 
-    def get_guild(self) -> typing.Optional[guilds.GatewayGuild]:
+    def get_guild(self) -> guilds.GatewayGuild | None:
         """Get the cached guild this event corresponds to, if known.
 
         !!! note
@@ -596,7 +596,7 @@ class DMMessageDeleteEvent(MessageDeleteEvent):
     message_id: snowflakes.Snowflake = attrs.field()
     # <<inherited docstring from MessageDeleteEvent>>
 
-    old_message: typing.Optional[messages.Message] = attrs.field()
+    old_message: messages.Message | None = attrs.field()
     # <<inherited docstring from MessageDeleteEvent>>
 
     shard: shard_.GatewayShard = attrs.field(metadata={attrs_extensions.SKIP_DEEP_COPY: True})
@@ -635,7 +635,7 @@ class GuildBulkMessageDeleteEvent(shard_events.ShardEvent):
     shard: shard_.GatewayShard = attrs.field(metadata={attrs_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>
 
-    def get_channel(self) -> typing.Optional[channels.TextableGuildChannel]:
+    def get_channel(self) -> channels.TextableGuildChannel | None:
         """Get the cached channel the messages were sent in, if known.
 
         Returns
@@ -653,7 +653,7 @@ class GuildBulkMessageDeleteEvent(shard_events.ShardEvent):
         )
         return channel
 
-    def get_guild(self) -> typing.Optional[guilds.GatewayGuild]:
+    def get_guild(self) -> guilds.GatewayGuild | None:
         """Get the cached guild this event corresponds to, if known.
 
         !!! note

--- a/hikari/events/poll_events.py
+++ b/hikari/events/poll_events.py
@@ -57,7 +57,7 @@ class BasePollVoteEvent(shard_events.ShardEvent):
     message_id: snowflakes.Snowflake = attrs.field()
     """ID of the message that the poll is in."""
 
-    guild_id: typing.Optional[snowflakes.Snowflake] = attrs.field()
+    guild_id: snowflakes.Snowflake | None = attrs.field()
     """ID of the guild that the poll is in."""
 
     answer_id: int = attrs.field()

--- a/hikari/events/reaction_events.py
+++ b/hikari/events/reaction_events.py
@@ -108,7 +108,7 @@ class ReactionAddEvent(ReactionEvent, abc.ABC):
 
     @property
     @abc.abstractmethod
-    def emoji_name(self) -> typing.Union[emojis.UnicodeEmoji, str, None]:
+    def emoji_name(self) -> emojis.UnicodeEmoji | str | None:
         """Name of the emoji which was added if known.
 
         This can either be the string name of the custom emoji which was added,
@@ -119,7 +119,7 @@ class ReactionAddEvent(ReactionEvent, abc.ABC):
 
     @property
     @abc.abstractmethod
-    def emoji_id(self) -> typing.Optional[snowflakes.Snowflake]:
+    def emoji_id(self) -> snowflakes.Snowflake | None:
         """ID of the emoji which was added if it is custom, else [`None`][]."""
 
     @property
@@ -127,7 +127,7 @@ class ReactionAddEvent(ReactionEvent, abc.ABC):
     def is_animated(self) -> bool:
         """Whether the emoji which was added is animated."""
 
-    def is_for_emoji(self, emoji: typing.Union[emojis.Emoji, str], /) -> bool:
+    def is_for_emoji(self, emoji: emojis.Emoji | str, /) -> bool:
         """Get whether the reaction event is for a specific emoji.
 
         Parameters
@@ -158,7 +158,7 @@ class ReactionDeleteEvent(ReactionEvent, abc.ABC):
 
     @property
     @abc.abstractmethod
-    def emoji_name(self) -> typing.Union[emojis.UnicodeEmoji, str, None]:
+    def emoji_name(self) -> emojis.UnicodeEmoji | str | None:
         """Name of the emoji which was removed.
 
         Either the string name of the custom emoji which was removed, the object
@@ -169,10 +169,10 @@ class ReactionDeleteEvent(ReactionEvent, abc.ABC):
 
     @property
     @abc.abstractmethod
-    def emoji_id(self) -> typing.Optional[snowflakes.Snowflake]:
+    def emoji_id(self) -> snowflakes.Snowflake | None:
         """ID of the emoji which was added if it is custom, else [`None`][]."""
 
-    def is_for_emoji(self, emoji: typing.Union[emojis.Emoji, str], /) -> bool:
+    def is_for_emoji(self, emoji: emojis.Emoji | str, /) -> bool:
         """Get whether the reaction event is for a specific emoji.
 
         Parameters
@@ -205,7 +205,7 @@ class ReactionDeleteEmojiEvent(ReactionEvent, abc.ABC):
 
     @property
     @abc.abstractmethod
-    def emoji_name(self) -> typing.Union[emojis.UnicodeEmoji, str, None]:
+    def emoji_name(self) -> emojis.UnicodeEmoji | str | None:
         """Name of the emoji which was removed.
 
         Either the string name of the custom emoji which was removed, the object
@@ -216,10 +216,10 @@ class ReactionDeleteEmojiEvent(ReactionEvent, abc.ABC):
 
     @property
     @abc.abstractmethod
-    def emoji_id(self) -> typing.Optional[snowflakes.Snowflake]:
+    def emoji_id(self) -> snowflakes.Snowflake | None:
         """ID of the emoji which was added if it is custom, else [`None`][]."""
 
-    def is_for_emoji(self, emoji: typing.Union[emojis.Emoji, str], /) -> bool:
+    def is_for_emoji(self, emoji: emojis.Emoji | str, /) -> bool:
         """Get whether the reaction event is for a specific emoji.
 
         Parameters
@@ -255,10 +255,10 @@ class GuildReactionAddEvent(GuildReactionEvent, ReactionAddEvent):
     message_id: snowflakes.Snowflake = attrs.field()
     # <<inherited docstring from ReactionEvent>>.
 
-    emoji_name: typing.Union[str, emojis.UnicodeEmoji, None] = attrs.field()
+    emoji_name: str | emojis.UnicodeEmoji | None = attrs.field()
     # <<inherited docstring from ReactionAddEvent>>.
 
-    emoji_id: typing.Optional[snowflakes.Snowflake] = attrs.field()
+    emoji_id: snowflakes.Snowflake | None = attrs.field()
     # <<inherited docstring from ReactionAddEvent>>.
 
     is_animated: bool = attrs.field()
@@ -307,10 +307,10 @@ class GuildReactionDeleteEvent(GuildReactionEvent, ReactionDeleteEvent):
     message_id: snowflakes.Snowflake = attrs.field()
     # <<inherited docstring from ReactionEvent>>.
 
-    emoji_name: typing.Union[str, emojis.UnicodeEmoji, None] = attrs.field()
+    emoji_name: str | emojis.UnicodeEmoji | None = attrs.field()
     # <<inherited docstring from ReactionDeleteEvent>>.
 
-    emoji_id: typing.Optional[snowflakes.Snowflake] = attrs.field()
+    emoji_id: snowflakes.Snowflake | None = attrs.field()
     # <<inherited docstring from ReactionDeleteEvent>>.
 
 
@@ -335,10 +335,10 @@ class GuildReactionDeleteEmojiEvent(GuildReactionEvent, ReactionDeleteEmojiEvent
     message_id: snowflakes.Snowflake = attrs.field()
     # <<inherited docstring from ReactionEvent>>.
 
-    emoji_name: typing.Union[str, emojis.UnicodeEmoji, None] = attrs.field()
+    emoji_name: str | emojis.UnicodeEmoji | None = attrs.field()
     # <<inherited docstring from ReactionDeleteEmojiEvent>>.
 
-    emoji_id: typing.Optional[snowflakes.Snowflake] = attrs.field()
+    emoji_id: snowflakes.Snowflake | None = attrs.field()
     # <<inherited docstring from ReactionDeleteEmojiEvent>>.
 
 
@@ -385,10 +385,10 @@ class DMReactionAddEvent(DMReactionEvent, ReactionAddEvent):
     message_id: snowflakes.Snowflake = attrs.field()
     # <<inherited docstring from ReactionEvent>>.
 
-    emoji_name: typing.Union[str, emojis.UnicodeEmoji, None] = attrs.field()
+    emoji_name: str | emojis.UnicodeEmoji | None = attrs.field()
     # <<inherited docstring from ReactionAddEvent>>.
 
-    emoji_id: typing.Optional[snowflakes.Snowflake] = attrs.field()
+    emoji_id: snowflakes.Snowflake | None = attrs.field()
     # <<inherited docstring from ReactionAddEvent>>.
 
     is_animated: bool = attrs.field()
@@ -416,10 +416,10 @@ class DMReactionDeleteEvent(DMReactionEvent, ReactionDeleteEvent):
     message_id: snowflakes.Snowflake = attrs.field()
     # <<inherited docstring from ReactionEvent>>.
 
-    emoji_name: typing.Union[str, emojis.UnicodeEmoji, None] = attrs.field()
+    emoji_name: str | emojis.UnicodeEmoji | None = attrs.field()
     # <<inherited docstring from ReactionDeleteEvent>>.
 
-    emoji_id: typing.Optional[snowflakes.Snowflake] = attrs.field()
+    emoji_id: snowflakes.Snowflake | None = attrs.field()
     # <<inherited docstring from ReactionDeleteEvent>>.
 
 
@@ -441,10 +441,10 @@ class DMReactionDeleteEmojiEvent(DMReactionEvent, ReactionDeleteEmojiEvent):
     message_id: snowflakes.Snowflake = attrs.field()
     # <<inherited docstring from ReactionEvent>>.
 
-    emoji_name: typing.Union[str, emojis.UnicodeEmoji, None] = attrs.field()
+    emoji_name: str | emojis.UnicodeEmoji | None = attrs.field()
     # <<inherited docstring from ReactionDeleteEmojiEvent>>.
 
-    emoji_id: typing.Optional[snowflakes.Snowflake] = attrs.field()
+    emoji_id: snowflakes.Snowflake | None = attrs.field()
     # <<inherited docstring from ReactionDeleteEmojiEvent>>.
 
 

--- a/hikari/events/role_events.py
+++ b/hikari/events/role_events.py
@@ -99,7 +99,7 @@ class RoleUpdateEvent(RoleEvent):
     shard: gateway_shard.GatewayShard = attrs.field(metadata={attrs_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>.
 
-    old_role: typing.Optional[guilds.Role] = attrs.field()
+    old_role: guilds.Role | None = attrs.field()
     """The old role object.
 
     This will be [`None`][] if the role missing from the cache.
@@ -145,7 +145,7 @@ class RoleDeleteEvent(RoleEvent):
     role_id: snowflakes.Snowflake = attrs.field()
     # <<inherited docstring from RoleEvent>>.
 
-    old_role: typing.Optional[guilds.Role] = attrs.field()
+    old_role: guilds.Role | None = attrs.field()
     """The old role object.
 
     This will be [`None`][] if the role was missing from the cache.

--- a/hikari/events/shard_events.py
+++ b/hikari/events/shard_events.py
@@ -210,7 +210,7 @@ class MemberChunkEvent(ShardEvent, typing.Sequence["guilds.Member"]):
     not passed as [`True`][] while requesting the member chunks.
     """
 
-    nonce: typing.Optional[str] = attrs.field(repr=True)
+    nonce: str | None = attrs.field(repr=True)
     """String nonce used to identify the request member chunks are associated with.
 
     This is the nonce value passed while requesting member chunks or [`None`][]
@@ -224,9 +224,7 @@ class MemberChunkEvent(ShardEvent, typing.Sequence["guilds.Member"]):
     def __getitem__(self, index_or_slice: slice, /) -> typing.Sequence[guilds.Member]: ...
 
     @typing_extensions.override
-    def __getitem__(
-        self, index_or_slice: typing.Union[int, slice], /
-    ) -> typing.Union[guilds.Member, typing.Sequence[guilds.Member]]:
+    def __getitem__(self, index_or_slice: int | slice, /) -> guilds.Member | typing.Sequence[guilds.Member]:
         return collections.get_index_or_slice(self.members, index_or_slice)
 
     @typing_extensions.override

--- a/hikari/events/typing_events.py
+++ b/hikari/events/typing_events.py
@@ -80,7 +80,7 @@ class TypingEvent(shard_events.ShardEvent, abc.ABC):
         assert isinstance(channel, channels.TextableChannel)
         return channel
 
-    def get_user(self) -> typing.Optional[users.User]:
+    def get_user(self) -> users.User | None:
         """Get the cached user that is typing, if known.
 
         Returns
@@ -205,7 +205,7 @@ class GuildTypingEvent(TypingEvent):
         """
         return await self.app.rest.fetch_member(self.guild_id, self.user_id)
 
-    def get_channel(self) -> typing.Optional[channels.TextableGuildChannel]:
+    def get_channel(self) -> channels.TextableGuildChannel | None:
         """Get the cached channel object this typing event occurred in.
 
         Returns
@@ -222,7 +222,7 @@ class GuildTypingEvent(TypingEvent):
         )
         return channel
 
-    def get_guild(self) -> typing.Optional[guilds.GatewayGuild]:
+    def get_guild(self) -> guilds.GatewayGuild | None:
         """Get the cached object of the guild this typing event occurred in.
 
         If the guild is not found then this will return [`None`][].

--- a/hikari/events/user_events.py
+++ b/hikari/events/user_events.py
@@ -46,7 +46,7 @@ class OwnUserUpdateEvent(shard_events.ShardEvent):
     shard: gateway_shard.GatewayShard = attrs.field(metadata={attrs_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring from ShardEvent>>.
 
-    old_user: typing.Optional[users.OwnUser] = attrs.field()
+    old_user: users.OwnUser | None = attrs.field()
     """The old application user.
 
     This will be [`None`][] if the user missing from the cache.

--- a/hikari/events/voice_events.py
+++ b/hikari/events/voice_events.py
@@ -68,7 +68,7 @@ class VoiceStateUpdateEvent(VoiceEvent):
     shard: gateway_shard.GatewayShard = attrs.field(metadata={attrs_extensions.SKIP_DEEP_COPY: True})
     # <<inherited docstring>>.
 
-    old_state: typing.Optional[voices.VoiceState] = attrs.field(repr=True)
+    old_state: voices.VoiceState | None = attrs.field(repr=True)
     """The old voice state.
 
     This will be [`None`][] if the voice state missing from the cache.
@@ -111,7 +111,7 @@ class VoiceServerUpdateEvent(VoiceEvent):
     token: str = attrs.field(repr=False)
     """Token that should be used to authenticate with the voice gateway."""
 
-    raw_endpoint: typing.Optional[str] = attrs.field(repr=True)
+    raw_endpoint: str | None = attrs.field(repr=True)
     """Raw endpoint URI that Discord sent.
 
     If this is [`None`][], it means that the server has been deallocated
@@ -125,7 +125,7 @@ class VoiceServerUpdateEvent(VoiceEvent):
     """
 
     @property
-    def endpoint(self) -> typing.Optional[str]:
+    def endpoint(self) -> str | None:
         """URI for this voice server host, with the correct scheme prepended.
 
         If this is [`None`][], it means that the server has been deallocated

--- a/hikari/guilds.py
+++ b/hikari/guilds.py
@@ -296,13 +296,13 @@ class GuildWidget:
     )
     """Client application that models may use for procedures."""
 
-    channel_id: typing.Optional[snowflakes.Snowflake] = attrs.field(repr=True)
+    channel_id: snowflakes.Snowflake | None = attrs.field(repr=True)
     """The ID of the channel the invite for this embed targets, if enabled."""
 
     is_enabled: bool = attrs.field(repr=True)
     """Whether this embed is enabled."""
 
-    async def fetch_channel(self) -> typing.Optional[channels_.GuildChannel]:
+    async def fetch_channel(self) -> channels_.GuildChannel | None:
         """Fetch the widget channel.
 
         This will be [`None`][] if not set.
@@ -385,26 +385,26 @@ class Member(users.User):
     This will be [`hikari.undefined.UNDEFINED`][] if it's state is unknown.
     """
 
-    joined_at: typing.Optional[datetime.datetime] = attrs.field(repr=True)
+    joined_at: datetime.datetime | None = attrs.field(repr=True)
     """The datetime of when this member joined the guild they belong to.
 
     This will be [`None`][] for guest members that have been temporarily
     invited.
     """
 
-    nickname: typing.Optional[str] = attrs.field(repr=True)
+    nickname: str | None = attrs.field(repr=True)
     """This member's nickname.
 
     This will be [`None`][] if not set.
     """
 
-    premium_since: typing.Optional[datetime.datetime] = attrs.field(repr=False)
+    premium_since: datetime.datetime | None = attrs.field(repr=False)
     """The datetime of when this member started "boosting" this guild.
 
     Will be [`None`][] if the member is not a premium user.
     """
 
-    raw_communication_disabled_until: typing.Optional[datetime.datetime] = attrs.field(repr=False)
+    raw_communication_disabled_until: datetime.datetime | None = attrs.field(repr=False)
     """The datetime when this member's timeout will expire.
 
      Will be [`None`][] if the member is not timed out.
@@ -427,21 +427,21 @@ class Member(users.User):
     user: users.User = attrs.field(repr=True)
     """This member's corresponding user object."""
 
-    guild_avatar_hash: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    guild_avatar_hash: str | None = attrs.field(eq=False, hash=False, repr=False)
     """Hash of the member's guild avatar if set, else [`None`][].
 
     !!! note
         This takes precedence over [`hikari.guilds.Member.avatar_hash`][].
     """
 
-    guild_banner_hash: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    guild_banner_hash: str | None = attrs.field(eq=False, hash=False, repr=False)
     """Hash of the member's guild banner if set, else [`None`][].
 
     !!! note
         This takes precedence over [`hikari.guilds.Member.banner_hash`][].
     """
 
-    guild_flags: typing.Union[GuildMemberFlags, int] = attrs.field(eq=False, hash=False, repr=False)
+    guild_flags: GuildMemberFlags | int = attrs.field(eq=False, hash=False, repr=False)
     """The flags this member has in the guild."""
 
     @property
@@ -452,16 +452,16 @@ class Member(users.User):
 
     @property
     @typing_extensions.override
-    def avatar_hash(self) -> typing.Optional[str]:
+    def avatar_hash(self) -> str | None:
         return self.user.avatar_hash
 
     @property
     @typing_extensions.override
-    def avatar_url(self) -> typing.Optional[files.URL]:
+    def avatar_url(self) -> files.URL | None:
         return self.user.avatar_url
 
     @property
-    def guild_avatar_url(self) -> typing.Optional[files.URL]:
+    def guild_avatar_url(self) -> files.URL | None:
         """Guild Avatar URL for the user, if they have one set.
 
         May be [`None`][] if no guild avatar is set. In this case, you
@@ -481,16 +481,16 @@ class Member(users.User):
 
     @property
     @typing_extensions.override
-    def banner_hash(self) -> typing.Optional[str]:
+    def banner_hash(self) -> str | None:
         return self.user.banner_hash
 
     @property
     @typing_extensions.override
-    def banner_url(self) -> typing.Optional[files.URL]:
+    def banner_url(self) -> files.URL | None:
         return self.user.banner_url
 
     @property
-    def guild_banner_url(self) -> typing.Optional[files.URL]:
+    def guild_banner_url(self) -> files.URL | None:
         """Guild Banner URL for the user, if they have one set.
 
         May be [`None`][] if no guild banner is set. In this case, you
@@ -500,12 +500,12 @@ class Member(users.User):
 
     @property
     @typing_extensions.override
-    def display_banner_url(self) -> typing.Optional[files.URL]:
+    def display_banner_url(self) -> files.URL | None:
         return self.make_guild_banner_url() or super().display_banner_url
 
     @property
     @typing_extensions.override
-    def accent_color(self) -> typing.Optional[colors.Color]:
+    def accent_color(self) -> colors.Color | None:
         return self.user.accent_color
 
     @property
@@ -555,7 +555,7 @@ class Member(users.User):
     def mention(self) -> str:
         return self.user.mention
 
-    def communication_disabled_until(self) -> typing.Optional[datetime.datetime]:
+    def communication_disabled_until(self) -> datetime.datetime | None:
         """Return when the timeout for this member ends.
 
         Unlike `raw_communication_disabled_until`, this will always be
@@ -572,7 +572,7 @@ class Member(users.User):
             return self.raw_communication_disabled_until
         return None
 
-    def get_guild(self) -> typing.Optional[Guild]:
+    def get_guild(self) -> Guild | None:
         """Return the guild associated with this member.
 
         Returns
@@ -585,7 +585,7 @@ class Member(users.User):
 
         return self.user.app.cache.get_guild(self.guild_id)
 
-    def get_presence(self) -> typing.Optional[presences_.MemberPresence]:
+    def get_presence(self) -> presences_.MemberPresence | None:
         """Get the cached presence for this member, if known.
 
         Presence info includes user status and activities.
@@ -617,7 +617,7 @@ class Member(users.User):
 
         return [role for role_id in self.role_ids if (role := self.user.app.cache.get_role(role_id))]
 
-    def get_top_role(self) -> typing.Optional[Role]:
+    def get_top_role(self) -> Role | None:
         """Return the highest role the member has.
 
         Returns
@@ -640,16 +640,14 @@ class Member(users.User):
 
     @property
     @typing_extensions.override
-    def global_name(self) -> typing.Optional[str]:
+    def global_name(self) -> str | None:
         return self.user.global_name
 
     @typing_extensions.override
-    def make_avatar_url(self, *, ext: typing.Optional[str] = None, size: int = 4096) -> typing.Optional[files.URL]:
+    def make_avatar_url(self, *, ext: str | None = None, size: int = 4096) -> files.URL | None:
         return self.user.make_avatar_url(ext=ext, size=size)
 
-    def make_guild_avatar_url(
-        self, *, ext: typing.Optional[str] = None, size: int = 4096
-    ) -> typing.Optional[files.URL]:
+    def make_guild_avatar_url(self, *, ext: str | None = None, size: int = 4096) -> files.URL | None:
         """Generate the guild specific avatar url for this member, if set.
 
         If no guild avatar is set, this returns [`None`][].
@@ -696,12 +694,10 @@ class Member(users.User):
         )
 
     @typing_extensions.override
-    def make_banner_url(self, *, ext: typing.Optional[str] = None, size: int = 4096) -> typing.Optional[files.URL]:
+    def make_banner_url(self, *, ext: str | None = None, size: int = 4096) -> files.URL | None:
         return self.user.make_banner_url(ext=ext, size=size)
 
-    def make_guild_banner_url(
-        self, *, ext: typing.Optional[str] = None, size: int = 4096
-    ) -> typing.Optional[files.URL]:
+    def make_guild_banner_url(self, *, ext: str | None = None, size: int = 4096) -> files.URL | None:
         """Generate the guild specific banner url for this member, if set.
 
         If no guild banner is set, this returns [`None`][].
@@ -1092,10 +1088,10 @@ class Role(PartialRole):
     Members will be hoisted under their highest role where this is set to [`True`][].
     """
 
-    icon_hash: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    icon_hash: str | None = attrs.field(eq=False, hash=False, repr=False)
     """Hash of the role's icon if set, else [`None`][]."""
 
-    unicode_emoji: typing.Optional[emojis_.UnicodeEmoji] = attrs.field(eq=False, hash=False, repr=False)
+    unicode_emoji: emojis_.UnicodeEmoji | None = attrs.field(eq=False, hash=False, repr=False)
     """Role's icon as an unicode emoji if set, else [`None`][]."""
 
     is_managed: bool = attrs.field(eq=False, hash=False, repr=False)
@@ -1117,13 +1113,13 @@ class Role(PartialRole):
     and increase as you go up the hierarchy.
     """
 
-    bot_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=True)
+    bot_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=True)
     """The ID of the bot this role belongs to.
 
     If [`None`][], this is not a bot role.
     """
 
-    integration_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=True)
+    integration_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=True)
     """The ID of the integration this role belongs to.
 
     If [`None`][], this is not a integration role.
@@ -1132,7 +1128,7 @@ class Role(PartialRole):
     is_premium_subscriber_role: bool = attrs.field(eq=False, hash=False, repr=True)
     """Whether this role is the guild's nitro subscriber role."""
 
-    subscription_listing_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=True)
+    subscription_listing_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=True)
     """The ID of this role's subscription SKU and listing.
 
     If [`None`][], this is not a purchasable role.
@@ -1150,7 +1146,7 @@ class Role(PartialRole):
         return self.color
 
     @property
-    def icon_url(self) -> typing.Optional[files.URL]:
+    def icon_url(self) -> files.URL | None:
         """Role icon URL, if there is one."""
         return self.make_icon_url()
 
@@ -1167,7 +1163,7 @@ class Role(PartialRole):
 
         return super().mention
 
-    def make_icon_url(self, *, ext: str = "png", size: int = 4096) -> typing.Optional[files.URL]:
+    def make_icon_url(self, *, ext: str = "png", size: int = 4096) -> files.URL | None:
         """Generate the icon URL for this role, if set.
 
         If no role icon is set, this returns [`None`][].
@@ -1255,10 +1251,10 @@ class PartialApplication(snowflakes.Unique):
     name: str = attrs.field(eq=False, hash=False, repr=True)
     """The name of this application."""
 
-    description: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    description: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The description of this application, if any."""
 
-    icon_hash: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    icon_hash: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The CDN hash of this application's icon, if set."""
 
     @typing_extensions.override
@@ -1266,11 +1262,11 @@ class PartialApplication(snowflakes.Unique):
         return self.name
 
     @property
-    def icon_url(self) -> typing.Optional[files.URL]:
+    def icon_url(self) -> files.URL | None:
         """Team icon URL, if there is one."""
         return self.make_icon_url()
 
-    def make_icon_url(self, *, ext: str = "png", size: int = 4096) -> typing.Optional[files.URL]:
+    def make_icon_url(self, *, ext: str = "png", size: int = 4096) -> files.URL | None:
         """Generate the icon URL for this application.
 
         Parameters
@@ -1306,7 +1302,7 @@ class PartialApplication(snowflakes.Unique):
 class IntegrationApplication(PartialApplication):
     """An application that's linked to an integration."""
 
-    bot: typing.Optional[users.User] = attrs.field(eq=False, hash=False, repr=False)
+    bot: users.User | None = attrs.field(eq=False, hash=False, repr=False)
     """The bot associated with this application."""
 
 
@@ -1324,7 +1320,7 @@ class PartialIntegration(snowflakes.Unique):
     name: str = attrs.field(eq=False, hash=False, repr=True)
     """The name of this integration."""
 
-    type: typing.Union[IntegrationType, str] = attrs.field(eq=False, hash=False, repr=True)
+    type: IntegrationType | str = attrs.field(eq=False, hash=False, repr=True)
     """The type of this integration."""
 
     @typing_extensions.override
@@ -1339,7 +1335,7 @@ class Integration(PartialIntegration):
     guild_id: snowflakes.Snowflake = attrs.field()
     """The ID of the guild this integration belongs to."""
 
-    expire_behavior: typing.Union[IntegrationExpireBehaviour, int, None] = attrs.field(eq=False, hash=False, repr=False)
+    expire_behavior: IntegrationExpireBehaviour | int | None = attrs.field(eq=False, hash=False, repr=False)
     """How members should be treated after their connected subscription expires.
 
     This will not be enacted until after `GuildIntegration.expire_grace_period`
@@ -1349,7 +1345,7 @@ class Integration(PartialIntegration):
         This will always be [`None`][] for Discord integrations.
     """
 
-    expire_grace_period: typing.Optional[datetime.timedelta] = attrs.field(eq=False, hash=False, repr=False)
+    expire_grace_period: datetime.timedelta | None = attrs.field(eq=False, hash=False, repr=False)
     """How many days users with expired subscriptions are given until the expire behavior is enacted out on them.
 
     !!! note
@@ -1359,28 +1355,28 @@ class Integration(PartialIntegration):
     is_enabled: bool = attrs.field(eq=False, hash=False, repr=True)
     """Whether this integration is enabled."""
 
-    is_syncing: typing.Optional[bool] = attrs.field(eq=False, hash=False, repr=False)
+    is_syncing: bool | None = attrs.field(eq=False, hash=False, repr=False)
     """Whether this integration is syncing subscribers/emojis."""
 
-    is_emojis_enabled: typing.Optional[bool] = attrs.field(eq=False, hash=False, repr=False)
+    is_emojis_enabled: bool | None = attrs.field(eq=False, hash=False, repr=False)
     """Whether users under this integration are allowed to use it's custom emojis."""
 
-    is_revoked: typing.Optional[bool] = attrs.field(eq=False, hash=False, repr=False)
+    is_revoked: bool | None = attrs.field(eq=False, hash=False, repr=False)
     """Whether the integration has been revoked."""
 
-    last_synced_at: typing.Optional[datetime.datetime] = attrs.field(eq=False, hash=False, repr=False)
+    last_synced_at: datetime.datetime | None = attrs.field(eq=False, hash=False, repr=False)
     """The datetime of when this integration's subscribers were last synced."""
 
-    role_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    role_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """The ID of the managed role used for this integration's subscribers."""
 
-    user: typing.Optional[users.User] = attrs.field(eq=False, hash=False, repr=False)
+    user: users.User | None = attrs.field(eq=False, hash=False, repr=False)
     """The user this integration belongs to."""
 
-    subscriber_count: typing.Optional[int] = attrs.field(eq=False, hash=False, repr=False)
+    subscriber_count: int | None = attrs.field(eq=False, hash=False, repr=False)
     """The number of subscribers this integration has."""
 
-    application: typing.Optional[IntegrationApplication] = attrs.field(eq=False, hash=False, repr=False)
+    application: IntegrationApplication | None = attrs.field(eq=False, hash=False, repr=False)
     """The bot/OAuth2 application associated with this integration.
 
     !!! note
@@ -1399,9 +1395,7 @@ class WelcomeChannel:
     description: str = attrs.field(hash=False, repr=False)
     """The description shown for this channel."""
 
-    emoji_name: typing.Union[str, emojis_.UnicodeEmoji, None] = attrs.field(
-        default=None, kw_only=True, hash=False, repr=True
-    )
+    emoji_name: str | emojis_.UnicodeEmoji | None = attrs.field(default=None, kw_only=True, hash=False, repr=True)
     """The emoji shown in the welcome screen channel if set to a unicode emoji.
 
     !!! warning
@@ -1409,7 +1403,7 @@ class WelcomeChannel:
         to be provided nor accurate.
     """
 
-    emoji_id: typing.Optional[snowflakes.Snowflake] = attrs.field(default=None, kw_only=True, hash=False, repr=True)
+    emoji_id: snowflakes.Snowflake | None = attrs.field(default=None, kw_only=True, hash=False, repr=True)
     """ID of the emoji shown in the welcome screen channel if it's set to a custom emoji."""
 
 
@@ -1418,7 +1412,7 @@ class WelcomeChannel:
 class WelcomeScreen:
     """Used to represent guild welcome screens on Discord."""
 
-    description: typing.Optional[str] = attrs.field(hash=False, repr=True)
+    description: str | None = attrs.field(hash=False, repr=True)
     """The guild's description shown in the welcome screen."""
 
     channels: typing.Sequence[WelcomeChannel] = attrs.field(hash=False, repr=True)
@@ -1430,7 +1424,7 @@ class WelcomeScreen:
 class GuildBan:
     """Used to represent guild bans."""
 
-    reason: typing.Optional[str] = attrs.field(repr=True)
+    reason: str | None = attrs.field(repr=True)
     """The reason for this ban, will be [`None`][] if no reason was given."""
 
     user: users.User = attrs.field(repr=True)
@@ -1450,7 +1444,7 @@ class PartialGuild(snowflakes.Unique):
     id: snowflakes.Snowflake = attrs.field(hash=True, repr=True)
     """The ID of this entity."""
 
-    icon_hash: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    icon_hash: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The hash for the guild icon, if there is one."""
 
     name: str = attrs.field(eq=False, hash=False, repr=True)
@@ -1461,12 +1455,12 @@ class PartialGuild(snowflakes.Unique):
         return self.name
 
     @property
-    def icon_url(self) -> typing.Optional[files.URL]:
+    def icon_url(self) -> files.URL | None:
         """Icon URL for the guild, if set; otherwise [`None`][]."""
         return self.make_icon_url()
 
     @property
-    def shard_id(self) -> typing.Optional[int]:
+    def shard_id(self) -> int | None:
         """Return the ID of the shard this guild is served by.
 
         This may return [`None`][] if the application does not have a gateway
@@ -1479,7 +1473,7 @@ class PartialGuild(snowflakes.Unique):
         assert isinstance(shard_count, int)
         return snowflakes.calculate_shard_id(shard_count, self.id)
 
-    def make_icon_url(self, *, ext: typing.Optional[str] = None, size: int = 4096) -> typing.Optional[files.URL]:
+    def make_icon_url(self, *, ext: str | None = None, size: int = 4096) -> files.URL | None:
         """Generate the guild's icon URL, if set.
 
         Parameters
@@ -1646,7 +1640,7 @@ class PartialGuild(snowflakes.Unique):
         public_updates_channel: undefined.UndefinedNoneOr[
             snowflakes.SnowflakeishOr[channels_.GuildTextChannel]
         ] = undefined.UNDEFINED,
-        preferred_locale: undefined.UndefinedOr[typing.Union[str, locales.Locale]] = undefined.UNDEFINED,
+        preferred_locale: undefined.UndefinedOr[str | locales.Locale] = undefined.UNDEFINED,
         features: undefined.UndefinedOr[typing.Sequence[GuildFeature]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> RESTGuild:
@@ -2192,14 +2186,13 @@ class PartialGuild(snowflakes.Unique):
         rate_limit_per_user: undefined.UndefinedOr[time.Intervalish] = undefined.UNDEFINED,
         default_auto_archive_duration: undefined.UndefinedOr[time.Intervalish] = undefined.UNDEFINED,
         default_thread_rate_limit_per_user: undefined.UndefinedOr[time.Intervalish] = undefined.UNDEFINED,
-        default_forum_layout: undefined.UndefinedOr[typing.Union[channels_.ForumLayoutType, int]] = undefined.UNDEFINED,
-        default_sort_order: undefined.UndefinedOr[
-            typing.Union[channels_.ForumSortOrderType, int]
-        ] = undefined.UNDEFINED,
+        default_forum_layout: undefined.UndefinedOr[channels_.ForumLayoutType | int] = undefined.UNDEFINED,
+        default_sort_order: undefined.UndefinedOr[channels_.ForumSortOrderType | int] = undefined.UNDEFINED,
         available_tags: undefined.UndefinedOr[typing.Sequence[channels_.ForumTag]] = undefined.UNDEFINED,
-        default_reaction_emoji: typing.Union[
-            str, emojis_.Emoji, undefined.UndefinedType, snowflakes.Snowflake
-        ] = undefined.UNDEFINED,
+        default_reaction_emoji: str
+        | emojis_.Emoji
+        | undefined.UndefinedType
+        | snowflakes.Snowflake = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> channels_.GuildForumChannel:
         """Create a forum channel in the guild.
@@ -2291,11 +2284,11 @@ class PartialGuild(snowflakes.Unique):
         position: undefined.UndefinedOr[int] = undefined.UNDEFINED,
         user_limit: undefined.UndefinedOr[int] = undefined.UNDEFINED,
         bitrate: undefined.UndefinedOr[int] = undefined.UNDEFINED,
-        video_quality_mode: undefined.UndefinedOr[typing.Union[channels_.VideoQualityMode, int]] = undefined.UNDEFINED,
+        video_quality_mode: undefined.UndefinedOr[channels_.VideoQualityMode | int] = undefined.UNDEFINED,
         permission_overwrites: undefined.UndefinedOr[
             typing.Sequence[channels_.PermissionOverwrite]
         ] = undefined.UNDEFINED,
-        region: undefined.UndefinedOr[typing.Union[voices_.VoiceRegion, str]] = undefined.UNDEFINED,
+        region: undefined.UndefinedOr[voices_.VoiceRegion | str] = undefined.UNDEFINED,
         category: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.GuildCategory]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> channels_.GuildVoiceChannel:
@@ -2375,7 +2368,7 @@ class PartialGuild(snowflakes.Unique):
         permission_overwrites: undefined.UndefinedOr[
             typing.Sequence[channels_.PermissionOverwrite]
         ] = undefined.UNDEFINED,
-        region: undefined.UndefinedOr[typing.Union[voices_.VoiceRegion, str]] = undefined.UNDEFINED,
+        region: undefined.UndefinedOr[voices_.VoiceRegion | str] = undefined.UNDEFINED,
         category: undefined.UndefinedOr[snowflakes.SnowflakeishOr[channels_.GuildCategory]] = undefined.UNDEFINED,
         reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> channels_.GuildStageChannel:
@@ -2535,13 +2528,13 @@ class PartialGuild(snowflakes.Unique):
 class GuildPreview(PartialGuild):
     """A preview of a guild with the [`hikari.guilds.GuildFeature.DISCOVERABLE`][] feature."""
 
-    features: typing.Sequence[typing.Union[str, GuildFeature]] = attrs.field(eq=False, hash=False, repr=False)
+    features: typing.Sequence[str | GuildFeature] = attrs.field(eq=False, hash=False, repr=False)
     """A list of the features in this guild."""
 
-    splash_hash: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    splash_hash: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The hash of the splash for the guild, if there is one."""
 
-    discovery_splash_hash: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    discovery_splash_hash: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The hash of the discovery splash for the guild, if there is one."""
 
     emojis: typing.Mapping[snowflakes.Snowflake, emojis_.KnownCustomEmoji] = attrs.field(
@@ -2555,20 +2548,20 @@ class GuildPreview(PartialGuild):
     approximate_member_count: int = attrs.field(eq=False, hash=False, repr=True)
     """The approximate amount of members in this guild."""
 
-    description: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    description: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The guild's description, if set."""
 
     @property
-    def discovery_splash_url(self) -> typing.Optional[files.URL]:
+    def discovery_splash_url(self) -> files.URL | None:
         """Discovery URL splash for the guild, if set."""
         return self.make_discovery_splash_url()
 
     @property
-    def splash_url(self) -> typing.Optional[files.URL]:
+    def splash_url(self) -> files.URL | None:
         """Splash URL for the guild, if set."""
         return self.make_splash_url()
 
-    def make_discovery_splash_url(self, *, ext: str = "png", size: int = 4096) -> typing.Optional[files.URL]:
+    def make_discovery_splash_url(self, *, ext: str = "png", size: int = 4096) -> files.URL | None:
         """Generate the guild's discovery splash image URL, if set.
 
         Parameters
@@ -2597,7 +2590,7 @@ class GuildPreview(PartialGuild):
             urls.CDN_URL, guild_id=self.id, hash=self.discovery_splash_hash, size=size, file_format=ext
         )
 
-    def make_splash_url(self, *, ext: str = "png", size: int = 4096) -> typing.Optional[files.URL]:
+    def make_splash_url(self, *, ext: str = "png", size: int = 4096) -> files.URL | None:
         """Generate the guild's splash image URL, if set.
 
         Parameters
@@ -2631,16 +2624,16 @@ class GuildPreview(PartialGuild):
 class Guild(PartialGuild):
     """A representation of a guild on Discord."""
 
-    features: typing.Sequence[typing.Union[str, GuildFeature]] = attrs.field(eq=False, hash=False, repr=False)
+    features: typing.Sequence[str | GuildFeature] = attrs.field(eq=False, hash=False, repr=False)
     """A list of the features in this guild."""
 
-    application_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    application_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """The ID of the application that created this guild.
 
     This will always be [`None`][] for guilds that weren't created by a bot.
     """
 
-    afk_channel_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    afk_channel_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """The ID for the channel that AFK voice users get sent to.
 
     If [`None`][], then no AFK channel is set up for this guild.
@@ -2653,81 +2646,77 @@ class Guild(PartialGuild):
     AFK and are moved to the AFK channel ([`hikari.guilds.Guild.afk_channel_id`][]).
     """
 
-    banner_hash: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    banner_hash: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The hash for the guild's banner.
 
     This is only present if the guild has [`hikari.guilds.GuildFeature.BANNER`][] in
     [`hikari.guilds.Guild.features`][] for this guild. For all other purposes, it is [`None`][].
     """
 
-    default_message_notifications: typing.Union[GuildMessageNotificationsLevel, int] = attrs.field(
-        eq=False, hash=False, repr=False
-    )
+    default_message_notifications: GuildMessageNotificationsLevel | int = attrs.field(eq=False, hash=False, repr=False)
     """The default setting for message notifications in this guild."""
 
-    description: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    description: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The guild's description.
 
     This is only present if certain [`hikari.guilds.GuildFeature`][]'s are set in
     [`hikari.guilds.Guild.features`][] for this guild. Otherwise, this will always be [`None`][].
     """
 
-    discovery_splash_hash: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    discovery_splash_hash: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The hash of the discovery splash for the guild, if there is one."""
 
-    explicit_content_filter: typing.Union[GuildExplicitContentFilterLevel, int] = attrs.field(
-        eq=False, hash=False, repr=False
-    )
+    explicit_content_filter: GuildExplicitContentFilterLevel | int = attrs.field(eq=False, hash=False, repr=False)
     """The setting for the explicit content filter in this guild."""
 
-    is_widget_enabled: typing.Optional[bool] = attrs.field(eq=False, hash=False, repr=False)
+    is_widget_enabled: bool | None = attrs.field(eq=False, hash=False, repr=False)
     """Describes whether the guild widget is enabled or not.
 
     If this information is not present, this will be [`None`][].
     """
 
-    max_video_channel_users: typing.Optional[int] = attrs.field(eq=False, hash=False, repr=False)
+    max_video_channel_users: int | None = attrs.field(eq=False, hash=False, repr=False)
     """The maximum number of users allowed in a video channel together.
 
     This information may not be present, in which case, it will be [`None`][].
     """
 
-    mfa_level: typing.Union[GuildMFALevel, int] = attrs.field(eq=False, hash=False, repr=False)
+    mfa_level: GuildMFALevel | int = attrs.field(eq=False, hash=False, repr=False)
     """The required MFA level for users wishing to participate in this guild."""
 
     owner_id: snowflakes.Snowflake = attrs.field(eq=False, hash=False, repr=True)
     """The ID of the owner of this guild."""
 
-    preferred_locale: typing.Union[str, locales.Locale] = attrs.field(eq=False, hash=False, repr=False)
+    preferred_locale: str | locales.Locale = attrs.field(eq=False, hash=False, repr=False)
     """The preferred locale to use for this guild.
 
     This can only be change if [`hikari.guilds.GuildFeature.COMMUNITY`][] is in [`hikari.guilds.Guild.features`][]
     for this guild and will otherwise default to `en-US`.
     """
 
-    premium_subscription_count: typing.Optional[int] = attrs.field(eq=False, hash=False, repr=False)
+    premium_subscription_count: int | None = attrs.field(eq=False, hash=False, repr=False)
     """The number of nitro boosts that the server currently has.
 
     This information may not be present, in which case, it will be [`None`][].
     """
 
-    premium_tier: typing.Union[GuildPremiumTier, int] = attrs.field(eq=False, hash=False, repr=False)
+    premium_tier: GuildPremiumTier | int = attrs.field(eq=False, hash=False, repr=False)
     """The premium tier for this guild."""
 
-    public_updates_channel_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    public_updates_channel_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """The channel ID of the channel where admins and moderators receive notices from Discord.
 
     This is only present if [`hikari.guilds.GuildFeature.COMMUNITY`][] is in [`hikari.guilds.Guild.features`][] for
     this guild. For all other purposes, it should be considered to be [`None`][].
     """
 
-    rules_channel_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    rules_channel_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """The ID of the channel where rules and guidelines will be displayed.
 
     If the [`hikari.guilds.GuildFeature.COMMUNITY`][] feature is not defined, then this is [`None`][].
     """
 
-    splash_hash: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    splash_hash: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The hash of the splash for the guild, if there is one."""
 
     system_channel_flags: GuildSystemChannelFlag = attrs.field(eq=False, hash=False, repr=False)
@@ -2736,23 +2725,23 @@ class Guild(PartialGuild):
     These are used to describe which notifications are suppressed.
     """
 
-    system_channel_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    system_channel_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """The ID of the system channel or [`None`][] if it is not enabled.
 
     Welcome messages and Nitro boost messages may be sent to this channel.
     """
 
-    vanity_url_code: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    vanity_url_code: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The vanity URL code for the guild's vanity URL.
 
     This is only present if [`hikari.guilds.GuildFeature.VANITY_URL`][] is in [`hikari.guilds.Guild.features`][] for
     this guild. If not, this will always be [`None`][].
     """
 
-    verification_level: typing.Union[GuildVerificationLevel, int] = attrs.field(eq=False, hash=False, repr=False)
+    verification_level: GuildVerificationLevel | int = attrs.field(eq=False, hash=False, repr=False)
     """The verification level needed for a user to participate in this guild."""
 
-    widget_channel_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    widget_channel_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """The channel ID that the widget's generated invite will send the user to.
 
     If this information is unavailable or this is not enabled for the guild then
@@ -2763,17 +2752,17 @@ class Guild(PartialGuild):
     """The NSFW level of the guild."""
 
     @property
-    def banner_url(self) -> typing.Optional[files.URL]:
+    def banner_url(self) -> files.URL | None:
         """Banner URL for the guild, if set."""
         return self.make_banner_url()
 
     @property
-    def discovery_splash_url(self) -> typing.Optional[files.URL]:
+    def discovery_splash_url(self) -> files.URL | None:
         """Discovery splash URL for the guild, if set."""
         return self.make_discovery_splash_url()
 
     @property
-    def splash_url(self) -> typing.Optional[files.URL]:
+    def splash_url(self) -> files.URL | None:
         """Splash URL for the guild, if set."""
         return self.make_splash_url()
 
@@ -2871,7 +2860,7 @@ class Guild(PartialGuild):
 
         return self.app.cache.get_roles_view_for_guild(self.id)
 
-    def make_banner_url(self, *, ext: typing.Optional[str] = None, size: int = 4096) -> typing.Optional[files.URL]:
+    def make_banner_url(self, *, ext: str | None = None, size: int = 4096) -> files.URL | None:
         """Generate the guild's banner image URL, if set.
 
         Parameters
@@ -2907,7 +2896,7 @@ class Guild(PartialGuild):
             urls.CDN_URL, guild_id=self.id, hash=self.banner_hash, size=size, file_format=ext
         )
 
-    def make_discovery_splash_url(self, *, ext: str = "png", size: int = 4096) -> typing.Optional[files.URL]:
+    def make_discovery_splash_url(self, *, ext: str = "png", size: int = 4096) -> files.URL | None:
         """Generate the guild's discovery splash image URL, if set.
 
         Parameters
@@ -2936,7 +2925,7 @@ class Guild(PartialGuild):
             urls.CDN_URL, guild_id=self.id, hash=self.discovery_splash_hash, size=size, file_format=ext
         )
 
-    def make_splash_url(self, *, ext: str = "png", size: int = 4096) -> typing.Optional[files.URL]:
+    def make_splash_url(self, *, ext: str = "png", size: int = 4096) -> files.URL | None:
         """Generate the guild's splash image URL, if set.
 
         Parameters
@@ -2967,7 +2956,7 @@ class Guild(PartialGuild):
 
     def get_channel(
         self, channel: snowflakes.SnowflakeishOr[channels_.PartialChannel]
-    ) -> typing.Optional[channels_.PermissibleGuildChannel]:
+    ) -> channels_.PermissibleGuildChannel | None:
         """Get a cached channel that belongs to the guild by it's ID or object.
 
         Parameters
@@ -2989,7 +2978,7 @@ class Guild(PartialGuild):
 
         return None
 
-    def get_member(self, user: snowflakes.SnowflakeishOr[users.PartialUser]) -> typing.Optional[Member]:
+    def get_member(self, user: snowflakes.SnowflakeishOr[users.PartialUser]) -> Member | None:
         """Get a cached member that belongs to the guild by it's user ID or object.
 
         Parameters
@@ -3007,7 +2996,7 @@ class Guild(PartialGuild):
 
         return self.app.cache.get_member(self.id, user)
 
-    def get_my_member(self) -> typing.Optional[Member]:
+    def get_my_member(self) -> Member | None:
         """Return the cached member for the bot user in this guild, if known.
 
         Returns
@@ -3024,9 +3013,7 @@ class Guild(PartialGuild):
 
         return self.get_member(me.id)
 
-    def get_presence(
-        self, user: snowflakes.SnowflakeishOr[users.PartialUser]
-    ) -> typing.Optional[presences_.MemberPresence]:
+    def get_presence(self, user: snowflakes.SnowflakeishOr[users.PartialUser]) -> presences_.MemberPresence | None:
         """Get a cached presence that belongs to the guild by it's user ID or object.
 
         Parameters
@@ -3044,9 +3031,7 @@ class Guild(PartialGuild):
 
         return self.app.cache.get_presence(self.id, user)
 
-    def get_voice_state(
-        self, user: snowflakes.SnowflakeishOr[users.PartialUser]
-    ) -> typing.Optional[voices_.VoiceState]:
+    def get_voice_state(self, user: snowflakes.SnowflakeishOr[users.PartialUser]) -> voices_.VoiceState | None:
         """Get a cached voice state that belongs to the guild by it's user.
 
         Parameters
@@ -3064,9 +3049,7 @@ class Guild(PartialGuild):
 
         return self.app.cache.get_voice_state(self.id, user)
 
-    def get_emoji(
-        self, emoji: snowflakes.SnowflakeishOr[emojis_.CustomEmoji]
-    ) -> typing.Optional[emojis_.KnownCustomEmoji]:
+    def get_emoji(self, emoji: snowflakes.SnowflakeishOr[emojis_.CustomEmoji]) -> emojis_.KnownCustomEmoji | None:
         """Get a cached emoji that belongs to the guild by it's ID or object.
 
         Parameters
@@ -3089,9 +3072,7 @@ class Guild(PartialGuild):
 
         return None
 
-    def get_sticker(
-        self, sticker: snowflakes.SnowflakeishOr[stickers.GuildSticker]
-    ) -> typing.Optional[stickers.GuildSticker]:
+    def get_sticker(self, sticker: snowflakes.SnowflakeishOr[stickers.GuildSticker]) -> stickers.GuildSticker | None:
         """Get a cached sticker that belongs to the guild by it's ID or object.
 
         Parameters
@@ -3114,7 +3095,7 @@ class Guild(PartialGuild):
 
         return None
 
-    def get_role(self, role: snowflakes.SnowflakeishOr[PartialRole]) -> typing.Optional[Role]:
+    def get_role(self, role: snowflakes.SnowflakeishOr[PartialRole]) -> Role | None:
         """Get a cached role that belongs to the guild by it's ID or object.
 
         Parameters
@@ -3158,7 +3139,7 @@ class Guild(PartialGuild):
         """
         return await self.app.rest.fetch_member(self.id, self.owner_id)
 
-    async def fetch_widget_channel(self) -> typing.Optional[channels_.GuildChannel]:
+    async def fetch_widget_channel(self) -> channels_.GuildChannel | None:
         """Fetch the widget channel.
 
         This will be [`None`][] if not set.
@@ -3189,7 +3170,7 @@ class Guild(PartialGuild):
         assert isinstance(widget_channel, channels_.GuildChannel)
         return widget_channel
 
-    async def fetch_afk_channel(self) -> typing.Optional[channels_.GuildVoiceChannel]:
+    async def fetch_afk_channel(self) -> channels_.GuildVoiceChannel | None:
         """Fetch the channel that AFK voice users get sent to.
 
         Returns
@@ -3218,7 +3199,7 @@ class Guild(PartialGuild):
         assert isinstance(afk_channel, channels_.GuildVoiceChannel)
         return afk_channel
 
-    async def fetch_system_channel(self) -> typing.Optional[channels_.GuildTextChannel]:
+    async def fetch_system_channel(self) -> channels_.GuildTextChannel | None:
         """Fetch the system channel.
 
         Returns
@@ -3248,7 +3229,7 @@ class Guild(PartialGuild):
         assert isinstance(system_channel, channels_.GuildTextChannel)
         return system_channel
 
-    async def fetch_rules_channel(self) -> typing.Optional[channels_.GuildTextChannel]:
+    async def fetch_rules_channel(self) -> channels_.GuildTextChannel | None:
         """Fetch the channel where guilds display rules and guidelines.
 
         If the [`hikari.guilds.GuildFeature.COMMUNITY`][] feature is not defined, then this is [`None`][].
@@ -3279,7 +3260,7 @@ class Guild(PartialGuild):
         assert isinstance(rules_channel, channels_.GuildTextChannel)
         return rules_channel
 
-    async def fetch_public_updates_channel(self) -> typing.Optional[channels_.GuildTextChannel]:
+    async def fetch_public_updates_channel(self) -> channels_.GuildTextChannel | None:
         """Fetch channel ID of the channel where admins and moderators receive notices from Discord.
 
         This is only present if [`hikari.guilds.GuildFeature.COMMUNITY`][] is in [`hikari.guilds.Guild.features`][] for
@@ -3329,19 +3310,19 @@ class RESTGuild(Guild):
     roles: typing.Mapping[snowflakes.Snowflake, Role] = attrs.field(eq=False, hash=False, repr=False)
     """The roles in this guild, represented as a mapping of role ID to role object."""
 
-    approximate_active_member_count: typing.Optional[int] = attrs.field(eq=False, hash=False, repr=False)
+    approximate_active_member_count: int | None = attrs.field(eq=False, hash=False, repr=False)
     """The approximate number of members in the guild that are not offline.
 
     This will be [`None`][] when creating a guild.
     """
 
-    approximate_member_count: typing.Optional[int] = attrs.field(eq=False, hash=False, repr=False)
+    approximate_member_count: int | None = attrs.field(eq=False, hash=False, repr=False)
     """The approximate number of members in the guild.
 
     This will be [`None`][] when creating a guild.
     """
 
-    max_presences: typing.Optional[int] = attrs.field(eq=False, hash=False, repr=False)
+    max_presences: int | None = attrs.field(eq=False, hash=False, repr=False)
     """The maximum number of presences for the guild.
 
     If [`None`][], then there is no limit.
@@ -3355,7 +3336,7 @@ class RESTGuild(Guild):
 class GatewayGuild(Guild):
     """Guild specialization that is sent via the gateway only."""
 
-    is_large: typing.Optional[bool] = attrs.field(eq=False, hash=False, repr=False)
+    is_large: bool | None = attrs.field(eq=False, hash=False, repr=False)
     """Whether the guild is considered to be large or not.
 
     This information is only available if the guild was sent via a `GUILD_CREATE`
@@ -3366,7 +3347,7 @@ class GatewayGuild(Guild):
     sent about members who are offline or invisible.
     """
 
-    joined_at: typing.Optional[datetime.datetime] = attrs.field(eq=False, hash=False, repr=False)
+    joined_at: datetime.datetime | None = attrs.field(eq=False, hash=False, repr=False)
     """The date and time that the bot user joined this guild.
 
     This information is only available if the guild was sent via a `GUILD_CREATE`
@@ -3374,7 +3355,7 @@ class GatewayGuild(Guild):
     [`None`][].
     """
 
-    member_count: typing.Optional[int] = attrs.field(eq=False, hash=False, repr=False)
+    member_count: int | None = attrs.field(eq=False, hash=False, repr=False)
     """The number of members in this guild.
 
     This information is only available if the guild was sent via a `GUILD_CREATE`

--- a/hikari/impl/buckets.py
+++ b/hikari/impl/buckets.py
@@ -254,10 +254,7 @@ class RESTBucket(rate_limits.WindowedBurstRateLimiter):
         await self.acquire()
 
     async def __aexit__(
-        self,
-        exc_type: typing.Optional[type[BaseException]],
-        exc: typing.Optional[BaseException],
-        exc_tb: typing.Optional[types.TracebackType],
+        self, exc_type: type[BaseException] | None, exc: BaseException | None, exc_tb: types.TracebackType | None
     ) -> None:
         self.release()
 
@@ -364,7 +361,7 @@ class RESTBucket(rate_limits.WindowedBurstRateLimiter):
         self.name: str = real_bucket_hash
 
 
-def _create_authentication_hash(authentication: typing.Optional[str]) -> str:
+def _create_authentication_hash(authentication: str | None) -> str:
     return str(hash(authentication))
 
 
@@ -397,7 +394,7 @@ class RESTBucketManager:
     def __init__(self, max_rate_limit: float) -> None:
         self._routes_to_hashes: dict[routes.Route, str] = {}
         self._real_hashes_to_buckets: dict[str, RESTBucket] = {}
-        self._gc_task: typing.Optional[asyncio.Task[None]] = None
+        self._gc_task: asyncio.Task[None] | None = None
         self._max_rate_limit = max_rate_limit
         self._global_ratelimit = rate_limits.ManualRateLimiter()
 
@@ -506,7 +503,7 @@ class RESTBucketManager:
             _LOGGER.log(ux.TRACE, "no buckets purged, %s remain in survival, %s active", survival, active)
 
     def acquire_bucket(
-        self, compiled_route: routes.CompiledRoute, authentication: typing.Optional[str]
+        self, compiled_route: routes.CompiledRoute, authentication: str | None
     ) -> typing.AsyncContextManager[None]:
         """Acquire a bucket for the given route.
 
@@ -550,7 +547,7 @@ class RESTBucketManager:
     def update_rate_limits(
         self,
         compiled_route: routes.CompiledRoute,
-        authentication: typing.Optional[str],
+        authentication: str | None,
         bucket_header: str,
         remaining_header: int,
         limit_header: int,

--- a/hikari/impl/cache.py
+++ b/hikari/impl/cache.py
@@ -84,7 +84,7 @@ class CacheImpl(cache.MutableCache):
     )
 
     # For the sake of keeping things clean, the annotations are being kept separate from the assignment here.
-    _me: typing.Optional[users.OwnUser]
+    _me: users.OwnUser | None
     _emoji_entries: collections.ExtendedMutableMapping[snowflakes.Snowflake, cache_utility.KnownCustomEmojiData]
     _dm_channel_entries: collections.ExtendedMutableMapping[snowflakes.Snowflake, snowflakes.Snowflake]
     _guild_channel_entries: collections.ExtendedMutableMapping[snowflakes.Snowflake, channels_.PermissibleGuildChannel]
@@ -159,16 +159,14 @@ class CacheImpl(cache.MutableCache):
     @typing_extensions.override
     def delete_dm_channel_id(
         self, user: snowflakes.SnowflakeishOr[users.PartialUser], /
-    ) -> typing.Optional[snowflakes.Snowflake]:
+    ) -> snowflakes.Snowflake | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.DM_CHANNEL_IDS):
             return None
 
         return self._dm_channel_entries.pop(snowflakes.Snowflake(user), None)
 
     @typing_extensions.override
-    def get_dm_channel_id(
-        self, user: snowflakes.SnowflakeishOr[users.PartialUser], /
-    ) -> typing.Optional[snowflakes.Snowflake]:
+    def get_dm_channel_id(self, user: snowflakes.SnowflakeishOr[users.PartialUser], /) -> snowflakes.Snowflake | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.DM_CHANNEL_IDS):
             return None
 
@@ -237,9 +235,7 @@ class CacheImpl(cache.MutableCache):
         return cache_utility.CacheMappingView(cached_emojis, builder=self._build_emoji)
 
     @typing_extensions.override
-    def delete_emoji(
-        self, emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji], /
-    ) -> typing.Optional[emojis.KnownCustomEmoji]:
+    def delete_emoji(self, emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji], /) -> emojis.KnownCustomEmoji | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.EMOJIS):
             return None
 
@@ -262,9 +258,7 @@ class CacheImpl(cache.MutableCache):
         return self._build_emoji(emoji_data)
 
     @typing_extensions.override
-    def get_emoji(
-        self, emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji], /
-    ) -> typing.Optional[emojis.KnownCustomEmoji]:
+    def get_emoji(self, emoji: snowflakes.SnowflakeishOr[emojis.CustomEmoji], /) -> emojis.KnownCustomEmoji | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.EMOJIS):
             return None
 
@@ -301,7 +295,7 @@ class CacheImpl(cache.MutableCache):
             msg = "Cannot cache an emoji without a guild ID."
             raise ValueError(msg)
 
-        user: typing.Optional[cache_utility.RefCell[users.User]] = None
+        user: cache_utility.RefCell[users.User] | None = None
         if emoji.user:
             user = self._set_user(emoji.user)
             if emoji.id not in self._emoji_entries:
@@ -319,7 +313,7 @@ class CacheImpl(cache.MutableCache):
     @typing_extensions.override
     def update_emoji(
         self, emoji: emojis.KnownCustomEmoji, /
-    ) -> tuple[typing.Optional[emojis.KnownCustomEmoji], typing.Optional[emojis.KnownCustomEmoji]]:
+    ) -> tuple[emojis.KnownCustomEmoji | None, emojis.KnownCustomEmoji | None]:
         if not self._is_cache_enabled_for(config_api.CacheComponents.EMOJIS):
             return None, None
 
@@ -375,9 +369,7 @@ class CacheImpl(cache.MutableCache):
         return cache_utility.CacheMappingView(cached_stickers, builder=self._build_sticker)
 
     @typing_extensions.override
-    def get_sticker(
-        self, sticker: snowflakes.SnowflakeishOr[stickers.GuildSticker], /
-    ) -> typing.Optional[stickers.GuildSticker]:
+    def get_sticker(self, sticker: snowflakes.SnowflakeishOr[stickers.GuildSticker], /) -> stickers.GuildSticker | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.GUILD_STICKERS):
             return None
 
@@ -408,7 +400,7 @@ class CacheImpl(cache.MutableCache):
     @typing_extensions.override
     def delete_sticker(
         self, sticker: snowflakes.SnowflakeishOr[stickers.GuildSticker], /
-    ) -> typing.Optional[stickers.GuildSticker]:
+    ) -> stickers.GuildSticker | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.GUILD_STICKERS):
             return None
 
@@ -434,7 +426,7 @@ class CacheImpl(cache.MutableCache):
         if not self._is_cache_enabled_for(config_api.CacheComponents.GUILD_STICKERS):
             return
 
-        user: typing.Optional[cache_utility.RefCell[users.User]] = None
+        user: cache_utility.RefCell[users.User] | None = None
         if sticker.user:
             user = self._set_user(sticker.user)
             if sticker.id not in self._sticker_entries:
@@ -478,9 +470,7 @@ class CacheImpl(cache.MutableCache):
         return cache_utility.CacheMappingView(cached_guilds) if cached_guilds else cache_utility.EmptyCacheView()
 
     @typing_extensions.override
-    def delete_guild(
-        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
-    ) -> typing.Optional[guilds.GatewayGuild]:
+    def delete_guild(self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /) -> guilds.GatewayGuild | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.GUILDS):
             return None
 
@@ -500,7 +490,7 @@ class CacheImpl(cache.MutableCache):
 
     def _get_guild(
         self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /, *, availability: bool
-    ) -> typing.Optional[guilds.GatewayGuild]:
+    ) -> guilds.GatewayGuild | None:
         guild_record = self._guild_entries.get(snowflakes.Snowflake(guild))
         if not guild_record or not guild_record.guild or guild_record.is_available is not availability:
             return None
@@ -508,9 +498,7 @@ class CacheImpl(cache.MutableCache):
         return copy.copy(guild_record.guild)
 
     @typing_extensions.override
-    def get_guild(
-        self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
-    ) -> typing.Optional[guilds.GatewayGuild]:
+    def get_guild(self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /) -> guilds.GatewayGuild | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.GUILDS):
             return None
 
@@ -520,7 +508,7 @@ class CacheImpl(cache.MutableCache):
     @typing_extensions.override
     def get_available_guild(
         self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
-    ) -> typing.Optional[guilds.GatewayGuild]:
+    ) -> guilds.GatewayGuild | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.GUILDS):
             return None
 
@@ -529,7 +517,7 @@ class CacheImpl(cache.MutableCache):
     @typing_extensions.override
     def get_unavailable_guild(
         self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild], /
-    ) -> typing.Optional[guilds.GatewayGuild]:
+    ) -> guilds.GatewayGuild | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.GUILDS):
             return None
 
@@ -591,7 +579,7 @@ class CacheImpl(cache.MutableCache):
     @typing_extensions.override
     def update_guild(
         self, guild: guilds.GatewayGuild, /
-    ) -> tuple[typing.Optional[guilds.GatewayGuild], typing.Optional[guilds.GatewayGuild]]:
+    ) -> tuple[guilds.GatewayGuild | None, guilds.GatewayGuild | None]:
         if not self._is_cache_enabled_for(config_api.CacheComponents.GUILDS):
             return None, None
 
@@ -670,7 +658,7 @@ class CacheImpl(cache.MutableCache):
     @typing_extensions.override
     def delete_thread(
         self, thread: snowflakes.SnowflakeishOr[channels_.PartialChannel], /
-    ) -> typing.Optional[channels_.GuildThreadChannel]:
+    ) -> channels_.GuildThreadChannel | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.GUILD_THREADS):
             return None
 
@@ -692,7 +680,7 @@ class CacheImpl(cache.MutableCache):
     @typing_extensions.override
     def get_thread(
         self, thread: snowflakes.SnowflakeishOr[channels_.PartialChannel], /
-    ) -> typing.Optional[channels_.GuildThreadChannel]:
+    ) -> channels_.GuildThreadChannel | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.GUILD_THREADS):
             return None
 
@@ -750,7 +738,7 @@ class CacheImpl(cache.MutableCache):
     @typing_extensions.override
     def update_thread(
         self, thread: channels_.GuildThreadChannel, /
-    ) -> tuple[typing.Optional[channels_.GuildThreadChannel], typing.Optional[channels_.GuildThreadChannel]]:
+    ) -> tuple[channels_.GuildThreadChannel | None, channels_.GuildThreadChannel | None]:
         if not self._is_cache_enabled_for(config_api.CacheComponents.GUILD_THREADS):
             return None, None
 
@@ -793,7 +781,7 @@ class CacheImpl(cache.MutableCache):
     @typing_extensions.override
     def delete_guild_channel(
         self, channel: snowflakes.SnowflakeishOr[channels_.PartialChannel], /
-    ) -> typing.Optional[channels_.PermissibleGuildChannel]:
+    ) -> channels_.PermissibleGuildChannel | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.GUILD_CHANNELS):
             return None
 
@@ -815,7 +803,7 @@ class CacheImpl(cache.MutableCache):
     @typing_extensions.override
     def get_guild_channel(
         self, channel: snowflakes.SnowflakeishOr[channels_.PartialChannel], /
-    ) -> typing.Optional[channels_.PermissibleGuildChannel]:
+    ) -> channels_.PermissibleGuildChannel | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.GUILD_CHANNELS):
             return None
 
@@ -879,7 +867,7 @@ class CacheImpl(cache.MutableCache):
     @typing_extensions.override
     def update_guild_channel(
         self, channel: channels_.PermissibleGuildChannel, /
-    ) -> tuple[typing.Optional[channels_.PermissibleGuildChannel], typing.Optional[channels_.PermissibleGuildChannel]]:
+    ) -> tuple[channels_.PermissibleGuildChannel | None, channels_.PermissibleGuildChannel | None]:
         if not self._is_cache_enabled_for(config_api.CacheComponents.GUILD_CHANNELS):
             return None, None
 
@@ -972,9 +960,7 @@ class CacheImpl(cache.MutableCache):
         return cache_utility.CacheMappingView(cached_invites, builder=self._build_invite)
 
     @typing_extensions.override
-    def delete_invite(
-        self, code: typing.Union[invites.InviteCode, str], /
-    ) -> typing.Optional[invites.InviteWithMetadata]:
+    def delete_invite(self, code: invites.InviteCode | str, /) -> invites.InviteWithMetadata | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.INVITES):
             return None
 
@@ -997,7 +983,7 @@ class CacheImpl(cache.MutableCache):
         return self._build_invite(invite_data)
 
     @typing_extensions.override
-    def get_invite(self, code: typing.Union[invites.InviteCode, str], /) -> typing.Optional[invites.InviteWithMetadata]:
+    def get_invite(self, code: invites.InviteCode | str, /) -> invites.InviteWithMetadata | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.INVITES):
             return None
 
@@ -1055,13 +1041,13 @@ class CacheImpl(cache.MutableCache):
         if not self._is_cache_enabled_for(config_api.CacheComponents.INVITES):
             return
 
-        inviter: typing.Optional[cache_utility.RefCell[users.User]] = None
+        inviter: cache_utility.RefCell[users.User] | None = None
         if invite.inviter:
             inviter = self._set_user(invite.inviter)
             if invite.code not in self._invite_entries:
                 self._increment_ref_count(inviter)
 
-        target_user: typing.Optional[cache_utility.RefCell[users.User]] = None
+        target_user: cache_utility.RefCell[users.User] | None = None
         if invite.target_user:
             target_user = self._set_user(invite.target_user)
             if invite.code not in self._invite_entries:
@@ -1081,7 +1067,7 @@ class CacheImpl(cache.MutableCache):
     @typing_extensions.override
     def update_invite(
         self, invite: invites.InviteWithMetadata, /
-    ) -> tuple[typing.Optional[invites.InviteWithMetadata], typing.Optional[invites.InviteWithMetadata]]:
+    ) -> tuple[invites.InviteWithMetadata | None, invites.InviteWithMetadata | None]:
         if not self._is_cache_enabled_for(config_api.CacheComponents.INVITES):
             return None, None
 
@@ -1090,13 +1076,13 @@ class CacheImpl(cache.MutableCache):
         return cached_invite, self.get_invite(invite.code)
 
     @typing_extensions.override
-    def delete_me(self) -> typing.Optional[users.OwnUser]:
+    def delete_me(self) -> users.OwnUser | None:
         cached_user = self._me
         self._me = None
         return cached_user
 
     @typing_extensions.override
-    def get_me(self) -> typing.Optional[users.OwnUser]:
+    def get_me(self) -> users.OwnUser | None:
         return copy.copy(self._me)
 
     @typing_extensions.override
@@ -1106,9 +1092,7 @@ class CacheImpl(cache.MutableCache):
             self._me = copy.copy(user)
 
     @typing_extensions.override
-    def update_me(
-        self, user: users.OwnUser, /
-    ) -> tuple[typing.Optional[users.OwnUser], typing.Optional[users.OwnUser]]:
+    def update_me(self, user: users.OwnUser, /) -> tuple[users.OwnUser | None, users.OwnUser | None]:
         if not self._is_cache_enabled_for(config_api.CacheComponents.ME):
             return None, None
 
@@ -1128,9 +1112,9 @@ class CacheImpl(cache.MutableCache):
         guild_record: cache_utility.GuildRecord,
         member: cache_utility.RefCell[cache_utility.MemberData],
         *,
-        decrement: typing.Optional[int] = None,
+        decrement: int | None = None,
         deleting: bool = False,
-    ) -> typing.Optional[cache_utility.RefCell[cache_utility.MemberData]]:
+    ) -> cache_utility.RefCell[cache_utility.MemberData] | None:
         if deleting:
             member.object.has_been_deleted = True
 
@@ -1188,7 +1172,7 @@ class CacheImpl(cache.MutableCache):
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
         user: snowflakes.SnowflakeishOr[users.PartialUser],
         /,
-    ) -> typing.Optional[guilds.Member]:
+    ) -> guilds.Member | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.MEMBERS):
             return None
 
@@ -1216,7 +1200,7 @@ class CacheImpl(cache.MutableCache):
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
         user: snowflakes.SnowflakeishOr[users.PartialUser],
         /,
-    ) -> typing.Optional[guilds.Member]:
+    ) -> guilds.Member | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.MEMBERS):
             return None
 
@@ -1295,9 +1279,7 @@ class CacheImpl(cache.MutableCache):
         return guild_record.members[member.id]
 
     @typing_extensions.override
-    def update_member(
-        self, member: guilds.Member, /
-    ) -> tuple[typing.Optional[guilds.Member], typing.Optional[guilds.Member]]:
+    def update_member(self, member: guilds.Member, /) -> tuple[guilds.Member | None, guilds.Member | None]:
         if not self._is_cache_enabled_for(config_api.CacheComponents.MEMBERS):
             return None, None
 
@@ -1309,7 +1291,7 @@ class CacheImpl(cache.MutableCache):
         return presence_data.build_entity(self._app)
 
     def _garbage_collect_unknown_custom_emoji(
-        self, emoji: cache_utility.RefCell[emojis.CustomEmoji], *, decrement: typing.Optional[int] = None
+        self, emoji: cache_utility.RefCell[emojis.CustomEmoji], *, decrement: int | None = None
     ) -> None:
         if decrement is not None:
             self._increment_ref_count(emoji, -decrement)
@@ -1359,7 +1341,7 @@ class CacheImpl(cache.MutableCache):
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
         user: snowflakes.SnowflakeishOr[users.PartialUser],
         /,
-    ) -> typing.Optional[presences.MemberPresence]:
+    ) -> presences.MemberPresence | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.PRESENCES):
             return None
 
@@ -1388,7 +1370,7 @@ class CacheImpl(cache.MutableCache):
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
         user: snowflakes.SnowflakeishOr[users.PartialUser],
         /,
-    ) -> typing.Optional[presences.MemberPresence]:
+    ) -> presences.MemberPresence | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.PRESENCES):
             return None
 
@@ -1458,7 +1440,7 @@ class CacheImpl(cache.MutableCache):
     @typing_extensions.override
     def update_presence(
         self, presence: presences.MemberPresence, /
-    ) -> tuple[typing.Optional[presences.MemberPresence], typing.Optional[presences.MemberPresence]]:
+    ) -> tuple[presences.MemberPresence | None, presences.MemberPresence | None]:
         if not self._is_cache_enabled_for(config_api.CacheComponents.PRESENCES):
             return None, None
 
@@ -1501,7 +1483,7 @@ class CacheImpl(cache.MutableCache):
         return view
 
     @typing_extensions.override
-    def delete_role(self, role: snowflakes.SnowflakeishOr[guilds.PartialRole], /) -> typing.Optional[guilds.Role]:
+    def delete_role(self, role: snowflakes.SnowflakeishOr[guilds.PartialRole], /) -> guilds.Role | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.ROLES):
             return None
 
@@ -1521,7 +1503,7 @@ class CacheImpl(cache.MutableCache):
         return role
 
     @typing_extensions.override
-    def get_role(self, role: snowflakes.SnowflakeishOr[guilds.PartialRole], /) -> typing.Optional[guilds.Role]:
+    def get_role(self, role: snowflakes.SnowflakeishOr[guilds.PartialRole], /) -> guilds.Role | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.ROLES):
             return None
 
@@ -1562,7 +1544,7 @@ class CacheImpl(cache.MutableCache):
         guild_record.roles.add(role.id)
 
     @typing_extensions.override
-    def update_role(self, role: guilds.Role, /) -> tuple[typing.Optional[guilds.Role], typing.Optional[guilds.Role]]:
+    def update_role(self, role: guilds.Role, /) -> tuple[guilds.Role | None, guilds.Role | None]:
         if not self._is_cache_enabled_for(config_api.CacheComponents.ROLES):
             return None, None
 
@@ -1574,9 +1556,7 @@ class CacheImpl(cache.MutableCache):
     def _can_remove_user(user_data: cache_utility.RefCell[users.User]) -> bool:
         return user_data.ref_count < 1
 
-    def _garbage_collect_user(
-        self, user: cache_utility.RefCell[users.User], *, decrement: typing.Optional[int] = None
-    ) -> None:
+    def _garbage_collect_user(self, user: cache_utility.RefCell[users.User], *, decrement: int | None = None) -> None:
         if decrement is not None:
             self._increment_ref_count(user, -decrement)
 
@@ -1585,7 +1565,7 @@ class CacheImpl(cache.MutableCache):
             self._dm_channel_entries.pop(user.object.id, None)
 
     @typing_extensions.override
-    def get_user(self, user: snowflakes.SnowflakeishOr[users.PartialUser], /) -> typing.Optional[users.User]:
+    def get_user(self, user: snowflakes.SnowflakeishOr[users.PartialUser], /) -> users.User | None:
         user = self._user_entries.get(snowflakes.Snowflake(user))
         return user.copy() if user else None
 
@@ -1682,7 +1662,7 @@ class CacheImpl(cache.MutableCache):
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
         user: snowflakes.SnowflakeishOr[users.PartialUser],
         /,
-    ) -> typing.Optional[voices.VoiceState]:
+    ) -> voices.VoiceState | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.VOICE_STATES):
             return None
 
@@ -1711,7 +1691,7 @@ class CacheImpl(cache.MutableCache):
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
         user: snowflakes.SnowflakeishOr[users.PartialUser],
         /,
-    ) -> typing.Optional[voices.VoiceState]:
+    ) -> voices.VoiceState | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.VOICE_STATES):
             return None
 
@@ -1800,7 +1780,7 @@ class CacheImpl(cache.MutableCache):
     @typing_extensions.override
     def update_voice_state(
         self, voice_state: voices.VoiceState, /
-    ) -> tuple[typing.Optional[voices.VoiceState], typing.Optional[voices.VoiceState]]:
+    ) -> tuple[voices.VoiceState | None, voices.VoiceState | None]:
         if not self._is_cache_enabled_for(config_api.CacheComponents.VOICE_STATES):
             return None, None
 
@@ -1818,9 +1798,9 @@ class CacheImpl(cache.MutableCache):
         self,
         message: cache_utility.RefCell[cache_utility.MessageData],
         *,
-        decrement: typing.Optional[int] = None,
+        decrement: int | None = None,
         override_ref: bool = False,
-    ) -> typing.Optional[cache_utility.RefCell[cache_utility.MessageData]]:
+    ) -> cache_utility.RefCell[cache_utility.MessageData] | None:
         if decrement is not None:
             self._increment_ref_count(message, -decrement)
 
@@ -1869,9 +1849,7 @@ class CacheImpl(cache.MutableCache):
         return cache_utility.CacheMappingView(cached_messages, builder=self._build_message)  # type: ignore[type-var]
 
     @typing_extensions.override
-    def delete_message(
-        self, message: snowflakes.SnowflakeishOr[messages.PartialMessage], /
-    ) -> typing.Optional[messages.Message]:
+    def delete_message(self, message: snowflakes.SnowflakeishOr[messages.PartialMessage], /) -> messages.Message | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.MESSAGES):
             return None
 
@@ -1888,9 +1866,7 @@ class CacheImpl(cache.MutableCache):
         return self._build_message(message_data)
 
     @typing_extensions.override
-    def get_message(
-        self, message: snowflakes.SnowflakeishOr[messages.PartialMessage], /
-    ) -> typing.Optional[messages.Message]:
+    def get_message(self, message: snowflakes.SnowflakeishOr[messages.PartialMessage], /) -> messages.Message | None:
         if not self._is_cache_enabled_for(config_api.CacheComponents.MESSAGES):
             return None
 
@@ -1920,7 +1896,7 @@ class CacheImpl(cache.MutableCache):
         if message.user_mentions is not undefined.UNDEFINED:
             user_mentions = {user_id: self._set_user(user) for user_id, user in message.user_mentions.items()}
 
-        referenced_message: typing.Optional[cache_utility.RefCell[cache_utility.MessageData]] = None
+        referenced_message: cache_utility.RefCell[cache_utility.MessageData] | None = None
         if message.referenced_message:
             reference_id = message.referenced_message.id
             referenced_message = self._message_entries.get(reference_id) or self._referenced_messages.get(reference_id)
@@ -1972,8 +1948,8 @@ class CacheImpl(cache.MutableCache):
 
     @typing_extensions.override
     def update_message(
-        self, message: typing.Union[messages.PartialMessage, messages.Message], /
-    ) -> tuple[typing.Optional[messages.Message], typing.Optional[messages.Message]]:
+        self, message: messages.PartialMessage | messages.Message, /
+    ) -> tuple[messages.Message | None, messages.Message | None]:
         if not self._is_cache_enabled_for(config_api.CacheComponents.MESSAGES):
             return None, None
 

--- a/hikari/impl/config.py
+++ b/hikari/impl/config.py
@@ -46,7 +46,7 @@ _BASICAUTH_TOKEN_PREFIX: typing.Final[str] = "Basic"  # noqa: S105
 _PROXY_AUTHENTICATION_HEADER: typing.Final[str] = "Proxy-Authentication"
 
 
-def _ssl_factory(value: typing.Union[bool, ssl_.SSLContext]) -> ssl_.SSLContext:
+def _ssl_factory(value: bool | ssl_.SSLContext) -> ssl_.SSLContext:
     if not isinstance(value, bool):
         return value
 
@@ -111,10 +111,10 @@ class ProxySettings(config.ProxySettings):
     result in no authentication being provided.
     """
 
-    headers: typing.Optional[data_binding.Headers] = attrs.field(default=None)
+    headers: data_binding.Headers | None = attrs.field(default=None)
     """Additional headers to use for requests via a proxy, if required."""
 
-    url: typing.Union[None, str] = attrs.field(default=None)
+    url: None | str = attrs.field(default=None)
     """Proxy URL to use.
 
     Defaults to [`None`][] which disables the use of an explicit proxy.
@@ -137,7 +137,7 @@ class ProxySettings(config.ProxySettings):
     """
 
     @property
-    def all_headers(self) -> typing.Optional[data_binding.Headers]:
+    def all_headers(self) -> data_binding.Headers | None:
         """Return all proxy headers.
 
         Will be [`None`][] if no headers are to be send with any request.
@@ -157,28 +157,28 @@ class ProxySettings(config.ProxySettings):
 class HTTPTimeoutSettings:
     """Settings to control HTTP request timeouts."""
 
-    acquire_and_connect: typing.Optional[float] = attrs.field(default=None)
+    acquire_and_connect: float | None = attrs.field(default=None)
     """Timeout for `request_socket_connect` PLUS connection acquisition.
 
     By default, this has no timeout allocated. Setting it to [`None`][]
     will disable it.
     """
 
-    request_socket_connect: typing.Optional[float] = attrs.field(default=None)
+    request_socket_connect: float | None = attrs.field(default=None)
     """Timeout for connecting a socket.
 
     By default, this has no timeout allocated. Setting it to [`None`][]
     will disable it.
     """
 
-    request_socket_read: typing.Optional[float] = attrs.field(default=None)
+    request_socket_read: float | None = attrs.field(default=None)
     """Timeout for reading a socket.
 
     By default, this has no timeout allocated. Setting it to [`None`][]
     will disable it.
     """
 
-    total: typing.Optional[float] = attrs.field(default=30.0)
+    total: float | None = attrs.field(default=30.0)
     """Total timeout for entire request.
 
     By default, this has a 30 second timeout allocated. Setting it to [`None`][]
@@ -189,7 +189,7 @@ class HTTPTimeoutSettings:
     @request_socket_connect.validator
     @request_socket_read.validator
     @total.validator
-    def _(self, attrsib: attrs.Attribute[typing.Optional[float]], value: object) -> None:
+    def _(self, attrsib: attrs.Attribute[float | None], value: object) -> None:
         # This error won't occur until some time in the future where it will be annoying to
         # try and determine the root cause, so validate it NOW.
         if value is not None and (not isinstance(value, (float, int)) or value <= 0):
@@ -220,7 +220,7 @@ class HTTPSettings(config.HTTPSettings):
     behavior internally.
     """
 
-    max_redirects: typing.Optional[int] = attrs.field(default=10)
+    max_redirects: int | None = attrs.field(default=10)
     """Behavior for handling redirect HTTP responses.
 
     If a [`int`][], allow following redirects from `3xx` HTTP responses
@@ -241,7 +241,7 @@ class HTTPSettings(config.HTTPSettings):
     """
 
     @max_redirects.validator
-    def _(self, _: attrs.Attribute[typing.Optional[int]], value: object) -> None:
+    def _(self, _: attrs.Attribute[int | None], value: object) -> None:
         # This error won't occur until some time in the future where it will be annoying to
         # try and determine the root cause, so validate it NOW.
         if value is not None and (not isinstance(value, int) or value <= 0):

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -91,19 +91,19 @@ def _with_int_cast(cast: typing.Callable[[int], ValueT]) -> typing.Callable[[typ
     return lambda value: cast(int(value))
 
 
-def _deserialize_seconds_timedelta(seconds: typing.Union[str, int]) -> datetime.timedelta:
+def _deserialize_seconds_timedelta(seconds: str | int) -> datetime.timedelta:
     return datetime.timedelta(seconds=int(seconds))
 
 
-def _deserialize_day_timedelta(days: typing.Union[str, int]) -> datetime.timedelta:
+def _deserialize_day_timedelta(days: str | int) -> datetime.timedelta:
     return datetime.timedelta(days=int(days))
 
 
-def _deserialize_max_uses(age: int) -> typing.Optional[int]:
+def _deserialize_max_uses(age: int) -> int | None:
     return age if age > 0 else None
 
 
-def _deserialize_max_age(seconds: int) -> typing.Optional[datetime.timedelta]:
+def _deserialize_max_age(seconds: int) -> datetime.timedelta | None:
     return datetime.timedelta(seconds=seconds) if seconds > 0 else None
 
 
@@ -111,10 +111,10 @@ def _deserialize_max_age(seconds: int) -> typing.Optional[datetime.timedelta]:
 @attrs.define(kw_only=True, repr=False, weakref_slot=False)
 class _GuildChannelFields:
     id: snowflakes.Snowflake = attrs.field()
-    name: typing.Optional[str] = attrs.field()
-    type: typing.Union[channel_models.ChannelType, int] = attrs.field()
+    name: str | None = attrs.field()
+    type: channel_models.ChannelType | int = attrs.field()
     guild_id: snowflakes.Snowflake = attrs.field()
-    parent_id: typing.Optional[snowflakes.Snowflake] = attrs.field()
+    parent_id: snowflakes.Snowflake | None = attrs.field()
 
 
 @attrs_extensions.with_copy
@@ -122,7 +122,7 @@ class _GuildChannelFields:
 class _IntegrationFields:
     id: snowflakes.Snowflake = attrs.field()
     name: str = attrs.field()
-    type: typing.Union[guild_models.IntegrationType, str] = attrs.field()
+    type: guild_models.IntegrationType | str = attrs.field()
     account: guild_models.IntegrationAccount = attrs.field()
 
 
@@ -132,30 +132,30 @@ class _GuildFields:
     id: snowflakes.Snowflake = attrs.field()
     name: str = attrs.field()
     icon_hash: str = attrs.field()
-    features: list[typing.Union[guild_models.GuildFeature, str]] = attrs.field()
-    splash_hash: typing.Optional[str] = attrs.field()
-    discovery_splash_hash: typing.Optional[str] = attrs.field()
+    features: list[guild_models.GuildFeature | str] = attrs.field()
+    splash_hash: str | None = attrs.field()
+    discovery_splash_hash: str | None = attrs.field()
     owner_id: snowflakes.Snowflake = attrs.field()
-    afk_channel_id: typing.Optional[snowflakes.Snowflake] = attrs.field()
+    afk_channel_id: snowflakes.Snowflake | None = attrs.field()
     afk_timeout: datetime.timedelta = attrs.field()
-    verification_level: typing.Union[guild_models.GuildVerificationLevel, int] = attrs.field()
-    default_message_notifications: typing.Union[guild_models.GuildMessageNotificationsLevel, int] = attrs.field()
-    explicit_content_filter: typing.Union[guild_models.GuildVerificationLevel, int] = attrs.field()
-    mfa_level: typing.Union[guild_models.GuildMFALevel, int] = attrs.field()
-    application_id: typing.Optional[snowflakes.Snowflake] = attrs.field()
-    widget_channel_id: typing.Optional[snowflakes.Snowflake] = attrs.field()
-    system_channel_id: typing.Optional[snowflakes.Snowflake] = attrs.field()
-    is_widget_enabled: typing.Optional[bool] = attrs.field()
+    verification_level: guild_models.GuildVerificationLevel | int = attrs.field()
+    default_message_notifications: guild_models.GuildMessageNotificationsLevel | int = attrs.field()
+    explicit_content_filter: guild_models.GuildVerificationLevel | int = attrs.field()
+    mfa_level: guild_models.GuildMFALevel | int = attrs.field()
+    application_id: snowflakes.Snowflake | None = attrs.field()
+    widget_channel_id: snowflakes.Snowflake | None = attrs.field()
+    system_channel_id: snowflakes.Snowflake | None = attrs.field()
+    is_widget_enabled: bool | None = attrs.field()
     system_channel_flags: guild_models.GuildSystemChannelFlag = attrs.field()
-    rules_channel_id: typing.Optional[snowflakes.Snowflake] = attrs.field()
-    max_video_channel_users: typing.Optional[int] = attrs.field()
-    vanity_url_code: typing.Optional[str] = attrs.field()
-    description: typing.Optional[str] = attrs.field()
-    banner_hash: typing.Optional[str] = attrs.field()
-    premium_tier: typing.Union[guild_models.GuildPremiumTier, int] = attrs.field()
-    premium_subscription_count: typing.Optional[int] = attrs.field()
-    preferred_locale: typing.Union[str, locales.Locale] = attrs.field()
-    public_updates_channel_id: typing.Optional[snowflakes.Snowflake] = attrs.field()
+    rules_channel_id: snowflakes.Snowflake | None = attrs.field()
+    max_video_channel_users: int | None = attrs.field()
+    vanity_url_code: str | None = attrs.field()
+    description: str | None = attrs.field()
+    banner_hash: str | None = attrs.field()
+    premium_tier: guild_models.GuildPremiumTier | int = attrs.field()
+    premium_subscription_count: int | None = attrs.field()
+    preferred_locale: str | locales.Locale = attrs.field()
+    public_updates_channel_id: snowflakes.Snowflake | None = attrs.field()
     nsfw_level: guild_models.GuildNSFWLevel = attrs.field()
 
     @classmethod
@@ -214,16 +214,16 @@ class _GuildFields:
 @attrs.define(kw_only=True, repr=False, weakref_slot=False)
 class _InviteFields:
     code: str = attrs.field()
-    guild: typing.Optional[invite_models.InviteGuild] = attrs.field()
-    guild_id: typing.Optional[snowflakes.Snowflake] = attrs.field()
-    channel: typing.Optional[channel_models.PartialChannel] = attrs.field()
+    guild: invite_models.InviteGuild | None = attrs.field()
+    guild_id: snowflakes.Snowflake | None = attrs.field()
+    channel: channel_models.PartialChannel | None = attrs.field()
     channel_id: snowflakes.Snowflake = attrs.field()
-    inviter: typing.Optional[user_models.User] = attrs.field()
-    target_user: typing.Optional[user_models.User] = attrs.field()
-    target_application: typing.Optional[application_models.InviteApplication] = attrs.field()
-    target_type: typing.Union[invite_models.TargetType, int, None] = attrs.field()
-    approximate_active_member_count: typing.Optional[int] = attrs.field()
-    approximate_member_count: typing.Optional[int] = attrs.field()
+    inviter: user_models.User | None = attrs.field()
+    target_user: user_models.User | None = attrs.field()
+    target_application: application_models.InviteApplication | None = attrs.field()
+    target_type: invite_models.TargetType | int | None = attrs.field()
+    approximate_active_member_count: int | None = attrs.field()
+    approximate_member_count: int | None = attrs.field()
 
 
 @attrs_extensions.with_copy
@@ -232,10 +232,10 @@ class _UserFields:
     id: snowflakes.Snowflake = attrs.field()
     discriminator: str = attrs.field()
     username: str = attrs.field()
-    global_name: typing.Optional[str] = attrs.field()
+    global_name: str | None = attrs.field()
     avatar_hash: str = attrs.field()
-    banner_hash: typing.Optional[str] = attrs.field()
-    accent_color: typing.Optional[color_models.Color] = attrs.field()
+    banner_hash: str | None = attrs.field()
+    accent_color: color_models.Color | None = attrs.field()
     is_bot: bool = attrs.field()
     is_system: bool = attrs.field()
 
@@ -503,7 +503,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             audit_log_models.AuditLogChangeKey.COMMUNICATION_DISABLED_UNTIL: time.iso8601_datetime_string_to_datetime,
         }
         self._audit_log_event_mapping: dict[
-            typing.Union[int, audit_log_models.AuditLogEventType],
+            int | audit_log_models.AuditLogEventType,
             typing.Callable[[data_binding.JSONObject], audit_log_models.BaseAuditLogEntryInfo],
         ] = {
             audit_log_models.AuditLogEventType.CHANNEL_OVERWRITE_CREATE: self._deserialize_channel_overwrite_entry_info,
@@ -632,7 +632,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
 
     @typing_extensions.override
     def deserialize_application(self, payload: data_binding.JSONObject) -> application_models.Application:
-        team: typing.Optional[application_models.Team] = None
+        team: application_models.Team | None = None
         if (team_payload := payload.get("team")) is not None:
             members = {}
             for member_payload in team_payload["members"]:
@@ -653,7 +653,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
                 owner_id=snowflakes.Snowflake(team_payload["owner_user_id"]),
             )
 
-        install_parameters: typing.Optional[application_models.ApplicationInstallParameters] = None
+        install_parameters: application_models.ApplicationInstallParameters | None = None
         if (install_payload := payload.get("install_params")) is not None:
             install_parameters = application_models.ApplicationInstallParameters(
                 scopes=[application_models.OAuth2Scope(scope) for scope in install_payload["scopes"]],
@@ -890,7 +890,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         changes: list[audit_log_models.AuditLogChange] = []
         if (change_payloads := payload.get("changes")) is not None:
             for change_payload in change_payloads:
-                key: typing.Union[audit_log_models.AuditLogChangeKey, str] = audit_log_models.AuditLogChangeKey(
+                key: audit_log_models.AuditLogChangeKey | str = audit_log_models.AuditLogChangeKey(
                     change_payload["key"]
                 )
 
@@ -905,18 +905,18 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
 
                 changes.append(audit_log_models.AuditLogChange(key=key, new_value=new_value, old_value=old_value))
 
-        target_id: typing.Optional[snowflakes.Snowflake] = None
+        target_id: snowflakes.Snowflake | None = None
         if (raw_target_id := payload["target_id"]) is not None:
             target_id = snowflakes.Snowflake(raw_target_id)
 
-        user_id: typing.Optional[snowflakes.Snowflake] = None
+        user_id: snowflakes.Snowflake | None = None
         if (raw_user_id := payload["user_id"]) is not None:
             user_id = snowflakes.Snowflake(raw_user_id)
 
-        action_type: typing.Union[audit_log_models.AuditLogEventType, int]
+        action_type: audit_log_models.AuditLogEventType | int
         action_type = audit_log_models.AuditLogEventType(payload["action_type"])
 
-        options: typing.Optional[audit_log_models.BaseAuditLogEntryInfo] = None
+        options: audit_log_models.BaseAuditLogEntryInfo | None = None
         if (raw_option := payload.get("options")) is not None:
             if option_converter := self._audit_log_event_mapping.get(action_type):
                 options = option_converter(raw_option)
@@ -1027,7 +1027,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
 
     @typing_extensions.override
     def deserialize_dm(self, payload: data_binding.JSONObject) -> channel_models.DMChannel:
-        last_message_id: typing.Optional[snowflakes.Snowflake] = None
+        last_message_id: snowflakes.Snowflake | None = None
         if (raw_last_message_id := payload.get("last_message_id")) is not None:
             last_message_id = snowflakes.Snowflake(raw_last_message_id)
 
@@ -1042,7 +1042,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
 
     @typing_extensions.override
     def deserialize_group_dm(self, payload: data_binding.JSONObject) -> channel_models.GroupDMChannel:
-        last_message_id: typing.Optional[snowflakes.Snowflake] = None
+        last_message_id: snowflakes.Snowflake | None = None
         if (raw_last_message_id := payload.get("last_message_id")) is not None:
             last_message_id = snowflakes.Snowflake(raw_last_message_id)
 
@@ -1072,7 +1072,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         if guild_id is undefined.UNDEFINED:
             guild_id = snowflakes.Snowflake(payload["guild_id"])
 
-        parent_id: typing.Optional[snowflakes.Snowflake] = None
+        parent_id: snowflakes.Snowflake | None = None
         if (raw_parent_id := payload.get("parent_id")) is not None:
             parent_id = snowflakes.Snowflake(raw_parent_id)
 
@@ -1124,11 +1124,11 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             for overwrite in payload["permission_overwrites"]
         }
 
-        last_message_id: typing.Optional[snowflakes.Snowflake] = None
+        last_message_id: snowflakes.Snowflake | None = None
         if (raw_last_message_id := payload.get("last_message_id")) is not None:
             last_message_id = snowflakes.Snowflake(raw_last_message_id)
 
-        last_pin_timestamp: typing.Optional[datetime.datetime] = None
+        last_pin_timestamp: datetime.datetime | None = None
         if (raw_last_pin_timestamp := payload.get("last_pin_timestamp")) is not None:
             last_pin_timestamp = time.iso8601_datetime_string_to_datetime(raw_last_pin_timestamp)
 
@@ -1168,11 +1168,11 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             for overwrite in payload["permission_overwrites"]
         }
 
-        last_message_id: typing.Optional[snowflakes.Snowflake] = None
+        last_message_id: snowflakes.Snowflake | None = None
         if (raw_last_message_id := payload.get("last_message_id")) is not None:
             last_message_id = snowflakes.Snowflake(raw_last_message_id)
 
-        last_pin_timestamp: typing.Optional[datetime.datetime] = None
+        last_pin_timestamp: datetime.datetime | None = None
         if (raw_last_pin_timestamp := payload.get("last_pin_timestamp")) is not None:
             last_pin_timestamp = time.iso8601_datetime_string_to_datetime(raw_last_pin_timestamp)
 
@@ -1203,7 +1203,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         # Discord seems to be only returning this after it's been initially PATCHed in for older channels.
         video_quality_mode = payload.get("video_quality_mode", channel_models.VideoQualityMode.AUTO)
 
-        last_message_id: typing.Optional[snowflakes.Snowflake] = None
+        last_message_id: snowflakes.Snowflake | None = None
         if (raw_last_message_id := payload.get("last_message_id")) is not None:
             last_message_id = snowflakes.Snowflake(raw_last_message_id)
 
@@ -1241,7 +1241,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         # Discord seems to be only returning this after it's been initially PATCHed in for older channels.
         video_quality_mode = payload.get("video_quality_mode", channel_models.VideoQualityMode.AUTO)
 
-        last_message_id: typing.Optional[snowflakes.Snowflake] = None
+        last_message_id: snowflakes.Snowflake | None = None
         if (raw_last_message_id := payload.get("last_message_id")) is not None:
             last_message_id = snowflakes.Snowflake(raw_last_message_id)
 
@@ -1286,13 +1286,13 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             for overwrite in payload["permission_overwrites"]
         }
 
-        last_thread_id: typing.Optional[snowflakes.Snowflake] = None
+        last_thread_id: snowflakes.Snowflake | None = None
         if raw_last_thread_id := payload.get("last_message_id"):
             last_thread_id = snowflakes.Snowflake(raw_last_thread_id)
 
         available_tags: list[channel_models.ForumTag] = []
         for tag_payload in payload.get("available_tags", ()):
-            tag_emoji: typing.Union[emoji_models.UnicodeEmoji, snowflakes.Snowflake, None]
+            tag_emoji: emoji_models.UnicodeEmoji | snowflakes.Snowflake | None
             if tag_emoji := tag_payload["emoji_id"]:
                 tag_emoji = snowflakes.Snowflake(tag_emoji)
 
@@ -1308,8 +1308,8 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
                 )
             )
 
-        reaction_emoji_id: typing.Optional[snowflakes.Snowflake] = None
-        reaction_emoji_name: typing.Union[None, emoji_models.UnicodeEmoji, str] = None
+        reaction_emoji_id: snowflakes.Snowflake | None = None
+        reaction_emoji_name: None | emoji_models.UnicodeEmoji | str = None
         if reaction_emoji_payload := payload.get("default_reaction_emoji"):
             if reaction_emoji_id := reaction_emoji_payload["emoji_id"]:
                 reaction_emoji_id = snowflakes.Snowflake(reaction_emoji_id)
@@ -1388,7 +1388,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         raise errors.UnrecognisedEntityError(msg)
 
     def _deserialize_thread_metadata(self, payload: data_binding.JSONObject) -> channel_models.ThreadMetadata:
-        created_at: typing.Optional[datetime.datetime] = None
+        created_at: datetime.datetime | None = None
         if raw_created_at := payload.get("create_timestamp"):
             created_at = time.iso8601_datetime_string_to_datetime(raw_created_at)
 
@@ -1411,11 +1411,11 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         user_id: undefined.UndefinedOr[snowflakes.Snowflake] = undefined.UNDEFINED,
     ) -> channel_models.GuildNewsThread:
         channel_fields = self._set_guild_channel_attributes(payload, guild_id=guild_id)
-        last_message_id: typing.Optional[snowflakes.Snowflake] = None
+        last_message_id: snowflakes.Snowflake | None = None
         if (raw_last_message_id := payload.get("last_message_id")) is not None:
             last_message_id = snowflakes.Snowflake(raw_last_message_id)
 
-        last_pin_timestamp: typing.Optional[datetime.datetime] = None
+        last_pin_timestamp: datetime.datetime | None = None
         if (raw_last_pin_timestamp := payload.get("last_pin_timestamp")) is not None:
             last_pin_timestamp = time.iso8601_datetime_string_to_datetime(raw_last_pin_timestamp)
 
@@ -1457,11 +1457,11 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             else channel_models.ChannelFlag.NONE
         )
 
-        last_message_id: typing.Optional[snowflakes.Snowflake] = None
+        last_message_id: snowflakes.Snowflake | None = None
         if (raw_last_message_id := payload.get("last_message_id")) is not None:
             last_message_id = snowflakes.Snowflake(raw_last_message_id)
 
-        last_pin_timestamp: typing.Optional[datetime.datetime] = None
+        last_pin_timestamp: datetime.datetime | None = None
         if (raw_last_pin_timestamp := payload.get("last_pin_timestamp")) is not None:
             last_pin_timestamp = time.iso8601_datetime_string_to_datetime(raw_last_pin_timestamp)
 
@@ -1499,11 +1499,11 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         user_id: undefined.UndefinedOr[snowflakes.Snowflake] = undefined.UNDEFINED,
     ) -> channel_models.GuildPrivateThread:
         channel_fields = self._set_guild_channel_attributes(payload, guild_id=guild_id)
-        last_message_id: typing.Optional[snowflakes.Snowflake] = None
+        last_message_id: snowflakes.Snowflake | None = None
         if (raw_last_message_id := payload.get("last_message_id")) is not None:
             last_message_id = snowflakes.Snowflake(raw_last_message_id)
 
-        last_pin_timestamp: typing.Optional[datetime.datetime] = None
+        last_pin_timestamp: datetime.datetime | None = None
         if (raw_last_pin_timestamp := payload.get("last_pin_timestamp")) is not None:
             last_pin_timestamp = time.iso8601_datetime_string_to_datetime(raw_last_pin_timestamp)
 
@@ -1578,9 +1578,9 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         url = payload.get("url")
         color = color_models.Color(payload["color"]) if "color" in payload else None
         timestamp = time.iso8601_datetime_string_to_datetime(payload["timestamp"]) if "timestamp" in payload else None
-        fields: typing.Optional[list[embed_models.EmbedField]] = None
+        fields: list[embed_models.EmbedField] | None = None
 
-        image: typing.Optional[embed_models.EmbedImage] = None
+        image: embed_models.EmbedImage | None = None
         if (image_payload := payload.get("image")) and "url" in image_payload:
             proxy = files.ensure_resource(image_payload["proxy_url"]) if "proxy_url" in image_payload else None
             image = embed_models.EmbedImage(
@@ -1590,7 +1590,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
                 width=image_payload.get("width"),
             )
 
-        thumbnail: typing.Optional[embed_models.EmbedImage] = None
+        thumbnail: embed_models.EmbedImage | None = None
         if (thumbnail_payload := payload.get("thumbnail")) and "url" in thumbnail_payload:
             proxy = files.ensure_resource(thumbnail_payload["proxy_url"]) if "proxy_url" in thumbnail_payload else None
             thumbnail = embed_models.EmbedImage(
@@ -1600,7 +1600,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
                 width=thumbnail_payload.get("width"),
             )
 
-        video: typing.Optional[embed_models.EmbedVideo] = None
+        video: embed_models.EmbedVideo | None = None
         if (video_payload := payload.get("video")) and "url" in video_payload:
             raw_proxy_url = video_payload.get("proxy_url")
             video = embed_models.EmbedVideo(
@@ -1610,12 +1610,12 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
                 width=video_payload.get("width"),
             )
 
-        provider: typing.Optional[embed_models.EmbedProvider] = None
+        provider: embed_models.EmbedProvider | None = None
         if provider_payload := payload.get("provider"):
             provider = embed_models.EmbedProvider(name=provider_payload.get("name"), url=provider_payload.get("url"))
 
-        icon: typing.Optional[embed_models.EmbedResourceWithProxy]
-        author: typing.Optional[embed_models.EmbedAuthor] = None
+        icon: embed_models.EmbedResourceWithProxy | None
+        author: embed_models.EmbedAuthor | None = None
         if author_payload := payload.get("author"):
             icon = None
             if "icon_url" in author_payload:
@@ -1627,7 +1627,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
 
             author = embed_models.EmbedAuthor(name=author_payload.get("name"), url=author_payload.get("url"), icon=icon)
 
-        footer: typing.Optional[embed_models.EmbedFooter] = None
+        footer: embed_models.EmbedFooter | None = None
         if footer_payload := payload.get("footer"):
             icon = None
             if "icon_url" in footer_payload:
@@ -1782,7 +1782,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
     ) -> emoji_models.KnownCustomEmoji:
         role_ids = [snowflakes.Snowflake(role_id) for role_id in payload["roles"]] if "roles" in payload else []
 
-        user: typing.Optional[user_models.User] = None
+        user: user_models.User | None = None
         if (raw_user := payload.get("user")) is not None:
             user = self.deserialize_user(raw_user)
 
@@ -1802,7 +1802,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
     @typing_extensions.override
     def deserialize_emoji(
         self, payload: data_binding.JSONObject
-    ) -> typing.Union[emoji_models.UnicodeEmoji, emoji_models.CustomEmoji]:
+    ) -> emoji_models.UnicodeEmoji | emoji_models.CustomEmoji:
         if payload.get("id") is not None:
             return self.deserialize_custom_emoji(payload)
 
@@ -1833,7 +1833,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
 
     @typing_extensions.override
     def deserialize_guild_widget(self, payload: data_binding.JSONObject) -> guild_models.GuildWidget:
-        channel_id: typing.Optional[snowflakes.Snowflake] = None
+        channel_id: snowflakes.Snowflake | None = None
         if (raw_channel_id := payload["channel_id"]) is not None:
             channel_id = snowflakes.Snowflake(raw_channel_id)
 
@@ -1847,7 +1847,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             raw_emoji_id = channel_payload["emoji_id"]
             emoji_id = snowflakes.Snowflake(raw_emoji_id) if raw_emoji_id else None
 
-            emoji_name: typing.Union[None, emoji_models.UnicodeEmoji, str]
+            emoji_name: None | emoji_models.UnicodeEmoji | str
             if (emoji_name := channel_payload["emoji_name"]) and not emoji_id:
                 emoji_name = emoji_models.UnicodeEmoji(emoji_name)
 
@@ -1906,7 +1906,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
 
         guild_flags = guild_models.GuildMemberFlags(payload.get("flags") or guild_models.GuildMemberFlags.NONE)
 
-        communication_disabled_until: typing.Optional[datetime.datetime] = None
+        communication_disabled_until: datetime.datetime | None = None
         if raw_communication_disabled_until := payload.get("communication_disabled_until"):
             communication_disabled_until = time.iso8601_datetime_string_to_datetime(raw_communication_disabled_until)
 
@@ -1930,9 +1930,9 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
     def deserialize_role(
         self, payload: data_binding.JSONObject, *, guild_id: snowflakes.Snowflake
     ) -> guild_models.Role:
-        bot_id: typing.Optional[snowflakes.Snowflake] = None
-        integration_id: typing.Optional[snowflakes.Snowflake] = None
-        subscription_listing_id: typing.Optional[snowflakes.Snowflake] = None
+        bot_id: snowflakes.Snowflake | None = None
+        integration_id: snowflakes.Snowflake | None = None
+        subscription_listing_id: snowflakes.Snowflake | None = None
         is_premium_subscriber_role: bool = False
         is_available_for_purchase: bool = False
         is_guild_linked_role: bool = False
@@ -1951,7 +1951,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             if "guild_connections" in tags_payload:
                 is_guild_linked_role = True
 
-        emoji: typing.Optional[emoji_models.UnicodeEmoji] = None
+        emoji: emoji_models.UnicodeEmoji | None = None
         if (raw_emoji := payload.get("unicode_emoji")) is not None:
             emoji = emoji_models.UnicodeEmoji(raw_emoji)
 
@@ -2006,29 +2006,29 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
     ) -> guild_models.Integration:
         integration_fields = self._set_partial_integration_attributes(payload)
 
-        role_id: typing.Optional[snowflakes.Snowflake] = None
+        role_id: snowflakes.Snowflake | None = None
         if (raw_role_id := payload.get("role_id")) is not None:
             role_id = snowflakes.Snowflake(raw_role_id)
 
-        last_synced_at: typing.Optional[datetime.datetime] = None
+        last_synced_at: datetime.datetime | None = None
         if (raw_last_synced_at := payload.get("synced_at")) is not None:
             last_synced_at = time.iso8601_datetime_string_to_datetime(raw_last_synced_at)
 
-        expire_grace_period: typing.Optional[datetime.timedelta] = None
+        expire_grace_period: datetime.timedelta | None = None
         if (raw_expire_grace_period := payload.get("expire_grace_period")) is not None:
             expire_grace_period = datetime.timedelta(days=raw_expire_grace_period)
 
-        expire_behavior: typing.Union[guild_models.IntegrationExpireBehaviour, int, None] = None
+        expire_behavior: guild_models.IntegrationExpireBehaviour | int | None = None
         if (raw_expire_behavior := payload.get("expire_behavior")) is not None:
             expire_behavior = guild_models.IntegrationExpireBehaviour(raw_expire_behavior)
 
-        user: typing.Optional[user_models.User] = None
+        user: user_models.User | None = None
         if (raw_user := payload.get("user")) is not None:
             user = self.deserialize_user(raw_user)
 
-        application: typing.Optional[guild_models.IntegrationApplication] = None
+        application: guild_models.IntegrationApplication | None = None
         if (raw_application := payload.get("application")) is not None:
-            bot: typing.Optional[user_models.User] = None
+            bot: user_models.User | None = None
             if (raw_application_bot := raw_application.get("bot")) is not None:
                 bot = self.deserialize_user(raw_application_bot)
 
@@ -2088,11 +2088,11 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
     def deserialize_rest_guild(self, payload: data_binding.JSONObject) -> guild_models.RESTGuild:
         guild_fields = _GuildFields.from_payload(payload)
 
-        approximate_member_count: typing.Optional[int] = None
+        approximate_member_count: int | None = None
         if "approximate_member_count" in payload:
             approximate_member_count = int(payload["approximate_member_count"])
 
-        approximate_active_member_count: typing.Optional[int] = None
+        approximate_active_member_count: int | None = None
         if "approximate_presence_count" in payload:
             approximate_active_member_count = int(payload["approximate_presence_count"])
 
@@ -2168,8 +2168,8 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         return invite_models.VanityURL(app=self._app, code=payload["code"], uses=int(payload["uses"]))
 
     def _set_invite_attributes(self, payload: data_binding.JSONObject) -> _InviteFields:
-        guild: typing.Optional[invite_models.InviteGuild] = None
-        guild_id: typing.Optional[snowflakes.Snowflake] = None
+        guild: invite_models.InviteGuild | None = None
+        guild_id: snowflakes.Snowflake | None = None
         if "guild" in payload:
             guild_payload = payload["guild"]
             raw_welcome_screen = guild_payload.get("welcome_screen")
@@ -2192,14 +2192,14 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         elif "guild_id" in payload:
             guild_id = snowflakes.Snowflake(payload["guild_id"])
 
-        channel: typing.Optional[channel_models.PartialChannel] = None
+        channel: channel_models.PartialChannel | None = None
         if (raw_channel := payload.get("channel")) is not None:
             channel = self.deserialize_partial_channel(raw_channel)
             channel_id = channel.id
         else:
             channel_id = snowflakes.Snowflake(payload["channel_id"])
 
-        target_application: typing.Optional[application_models.InviteApplication] = None
+        target_application: application_models.InviteApplication | None = None
         if (invite_payload := payload.get("target_application")) is not None:
             target_application = application_models.InviteApplication(
                 app=self._app,
@@ -2235,7 +2235,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
     def deserialize_invite(self, payload: data_binding.JSONObject) -> invite_models.Invite:
         invite_fields = self._set_invite_attributes(payload)
 
-        expires_at: typing.Optional[datetime.datetime] = None
+        expires_at: datetime.datetime | None = None
         if raw_expires_at := payload.get("expires_at"):
             expires_at = time.iso8601_datetime_string_to_datetime(raw_expires_at)
 
@@ -2261,8 +2261,8 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         created_at = time.iso8601_datetime_string_to_datetime(payload["created_at"])
         max_uses = int(payload["max_uses"])
 
-        expires_at: typing.Optional[datetime.datetime] = None
-        max_age: typing.Optional[datetime.timedelta] = None
+        expires_at: datetime.datetime | None = None
+        max_age: datetime.timedelta | None = None
         if (raw_max_age := payload["max_age"]) > 0:
             max_age = datetime.timedelta(seconds=raw_max_age)
             expires_at = created_at + max_age
@@ -2293,7 +2293,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
     ######################
 
     def _deserialize_command_option(self, payload: data_binding.JSONObject) -> commands.CommandOption:
-        choices: typing.Optional[list[commands.CommandChoice]] = None
+        choices: list[commands.CommandChoice] | None = None
         if raw_choices := payload.get("choices"):
             choices = [
                 commands.CommandChoice(
@@ -2304,11 +2304,11 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
                 for choice in raw_choices
             ]
 
-        suboptions: typing.Optional[list[commands.CommandOption]] = None
+        suboptions: list[commands.CommandOption] | None = None
         if raw_options := payload.get("options"):
             suboptions = [self._deserialize_command_option(option) for option in raw_options]
 
-        channel_types: typing.Optional[typing.Sequence[typing.Union[channel_models.ChannelType, int]]] = None
+        channel_types: typing.Sequence[channel_models.ChannelType | int] | None = None
         if raw_channel_types := payload.get("channel_types"):
             channel_types = [channel_models.ChannelType(channel_type) for channel_type in raw_channel_types]
 
@@ -2354,17 +2354,17 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             raw_guild_id = payload["guild_id"]
             guild_id = snowflakes.Snowflake(raw_guild_id) if raw_guild_id is not None else None
 
-        options: typing.Optional[list[commands.CommandOption]] = None
+        options: list[commands.CommandOption] | None = None
         if raw_options := payload.get("options"):
             options = [self._deserialize_command_option(option) for option in raw_options]
 
-        name_localizations: typing.Mapping[typing.Union[locales.Locale, str], str]
+        name_localizations: typing.Mapping[locales.Locale | str, str]
         if raw_name_localizations := payload.get("name_localizations"):
             name_localizations = {locales.Locale(k): raw_name_localizations[k] for k in raw_name_localizations}
         else:
             name_localizations = {}
 
-        description_localizations: typing.Mapping[typing.Union[locales.Locale, str], str]
+        description_localizations: typing.Mapping[locales.Locale | str, str]
         if raw_description_localizations := payload.get("description_localizations"):
             description_localizations = {
                 locales.Locale(k): raw_description_localizations[k] for k in raw_description_localizations
@@ -2418,7 +2418,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             raw_guild_id = payload["guild_id"]
             guild_id = snowflakes.Snowflake(raw_guild_id) if raw_guild_id is not None else None
 
-        name_localizations: typing.Mapping[typing.Union[locales.Locale, str], str]
+        name_localizations: typing.Mapping[locales.Locale | str, str]
         if raw_name_localizations := payload.get("name_localizations"):
             name_localizations = {locales.Locale(k): raw_name_localizations[k] for k in raw_name_localizations}
         else:
@@ -2499,7 +2499,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
     def _deserialize_interaction_command_option(
         self, payload: data_binding.JSONObject
     ) -> command_interactions.CommandInteractionOption:
-        suboptions: typing.Optional[typing.Sequence[command_interactions.CommandInteractionOption]] = None
+        suboptions: typing.Sequence[command_interactions.CommandInteractionOption] | None = None
         if raw_suboptions := payload.get("options"):
             suboptions = [self._deserialize_interaction_command_option(suboption) for suboption in raw_suboptions]
 
@@ -2518,7 +2518,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
     def _deserialize_autocomplete_interaction_option(
         self, payload: data_binding.JSONObject
     ) -> command_interactions.AutocompleteInteractionOption:
-        suboptions: typing.Optional[typing.Sequence[command_interactions.AutocompleteInteractionOption]] = None
+        suboptions: typing.Sequence[command_interactions.AutocompleteInteractionOption] | None = None
         if raw_suboptions := payload.get("options"):
             suboptions = [self._deserialize_autocomplete_interaction_option(suboption) for suboption in raw_suboptions]
 
@@ -2538,11 +2538,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         )
 
     def _deserialize_interaction_member(
-        self,
-        payload: data_binding.JSONObject,
-        *,
-        guild_id: snowflakes.Snowflake,
-        user: typing.Optional[user_models.User] = None,
+        self, payload: data_binding.JSONObject, *, guild_id: snowflakes.Snowflake, user: user_models.User | None = None
     ) -> base_interactions.InteractionMember:
         if not user:
             user = self.deserialize_user(payload["user"])
@@ -2552,7 +2548,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         if guild_id not in role_ids:
             role_ids.append(guild_id)
 
-        premium_since: typing.Optional[datetime.datetime] = None
+        premium_since: datetime.datetime | None = None
         if (raw_premium_since := payload.get("premium_since")) is not None:
             premium_since = time.iso8601_datetime_string_to_datetime(raw_premium_since)
 
@@ -2603,7 +2599,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         )
 
     def _deserialize_resolved_option_data(
-        self, payload: data_binding.JSONObject, *, guild_id: typing.Optional[snowflakes.Snowflake] = None
+        self, payload: data_binding.JSONObject, *, guild_id: snowflakes.Snowflake | None = None
     ) -> base_interactions.ResolvedOptionData:
         channels: dict[snowflakes.Snowflake, base_interactions.InteractionChannel] = {}
         if raw_channels := payload.get("channels"):
@@ -2656,13 +2652,13 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
     ) -> command_interactions.CommandInteraction:
         data_payload = payload["data"]
 
-        guild_id: typing.Optional[snowflakes.Snowflake] = None
+        guild_id: snowflakes.Snowflake | None = None
         if raw_guild_id := payload.get("guild_id"):
             guild_id = snowflakes.Snowflake(raw_guild_id)
 
         options = [self._deserialize_interaction_command_option(option) for option in data_payload.get("options", ())]
 
-        member: typing.Optional[base_interactions.InteractionMember]
+        member: base_interactions.InteractionMember | None
         if member_payload := payload.get("member"):
             assert guild_id is not None
             member = self._deserialize_interaction_member(member_payload, guild_id=guild_id)
@@ -2673,11 +2669,11 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             member = None
             user = self.deserialize_user(payload["user"])
 
-        resolved: typing.Optional[base_interactions.ResolvedOptionData] = None
+        resolved: base_interactions.ResolvedOptionData | None = None
         if resolved_payload := data_payload.get("resolved"):
             resolved = self._deserialize_resolved_option_data(resolved_payload, guild_id=guild_id)
 
-        target_id: typing.Optional[snowflakes.Snowflake] = None
+        target_id: snowflakes.Snowflake | None = None
         if raw_target_id := data_payload.get("target_id"):
             target_id = snowflakes.Snowflake(raw_target_id)
 
@@ -2722,13 +2718,13 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
     ) -> command_interactions.AutocompleteInteraction:
         data_payload = payload["data"]
 
-        guild_id: typing.Optional[snowflakes.Snowflake] = None
+        guild_id: snowflakes.Snowflake | None = None
         if raw_guild_id := payload.get("guild_id"):
             guild_id = snowflakes.Snowflake(raw_guild_id)
 
         options = [self._deserialize_autocomplete_interaction_option(option) for option in data_payload["options"]]
 
-        member: typing.Optional[base_interactions.InteractionMember]
+        member: base_interactions.InteractionMember | None
         if member_payload := payload.get("member"):
             assert guild_id is not None
             member = self._deserialize_interaction_member(member_payload, guild_id=guild_id)
@@ -2774,11 +2770,11 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
     def deserialize_modal_interaction(self, payload: data_binding.JSONObject) -> modal_interactions.ModalInteraction:
         data_payload = payload["data"]
 
-        guild_id: typing.Optional[snowflakes.Snowflake] = None
+        guild_id: snowflakes.Snowflake | None = None
         if raw_guild_id := payload.get("guild_id"):
             guild_id = snowflakes.Snowflake(raw_guild_id)
 
-        member: typing.Optional[base_interactions.InteractionMember]
+        member: base_interactions.InteractionMember | None
         if member_payload := payload.get("member"):
             assert guild_id is not None
             member = self._deserialize_interaction_member(member_payload, guild_id=guild_id)
@@ -2789,7 +2785,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             member = None
             user = self.deserialize_user(payload["user"])
 
-        message: typing.Optional[message_models.Message] = None
+        message: message_models.Message | None = None
         if message_payload := payload.get("message"):
             message = self.deserialize_message(message_payload)
 
@@ -2881,7 +2877,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         if raw_guild_id := payload.get("guild_id"):
             guild_id = snowflakes.Snowflake(raw_guild_id)
 
-        member: typing.Optional[base_interactions.InteractionMember]
+        member: base_interactions.InteractionMember | None
         if member_payload := payload.get("member"):
             assert guild_id is not None
             member = self._deserialize_interaction_member(member_payload, guild_id=guild_id)
@@ -2892,7 +2888,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             member = None
             user = self.deserialize_user(payload["user"])
 
-        resolved: typing.Optional[base_interactions.ResolvedOptionData] = None
+        resolved: base_interactions.ResolvedOptionData | None = None
         if resolved_payload := data_payload.get("resolved"):
             resolved = self._deserialize_resolved_option_data(resolved_payload, guild_id=guild_id)
 
@@ -2937,11 +2933,11 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             self.deserialize_standard_sticker(p) for p in payload["stickers"]
         ]
 
-        cover_sticker_id: typing.Optional[snowflakes.Snowflake] = None
+        cover_sticker_id: snowflakes.Snowflake | None = None
         if raw_cover_sticker_id := payload.get("cover_sticker_id"):
             cover_sticker_id = snowflakes.Snowflake(raw_cover_sticker_id)
 
-        banner_asset_id: typing.Optional[snowflakes.Snowflake] = None
+        banner_asset_id: snowflakes.Snowflake | None = None
         if raw_banner_asset_id := payload.get("banner_asset_id"):
             banner_asset_id = snowflakes.Snowflake(raw_banner_asset_id)
 
@@ -3095,7 +3091,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
     def _deserialize_channel_select_menu(
         self, payload: data_binding.JSONObject
     ) -> component_models.ChannelSelectMenuComponent:
-        channel_types: list[typing.Union[int, channel_models.ChannelType]] = []
+        channel_types: list[int | channel_models.ChannelType] = []
         if "channel_types" in payload:
             channel_types.extend(channel_models.ChannelType(t) for t in payload["channel_types"])
 
@@ -3155,11 +3151,11 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         )
 
     def _deserialize_message_reference(self, payload: data_binding.JSONObject) -> message_models.MessageReference:
-        message_reference_message_id: typing.Optional[snowflakes.Snowflake] = None
+        message_reference_message_id: snowflakes.Snowflake | None = None
         if "message_id" in payload:
             message_reference_message_id = snowflakes.Snowflake(payload["message_id"])
 
-        message_reference_guild_id: typing.Optional[snowflakes.Snowflake] = None
+        message_reference_guild_id: snowflakes.Snowflake | None = None
         if "guild_id" in payload:
             message_reference_guild_id = snowflakes.Snowflake(payload["guild_id"])
 
@@ -3255,7 +3251,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         if author_pl := payload.get("author"):
             author = self.deserialize_user(author_pl)
 
-        guild_id: typing.Optional[snowflakes.Snowflake] = None
+        guild_id: snowflakes.Snowflake | None = None
         member: undefined.UndefinedNoneOr[guild_models.Member] = None
         if "guild_id" in payload:
             guild_id = snowflakes.Snowflake(payload["guild_id"])
@@ -3388,15 +3384,15 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
     def deserialize_message(self, payload: data_binding.JSONObject) -> message_models.Message:  # noqa: PLR0912, PLR0915
         author = self.deserialize_user(payload["author"])
 
-        guild_id: typing.Optional[snowflakes.Snowflake] = None
-        member: typing.Optional[guild_models.Member] = None
+        guild_id: snowflakes.Snowflake | None = None
+        member: guild_models.Member | None = None
         if "guild_id" in payload:
             guild_id = snowflakes.Snowflake(payload["guild_id"])
 
             if member_pl := payload.get("member"):
                 member = self.deserialize_member(member_pl, user=author, guild_id=guild_id)
 
-        edited_timestamp: typing.Optional[datetime.datetime] = None
+        edited_timestamp: datetime.datetime | None = None
         if (raw_edited_timestamp := payload["edited_timestamp"]) is not None:
             edited_timestamp = time.iso8601_datetime_string_to_datetime(raw_edited_timestamp)
 
@@ -3404,7 +3400,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
 
         embeds = [self.deserialize_embed(embed) for embed in payload["embeds"]]
 
-        poll: typing.Optional[poll_models.Poll] = None
+        poll: poll_models.Poll | None = None
         if "poll" in payload:
             poll = self.deserialize_poll(payload["poll"])
 
@@ -3413,19 +3409,19 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         else:
             reactions = []
 
-        activity: typing.Optional[message_models.MessageActivity] = None
+        activity: message_models.MessageActivity | None = None
         if "activity" in payload:
             activity = self._deserialize_message_activity(payload["activity"])
 
-        message_reference: typing.Optional[message_models.MessageReference] = None
+        message_reference: message_models.MessageReference | None = None
         if "message_reference" in payload:
             message_reference = self._deserialize_message_reference(payload["message_reference"])
 
-        referenced_message: typing.Optional[message_models.PartialMessage] = None
+        referenced_message: message_models.PartialMessage | None = None
         if referenced_message_payload := payload.get("referenced_message"):
             referenced_message = self.deserialize_partial_message(referenced_message_payload)
 
-        application: typing.Optional[message_models.MessageApplication] = None
+        application: message_models.MessageApplication | None = None
         if "application" in payload:
             application = self._deserialize_message_application(payload["application"])
 
@@ -3436,7 +3432,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         else:
             stickers = []
 
-        thread: typing.Optional[channel_models.GuildThreadChannel] = None
+        thread: channel_models.GuildThreadChannel | None = None
         if thread_payload := payload.get("thread"):
             thread = self.deserialize_guild_thread(thread_payload)
 
@@ -3503,7 +3499,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
     ) -> presence_models.MemberPresence:
         activities: list[presence_models.RichActivity] = []
         for activity_payload in payload["activities"]:
-            timestamps: typing.Optional[presence_models.ActivityTimestamps] = None
+            timestamps: presence_models.ActivityTimestamps | None = None
             if "timestamps" in activity_payload:
                 timestamps_payload = activity_payload["timestamps"]
                 start = (
@@ -3518,12 +3514,12 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
                 else None
             )
 
-            party: typing.Optional[presence_models.ActivityParty] = None
+            party: presence_models.ActivityParty | None = None
             if "party" in activity_payload:
                 party_payload = activity_payload["party"]
 
-                current_size: typing.Optional[int]
-                max_size: typing.Optional[int]
+                current_size: int | None
+                max_size: int | None
                 if "size" in party_payload:
                     raw_current_size, raw_max_size = party_payload["size"]
                     current_size = int(raw_current_size)
@@ -3535,7 +3531,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
                     id=party_payload.get("id"), current_size=current_size, max_size=max_size
                 )
 
-            assets: typing.Optional[presence_models.ActivityAssets] = None
+            assets: presence_models.ActivityAssets | None = None
             if "assets" in activity_payload:
                 assets_payload = activity_payload["assets"]
                 assets = presence_models.ActivityAssets(
@@ -3546,7 +3542,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
                     small_text=assets_payload.get("small_text"),
                 )
 
-            secrets: typing.Optional[presence_models.ActivitySecret] = None
+            secrets: presence_models.ActivitySecret | None = None
             if "secrets" in activity_payload:
                 secrets_payload = activity_payload["secrets"]
                 secrets = presence_models.ActivitySecret(
@@ -3555,7 +3551,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
                     match=secrets_payload.get("match"),
                 )
 
-            emoji: typing.Optional[emoji_models.Emoji] = None
+            emoji: emoji_models.Emoji | None = None
             raw_emoji = activity_payload.get("emoji")
             if raw_emoji is not None:
                 emoji = self.deserialize_emoji(raw_emoji)
@@ -3615,7 +3611,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
     def deserialize_scheduled_external_event(
         self, payload: data_binding.JSONObject
     ) -> scheduled_events_models.ScheduledExternalEvent:
-        creator: typing.Optional[user_models.User] = None
+        creator: user_models.User | None = None
         if raw_creator := payload.get("creator"):
             creator = self.deserialize_user(raw_creator)
 
@@ -3640,11 +3636,11 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
     def deserialize_scheduled_stage_event(
         self, payload: data_binding.JSONObject
     ) -> scheduled_events_models.ScheduledStageEvent:
-        creator: typing.Optional[user_models.User] = None
+        creator: user_models.User | None = None
         if raw_creator := payload.get("creator"):
             creator = self.deserialize_user(raw_creator)
 
-        end_time: typing.Optional[datetime.datetime] = None
+        end_time: datetime.datetime | None = None
         if raw_end_time := payload.get("scheduled_end_time"):
             end_time = time.iso8601_datetime_string_to_datetime(raw_end_time)
 
@@ -3669,11 +3665,11 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
     def deserialize_scheduled_voice_event(
         self, payload: data_binding.JSONObject
     ) -> scheduled_events_models.ScheduledVoiceEvent:
-        creator: typing.Optional[user_models.User] = None
+        creator: user_models.User | None = None
         if raw_creator := payload.get("creator"):
             creator = self.deserialize_user(raw_creator)
 
-        end_time: typing.Optional[datetime.datetime] = None
+        end_time: datetime.datetime | None = None
         if raw_end_time := payload.get("scheduled_end_time"):
             end_time = time.iso8601_datetime_string_to_datetime(raw_end_time)
 
@@ -3714,7 +3710,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
     ) -> scheduled_events_models.ScheduledEventUser:
         user = self.deserialize_user(payload["user"])
 
-        member: typing.Optional[guild_models.Member] = None
+        member: guild_models.Member | None = None
         if raw_member := payload.get("member"):
             member = self.deserialize_member(raw_member, user=user, guild_id=guild_id)
 
@@ -3869,11 +3865,11 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         if guild_id is undefined.UNDEFINED:
             guild_id = snowflakes.Snowflake(payload["guild_id"])
 
-        channel_id: typing.Optional[snowflakes.Snowflake] = None
+        channel_id: snowflakes.Snowflake | None = None
         if (raw_channel_id := payload["channel_id"]) is not None:
             channel_id = snowflakes.Snowflake(raw_channel_id)
 
-        member_obj: typing.Optional[guild_models.Member] = None
+        member_obj: guild_models.Member | None = None
         if member is undefined.UNDEFINED:
             # It is insanely rare for this to happen, but we can receive voice states
             # with no member object attached to them unfortunately.
@@ -3881,7 +3877,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         else:
             member_obj = member
 
-        requested_to_speak_at: typing.Optional[datetime.datetime] = None
+        requested_to_speak_at: datetime.datetime | None = None
         if raw_requested_to_speak_at := payload.get("request_to_speak_timestamp"):
             requested_to_speak_at = time.iso8601_datetime_string_to_datetime(raw_requested_to_speak_at)
 
@@ -3918,7 +3914,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
 
     @typing_extensions.override
     def deserialize_incoming_webhook(self, payload: data_binding.JSONObject) -> webhook_models.IncomingWebhook:
-        application_id: typing.Optional[snowflakes.Snowflake] = None
+        application_id: snowflakes.Snowflake | None = None
         if (raw_application_id := payload.get("application_id")) is not None:
             application_id = snowflakes.Snowflake(raw_application_id)
 
@@ -3939,18 +3935,18 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
     def deserialize_channel_follower_webhook(
         self, payload: data_binding.JSONObject
     ) -> webhook_models.ChannelFollowerWebhook:
-        application_id: typing.Optional[snowflakes.Snowflake] = None
+        application_id: snowflakes.Snowflake | None = None
         if raw_application_id := payload.get("application_id"):
             application_id = snowflakes.Snowflake(raw_application_id)
 
-        source_channel: typing.Optional[channel_models.PartialChannel] = None
+        source_channel: channel_models.PartialChannel | None = None
         if raw_source_channel := payload.get("source_channel"):
             # In this case the channel type isn't provided as we can safely
             # assume it's a news channel.
             raw_source_channel.setdefault("type", channel_models.ChannelType.GUILD_NEWS)
             source_channel = self.deserialize_partial_channel(raw_source_channel)
 
-        source_guild: typing.Optional[guild_models.PartialGuild] = None
+        source_guild: guild_models.PartialGuild | None = None
         if source_guild_payload := payload.get("source_guild"):
             source_guild = guild_models.PartialGuild(
                 app=self._app,
@@ -4047,11 +4043,11 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
 
             answers.append(answer)
 
-        expiry: typing.Optional[datetime.datetime] = None
+        expiry: datetime.datetime | None = None
         if expiry_payload := payload["expiry"]:
             expiry = time.iso8601_datetime_string_to_datetime(expiry_payload)
 
-        results: typing.Optional[poll_models.PollResult] = None
+        results: poll_models.PollResult | None = None
         if (result_payload := payload.get("results")) is not None:
             is_finalized = result_payload["is_finalized"]
 

--- a/hikari/impl/event_factory.py
+++ b/hikari/impl/event_factory.py
@@ -119,7 +119,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_channel: typing.Optional[channel_models.PermissibleGuildChannel] = None,
+        old_channel: channel_models.PermissibleGuildChannel | None = None,
     ) -> channel_events.GuildChannelUpdateEvent:
         channel = self._app.entity_factory.deserialize_channel(payload)
         assert isinstance(channel, channel_models.PermissibleGuildChannel), (
@@ -145,7 +145,7 @@ class EventFactoryImpl(event_factory.EventFactory):
 
         # Turns out this can be None or not present. Only set it if it is actually available.
         if (raw := payload.get("last_pin_timestamp")) is not None:
-            last_pin_timestamp: typing.Optional[datetime.datetime] = time.iso8601_datetime_string_to_datetime(raw)
+            last_pin_timestamp: datetime.datetime | None = time.iso8601_datetime_string_to_datetime(raw)
         else:
             last_pin_timestamp = None
 
@@ -242,7 +242,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> channel_events.ThreadListSyncEvent:
         guild_id = snowflakes.Snowflake(payload["guild_id"])
-        channel_ids: typing.Optional[list[snowflakes.Snowflake]] = None
+        channel_ids: list[snowflakes.Snowflake] | None = None
         if raw_channel_ids := payload.get("channel_ids"):
             channel_ids = [snowflakes.Snowflake(x) for x in raw_channel_ids]
 
@@ -280,7 +280,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_invite: typing.Optional[invite_models.InviteWithMetadata] = None,
+        old_invite: invite_models.InviteWithMetadata | None = None,
     ) -> channel_events.InviteDeleteEvent:
         return channel_events.InviteDeleteEvent(
             app=self._app,
@@ -361,7 +361,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_guild: typing.Optional[guild_models.GatewayGuild] = None,
+        old_guild: guild_models.GatewayGuild | None = None,
     ) -> guild_events.GuildUpdateEvent:
         guild_information = self._app.entity_factory.deserialize_gateway_guild(payload, user_id=shard.get_user_id())
         return guild_events.GuildUpdateEvent(
@@ -379,7 +379,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_guild: typing.Optional[guild_models.GatewayGuild] = None,
+        old_guild: guild_models.GatewayGuild | None = None,
     ) -> guild_events.GuildLeaveEvent:
         return guild_events.GuildLeaveEvent(
             app=self._app, shard=shard, guild_id=snowflakes.Snowflake(payload["id"]), old_guild=old_guild
@@ -419,7 +419,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_emojis: typing.Optional[typing.Sequence[emojis_models.KnownCustomEmoji]] = None,
+        old_emojis: typing.Sequence[emojis_models.KnownCustomEmoji] | None = None,
     ) -> guild_events.EmojisUpdateEvent:
         guild_id = snowflakes.Snowflake(payload["guild_id"])
         emojis = [
@@ -436,7 +436,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_stickers: typing.Optional[typing.Sequence[sticker_models.GuildSticker]] = None,
+        old_stickers: typing.Sequence[sticker_models.GuildSticker] | None = None,
     ) -> guild_events.StickersUpdateEvent:
         guild_id = snowflakes.Snowflake(payload["guild_id"])
         stickers = [self._app.entity_factory.deserialize_guild_sticker(sticker) for sticker in payload["stickers"]]
@@ -456,7 +456,7 @@ class EventFactoryImpl(event_factory.EventFactory):
     def deserialize_integration_delete_event(
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> guild_events.IntegrationDeleteEvent:
-        application_id: typing.Optional[snowflakes.Snowflake] = None
+        application_id: snowflakes.Snowflake | None = None
         if (raw_application_id := payload.get("application_id")) is not None:
             application_id = snowflakes.Snowflake(raw_application_id)
 
@@ -482,12 +482,12 @@ class EventFactoryImpl(event_factory.EventFactory):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_presence: typing.Optional[presences_models.MemberPresence] = None,
+        old_presence: presences_models.MemberPresence | None = None,
     ) -> guild_events.PresenceUpdateEvent:
         presence = self._app.entity_factory.deserialize_member_presence(payload)
 
         user_payload = payload["user"]
-        user: typing.Optional[user_models.PartialUser] = None
+        user: user_models.PartialUser | None = None
         # Here we're told that the only guaranteed field is "id", so if we only get 1 field in the user payload then
         # then we've only got an ID and there's no reason to form a user object.
         if len(user_payload) > 1:
@@ -554,7 +554,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_member: typing.Optional[guild_models.Member] = None,
+        old_member: guild_models.Member | None = None,
     ) -> member_events.MemberUpdateEvent:
         member = self._app.entity_factory.deserialize_member(payload)
         return member_events.MemberUpdateEvent(shard=shard, member=member, old_member=old_member)
@@ -565,7 +565,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_member: typing.Optional[guild_models.Member] = None,
+        old_member: guild_models.Member | None = None,
     ) -> member_events.MemberDeleteEvent:
         guild_id = snowflakes.Snowflake(payload["guild_id"])
         user = self._app.entity_factory.deserialize_user(payload["user"])
@@ -590,7 +590,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_role: typing.Optional[guild_models.Role] = None,
+        old_role: guild_models.Role | None = None,
     ) -> role_events.RoleUpdateEvent:
         role = self._app.entity_factory.deserialize_role(
             payload["role"], guild_id=snowflakes.Snowflake(payload["guild_id"])
@@ -603,7 +603,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_role: typing.Optional[guild_models.Role] = None,
+        old_role: guild_models.Role | None = None,
     ) -> role_events.RoleDeleteEvent:
         return role_events.RoleDeleteEvent(
             app=self._app,
@@ -706,7 +706,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_message: typing.Optional[messages_models.PartialMessage] = None,
+        old_message: messages_models.PartialMessage | None = None,
     ) -> message_events.MessageUpdateEvent:
         message = self._app.entity_factory.deserialize_partial_message(payload)
 
@@ -721,7 +721,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_message: typing.Optional[messages_models.Message] = None,
+        old_message: messages_models.Message | None = None,
     ) -> message_events.MessageDeleteEvent:
         channel_id = snowflakes.Snowflake(payload["channel_id"])
         message_id = snowflakes.Snowflake(payload["id"])
@@ -746,7 +746,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_messages: typing.Optional[typing.Mapping[snowflakes.Snowflake, messages_models.Message]] = None,
+        old_messages: typing.Mapping[snowflakes.Snowflake, messages_models.Message] | None = None,
     ) -> message_events.GuildBulkMessageDeleteEvent:
         return message_events.GuildBulkMessageDeleteEvent(
             app=self._app,
@@ -801,7 +801,7 @@ class EventFactoryImpl(event_factory.EventFactory):
 
     def _split_reaction_emoji(
         self, emoji_payload: data_binding.JSONObject, /
-    ) -> tuple[typing.Optional[snowflakes.Snowflake], typing.Union[str, emojis_models.UnicodeEmoji, None]]:
+    ) -> tuple[snowflakes.Snowflake | None, str | emojis_models.UnicodeEmoji | None]:
         if (emoji_id := emoji_payload.get("id")) is not None:
             return snowflakes.Snowflake(emoji_id), emoji_payload["name"]
 
@@ -970,7 +970,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_user: typing.Optional[user_models.OwnUser] = None,
+        old_user: user_models.OwnUser | None = None,
     ) -> user_events.OwnUserUpdateEvent:
         return user_events.OwnUserUpdateEvent(
             shard=shard, user=self._app.entity_factory.deserialize_my_user(payload), old_user=old_user
@@ -986,7 +986,7 @@ class EventFactoryImpl(event_factory.EventFactory):
         shard: gateway_shard.GatewayShard,
         payload: data_binding.JSONObject,
         *,
-        old_state: typing.Optional[voices_models.VoiceState] = None,
+        old_state: voices_models.VoiceState | None = None,
     ) -> voice_events.VoiceStateUpdateEvent:
         state = self._app.entity_factory.deserialize_voice_state(payload)
         return voice_events.VoiceStateUpdateEvent(shard=shard, state=state, old_state=old_state)

--- a/hikari/impl/event_manager.py
+++ b/hikari/impl/event_manager.py
@@ -109,7 +109,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         /,
         *,
         auto_chunk_members: bool = True,
-        cache: typing.Optional[cache_.MutableCache] = None,
+        cache: cache_.MutableCache | None = None,
     ) -> None:
         self._cache = cache
         self._auto_chunk_members = auto_chunk_members
@@ -191,7 +191,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
     )
     async def on_thread_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#thread-create for more info."""
-        event: typing.Union[channel_events.GuildThreadAccessEvent, channel_events.GuildThreadCreateEvent]
+        event: channel_events.GuildThreadAccessEvent | channel_events.GuildThreadCreateEvent
         if "newly_created" in payload:
             event = self._event_factory.deserialize_guild_thread_create_event(shard, payload)
 
@@ -263,7 +263,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-create for more info."""
-        event: typing.Union[guild_events.GuildAvailableEvent, guild_events.GuildJoinEvent, None]
+        event: guild_events.GuildAvailableEvent | guild_events.GuildJoinEvent | None
 
         unavailable = payload.get("unavailable")
 
@@ -424,7 +424,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
     # Internal granularity is preferred for GUILD_UPDATE over decorator based filtering due to its large scope.
     async def on_guild_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-update for more info."""
-        event: typing.Optional[guild_events.GuildUpdateEvent]
+        event: guild_events.GuildUpdateEvent | None
         if self._enabled_for_event(guild_events.GuildUpdateEvent):
             guild_id = snowflakes.Snowflake(payload["id"])
             old = self._cache.get_guild(guild_id) if self._cache else None
@@ -489,7 +489,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
     )
     async def on_guild_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-delete for more info."""
-        event: typing.Union[guild_events.GuildUnavailableEvent, guild_events.GuildLeaveEvent]
+        event: guild_events.GuildUnavailableEvent | guild_events.GuildLeaveEvent
         if payload.get("unavailable"):
             event = self._event_factory.deserialize_guild_unavailable_event(shard, payload)
 
@@ -497,7 +497,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
                 self._cache.set_guild_availability(event.guild_id, False)
 
         else:
-            old: typing.Optional[guilds.GatewayGuild] = None
+            old: guilds.GatewayGuild | None = None
             if self._cache:
                 guild_id = snowflakes.Snowflake(payload["id"])
                 #  TODO: this doesn't work in all intent scenarios
@@ -591,7 +591,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
     @event_manager_base.filtered(member_events.MemberDeleteEvent, config.CacheComponents.MEMBERS)
     async def on_guild_member_remove(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-member-remove for more info."""
-        old: typing.Optional[guilds.Member] = None
+        old: guilds.Member | None = None
         if self._cache:
             old = self._cache.delete_member(
                 snowflakes.Snowflake(payload["guild_id"]), snowflakes.Snowflake(payload["user"]["id"])
@@ -603,7 +603,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
     @event_manager_base.filtered(member_events.MemberUpdateEvent, config.CacheComponents.MEMBERS)
     async def on_guild_member_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-member-update for more info."""
-        old: typing.Optional[guilds.Member] = None
+        old: guilds.Member | None = None
         if self._cache:
             old = self._cache.get_member(
                 snowflakes.Snowflake(payload["guild_id"]), snowflakes.Snowflake(payload["user"]["id"])
@@ -654,7 +654,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
     @event_manager_base.filtered(role_events.RoleDeleteEvent, config.CacheComponents.ROLES)
     async def on_guild_role_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-role-delete for more info."""
-        old: typing.Optional[guilds.Role] = None
+        old: guilds.Role | None = None
         if self._cache:
             old = self._cache.delete_role(snowflakes.Snowflake(payload["role_id"]))
 
@@ -675,7 +675,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
     @event_manager_base.filtered(channel_events.InviteDeleteEvent, config.CacheComponents.INVITES)
     async def on_invite_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#invite-delete for more info."""
-        old: typing.Optional[invites.InviteWithMetadata] = None
+        old: invites.InviteWithMetadata | None = None
         if self._cache:
             old = self._cache.delete_invite(payload["code"])
 
@@ -778,7 +778,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
     @event_manager_base.filtered(guild_events.PresenceUpdateEvent, config.CacheComponents.PRESENCES)
     async def on_presence_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#presence-update for more info."""
-        old: typing.Optional[presences_.MemberPresence] = None
+        old: presences_.MemberPresence | None = None
 
         if self._cache:
             old = self._cache.get_presence(
@@ -814,7 +814,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
     @event_manager_base.filtered(voice_events.VoiceStateUpdateEvent, config.CacheComponents.VOICE_STATES)
     async def on_voice_state_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#voice-state-update for more info."""
-        old: typing.Optional[voices.VoiceState] = None
+        old: voices.VoiceState | None = None
         if self._cache:
             old = self._cache.get_voice_state(
                 snowflakes.Snowflake(payload["guild_id"]), snowflakes.Snowflake(payload["user_id"])

--- a/hikari/impl/gateway_bot.py
+++ b/hikari/impl/gateway_bot.py
@@ -313,21 +313,21 @@ class GatewayBot(traits.GatewayBotAware):
         token: str,
         *,
         allow_color: bool = True,
-        banner: typing.Optional[str] = "hikari",
+        banner: str | None = "hikari",
         suppress_optimization_warning: bool = False,
-        executor: typing.Optional[concurrent.futures.Executor] = None,
+        executor: concurrent.futures.Executor | None = None,
         force_color: bool = False,
-        cache_settings: typing.Optional[config_impl.CacheSettings] = None,
-        http_settings: typing.Optional[config_impl.HTTPSettings] = None,
+        cache_settings: config_impl.CacheSettings | None = None,
+        http_settings: config_impl.HTTPSettings | None = None,
         dumps: data_binding.JSONEncoder = data_binding.default_json_dumps,
         loads: data_binding.JSONDecoder = data_binding.default_json_loads,
         intents: intents_.Intents = intents_.Intents.ALL_UNPRIVILEGED,
         auto_chunk_members: bool = True,
-        logs: typing.Union[None, str, int, dict[str, typing.Any], os.PathLike[str]] = "INFO",
+        logs: None | str | int | dict[str, typing.Any] | os.PathLike[str] = "INFO",
         max_rate_limit: float = 300.0,
         max_retries: int = 3,
-        proxy_settings: typing.Optional[config_impl.ProxySettings] = None,
-        rest_url: typing.Optional[str] = None,
+        proxy_settings: config_impl.ProxySettings | None = None,
+        rest_url: str | None = None,
     ) -> None:
         # Beautification and logging
         ux.init_logging(logs, allow_color=allow_color, force_color=force_color)
@@ -335,8 +335,8 @@ class GatewayBot(traits.GatewayBotAware):
         ux.warn_if_not_optimized(suppress=suppress_optimization_warning)
 
         # Settings and state
-        self._closed_event: typing.Optional[asyncio.Event] = None
-        self._closing_event: typing.Optional[asyncio.Event] = None
+        self._closed_event: asyncio.Event | None = None
+        self._closing_event: asyncio.Event | None = None
         self._executor = executor
         self._http_settings = http_settings if http_settings is not None else config_impl.HTTPSettings()
         self._intents = intents
@@ -410,7 +410,7 @@ class GatewayBot(traits.GatewayBotAware):
 
     @property
     @typing_extensions.override
-    def executor(self) -> typing.Optional[concurrent.futures.Executor]:
+    def executor(self) -> concurrent.futures.Executor | None:
         return self._executor
 
     @property
@@ -465,7 +465,7 @@ class GatewayBot(traits.GatewayBotAware):
             raise errors.ComponentStateConflictError(msg)
 
     @typing_extensions.override
-    def get_me(self) -> typing.Optional[users_.OwnUser]:
+    def get_me(self) -> users_.OwnUser | None:
         return self._cache.get_me()
 
     @typing_extensions.override
@@ -656,11 +656,7 @@ class GatewayBot(traits.GatewayBotAware):
 
     @staticmethod
     def print_banner(
-        banner: typing.Optional[str],
-        *,
-        allow_color: bool,
-        force_color: bool,
-        extra_args: typing.Optional[dict[str, str]] = None,
+        banner: str | None, *, allow_color: bool, force_color: bool, extra_args: dict[str, str] | None = None
     ) -> None:
         """Print the banner.
 
@@ -700,21 +696,21 @@ class GatewayBot(traits.GatewayBotAware):
     def run(
         self,
         *,
-        activity: typing.Optional[presences.Activity] = None,
+        activity: presences.Activity | None = None,
         afk: bool = False,
-        asyncio_debug: typing.Optional[bool] = None,
+        asyncio_debug: bool | None = None,
         check_for_updates: bool = True,
         close_passed_executor: bool = False,
         close_loop: bool = True,
-        coroutine_tracking_depth: typing.Optional[int] = None,
-        enable_signal_handlers: typing.Optional[bool] = None,
-        idle_since: typing.Optional[datetime.datetime] = None,
+        coroutine_tracking_depth: int | None = None,
+        enable_signal_handlers: bool | None = None,
+        idle_since: datetime.datetime | None = None,
         ignore_session_start_limit: bool = False,
         large_threshold: int = 250,
         propagate_interrupts: bool = False,
         status: presences.Status = presences.Status.ONLINE,
-        shard_ids: typing.Optional[typing.Sequence[int]] = None,
-        shard_count: typing.Optional[int] = None,
+        shard_ids: typing.Sequence[int] | None = None,
+        shard_count: int | None = None,
     ) -> None:
         """Start the application and block until it's finished running.
 
@@ -875,14 +871,14 @@ class GatewayBot(traits.GatewayBotAware):
     async def start(
         self,
         *,
-        activity: typing.Optional[presences.Activity] = None,
+        activity: presences.Activity | None = None,
         afk: bool = False,
         check_for_updates: bool = True,
-        idle_since: typing.Optional[datetime.datetime] = None,
+        idle_since: datetime.datetime | None = None,
         ignore_session_start_limit: bool = False,
         large_threshold: int = 250,
-        shard_ids: typing.Optional[typing.Sequence[int]] = None,
-        shard_count: typing.Optional[int] = None,
+        shard_ids: typing.Sequence[int] | None = None,
+        shard_count: int | None = None,
         status: presences.Status = presences.Status.ONLINE,
     ) -> None:
         """Start the bot, wait for all shards to become ready, and then return.
@@ -1031,11 +1027,7 @@ class GatewayBot(traits.GatewayBotAware):
         _LOGGER.info("started successfully in approx %.2f seconds", time.monotonic() - start_time)
 
     def stream(
-        self,
-        event_type: type[base_events.EventT],
-        /,
-        timeout: typing.Union[float, None],
-        limit: typing.Optional[int] = None,
+        self, event_type: type[base_events.EventT], /, timeout: float | None, limit: int | None = None
     ) -> event_manager_.EventStream[base_events.EventT]:
         """Return a stream iterator for the given event and sub-events.
 
@@ -1186,8 +1178,8 @@ class GatewayBot(traits.GatewayBotAware):
         self,
         event_type: type[base_events.EventT],
         /,
-        timeout: typing.Union[float, None],
-        predicate: typing.Optional[event_manager_.PredicateT[base_events.EventT]] = None,
+        timeout: float | None,
+        predicate: event_manager_.PredicateT[base_events.EventT] | None = None,
     ) -> base_events.EventT:
         """Wait for a given event to occur once, then return the event.
 
@@ -1265,7 +1257,7 @@ class GatewayBot(traits.GatewayBotAware):
     async def update_voice_state(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        channel: typing.Optional[snowflakes.SnowflakeishOr[channels.GuildVoiceChannel]],
+        channel: snowflakes.SnowflakeishOr[channels.GuildVoiceChannel] | None,
         *,
         self_mute: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         self_deaf: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
@@ -1294,9 +1286,9 @@ class GatewayBot(traits.GatewayBotAware):
     async def _start_one_shard(
         self,
         *,
-        activity: typing.Optional[presences.Activity],
+        activity: presences.Activity | None,
         afk: bool,
-        idle_since: typing.Optional[datetime.datetime],
+        idle_since: datetime.datetime | None,
         status: presences.Status,
         large_threshold: int,
         shard_id: int,

--- a/hikari/impl/interaction_server.py
+++ b/hikari/impl/interaction_server.py
@@ -103,9 +103,9 @@ class _Response:
     def __init__(
         self,
         status_code: int,
-        payload: typing.Optional[bytes] = None,
+        payload: bytes | None = None,
         *,
-        content_type: typing.Optional[str] = None,
+        content_type: str | None = None,
         files: typing.Sequence[files_.Resource[files_.AsyncReader]] = (),
     ) -> None:
         if payload and not content_type:
@@ -117,11 +117,11 @@ class _Response:
         self._status_code = status_code
 
     @property
-    def content_type(self) -> typing.Optional[str]:
+    def content_type(self) -> str | None:
         return self._content_type
 
     @property
-    def charset(self) -> typing.Optional[str]:
+    def charset(self) -> str | None:
         # No cases of charset not being UTF-8
         return _UTF_8_CHARSET if self._payload else None
 
@@ -130,11 +130,11 @@ class _Response:
         return self._files
 
     @property
-    def headers(self) -> typing.Optional[typing.MutableMapping[str, str]]:
+    def headers(self) -> typing.MutableMapping[str, str] | None:
         return None
 
     @property
-    def payload(self) -> typing.Optional[bytes]:
+    def payload(self) -> bytes | None:
         return self._payload
 
     @property
@@ -157,8 +157,8 @@ class _FilePayload(aiohttp.Payload):
         content_type: str,
         /,
         *,
-        executor: typing.Optional[concurrent.futures.Executor] = None,
-        headers: typing.Optional[dict[str, str]] = None,
+        executor: concurrent.futures.Executor | None = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
         super().__init__(value=value, headers=headers, content_type=content_type)
         self._executor = executor
@@ -232,10 +232,10 @@ class InteractionServer(interaction_server.InteractionServer):
         *,
         dumps: data_binding.JSONEncoder = data_binding.default_json_dumps,
         entity_factory: entity_factory_api.EntityFactory,
-        executor: typing.Optional[concurrent.futures.Executor] = None,
+        executor: concurrent.futures.Executor | None = None,
         loads: data_binding.JSONDecoder = data_binding.default_json_loads,
         rest_client: rest_api.RESTClient,
-        public_key: typing.Optional[bytes] = None,
+        public_key: bytes | None = None,
     ) -> None:
         # This is kept inline as pynacl is an optional dependency.
         try:
@@ -247,9 +247,9 @@ class InteractionServer(interaction_server.InteractionServer):
             raise RuntimeError(msg) from exc
 
         # Building asyncio.Lock when there isn't a running loop may lead to runtime errors.
-        self._application_fetch_lock: typing.Optional[asyncio.Lock] = None
+        self._application_fetch_lock: asyncio.Lock | None = None
         # Building asyncio.Event when there isn't a running loop may lead to runtime errors.
-        self._close_event: typing.Optional[asyncio.Event] = None
+        self._close_event: asyncio.Event | None = None
         self._dumps = dumps
         self._entity_factory = entity_factory
         self._executor = executor
@@ -258,7 +258,7 @@ class InteractionServer(interaction_server.InteractionServer):
         self._loads = loads
         self._nacl = nacl
         self._rest_client = rest_client
-        self._server: typing.Optional[aiohttp.web_runner.AppRunner] = None
+        self._server: aiohttp.web_runner.AppRunner | None = None
         self._public_key = nacl.signing.VerifyKey(public_key) if public_key is not None else None
         self._running_generator_listeners: set[asyncio.Task[None]] = set()
 
@@ -271,7 +271,7 @@ class InteractionServer(interaction_server.InteractionServer):
         if self._application_fetch_lock is None:
             self._application_fetch_lock = asyncio.Lock()
 
-        application: typing.Union[applications.Application, applications.AuthorizationApplication]
+        application: applications.Application | applications.AuthorizationApplication
         async with self._application_fetch_lock:
             if self._public_key:
                 return self._public_key
@@ -511,14 +511,14 @@ class InteractionServer(interaction_server.InteractionServer):
     async def start(
         self,
         backlog: int = 128,
-        host: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None,
-        port: typing.Optional[int] = None,
-        path: typing.Optional[str] = None,
-        reuse_address: typing.Optional[bool] = None,
-        reuse_port: typing.Optional[bool] = None,
-        socket: typing.Optional[socket_.socket] = None,
+        host: str | typing.Sequence[str] | None = None,
+        port: int | None = None,
+        path: str | None = None,
+        reuse_address: bool | None = None,
+        reuse_port: bool | None = None,
+        socket: socket_.socket | None = None,
         shutdown_timeout: float = 60.0,
-        ssl_context: typing.Optional[ssl.SSLContext] = None,
+        ssl_context: ssl.SSLContext | None = None,
     ) -> None:
         """Start the bot and wait for the internal server to startup then return.
 
@@ -619,16 +619,15 @@ class InteractionServer(interaction_server.InteractionServer):
     @typing_extensions.override
     def get_listener(
         self, interaction_type: type[_InteractionT_co], /
-    ) -> typing.Optional[interaction_server.ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder]]:
+    ) -> interaction_server.ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder] | None:
         return self._listeners.get(interaction_type)
 
     @typing.overload
     def set_listener(
         self,
         interaction_type: type[command_interactions.CommandInteraction],
-        listener: typing.Optional[
-            interaction_server.ListenerT[command_interactions.CommandInteraction, _ModalOrMessageResponseBuilderT]
-        ],
+        listener: interaction_server.ListenerT[command_interactions.CommandInteraction, _ModalOrMessageResponseBuilderT]
+        | None,
         /,
         *,
         replace: bool = False,
@@ -638,9 +637,10 @@ class InteractionServer(interaction_server.InteractionServer):
     def set_listener(
         self,
         interaction_type: type[component_interactions.ComponentInteraction],
-        listener: typing.Optional[
-            interaction_server.ListenerT[component_interactions.ComponentInteraction, _ModalOrMessageResponseBuilderT]
-        ],
+        listener: interaction_server.ListenerT[
+            component_interactions.ComponentInteraction, _ModalOrMessageResponseBuilderT
+        ]
+        | None,
         /,
         *,
         replace: bool = False,
@@ -650,11 +650,10 @@ class InteractionServer(interaction_server.InteractionServer):
     def set_listener(
         self,
         interaction_type: type[command_interactions.AutocompleteInteraction],
-        listener: typing.Optional[
-            interaction_server.ListenerT[
-                command_interactions.AutocompleteInteraction, special_endpoints.InteractionAutocompleteBuilder
-            ]
-        ],
+        listener: interaction_server.ListenerT[
+            command_interactions.AutocompleteInteraction, special_endpoints.InteractionAutocompleteBuilder
+        ]
+        | None,
         /,
         *,
         replace: bool = False,
@@ -664,9 +663,7 @@ class InteractionServer(interaction_server.InteractionServer):
     def set_listener(
         self,
         interaction_type: type[modal_interactions.ModalInteraction],
-        listener: typing.Optional[
-            interaction_server.ListenerT[modal_interactions.ModalInteraction, _MessageResponseBuilderT]
-        ],
+        listener: interaction_server.ListenerT[modal_interactions.ModalInteraction, _MessageResponseBuilderT] | None,
         /,
         *,
         replace: bool = False,
@@ -676,9 +673,7 @@ class InteractionServer(interaction_server.InteractionServer):
     def set_listener(
         self,
         interaction_type: type[_InteractionT_co],
-        listener: typing.Optional[
-            interaction_server.ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder]
-        ],
+        listener: interaction_server.ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder] | None,
         /,
         *,
         replace: bool = False,
@@ -688,9 +683,7 @@ class InteractionServer(interaction_server.InteractionServer):
     def set_listener(
         self,
         interaction_type: type[_InteractionT_co],
-        listener: typing.Optional[
-            interaction_server.ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder]
-        ],
+        listener: interaction_server.ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder] | None,
         /,
         *,
         replace: bool = False,

--- a/hikari/impl/rate_limits.py
+++ b/hikari/impl/rate_limits.py
@@ -72,10 +72,7 @@ class BaseRateLimiter(abc.ABC):
         return self
 
     def __exit__(
-        self,
-        exc_type: typing.Optional[type[BaseException]],
-        exc_val: typing.Optional[BaseException],
-        exc_tb: typing.Optional[types.TracebackType],
+        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: types.TracebackType | None
     ) -> None:
         self.close()
 
@@ -92,7 +89,7 @@ class BurstRateLimiter(BaseRateLimiter, abc.ABC):
     name: str
     """The name of the rate limiter."""
 
-    throttle_task: typing.Optional[asyncio.Task[typing.Any]]
+    throttle_task: asyncio.Task[typing.Any] | None
     """The throttling task, or [`None`][] if it is not running."""
 
     queue: list[asyncio.Future[typing.Any]]
@@ -160,10 +157,10 @@ class ManualRateLimiter(BurstRateLimiter):
 
     __slots__: typing.Sequence[str] = ("reset_at",)
 
-    throttle_task: typing.Optional[asyncio.Task[typing.Any]]
+    throttle_task: asyncio.Task[typing.Any] | None
     # <<inherited docstring from BurstRateLimiter>>.
 
-    reset_at: typing.Optional[float]
+    reset_at: float | None
     """The monotonic [`time.monotonic`][] timestamp at which the ratelimit gets lifted."""
 
     def __init__(self) -> None:
@@ -298,7 +295,7 @@ class WindowedBurstRateLimiter(BurstRateLimiter):
 
     __slots__: typing.Sequence[str] = ("limit", "period", "remaining", "reset_at")
 
-    throttle_task: typing.Optional[asyncio.Task[typing.Any]]
+    throttle_task: asyncio.Task[typing.Any] | None
     # <<inherited docstring from BurstRateLimiter>>.
 
     reset_at: float

--- a/hikari/impl/rest_bot.py
+++ b/hikari/impl/rest_bot.py
@@ -235,57 +235,57 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
         self,
         token: rest_api.TokenStrategy,
         *,
-        public_key: typing.Union[bytes, str, None] = None,
+        public_key: bytes | str | None = None,
         allow_color: bool = True,
-        banner: typing.Optional[str] = "hikari",
+        banner: str | None = "hikari",
         suppress_optimization_warning: bool = False,
-        executor: typing.Optional[concurrent.futures.Executor] = None,
+        executor: concurrent.futures.Executor | None = None,
         force_color: bool = False,
-        http_settings: typing.Optional[config_impl.HTTPSettings] = None,
-        logs: typing.Union[None, str, int, dict[str, typing.Any], os.PathLike[str]] = "INFO",
+        http_settings: config_impl.HTTPSettings | None = None,
+        logs: None | str | int | dict[str, typing.Any] | os.PathLike[str] = "INFO",
         max_rate_limit: float = 300.0,
         max_retries: int = 3,
-        proxy_settings: typing.Optional[config_impl.ProxySettings] = None,
-        rest_url: typing.Optional[str] = None,
+        proxy_settings: config_impl.ProxySettings | None = None,
+        rest_url: str | None = None,
     ) -> None: ...
 
     @typing.overload
     def __init__(
         self,
         token: str,
-        token_type: typing.Union[str, applications.TokenType] = applications.TokenType.BOT,
-        public_key: typing.Union[bytes, str, None] = None,
+        token_type: str | applications.TokenType = applications.TokenType.BOT,
+        public_key: bytes | str | None = None,
         *,
         allow_color: bool = True,
-        banner: typing.Optional[str] = "hikari",
+        banner: str | None = "hikari",
         suppress_optimization_warning: bool = False,
-        executor: typing.Optional[concurrent.futures.Executor] = None,
+        executor: concurrent.futures.Executor | None = None,
         force_color: bool = False,
-        http_settings: typing.Optional[config_impl.HTTPSettings] = None,
-        logs: typing.Union[None, str, int, dict[str, typing.Any], os.PathLike[str]] = "INFO",
+        http_settings: config_impl.HTTPSettings | None = None,
+        logs: None | str | int | dict[str, typing.Any] | os.PathLike[str] = "INFO",
         max_rate_limit: float = 300.0,
         max_retries: int = 3,
-        proxy_settings: typing.Optional[config_impl.ProxySettings] = None,
-        rest_url: typing.Optional[str] = None,
+        proxy_settings: config_impl.ProxySettings | None = None,
+        rest_url: str | None = None,
     ) -> None: ...
 
     def __init__(
         self,
-        token: typing.Union[str, rest_api.TokenStrategy],
-        token_type: typing.Union[applications.TokenType, str, None] = None,
-        public_key: typing.Union[bytes, str, None] = None,
+        token: str | rest_api.TokenStrategy,
+        token_type: applications.TokenType | str | None = None,
+        public_key: bytes | str | None = None,
         *,
         allow_color: bool = True,
-        banner: typing.Optional[str] = "hikari",
+        banner: str | None = "hikari",
         suppress_optimization_warning: bool = False,
-        executor: typing.Optional[concurrent.futures.Executor] = None,
+        executor: concurrent.futures.Executor | None = None,
         force_color: bool = False,
-        http_settings: typing.Optional[config_impl.HTTPSettings] = None,
-        logs: typing.Union[None, str, int, dict[str, typing.Any], os.PathLike[str]] = "INFO",
+        http_settings: config_impl.HTTPSettings | None = None,
+        logs: None | str | int | dict[str, typing.Any] | os.PathLike[str] = "INFO",
         max_rate_limit: float = 300.0,
         max_retries: int = 3,
-        proxy_settings: typing.Optional[config_impl.ProxySettings] = None,
-        rest_url: typing.Optional[str] = None,
+        proxy_settings: config_impl.ProxySettings | None = None,
+        rest_url: str | None = None,
     ) -> None:
         if isinstance(public_key, str):
             public_key = bytes.fromhex(public_key)
@@ -302,7 +302,7 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
         ux.warn_if_not_optimized(suppress=suppress_optimization_warning)
 
         # Settings and state
-        self._close_event: typing.Optional[asyncio.Event] = None
+        self._close_event: asyncio.Event | None = None
         self._executor = executor
         self._http_settings = http_settings if http_settings is not None else config_impl.HTTPSettings()
         self._is_closing = False
@@ -376,16 +376,12 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
 
     @property
     @typing_extensions.override
-    def executor(self) -> typing.Optional[concurrent.futures.Executor]:
+    def executor(self) -> concurrent.futures.Executor | None:
         return self._executor
 
     @staticmethod
     def print_banner(
-        banner: typing.Optional[str],
-        *,
-        allow_color: bool,
-        force_color: bool,
-        extra_args: typing.Optional[dict[str, str]] = None,
+        banner: str | None, *, allow_color: bool, force_color: bool, extra_args: dict[str, str] | None = None
     ) -> None:
         """Print the banner.
 
@@ -493,17 +489,17 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
         check_for_updates: bool = True,
         close_loop: bool = True,
         close_passed_executor: bool = False,
-        coroutine_tracking_depth: typing.Optional[int] = None,
-        enable_signal_handlers: typing.Optional[bool] = None,
-        host: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None,
-        path: typing.Optional[str] = None,
-        port: typing.Optional[int] = None,
+        coroutine_tracking_depth: int | None = None,
+        enable_signal_handlers: bool | None = None,
+        host: str | typing.Sequence[str] | None = None,
+        path: str | None = None,
+        port: int | None = None,
         propagate_interrupts: bool = False,
-        reuse_address: typing.Optional[bool] = None,
-        reuse_port: typing.Optional[bool] = None,
+        reuse_address: bool | None = None,
+        reuse_port: bool | None = None,
         shutdown_timeout: float = 60.0,
-        socket: typing.Optional[socket_.socket] = None,
-        ssl_context: typing.Optional[ssl.SSLContext] = None,
+        socket: socket_.socket | None = None,
+        ssl_context: ssl.SSLContext | None = None,
     ) -> None:
         """Open this REST server and block until it closes.
 
@@ -641,14 +637,14 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
         *,
         backlog: int = 128,
         check_for_updates: bool = True,
-        host: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None,
-        port: typing.Optional[int] = None,
-        path: typing.Optional[str] = None,
-        reuse_address: typing.Optional[bool] = None,
-        reuse_port: typing.Optional[bool] = None,
-        socket: typing.Optional[socket_.socket] = None,
+        host: str | typing.Sequence[str] | None = None,
+        port: int | None = None,
+        path: str | None = None,
+        reuse_address: bool | None = None,
+        reuse_port: bool | None = None,
+        socket: socket_.socket | None = None,
         shutdown_timeout: float = 60.0,
-        ssl_context: typing.Optional[ssl.SSLContext] = None,
+        ssl_context: ssl.SSLContext | None = None,
     ) -> None:
         """Start the bot and wait for the internal server to startup then return.
 
@@ -720,16 +716,17 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
     @typing_extensions.override
     def get_listener(
         self, interaction_type: type[_InteractionT_co], /
-    ) -> typing.Optional[interaction_server_.ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder]]:
+    ) -> interaction_server_.ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder] | None:
         return self._server.get_listener(interaction_type)
 
     @typing.overload
     def set_listener(
         self,
         interaction_type: type[command_interactions.CommandInteraction],
-        listener: typing.Optional[
-            interaction_server_.ListenerT[command_interactions.CommandInteraction, _ModalOrMessageResponseBuilderT]
-        ],
+        listener: interaction_server_.ListenerT[
+            command_interactions.CommandInteraction, _ModalOrMessageResponseBuilderT
+        ]
+        | None,
         /,
         *,
         replace: bool = False,
@@ -739,9 +736,10 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
     def set_listener(
         self,
         interaction_type: type[component_interactions.ComponentInteraction],
-        listener: typing.Optional[
-            interaction_server_.ListenerT[component_interactions.ComponentInteraction, _ModalOrMessageResponseBuilderT]
-        ],
+        listener: interaction_server_.ListenerT[
+            component_interactions.ComponentInteraction, _ModalOrMessageResponseBuilderT
+        ]
+        | None,
         /,
         *,
         replace: bool = False,
@@ -751,11 +749,10 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
     def set_listener(
         self,
         interaction_type: type[command_interactions.AutocompleteInteraction],
-        listener: typing.Optional[
-            interaction_server_.ListenerT[
-                command_interactions.AutocompleteInteraction, special_endpoints.InteractionAutocompleteBuilder
-            ]
-        ],
+        listener: interaction_server_.ListenerT[
+            command_interactions.AutocompleteInteraction, special_endpoints.InteractionAutocompleteBuilder
+        ]
+        | None,
         /,
         *,
         replace: bool = False,
@@ -765,9 +762,7 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
     def set_listener(
         self,
         interaction_type: type[modal_interactions.ModalInteraction],
-        listener: typing.Optional[
-            interaction_server_.ListenerT[modal_interactions.ModalInteraction, _MessageResponseBuilderT]
-        ],
+        listener: interaction_server_.ListenerT[modal_interactions.ModalInteraction, _MessageResponseBuilderT] | None,
         /,
         *,
         replace: bool = False,
@@ -777,9 +772,7 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
     def set_listener(
         self,
         interaction_type: type[_InteractionT_co],
-        listener: typing.Optional[
-            interaction_server_.ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder]
-        ],
+        listener: interaction_server_.ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder] | None,
         /,
         *,
         replace: bool = False,
@@ -789,9 +782,7 @@ class RESTBot(traits.RESTBotAware, interaction_server_.InteractionServer):
     def set_listener(
         self,
         interaction_type: type[_InteractionT_co],
-        listener: typing.Optional[
-            interaction_server_.ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder]
-        ],
+        listener: interaction_server_.ListenerT[_InteractionT_co, special_endpoints.InteractionResponseBuilder] | None,
         /,
         *,
         replace: bool = False,

--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -348,19 +348,19 @@ class _GatewayTransport:
             raise
 
 
-def _serialize_datetime(dt: typing.Optional[datetime.datetime]) -> typing.Optional[int]:
+def _serialize_datetime(dt: datetime.datetime | None) -> int | None:
     if dt is None:
         return None
 
     return int(dt.timestamp() * 1_000)
 
 
-def _serialize_activity(activity: typing.Optional[presences.Activity]) -> data_binding.JSONish:
+def _serialize_activity(activity: presences.Activity | None) -> data_binding.JSONish:
     if activity is None:
         return None
 
     # Syntactic sugar, treat `name` as state if using `CUSTOM` and `state` is not passed.
-    state: typing.Optional[str]
+    state: str | None
     if activity.type is presences.ActivityType.CUSTOM and activity.name and not activity.state:
         name = _CUSTOM_STATUS_NAME
         state = activity.name
@@ -467,11 +467,11 @@ class GatewayShardImpl(shard.GatewayShard):
     def __init__(
         self,
         *,
-        compression: typing.Optional[str] = shard.GatewayCompression.TRANSPORT_ZLIB_STREAM,
+        compression: str | None = shard.GatewayCompression.TRANSPORT_ZLIB_STREAM,
         dumps: data_binding.JSONEncoder = data_binding.default_json_dumps,
         loads: data_binding.JSONDecoder = data_binding.default_json_loads,
-        initial_activity: typing.Optional[presences.Activity] = None,
-        initial_idle_since: typing.Optional[datetime.datetime] = None,
+        initial_activity: presences.Activity | None = None,
+        initial_idle_since: datetime.datetime | None = None,
         initial_is_afk: bool = False,
         initial_status: presences.Status = presences.Status.ONLINE,
         intents: intents_.Intents,
@@ -498,14 +498,14 @@ class GatewayShardImpl(shard.GatewayShard):
         self._event_manager = event_manager
         self._event_factory = event_factory
         self._gateway_url = url
-        self._handshake_event: typing.Optional[asyncio.Event] = None
+        self._handshake_event: asyncio.Event | None = None
         self._heartbeat_latency = float("nan")
         self._http_settings = http_settings
         self._idle_since = initial_idle_since
         self._intents = intents
         self._is_afk = initial_is_afk
         self._is_closing = False
-        self._keep_alive_task: typing.Optional[asyncio.Task[None]] = None
+        self._keep_alive_task: asyncio.Task[None] | None = None
         self._large_threshold = large_threshold
         self._last_heartbeat_ack_received = float("nan")
         self._last_heartbeat_sent = float("nan")
@@ -514,9 +514,9 @@ class GatewayShardImpl(shard.GatewayShard):
             f"shard {shard_id} non-priority rate limit", *_NON_PRIORITY_RATELIMIT
         )
         self._proxy_settings = proxy_settings
-        self._resume_gateway_url: typing.Optional[str] = None
-        self._seq: typing.Optional[int] = None
-        self._session_id: typing.Optional[str] = None
+        self._resume_gateway_url: str | None = None
+        self._seq: int | None = None
+        self._session_id: str | None = None
         self._shard_count = shard_count
         self._shard_id = shard_id
         self._status = initial_status
@@ -527,8 +527,8 @@ class GatewayShardImpl(shard.GatewayShard):
         self._transport_compression = compression is not None
         self._dumps = dumps
         self._loads = loads
-        self._user_id: typing.Optional[snowflakes.Snowflake] = None
-        self._ws: typing.Optional[_GatewayTransport] = None
+        self._user_id: snowflakes.Snowflake | None = None
+        self._ws: _GatewayTransport | None = None
 
     @property
     @typing_extensions.override
@@ -697,7 +697,7 @@ class GatewayShardImpl(shard.GatewayShard):
     async def update_voice_state(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        channel: typing.Optional[snowflakes.SnowflakeishOr[channels.GuildVoiceChannel]],
+        channel: snowflakes.SnowflakeishOr[channels.GuildVoiceChannel] | None,
         *,
         self_mute: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         self_deaf: undefined.UndefinedOr[bool] = undefined.UNDEFINED,

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -105,12 +105,12 @@ if typing.TYPE_CHECKING:
             self,
             compiled_route: routes.CompiledRoute,
             *,
-            query: typing.Optional[data_binding.StringMapBuilder] = None,
-            form_builder: typing.Optional[data_binding.URLEncodedFormBuilder] = None,
-            json: typing.Union[data_binding.JSONObjectBuilder, data_binding.JSONArray, None] = None,
+            query: data_binding.StringMapBuilder | None = None,
+            form_builder: data_binding.URLEncodedFormBuilder | None = None,
+            json: data_binding.JSONObjectBuilder | data_binding.JSONArray | None = None,
             reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
             auth: undefined.UndefinedNoneOr[str] = undefined.UNDEFINED,
-        ) -> typing.Union[None, data_binding.JSONObject, data_binding.JSONArray]: ...
+        ) -> None | data_binding.JSONObject | data_binding.JSONArray: ...
 
     _GuildThreadChannelT_co = typing.TypeVar(
         "_GuildThreadChannelT_co", bound=channels.GuildThreadChannel, covariant=True
@@ -157,7 +157,7 @@ class TypingIndicator(special_endpoints.TypingIndicator):
         self._route = routes.POST_CHANNEL_TYPING.compile(channel=channel)
         self._request_call = request_call
         self._task_name = f"repeatedly trigger typing in {channel}"
-        self._task: typing.Optional[asyncio.Task[None]] = None
+        self._task: asyncio.Task[None] | None = None
         self._rest_close_event = rest_close_event
 
     @typing_extensions.override
@@ -173,10 +173,7 @@ class TypingIndicator(special_endpoints.TypingIndicator):
 
     @typing_extensions.override
     async def __aexit__(
-        self,
-        exc_type: typing.Optional[type[BaseException]],
-        exc_val: typing.Optional[BaseException],
-        exc_tb: typing.Optional[types.TracebackType],
+        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: types.TracebackType | None
     ) -> None:
         # This will always be true, but this keeps MyPy quiet.
         if self._task is not None:
@@ -192,10 +189,7 @@ class TypingIndicator(special_endpoints.TypingIndicator):
             raise TypeError(msg) from None
 
         def __exit__(
-            self,
-            exc_type: typing.Optional[type[Exception]],
-            exc_val: typing.Optional[Exception],
-            exc_tb: typing.Optional[types.TracebackType],
+            self, exc_type: type[Exception] | None, exc_val: Exception | None, exc_tb: types.TracebackType | None
         ) -> None:
             return None
 
@@ -292,7 +286,7 @@ class GuildBuilder(special_endpoints.GuildBuilder):
     _entity_factory: entity_factory_.EntityFactory = attrs.field(
         alias="entity_factory", metadata={attrs_extensions.SKIP_DEEP_COPY: True}
     )
-    _executor: typing.Optional[concurrent.futures.Executor] = attrs.field(
+    _executor: concurrent.futures.Executor | None = attrs.field(
         alias="executor", metadata={attrs_extensions.SKIP_DEEP_COPY: True}
     )
     _name: str = attrs.field(alias="name")
@@ -306,7 +300,7 @@ class GuildBuilder(special_endpoints.GuildBuilder):
         default=undefined.UNDEFINED
     )
     icon: undefined.UndefinedOr[files.Resourceish] = attrs.field(default=undefined.UNDEFINED)
-    verification_level: undefined.UndefinedOr[typing.Union[guilds.GuildVerificationLevel, int]] = attrs.field(
+    verification_level: undefined.UndefinedOr[guilds.GuildVerificationLevel | int] = attrs.field(
         default=undefined.UNDEFINED
     )
 
@@ -452,12 +446,12 @@ class GuildBuilder(special_endpoints.GuildBuilder):
         *,
         parent_id: undefined.UndefinedOr[snowflakes.Snowflake] = undefined.UNDEFINED,
         bitrate: undefined.UndefinedOr[int] = undefined.UNDEFINED,
-        video_quality_mode: undefined.UndefinedOr[typing.Union[channels.VideoQualityMode, int]] = undefined.UNDEFINED,
+        video_quality_mode: undefined.UndefinedOr[channels.VideoQualityMode | int] = undefined.UNDEFINED,
         position: undefined.UndefinedOr[int] = undefined.UNDEFINED,
         permission_overwrites: undefined.UndefinedOr[
             typing.Collection[channels.PermissionOverwrite]
         ] = undefined.UNDEFINED,
-        region: undefined.UndefinedNoneOr[typing.Union[voices.VoiceRegion, str]],
+        region: undefined.UndefinedNoneOr[voices.VoiceRegion | str],
         user_limit: undefined.UndefinedOr[int] = undefined.UNDEFINED,
     ) -> snowflakes.Snowflake:
         snowflake_id = self._new_snowflake()
@@ -493,7 +487,7 @@ class GuildBuilder(special_endpoints.GuildBuilder):
         permission_overwrites: undefined.UndefinedOr[
             typing.Collection[channels.PermissionOverwrite]
         ] = undefined.UNDEFINED,
-        region: undefined.UndefinedNoneOr[typing.Union[voices.VoiceRegion, str]],
+        region: undefined.UndefinedNoneOr[voices.VoiceRegion | str],
         user_limit: undefined.UndefinedOr[int] = undefined.UNDEFINED,
     ) -> snowflakes.Snowflake:
         snowflake_id = self._new_snowflake()
@@ -546,7 +540,7 @@ class MessageIterator(iterators.BufferedLazyIterator["messages.Message"]):
         self._route = routes.GET_CHANNEL_MESSAGES.compile(channel=channel)
 
     @typing_extensions.override
-    async def _next_chunk(self) -> typing.Optional[typing.Generator[messages.Message, typing.Any, None]]:
+    async def _next_chunk(self) -> typing.Generator[messages.Message, typing.Any, None] | None:
         query = data_binding.StringMapBuilder()
         query.put(self._direction, self._first_id)
         query.put("limit", 100)
@@ -586,7 +580,7 @@ class ReactorIterator(iterators.BufferedLazyIterator["users.User"]):
         self._route = routes.GET_REACTIONS.compile(channel=channel, message=message, emoji=emoji)
 
     @typing_extensions.override
-    async def _next_chunk(self) -> typing.Optional[typing.Generator[users.User, typing.Any, None]]:
+    async def _next_chunk(self) -> typing.Generator[users.User, typing.Any, None] | None:
         query = data_binding.StringMapBuilder()
         query.put("after", self._first_id)
         query.put("limit", 100)
@@ -625,7 +619,7 @@ class OwnGuildIterator(iterators.BufferedLazyIterator["applications.OwnGuild"]):
         self._route = routes.GET_MY_GUILDS.compile()
 
     @typing_extensions.override
-    async def _next_chunk(self) -> typing.Optional[typing.Generator[applications.OwnGuild, typing.Any, None]]:
+    async def _next_chunk(self) -> typing.Generator[applications.OwnGuild, typing.Any, None] | None:
         query = data_binding.StringMapBuilder()
         query.put("with_counts", True)
         query.put("before" if self._newest_first else "after", self._first_id)
@@ -678,7 +672,7 @@ class GuildBanIterator(iterators.BufferedLazyIterator["guilds.GuildBan"]):
         self._newest_first = newest_first
 
     @typing_extensions.override
-    async def _next_chunk(self) -> typing.Optional[typing.Generator[guilds.GuildBan, typing.Any, None]]:
+    async def _next_chunk(self) -> typing.Generator[guilds.GuildBan, typing.Any, None] | None:
         query = data_binding.StringMapBuilder()
         query.put("before" if self._newest_first else "after", self._first_id)
         query.put("limit", 1000)
@@ -721,7 +715,7 @@ class MemberIterator(iterators.BufferedLazyIterator["guilds.Member"]):
         self._first_id = undefined.UNDEFINED
 
     @typing_extensions.override
-    async def _next_chunk(self) -> typing.Optional[typing.Generator[guilds.Member, typing.Any, None]]:
+    async def _next_chunk(self) -> typing.Generator[guilds.Member, typing.Any, None] | None:
         query = data_binding.StringMapBuilder()
         query.put("after", self._first_id)
         query.put("limit", 1000)
@@ -771,9 +765,7 @@ class ScheduledEventUserIterator(iterators.BufferedLazyIterator["scheduled_event
         self._route = routes.GET_GUILD_SCHEDULED_EVENT_USERS.compile(guild=guild, scheduled_event=event)
 
     @typing_extensions.override
-    async def _next_chunk(
-        self,
-    ) -> typing.Optional[typing.Generator[scheduled_events.ScheduledEventUser, typing.Any, None]]:
+    async def _next_chunk(self) -> typing.Generator[scheduled_events.ScheduledEventUser, typing.Any, None] | None:
         query = data_binding.StringMapBuilder()
         query.put("before" if self._newest_first else "after", self._first_id)
         query.put("limit", 100)
@@ -816,7 +808,7 @@ class AuditLogIterator(iterators.LazyIterator["audit_logs.AuditLog"]):
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
         before: undefined.UndefinedOr[str],
         user: undefined.UndefinedOr[snowflakes.SnowflakeishOr[users.PartialUser]],
-        action_type: undefined.UndefinedOr[typing.Union[audit_logs.AuditLogEventType, int]],
+        action_type: undefined.UndefinedOr[audit_logs.AuditLogEventType | int],
     ) -> None:
         self._action_type = action_type
         self._entity_factory = entity_factory
@@ -882,7 +874,7 @@ class GuildThreadIterator(iterators.BufferedLazyIterator[_GuildThreadChannelT]):
         self._route = route
 
     @typing_extensions.override
-    async def _next_chunk(self) -> typing.Optional[typing.Generator[_GuildThreadChannelT, typing.Any, None]]:
+    async def _next_chunk(self) -> typing.Generator[_GuildThreadChannelT, typing.Any, None] | None:
         if not self._has_more:
             return None
 
@@ -919,8 +911,8 @@ class GuildThreadIterator(iterators.BufferedLazyIterator[_GuildThreadChannelT]):
 
 
 def _maybe_cast(
-    callback: typing.Callable[[data_binding.JSONObject], _T], data: typing.Optional[data_binding.JSONObject]
-) -> typing.Optional[_T]:
+    callback: typing.Callable[[data_binding.JSONObject], _T], data: data_binding.JSONObject | None
+) -> _T | None:
     if data:
         return callback(data)
 
@@ -933,7 +925,7 @@ class AutocompleteChoiceBuilder(special_endpoints.AutocompleteChoiceBuilder):
     """Standard implementation of [`hikari.api.special_endpoints.AutocompleteChoiceBuilder`][]."""
 
     _name: str = attrs.field(alias="name")
-    _value: typing.Union[int, str, float] = attrs.field(alias="value")
+    _value: int | str | float = attrs.field(alias="value")
 
     @property
     @typing_extensions.override
@@ -942,7 +934,7 @@ class AutocompleteChoiceBuilder(special_endpoints.AutocompleteChoiceBuilder):
 
     @property
     @typing_extensions.override
-    def value(self) -> typing.Union[int, str, float]:
+    def value(self) -> int | str | float:
         return self._value
 
     @typing_extensions.override
@@ -951,7 +943,7 @@ class AutocompleteChoiceBuilder(special_endpoints.AutocompleteChoiceBuilder):
         return self
 
     @typing_extensions.override
-    def set_value(self, value: typing.Union[float, str], /) -> Self:
+    def set_value(self, value: float | str, /) -> Self:
         self._value = value
         return self
 
@@ -1007,7 +999,7 @@ class InteractionDeferredBuilder(special_endpoints.InteractionDeferredBuilder):
         validator=attrs.validators.in_(base_interactions.DEFERRED_RESPONSE_TYPES),
     )
 
-    _flags: typing.Union[undefined.UndefinedType, int, messages.MessageFlag] = attrs.field(
+    _flags: undefined.UndefinedType | int | messages.MessageFlag = attrs.field(
         alias="flags", default=undefined.UNDEFINED, kw_only=True
     )
 
@@ -1018,11 +1010,11 @@ class InteractionDeferredBuilder(special_endpoints.InteractionDeferredBuilder):
 
     @property
     @typing_extensions.override
-    def flags(self) -> typing.Union[undefined.UndefinedType, int, messages.MessageFlag]:
+    def flags(self) -> undefined.UndefinedType | int | messages.MessageFlag:
         return self._flags
 
     @typing_extensions.override
-    def set_flags(self, flags: typing.Union[undefined.UndefinedType, int, messages.MessageFlag], /) -> Self:
+    def set_flags(self, flags: undefined.UndefinedType | int | messages.MessageFlag, /) -> Self:
         self._flags = flags
         return self
 
@@ -1061,18 +1053,18 @@ class InteractionMessageBuilder(special_endpoints.InteractionMessageBuilder):
     _content: undefined.UndefinedNoneOr[str] = attrs.field(alias="content", default=undefined.UNDEFINED)
 
     # Key-word only not-required arguments.
-    _flags: typing.Union[int, messages.MessageFlag, undefined.UndefinedType] = attrs.field(
+    _flags: int | messages.MessageFlag | undefined.UndefinedType = attrs.field(
         alias="flags", default=undefined.UNDEFINED, kw_only=True
     )
     _is_tts: undefined.UndefinedOr[bool] = attrs.field(alias="is_tts", default=undefined.UNDEFINED, kw_only=True)
     _mentions_everyone: undefined.UndefinedOr[bool] = attrs.field(
         alias="mentions_everyone", default=undefined.UNDEFINED, kw_only=True
     )
-    _role_mentions: undefined.UndefinedOr[typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]] = (
-        attrs.field(alias="role_mentions", default=undefined.UNDEFINED, kw_only=True)
+    _role_mentions: undefined.UndefinedOr[snowflakes.SnowflakeishSequence[guilds.PartialRole] | bool] = attrs.field(
+        alias="role_mentions", default=undefined.UNDEFINED, kw_only=True
     )
-    _user_mentions: undefined.UndefinedOr[typing.Union[snowflakes.SnowflakeishSequence[users.PartialUser], bool]] = (
-        attrs.field(alias="user_mentions", default=undefined.UNDEFINED, kw_only=True)
+    _user_mentions: undefined.UndefinedOr[snowflakes.SnowflakeishSequence[users.PartialUser] | bool] = attrs.field(
+        alias="user_mentions", default=undefined.UNDEFINED, kw_only=True
     )
     _poll: undefined.UndefinedOr[special_endpoints.PollBuilder] = attrs.field(
         alias="poll", default=undefined.UNDEFINED, kw_only=True
@@ -1109,7 +1101,7 @@ class InteractionMessageBuilder(special_endpoints.InteractionMessageBuilder):
 
     @property
     @typing_extensions.override
-    def flags(self) -> typing.Union[undefined.UndefinedType, int, messages.MessageFlag]:
+    def flags(self) -> undefined.UndefinedType | int | messages.MessageFlag:
         return self._flags
 
     @property
@@ -1124,9 +1116,7 @@ class InteractionMessageBuilder(special_endpoints.InteractionMessageBuilder):
 
     @property
     @typing_extensions.override
-    def role_mentions(
-        self,
-    ) -> undefined.UndefinedOr[typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]]:
+    def role_mentions(self) -> undefined.UndefinedOr[snowflakes.SnowflakeishSequence[guilds.PartialRole] | bool]:
         return self._role_mentions
 
     @property
@@ -1136,9 +1126,7 @@ class InteractionMessageBuilder(special_endpoints.InteractionMessageBuilder):
 
     @property
     @typing_extensions.override
-    def user_mentions(
-        self,
-    ) -> undefined.UndefinedOr[typing.Union[snowflakes.SnowflakeishSequence[users.PartialUser], bool]]:
+    def user_mentions(self) -> undefined.UndefinedOr[snowflakes.SnowflakeishSequence[users.PartialUser] | bool]:
         return self._user_mentions
 
     @property
@@ -1195,7 +1183,7 @@ class InteractionMessageBuilder(special_endpoints.InteractionMessageBuilder):
         return self
 
     @typing_extensions.override
-    def set_flags(self, flags: typing.Union[undefined.UndefinedType, int, messages.MessageFlag], /) -> Self:
+    def set_flags(self, flags: undefined.UndefinedType | int | messages.MessageFlag, /) -> Self:
         self._flags = flags
         return self
 
@@ -1213,7 +1201,7 @@ class InteractionMessageBuilder(special_endpoints.InteractionMessageBuilder):
     def set_role_mentions(
         self,
         role_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
+            snowflakes.SnowflakeishSequence[guilds.PartialRole] | bool
         ] = undefined.UNDEFINED,
         /,
     ) -> Self:
@@ -1224,7 +1212,7 @@ class InteractionMessageBuilder(special_endpoints.InteractionMessageBuilder):
     def set_user_mentions(
         self,
         user_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[users.PartialUser], bool]
+            snowflakes.SnowflakeishSequence[users.PartialUser] | bool
         ] = undefined.UNDEFINED,
         /,
     ) -> Self:
@@ -1371,13 +1359,13 @@ class CommandBuilder(special_endpoints.CommandBuilder):
         alias="id", default=undefined.UNDEFINED, kw_only=True
     )
 
-    _default_member_permissions: typing.Union[undefined.UndefinedType, int, permissions_.Permissions] = attrs.field(
+    _default_member_permissions: undefined.UndefinedType | int | permissions_.Permissions = attrs.field(
         alias="default_member_permissions", default=undefined.UNDEFINED, kw_only=True
     )
 
     _is_nsfw: undefined.UndefinedOr[bool] = attrs.field(alias="is_nsfw", default=undefined.UNDEFINED, kw_only=True)
 
-    _name_localizations: typing.Mapping[typing.Union[locales.Locale, str], str] = attrs.field(
+    _name_localizations: typing.Mapping[locales.Locale | str, str] = attrs.field(
         alias="name_localizations", factory=dict, kw_only=True
     )
 
@@ -1396,7 +1384,7 @@ class CommandBuilder(special_endpoints.CommandBuilder):
 
     @property
     @typing_extensions.override
-    def default_member_permissions(self) -> typing.Union[undefined.UndefinedType, permissions_.Permissions, int]:
+    def default_member_permissions(self) -> undefined.UndefinedType | permissions_.Permissions | int:
         return self._default_member_permissions
 
     @property
@@ -1421,7 +1409,7 @@ class CommandBuilder(special_endpoints.CommandBuilder):
 
     @property
     @typing_extensions.override
-    def name_localizations(self) -> typing.Mapping[typing.Union[locales.Locale, str], str]:
+    def name_localizations(self) -> typing.Mapping[locales.Locale | str, str]:
         return self._name_localizations
 
     @typing_extensions.override
@@ -1436,7 +1424,7 @@ class CommandBuilder(special_endpoints.CommandBuilder):
 
     @typing_extensions.override
     def set_default_member_permissions(
-        self, default_member_permissions: typing.Union[undefined.UndefinedType, int, permissions_.Permissions], /
+        self, default_member_permissions: undefined.UndefinedType | int | permissions_.Permissions, /
     ) -> Self:
         self._default_member_permissions = default_member_permissions
         return self
@@ -1461,9 +1449,7 @@ class CommandBuilder(special_endpoints.CommandBuilder):
         return self
 
     @typing_extensions.override
-    def set_name_localizations(
-        self, name_localizations: typing.Mapping[typing.Union[locales.Locale, str], str], /
-    ) -> Self:
+    def set_name_localizations(self, name_localizations: typing.Mapping[locales.Locale | str, str], /) -> Self:
         self._name_localizations = name_localizations
         return self
 
@@ -1493,7 +1479,7 @@ class SlashCommandBuilder(CommandBuilder, special_endpoints.SlashCommandBuilder)
 
     _description: str = attrs.field(alias="description")
     _options: list[commands.CommandOption] = attrs.field(alias="options", factory=list, kw_only=True)
-    _description_localizations: typing.Mapping[typing.Union[locales.Locale, str], str] = attrs.field(
+    _description_localizations: typing.Mapping[locales.Locale | str, str] = attrs.field(
         alias="description_localizations", factory=dict, kw_only=True
     )
 
@@ -1514,7 +1500,7 @@ class SlashCommandBuilder(CommandBuilder, special_endpoints.SlashCommandBuilder)
 
     @property
     @typing_extensions.override
-    def description_localizations(self) -> typing.Mapping[typing.Union[locales.Locale, str], str]:
+    def description_localizations(self) -> typing.Mapping[locales.Locale | str, str]:
         return self._description_localizations
 
     @typing_extensions.override
@@ -1524,7 +1510,7 @@ class SlashCommandBuilder(CommandBuilder, special_endpoints.SlashCommandBuilder)
 
     @typing_extensions.override
     def set_description_localizations(
-        self, description_localizations: typing.Mapping[typing.Union[locales.Locale, str], str], /
+        self, description_localizations: typing.Mapping[locales.Locale | str, str], /
     ) -> Self:
         self._description_localizations = description_localizations
         return self
@@ -1603,7 +1589,7 @@ class ContextMenuCommandBuilder(CommandBuilder, special_endpoints.ContextMenuCom
 
 
 def _build_emoji(
-    emoji: typing.Union[snowflakes.Snowflakeish, emojis.Emoji, str, undefined.UndefinedType] = undefined.UNDEFINED,
+    emoji: snowflakes.Snowflakeish | emojis.Emoji | str | undefined.UndefinedType = undefined.UNDEFINED,
 ) -> tuple[undefined.UndefinedOr[str], undefined.UndefinedOr[str]]:
     """Build an emoji into the format accepted in buttons.
 
@@ -1631,10 +1617,10 @@ def _build_emoji(
 @attrs_extensions.with_copy
 @attrs.define(kw_only=True, weakref_slot=False)
 class _ButtonBuilder(special_endpoints.ButtonBuilder):
-    _style: typing.Union[int, component_models.ButtonStyle] = attrs.field(alias="style")
+    _style: int | component_models.ButtonStyle = attrs.field(alias="style")
     _custom_id: undefined.UndefinedOr[str] = attrs.field()
     _url: undefined.UndefinedOr[str] = attrs.field()
-    _emoji: typing.Union[snowflakes.Snowflakeish, emojis.Emoji, str, undefined.UndefinedType] = attrs.field(
+    _emoji: snowflakes.Snowflakeish | emojis.Emoji | str | undefined.UndefinedType = attrs.field(
         alias="emoji", default=undefined.UNDEFINED
     )
     _emoji_id: undefined.UndefinedOr[str] = attrs.field(init=False, default=undefined.UNDEFINED)
@@ -1652,12 +1638,12 @@ class _ButtonBuilder(special_endpoints.ButtonBuilder):
 
     @property
     @typing_extensions.override
-    def style(self) -> typing.Union[int, component_models.ButtonStyle]:
+    def style(self) -> int | component_models.ButtonStyle:
         return self._style
 
     @property
     @typing_extensions.override
-    def emoji(self) -> typing.Union[snowflakes.Snowflakeish, emojis.Emoji, str, undefined.UndefinedType]:
+    def emoji(self) -> snowflakes.Snowflakeish | emojis.Emoji | str | undefined.UndefinedType:
         return self._emoji
 
     @property
@@ -1671,9 +1657,7 @@ class _ButtonBuilder(special_endpoints.ButtonBuilder):
         return self._is_disabled
 
     @typing_extensions.override
-    def set_emoji(
-        self, emoji: typing.Union[snowflakes.Snowflakeish, emojis.Emoji, str, undefined.UndefinedType], /
-    ) -> Self:
+    def set_emoji(self, emoji: snowflakes.Snowflakeish | emojis.Emoji | str | undefined.UndefinedType, /) -> Self:
         self._emoji_id, self._emoji_name = _build_emoji(emoji)
         self._emoji = emoji
         return self
@@ -1753,7 +1737,7 @@ class SelectOptionBuilder(special_endpoints.SelectOptionBuilder):
     _description: undefined.UndefinedOr[str] = attrs.field(
         alias="description", default=undefined.UNDEFINED, kw_only=True
     )
-    _emoji: typing.Union[snowflakes.Snowflakeish, emojis.Emoji, str, undefined.UndefinedType] = attrs.field(
+    _emoji: snowflakes.Snowflakeish | emojis.Emoji | str | undefined.UndefinedType = attrs.field(
         alias="emoji", default=undefined.UNDEFINED, kw_only=True
     )
     _emoji_id: undefined.UndefinedOr[str] = attrs.field(init=False, default=undefined.UNDEFINED)
@@ -1780,7 +1764,7 @@ class SelectOptionBuilder(special_endpoints.SelectOptionBuilder):
 
     @property
     @typing_extensions.override
-    def emoji(self) -> typing.Union[snowflakes.Snowflakeish, emojis.Emoji, str, undefined.UndefinedType]:
+    def emoji(self) -> snowflakes.Snowflakeish | emojis.Emoji | str | undefined.UndefinedType:
         return self._emoji
 
     @property
@@ -1804,9 +1788,7 @@ class SelectOptionBuilder(special_endpoints.SelectOptionBuilder):
         return self
 
     @typing_extensions.override
-    def set_emoji(
-        self, emoji: typing.Union[snowflakes.Snowflakeish, emojis.Emoji, str, undefined.UndefinedType], /
-    ) -> Self:
+    def set_emoji(self, emoji: snowflakes.Snowflakeish | emojis.Emoji | str | undefined.UndefinedType, /) -> Self:
         self._emoji_id, self._emoji_name = _build_emoji(emoji)
         self._emoji = emoji
         return self
@@ -1839,7 +1821,7 @@ class SelectOptionBuilder(special_endpoints.SelectOptionBuilder):
 class SelectMenuBuilder(special_endpoints.SelectMenuBuilder):
     """Builder class for select menus."""
 
-    _type: typing.Union[component_models.ComponentType, int] = attrs.field(alias="type")
+    _type: component_models.ComponentType | int = attrs.field(alias="type")
     _custom_id: str = attrs.field(alias="custom_id")
     _placeholder: undefined.UndefinedOr[str] = attrs.field(alias="placeholder", default=undefined.UNDEFINED)
     _min_values: int = attrs.field(alias="min_values", default=0)
@@ -1848,7 +1830,7 @@ class SelectMenuBuilder(special_endpoints.SelectMenuBuilder):
 
     @property
     @typing_extensions.override
-    def type(self) -> typing.Union[int, component_models.ComponentType]:
+    def type(self) -> int | component_models.ComponentType:
         return self._type
 
     @property
@@ -1919,7 +1901,7 @@ class TextSelectMenuBuilder(SelectMenuBuilder, special_endpoints.TextSelectMenuB
     """Builder class for text select menus."""
 
     _options: list[special_endpoints.SelectOptionBuilder] = attrs.field()
-    _parent: typing.Optional[_ParentT] = attrs.field()
+    _parent: _ParentT | None = attrs.field()
     _type: typing.Literal[component_models.ComponentType.TEXT_SELECT_MENU] = attrs.field()
 
     if not typing.TYPE_CHECKING:
@@ -1956,7 +1938,7 @@ class TextSelectMenuBuilder(SelectMenuBuilder, special_endpoints.TextSelectMenuB
         self,
         *,
         custom_id: str,
-        parent: typing.Optional[_ParentT] = None,
+        parent: _ParentT | None = None,
         options: typing.Sequence[special_endpoints.SelectOptionBuilder] = (),
         placeholder: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         min_values: int = 0,
@@ -1996,7 +1978,7 @@ class TextSelectMenuBuilder(SelectMenuBuilder, special_endpoints.TextSelectMenuB
         /,
         *,
         description: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-        emoji: typing.Union[snowflakes.Snowflakeish, emojis.Emoji, str, undefined.UndefinedType] = undefined.UNDEFINED,
+        emoji: snowflakes.Snowflakeish | emojis.Emoji | str | undefined.UndefinedType = undefined.UNDEFINED,
         is_default: bool = False,
     ) -> Self:
         return self.add_raw_option(
@@ -2106,7 +2088,7 @@ class TextInputBuilder(special_endpoints.TextInputBuilder):
         return self._max_length
 
     @typing_extensions.override
-    def set_style(self, style: typing.Union[component_models.TextInputStyle, int], /) -> Self:
+    def set_style(self, style: component_models.TextInputStyle | int, /) -> Self:
         self._style = component_models.TextInputStyle(style)
         return self
 
@@ -2167,7 +2149,7 @@ class MessageActionRowBuilder(special_endpoints.MessageActionRowBuilder):
     """Standard implementation of [`hikari.api.special_endpoints.MessageActionRowBuilder`][]."""
 
     _components: list[special_endpoints.ComponentBuilder] = attrs.field(alias="components", factory=list)
-    _stored_type: typing.Optional[int] = attrs.field(default=None, init=False)
+    _stored_type: int | None = attrs.field(default=None, init=False)
 
     @property
     @typing_extensions.override
@@ -2179,7 +2161,7 @@ class MessageActionRowBuilder(special_endpoints.MessageActionRowBuilder):
     def components(self) -> typing.Sequence[special_endpoints.ComponentBuilder]:
         return self._components.copy()
 
-    def _assert_can_add_type(self, type_: typing.Union[component_models.ComponentType, int], /) -> None:
+    def _assert_can_add_type(self, type_: component_models.ComponentType | int, /) -> None:
         if self._stored_type is not None and self._stored_type != type_:
             msg = f"{type_} component type cannot be added to a container which already holds {self._stored_type}"
             raise ValueError(msg)
@@ -2199,7 +2181,7 @@ class MessageActionRowBuilder(special_endpoints.MessageActionRowBuilder):
         custom_id: str,
         /,
         *,
-        emoji: typing.Union[snowflakes.Snowflakeish, emojis.Emoji, str, undefined.UndefinedType] = undefined.UNDEFINED,
+        emoji: snowflakes.Snowflakeish | emojis.Emoji | str | undefined.UndefinedType = undefined.UNDEFINED,
         label: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         is_disabled: bool = False,
     ) -> Self:
@@ -2215,7 +2197,7 @@ class MessageActionRowBuilder(special_endpoints.MessageActionRowBuilder):
         url: str,
         /,
         *,
-        emoji: typing.Union[snowflakes.Snowflakeish, emojis.Emoji, str, undefined.UndefinedType] = undefined.UNDEFINED,
+        emoji: snowflakes.Snowflakeish | emojis.Emoji | str | undefined.UndefinedType = undefined.UNDEFINED,
         label: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         is_disabled: bool = False,
     ) -> Self:
@@ -2224,7 +2206,7 @@ class MessageActionRowBuilder(special_endpoints.MessageActionRowBuilder):
     @typing_extensions.override
     def add_select_menu(
         self,
-        type_: typing.Union[component_models.ComponentType, int],
+        type_: component_models.ComponentType | int,
         custom_id: str,
         /,
         *,
@@ -2302,7 +2284,7 @@ class ModalActionRowBuilder(special_endpoints.ModalActionRowBuilder):
     """Standard implementation of [`hikari.api.special_endpoints.ModalActionRowBuilder`][]."""
 
     _components: list[special_endpoints.ComponentBuilder] = attrs.field(alias="components", factory=list)
-    _stored_type: typing.Optional[int] = attrs.field(init=False, default=None)
+    _stored_type: int | None = attrs.field(init=False, default=None)
 
     @property
     @typing_extensions.override
@@ -2314,7 +2296,7 @@ class ModalActionRowBuilder(special_endpoints.ModalActionRowBuilder):
     def components(self) -> typing.Sequence[special_endpoints.ComponentBuilder]:
         return self._components.copy()
 
-    def _assert_can_add_type(self, type_: typing.Union[component_models.ComponentType, int], /) -> None:
+    def _assert_can_add_type(self, type_: component_models.ComponentType | int, /) -> None:
         if self._stored_type is not None and self._stored_type != type_:
             msg = f"{type_} component type cannot be added to a container which already holds {self._stored_type}"
             raise ValueError(msg)

--- a/hikari/impl/voice.py
+++ b/hikari/impl/voice.py
@@ -145,7 +145,7 @@ class VoiceComponentImpl(voice.VoiceComponent):
         *,
         deaf: bool = False,
         mute: bool = False,
-        timeout: typing.Optional[int] = 5,
+        timeout: int | None = 5,
         **kwargs: object,
     ) -> _VoiceConnectionT:
         self._check_if_alive()

--- a/hikari/interactions/base_interactions.py
+++ b/hikari/interactions/base_interactions.py
@@ -223,13 +223,13 @@ class PartialInteraction(snowflakes.Unique, webhooks.ExecutableWebhook):
     version: int = attrs.field(eq=False, repr=True)
     """Version of the interaction system this interaction is under."""
 
-    app_permissions: typing.Optional[permissions_.Permissions] = attrs.field(eq=False, hash=False, repr=False)
+    app_permissions: permissions_.Permissions | None = attrs.field(eq=False, hash=False, repr=False)
     """Permissions the bot has in this interaction's channel if it's in a guild."""
 
     user: users.User = attrs.field(eq=False, hash=False, repr=True)
     """The user who triggered this interaction."""
 
-    member: typing.Optional[InteractionMember] = attrs.field(eq=False, hash=False, repr=True)
+    member: InteractionMember | None = attrs.field(eq=False, hash=False, repr=True)
     """The member who triggered this interaction.
 
     This will be [`None`][] for interactions triggered in DMs.
@@ -242,13 +242,13 @@ class PartialInteraction(snowflakes.Unique, webhooks.ExecutableWebhook):
     channel: InteractionChannel = attrs.field(eq=False, repr=False)
     """The channel this interaction was triggered in."""
 
-    guild_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=True)
+    guild_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=True)
     """ID of the guild this modal interaction event was triggered in.
 
     This will be [`None`][] for modal interactions triggered in DMs.
     """
 
-    guild_locale: typing.Optional[typing.Union[str, locales.Locale]] = attrs.field(eq=False, hash=False, repr=True)
+    guild_locale: str | locales.Locale | None = attrs.field(eq=False, hash=False, repr=True)
     """The preferred language of the guild this component interaction was triggered in.
 
     This will be [`None`][] for component interactions triggered in DMs.
@@ -283,7 +283,7 @@ class PartialInteraction(snowflakes.Unique, webhooks.ExecutableWebhook):
         # <<inherited docstring from ExecutableWebhook>>.
         return self.application_id
 
-    async def fetch_guild(self) -> typing.Optional[guilds.RESTGuild]:
+    async def fetch_guild(self) -> guilds.RESTGuild | None:
         """Fetch the guild this interaction happened in.
 
         Returns
@@ -311,7 +311,7 @@ class PartialInteraction(snowflakes.Unique, webhooks.ExecutableWebhook):
 
         return await self.app.rest.fetch_guild(self.guild_id)
 
-    def get_guild(self) -> typing.Optional[guilds.GatewayGuild]:
+    def get_guild(self) -> guilds.GatewayGuild | None:
         """Get the object of the guild this interaction was triggered in from the cache.
 
         Returns
@@ -333,7 +333,7 @@ class PartialInteractionMetadata:
     interaction_id: snowflakes.Snowflake = attrs.field(hash=True, repr=True)
     """The ID for this message interaction."""
 
-    type: typing.Union[InteractionType, int] = attrs.field(eq=False, repr=True)
+    type: InteractionType | int = attrs.field(eq=False, repr=True)
     """The type of this message interaction."""
 
     user: users.User = attrs.field(eq=False, repr=True)
@@ -344,7 +344,7 @@ class PartialInteractionMetadata:
     )
     """A mapping of the [applications.ApplicationIntegrationType] to the related guild or user ID."""
 
-    original_response_message_id: typing.Optional[snowflakes.Snowflake] = attrs.field(hash=True, repr=True)
+    original_response_message_id: snowflakes.Snowflake | None = attrs.field(hash=True, repr=True)
     """The ID of the original response message."""
 
 
@@ -407,7 +407,7 @@ class MessageResponseMixin(PartialInteraction, typing.Generic[_CommandResponseTy
         response_type: _CommandResponseTypesT,
         content: undefined.UndefinedOr[typing.Any] = undefined.UNDEFINED,
         *,
-        flags: typing.Union[int, messages.MessageFlag, undefined.UndefinedType] = undefined.UNDEFINED,
+        flags: int | messages.MessageFlag | undefined.UndefinedType = undefined.UNDEFINED,
         tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         attachment: undefined.UndefinedNoneOr[files.Resourceish] = undefined.UNDEFINED,
         attachments: undefined.UndefinedNoneOr[typing.Sequence[files.Resourceish]] = undefined.UNDEFINED,
@@ -420,10 +420,10 @@ class MessageResponseMixin(PartialInteraction, typing.Generic[_CommandResponseTy
         poll: undefined.UndefinedOr[special_endpoints.PollBuilder] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[users.PartialUser], bool]
+            snowflakes.SnowflakeishSequence[users.PartialUser] | bool
         ] = undefined.UNDEFINED,
         role_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
+            snowflakes.SnowflakeishSequence[guilds.PartialRole] | bool
         ] = undefined.UNDEFINED,
     ) -> None:
         """Create the initial response for this interaction.
@@ -540,11 +540,9 @@ class MessageResponseMixin(PartialInteraction, typing.Generic[_CommandResponseTy
         self,
         content: undefined.UndefinedNoneOr[typing.Any] = undefined.UNDEFINED,
         *,
-        attachment: undefined.UndefinedNoneOr[
-            typing.Union[files.Resourceish, messages.Attachment]
-        ] = undefined.UNDEFINED,
+        attachment: undefined.UndefinedNoneOr[files.Resourceish | messages.Attachment] = undefined.UNDEFINED,
         attachments: undefined.UndefinedNoneOr[
-            typing.Sequence[typing.Union[files.Resourceish, messages.Attachment]]
+            typing.Sequence[files.Resourceish | messages.Attachment]
         ] = undefined.UNDEFINED,
         component: undefined.UndefinedNoneOr[special_endpoints.ComponentBuilder] = undefined.UNDEFINED,
         components: undefined.UndefinedNoneOr[
@@ -554,10 +552,10 @@ class MessageResponseMixin(PartialInteraction, typing.Generic[_CommandResponseTy
         embeds: undefined.UndefinedNoneOr[typing.Sequence[embeds_.Embed]] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[users.PartialUser], bool]
+            snowflakes.SnowflakeishSequence[users.PartialUser] | bool
         ] = undefined.UNDEFINED,
         role_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
+            snowflakes.SnowflakeishSequence[guilds.PartialRole] | bool
         ] = undefined.UNDEFINED,
     ) -> messages.Message:
         """Edit the initial response of this command interaction.
@@ -781,13 +779,13 @@ class InteractionChannel(channels.PartialChannel):
     permissions: permissions_.Permissions = attrs.field(eq=False, hash=False, repr=True)
     """Permissions the command's executor has in this channel."""
 
-    parent_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=True)
+    parent_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=True)
     """The parent ID of the channel.
 
     This will be [`None`][] for DM channels and guild channels that have no parent.
     """
 
-    thread_metadata: typing.Optional[channels.ThreadMetadata] = attrs.field(eq=False, hash=False, repr=False)
+    thread_metadata: channels.ThreadMetadata | None = attrs.field(eq=False, hash=False, repr=False)
     """The thread metadata, if the channel is a thread."""
 
 

--- a/hikari/interactions/command_interactions.py
+++ b/hikari/interactions/command_interactions.py
@@ -82,10 +82,10 @@ class CommandInteractionOption:
     name: str = attrs.field(repr=True)
     """Name of this option."""
 
-    type: typing.Union[commands.OptionType, int] = attrs.field(repr=True)
+    type: commands.OptionType | int = attrs.field(repr=True)
     """Type of this option."""
 
-    value: typing.Union[snowflakes.Snowflake, str, int, float, bool, None] = attrs.field(repr=True)
+    value: snowflakes.Snowflake | str | int | float | bool | None = attrs.field(repr=True)
     """Value provided for this option.
 
     Either [`hikari.interactions.command_interactions.CommandInteractionOption.value`][]
@@ -95,7 +95,7 @@ class CommandInteractionOption:
     subcommand or group.
     """
 
-    options: typing.Optional[typing.Sequence[Self]] = attrs.field(repr=True)
+    options: typing.Sequence[Self] | None = attrs.field(repr=True)
     """Options provided for this option.
 
     Either [`hikari.interactions.command_interactions.CommandInteractionOption.value`][]
@@ -133,10 +133,10 @@ class BaseCommandInteraction(base_interactions.PartialInteraction):
     command_name: str = attrs.field(eq=False, hash=False, repr=True)
     """Name of the command being invoked."""
 
-    command_type: typing.Union[commands.CommandType, int] = attrs.field(eq=False, hash=False, repr=True)
+    command_type: commands.CommandType | int = attrs.field(eq=False, hash=False, repr=True)
     """The type of the command."""
 
-    registered_guild_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=True)
+    registered_guild_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=True)
     """ID of the guild the command is registered to."""
 
     async def fetch_command(self) -> commands.PartialCommand:
@@ -182,10 +182,10 @@ class CommandInteraction(
     options: typing.Sequence[CommandInteractionOption] = attrs.field(eq=False, hash=False, repr=True)
     """Parameter values provided by the user invoking this command."""
 
-    resolved: typing.Optional[base_interactions.ResolvedOptionData] = attrs.field(eq=False, hash=False, repr=False)
+    resolved: base_interactions.ResolvedOptionData | None = attrs.field(eq=False, hash=False, repr=False)
     """Mappings of the objects resolved for the provided command options."""
 
-    target_id: typing.Optional[snowflakes.Snowflake] = attrs.field(default=None, eq=False, hash=False, repr=True)
+    target_id: snowflakes.Snowflake | None = attrs.field(default=None, eq=False, hash=False, repr=True)
     """The target of the command. Only available if the command is a context menu command."""
 
     def build_response(self) -> special_endpoints.InteractionMessageBuilder:
@@ -309,8 +309,8 @@ class AutocompleteInteraction(BaseCommandInteraction):
 class CommandInteractionMetadata(base_interactions.PartialInteractionMetadata):
     """The interaction metadata for a command initiated message."""
 
-    target_user: typing.Optional[users_.User] = attrs.field(eq=False, hash=False, repr=True)
+    target_user: users_.User | None = attrs.field(eq=False, hash=False, repr=True)
     """The user the command was run on, present only on user command interactions."""
 
-    target_message_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=True)
+    target_message_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=True)
     """The ID of the message the command was run on, present only on message command interactions."""

--- a/hikari/interactions/component_interactions.py
+++ b/hikari/interactions/component_interactions.py
@@ -89,7 +89,7 @@ class ComponentInteraction(
 ):
     """Represents a component interaction on Discord."""
 
-    component_type: typing.Union[components_.ComponentType, int] = attrs.field(eq=False)
+    component_type: components_.ComponentType | int = attrs.field(eq=False)
     """The type of component which triggers this interaction.
 
     !!! note
@@ -103,7 +103,7 @@ class ComponentInteraction(
     values: typing.Sequence[str] = attrs.field(eq=False)
     """Sequence of the values which were selected for a select menu component."""
 
-    resolved: typing.Optional[base_interactions.ResolvedOptionData] = attrs.field(eq=False, hash=False, repr=False)
+    resolved: base_interactions.ResolvedOptionData | None = attrs.field(eq=False, hash=False, repr=False)
     """Mappings of the objects resolved for the provided command options."""
 
     message: messages.Message = attrs.field(eq=False, repr=False)
@@ -190,7 +190,7 @@ class ComponentInteraction(
 class ComponentInteractionMetadata(base_interactions.PartialInteractionMetadata):
     """The interaction metadata for a component belonging to a message."""
 
-    original_response_message_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=True)
+    original_response_message_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=True)
     """The ID of the original response message, present only on follow-up messages."""
 
     interacted_message_id: snowflakes.Snowflake = attrs.field(eq=False, hash=False, repr=True)

--- a/hikari/interactions/modal_interactions.py
+++ b/hikari/interactions/modal_interactions.py
@@ -73,7 +73,7 @@ class ModalInteraction(
     custom_id: str = attrs.field(eq=False, hash=False, repr=True)
     """The custom id of the modal."""
 
-    message: typing.Optional[messages.Message] = attrs.field(eq=False, repr=False)
+    message: messages.Message | None = attrs.field(eq=False, repr=False)
     """The message whose component triggered the modal.
 
     This will be [`None`][] if the modal was a response to a command.
@@ -135,7 +135,7 @@ class ModalInteraction(
 class ModalInteractionMetadata(base_interactions.PartialInteractionMetadata):
     """The interaction metadata for a modal initiated message."""
 
-    original_response_message_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=True)
+    original_response_message_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=True)
     """The ID of the original response message, present only on follow-up messages."""
 
     triggering_interaction_metadata: base_interactions.PartialInteractionMetadata = attrs.field(

--- a/hikari/internal/aio.py
+++ b/hikari/internal/aio.py
@@ -35,7 +35,7 @@ T_co = typing.TypeVar("T_co", covariant=True)
 T_inv = typing.TypeVar("T_inv")
 
 
-def completed_future(result: typing.Optional[T_inv] = None, /) -> asyncio.Future[typing.Optional[T_inv]]:
+def completed_future(result: T_inv | None = None, /) -> asyncio.Future[T_inv | None]:
     """Create a future on the current running loop that is completed, then return it.
 
     Parameters
@@ -61,7 +61,7 @@ def completed_future(result: typing.Optional[T_inv] = None, /) -> asyncio.Future
     return future
 
 
-async def first_completed(*aws: typing.Awaitable[typing.Any], timeout: typing.Optional[float] = None) -> None:
+async def first_completed(*aws: typing.Awaitable[typing.Any], timeout: float | None = None) -> None:
     """Wait for the first awaitable to complete.
 
     The awaitables that don't complete first will be cancelled.
@@ -107,7 +107,7 @@ async def first_completed(*aws: typing.Awaitable[typing.Any], timeout: typing.Op
                     pass
 
 
-async def all_of(*aws: typing.Awaitable[T_co], timeout: typing.Optional[float] = None) -> typing.Sequence[T_co]:
+async def all_of(*aws: typing.Awaitable[T_co], timeout: float | None = None) -> typing.Sequence[T_co]:
     """Await the completion of all the given awaitable items.
 
     If any fail or time out, then they are all cancelled.

--- a/hikari/internal/attrs_extensions.py
+++ b/hikari/internal/attrs_extensions.py
@@ -215,7 +215,7 @@ def get_or_generate_deep_copier(
         return copier
 
 
-def deep_copy_attrs(model: ModelT, memo: typing.Optional[typing.MutableMapping[int, typing.Any]] = None) -> ModelT:
+def deep_copy_attrs(model: ModelT, memo: typing.MutableMapping[int, typing.Any] | None = None) -> ModelT:
     """Deep copy an attrs model with [`init`][] enabled.
 
     !!! note

--- a/hikari/internal/cache.py
+++ b/hikari/internal/cache.py
@@ -114,9 +114,9 @@ class CacheMappingView(cache.CacheView[KeyT, ValueT]):
 
     def __init__(
         self,
-        items: typing.Union[typing.Mapping[KeyT, ValueT], typing.Mapping[KeyT, DataT]],
+        items: typing.Mapping[KeyT, ValueT] | typing.Mapping[KeyT, DataT],
         *,
-        builder: typing.Optional[typing.Callable[[DataT], ValueT]] = None,
+        builder: typing.Callable[[DataT], ValueT] | None = None,
     ) -> None:
         self._builder = builder
         self._data = items
@@ -153,7 +153,7 @@ class CacheMappingView(cache.CacheView[KeyT, ValueT]):
     def get_item_at(self, index: slice, /) -> typing.Sequence[ValueT]: ...
 
     @typing_extensions.override
-    def get_item_at(self, index: typing.Union[slice, int], /) -> typing.Union[ValueT, typing.Sequence[ValueT]]:
+    def get_item_at(self, index: slice | int, /) -> ValueT | typing.Sequence[ValueT]:
         return collections.get_index_or_slice(self, index)
 
 
@@ -179,7 +179,7 @@ class EmptyCacheView(cache.CacheView[typing.Any, typing.Any]):
         return 0
 
     @typing_extensions.override
-    def get_item_at(self, index: typing.Union[slice, int]) -> typing.NoReturn:
+    def get_item_at(self, index: slice | int) -> typing.NoReturn:
         raise IndexError(index)
 
 
@@ -193,73 +193,73 @@ class GuildRecord:
     guild.
     """
 
-    is_available: typing.Optional[bool] = attrs.field(default=None)
+    is_available: bool | None = attrs.field(default=None)
     """Whether the cached guild is available or not.
 
     This will be [`None`][] when no `guild` is also
     [`None`][] else [`bool`][].
     """
 
-    guild: typing.Optional[guilds.GatewayGuild] = attrs.field(default=None)
+    guild: guilds.GatewayGuild | None = attrs.field(default=None)
     """A cached guild object.
 
     This will be [`None`][] if not cached.
     """
 
-    channels: typing.Optional[typing.MutableSet[snowflakes.Snowflake]] = attrs.field(default=None)
+    channels: typing.MutableSet[snowflakes.Snowflake] | None = attrs.field(default=None)
     """A set of the IDs of the guild channels cached for this guild.
 
     This will be [`None`][] if no channels are cached for this guild.
     """
 
-    threads: typing.Optional[typing.MutableSet[snowflakes.Snowflake]] = attrs.field(default=None)
+    threads: typing.MutableSet[snowflakes.Snowflake] | None = attrs.field(default=None)
     """A set of the IDs of the guild threads cached for this guild.
 
     This will be [`None`][] if no threads are cached for this guild.
     """
 
-    emojis: typing.Optional[typing.MutableSet[snowflakes.Snowflake]] = attrs.field(default=None)
+    emojis: typing.MutableSet[snowflakes.Snowflake] | None = attrs.field(default=None)
     """A set of the IDs of the emojis cached for this guild.
 
     This will be [`None`][] if no emojis are cached for this guild.
     """
 
-    stickers: typing.Optional[typing.MutableSet[snowflakes.Snowflake]] = attrs.field(default=None)
+    stickers: typing.MutableSet[snowflakes.Snowflake] | None = attrs.field(default=None)
     """A sequence of sticker IDs cached for this guild.
 
     This will be [`None`][] if no stickers are cached for this guild.
     """
 
-    invites: typing.Optional[typing.MutableSequence[str]] = attrs.field(default=None)
+    invites: typing.MutableSequence[str] | None = attrs.field(default=None)
     """A set of the [`str`][] codes of the invites cached for this guild.
 
     This will be [`None`][] if no invites are cached for this guild.
     """
 
-    members: typing.Optional[collections.ExtendedMutableMapping[snowflakes.Snowflake, RefCell[MemberData]]] = (
-        attrs.field(default=None)
+    members: collections.ExtendedMutableMapping[snowflakes.Snowflake, RefCell[MemberData]] | None = attrs.field(
+        default=None
     )
     """A mapping of user IDs to the objects of members cached for this guild.
 
     This will be [`None`][] if no members are cached for this guild.
     """
 
-    presences: typing.Optional[collections.ExtendedMutableMapping[snowflakes.Snowflake, MemberPresenceData]] = (
-        attrs.field(default=None)
+    presences: collections.ExtendedMutableMapping[snowflakes.Snowflake, MemberPresenceData] | None = attrs.field(
+        default=None
     )
     """A mapping of user IDs to objects of the presences cached for this guild.
 
     This will be [`None`][] if no presences are cached for this guild.
     """
 
-    roles: typing.Optional[typing.MutableSet[snowflakes.Snowflake]] = attrs.field(default=None)
+    roles: typing.MutableSet[snowflakes.Snowflake] | None = attrs.field(default=None)
     """A set of the IDs of the roles cached for this guild.
 
     This will be [`None`][] if no roles are cached for this guild.
     """
 
-    voice_states: typing.Optional[collections.ExtendedMutableMapping[snowflakes.Snowflake, VoiceStateData]] = (
-        attrs.field(default=None)
+    voice_states: collections.ExtendedMutableMapping[snowflakes.Snowflake, VoiceStateData] | None = attrs.field(
+        default=None
     )
     """A mapping of user IDs to objects of the voice states cached for this guild.
 
@@ -338,15 +338,15 @@ class InviteData(BaseData[invites.InviteWithMetadata]):
     """A data model for storing invite data in an in-memory cache."""
 
     code: str = attrs.field()
-    guild_id: typing.Optional[snowflakes.Snowflake] = attrs.field()
+    guild_id: snowflakes.Snowflake | None = attrs.field()
     channel_id: snowflakes.Snowflake = attrs.field()
-    inviter: typing.Optional[RefCell[users_.User]] = attrs.field()
-    target_type: typing.Union[invites.TargetType, int, None] = attrs.field()
-    target_user: typing.Optional[RefCell[users_.User]] = attrs.field()
-    target_application: typing.Optional[applications.InviteApplication] = attrs.field()
+    inviter: RefCell[users_.User] | None = attrs.field()
+    target_type: invites.TargetType | int | None = attrs.field()
+    target_user: RefCell[users_.User] | None = attrs.field()
+    target_application: applications.InviteApplication | None = attrs.field()
     uses: int = attrs.field()
-    max_uses: typing.Optional[int] = attrs.field()
-    max_age: typing.Optional[datetime.timedelta] = attrs.field()
+    max_uses: int | None = attrs.field()
+    max_age: datetime.timedelta | None = attrs.field()
     is_temporary: bool = attrs.field()
     created_at: datetime.datetime = attrs.field()
 
@@ -380,8 +380,8 @@ class InviteData(BaseData[invites.InviteWithMetadata]):
         invite: invites.InviteWithMetadata,
         /,
         *,
-        inviter: typing.Optional[RefCell[users_.User]] = None,
-        target_user: typing.Optional[RefCell[users_.User]] = None,
+        inviter: RefCell[users_.User] | None = None,
+        target_user: RefCell[users_.User] | None = None,
     ) -> InviteData:
         if not inviter and invite.inviter:
             inviter = RefCell(copy.copy(invite.inviter))
@@ -412,25 +412,23 @@ class MemberData(BaseData[guilds.Member]):
 
     user: RefCell[users_.User] = attrs.field()
     guild_id: snowflakes.Snowflake = attrs.field()
-    nickname: typing.Optional[str] = attrs.field()
-    guild_avatar_hash: typing.Optional[str] = attrs.field()
-    guild_banner_hash: typing.Optional[str] = attrs.field()
+    nickname: str | None = attrs.field()
+    guild_avatar_hash: str | None = attrs.field()
+    guild_banner_hash: str | None = attrs.field()
     role_ids: tuple[snowflakes.Snowflake, ...] = attrs.field()
-    joined_at: typing.Optional[datetime.datetime] = attrs.field()
-    premium_since: typing.Optional[datetime.datetime] = attrs.field()
+    joined_at: datetime.datetime | None = attrs.field()
+    premium_since: datetime.datetime | None = attrs.field()
     is_deaf: undefined.UndefinedOr[bool] = attrs.field()
     is_mute: undefined.UndefinedOr[bool] = attrs.field()
     is_pending: undefined.UndefinedOr[bool] = attrs.field()
-    raw_communication_disabled_until: typing.Optional[datetime.datetime] = attrs.field()
-    guild_flags: typing.Union[guilds.GuildMemberFlags, int] = attrs.field()
+    raw_communication_disabled_until: datetime.datetime | None = attrs.field()
+    guild_flags: guilds.GuildMemberFlags | int = attrs.field()
     # meta-attribute
     has_been_deleted: bool = attrs.field(default=False, init=False)
 
     @classmethod
     @typing_extensions.override
-    def build_from_entity(
-        cls, member: guilds.Member, /, *, user: typing.Optional[RefCell[users_.User]] = None
-    ) -> MemberData:
+    def build_from_entity(cls, member: guilds.Member, /, *, user: RefCell[users_.User] | None = None) -> MemberData:
         return cls(
             guild_id=member.guild_id,
             nickname=member.nickname,
@@ -478,7 +476,7 @@ class KnownCustomEmojiData(BaseData[emojis.KnownCustomEmoji]):
     is_animated: bool = attrs.field()
     guild_id: snowflakes.Snowflake = attrs.field()
     role_ids: tuple[snowflakes.Snowflake, ...] = attrs.field()
-    user: typing.Optional[RefCell[users_.User]] = attrs.field()
+    user: RefCell[users_.User] | None = attrs.field()
     is_colons_required: bool = attrs.field()
     is_managed: bool = attrs.field()
     is_available: bool = attrs.field()
@@ -486,7 +484,7 @@ class KnownCustomEmojiData(BaseData[emojis.KnownCustomEmoji]):
     @classmethod
     @typing_extensions.override
     def build_from_entity(
-        cls, emoji: emojis.KnownCustomEmoji, /, *, user: typing.Optional[RefCell[users_.User]] = None
+        cls, emoji: emojis.KnownCustomEmoji, /, *, user: RefCell[users_.User] | None = None
     ) -> KnownCustomEmojiData:
         if not user and emoji.user:
             user = RefCell(copy.copy(emoji.user))
@@ -531,17 +529,17 @@ class GuildStickerData(BaseData[stickers_.GuildSticker]):
 
     id: snowflakes.Snowflake = attrs.field()
     name: str = attrs.field()
-    description: typing.Optional[str] = attrs.field()
+    description: str | None = attrs.field()
     tag: str = attrs.field()
-    format_type: typing.Union[stickers_.StickerFormatType, int] = attrs.field()
+    format_type: stickers_.StickerFormatType | int = attrs.field()
     is_available: bool = attrs.field()
     guild_id: snowflakes.Snowflake = attrs.field()
-    user: typing.Optional[RefCell[users_.User]] = attrs.field()
+    user: RefCell[users_.User] | None = attrs.field()
 
     @classmethod
     @typing_extensions.override
     def build_from_entity(
-        cls, sticker: stickers_.GuildSticker, /, *, user: typing.Optional[RefCell[users_.User]] = None
+        cls, sticker: stickers_.GuildSticker, /, *, user: RefCell[users_.User] | None = None
     ) -> GuildStickerData:
         if not user and sticker.user:
             user = RefCell(copy.copy(sticker.user))
@@ -577,25 +575,25 @@ class RichActivityData(BaseData[presences.RichActivity]):
     """A data model for storing rich activity data in an in-memory cache."""
 
     name: str = attrs.field()
-    url: typing.Optional[str] = attrs.field()
-    type: typing.Union[presences.ActivityType, int] = attrs.field()
+    url: str | None = attrs.field()
+    type: presences.ActivityType | int = attrs.field()
     created_at: datetime.datetime = attrs.field()
-    timestamps: typing.Optional[presences.ActivityTimestamps] = attrs.field()
-    application_id: typing.Optional[snowflakes.Snowflake] = attrs.field()
-    details: typing.Optional[str] = attrs.field()
-    state: typing.Optional[str] = attrs.field()
-    emoji: typing.Union[RefCell[emojis.CustomEmoji], str, None] = attrs.field()
-    party: typing.Optional[presences.ActivityParty] = attrs.field()
-    assets: typing.Optional[presences.ActivityAssets] = attrs.field()
-    secrets: typing.Optional[presences.ActivitySecret] = attrs.field()
-    is_instance: typing.Optional[bool] = attrs.field()
-    flags: typing.Optional[presences.ActivityFlag] = attrs.field()
+    timestamps: presences.ActivityTimestamps | None = attrs.field()
+    application_id: snowflakes.Snowflake | None = attrs.field()
+    details: str | None = attrs.field()
+    state: str | None = attrs.field()
+    emoji: RefCell[emojis.CustomEmoji] | str | None = attrs.field()
+    party: presences.ActivityParty | None = attrs.field()
+    assets: presences.ActivityAssets | None = attrs.field()
+    secrets: presences.ActivitySecret | None = attrs.field()
+    is_instance: bool | None = attrs.field()
+    flags: presences.ActivityFlag | None = attrs.field()
     buttons: tuple[str, ...] = attrs.field()
 
     @classmethod
     @typing_extensions.override
     def build_from_entity(
-        cls, activity: presences.RichActivity, /, *, emoji: typing.Union[RefCell[emojis.CustomEmoji], str, None] = None
+        cls, activity: presences.RichActivity, /, *, emoji: RefCell[emojis.CustomEmoji] | str | None = None
     ) -> RichActivityData:
         if emoji:
             pass
@@ -630,7 +628,7 @@ class RichActivityData(BaseData[presences.RichActivity]):
 
     @typing_extensions.override
     def build_entity(self, _: traits.RESTAware, /) -> presences.RichActivity:
-        emoji: typing.Optional[emojis.Emoji] = None
+        emoji: emojis.Emoji | None = None
         if isinstance(self.emoji, RefCell):
             emoji = self.emoji.copy()
 
@@ -663,7 +661,7 @@ class MemberPresenceData(BaseData[presences.MemberPresence]):
 
     user_id: snowflakes.Snowflake = attrs.field()
     guild_id: snowflakes.Snowflake = attrs.field()
-    visible_status: typing.Union[presences.Status, str] = attrs.field()
+    visible_status: presences.Status | str = attrs.field()
     activities: tuple[RichActivityData, ...] = attrs.field()
     client_status: presences.ClientStatus = attrs.field()
 
@@ -716,12 +714,12 @@ class MessageData(BaseData[messages.Message]):
 
     id: snowflakes.Snowflake = attrs.field()
     channel_id: snowflakes.Snowflake = attrs.field()
-    guild_id: typing.Optional[snowflakes.Snowflake] = attrs.field()
+    guild_id: snowflakes.Snowflake | None = attrs.field()
     author: RefCell[users_.User] = attrs.field()
-    member: typing.Optional[RefCell[MemberData]] = attrs.field()
-    content: typing.Optional[str] = attrs.field()
+    member: RefCell[MemberData] | None = attrs.field()
+    content: str | None = attrs.field()
     timestamp: datetime.datetime = attrs.field()
-    edited_timestamp: typing.Optional[datetime.datetime] = attrs.field()
+    edited_timestamp: datetime.datetime | None = attrs.field()
     is_tts: bool = attrs.field()
     user_mentions: undefined.UndefinedOr[typing.Mapping[snowflakes.Snowflake, RefCell[users_.User]]] = attrs.field()
     role_mention_ids: undefined.UndefinedOr[tuple[snowflakes.Snowflake, ...]] = attrs.field()
@@ -732,21 +730,21 @@ class MessageData(BaseData[messages.Message]):
     attachments: tuple[messages.Attachment, ...] = attrs.field()
     embeds: tuple[embeds_.Embed, ...] = attrs.field()
     reactions: tuple[messages.Reaction, ...] = attrs.field()
-    poll: typing.Optional[polls_.Poll] = attrs.field()
+    poll: polls_.Poll | None = attrs.field()
     is_pinned: bool = attrs.field()
-    webhook_id: typing.Optional[snowflakes.Snowflake] = attrs.field()
-    type: typing.Union[messages.MessageType, int] = attrs.field()
-    activity: typing.Optional[messages.MessageActivity] = attrs.field()
-    application: typing.Optional[messages.MessageApplication] = attrs.field()
-    message_reference: typing.Optional[messages.MessageReference] = attrs.field()
+    webhook_id: snowflakes.Snowflake | None = attrs.field()
+    type: messages.MessageType | int = attrs.field()
+    activity: messages.MessageActivity | None = attrs.field()
+    application: messages.MessageApplication | None = attrs.field()
+    message_reference: messages.MessageReference | None = attrs.field()
     flags: messages.MessageFlag = attrs.field()
     stickers: tuple[stickers_.PartialSticker, ...] = attrs.field()
-    nonce: typing.Optional[str] = attrs.field()
-    referenced_message: typing.Optional[RefCell[MessageData]] = attrs.field()
-    application_id: typing.Optional[snowflakes.Snowflake] = attrs.field()
+    nonce: str | None = attrs.field()
+    referenced_message: RefCell[MessageData] | None = attrs.field()
+    application_id: snowflakes.Snowflake | None = attrs.field()
     components: tuple[components_.MessageActionRowComponent, ...] = attrs.field()
-    thread: typing.Optional[channels_.GuildThreadChannel] = attrs.field()
-    interaction_metadata: typing.Optional[base_interactions.PartialInteractionMetadata] = attrs.field()
+    thread: channels_.GuildThreadChannel | None = attrs.field()
+    interaction_metadata: base_interactions.PartialInteractionMetadata | None = attrs.field()
 
     @classmethod
     @typing_extensions.override
@@ -755,12 +753,12 @@ class MessageData(BaseData[messages.Message]):
         message: messages.Message,
         /,
         *,
-        author: typing.Optional[RefCell[users_.User]] = None,
-        member: typing.Optional[RefCell[MemberData]] = None,
+        author: RefCell[users_.User] | None = None,
+        member: RefCell[MemberData] | None = None,
         user_mentions: undefined.UndefinedOr[
             typing.Mapping[snowflakes.Snowflake, RefCell[users_.User]]
         ] = undefined.UNDEFINED,
-        referenced_message: typing.Optional[RefCell[MessageData]] = None,
+        referenced_message: RefCell[MessageData] | None = None,
     ) -> MessageData:
         if not member and message.member:
             member = RefCell(MemberData.build_from_entity(message.member))
@@ -910,7 +908,7 @@ class MessageData(BaseData[messages.Message]):
 class VoiceStateData(BaseData[voices.VoiceState]):
     """A data model for storing voice state data in an in-memory cache."""
 
-    channel_id: typing.Optional[snowflakes.Snowflake] = attrs.field()
+    channel_id: snowflakes.Snowflake | None = attrs.field()
     guild_id: snowflakes.Snowflake = attrs.field()
     user_id: snowflakes.Snowflake = attrs.field()
     is_guild_deafened: bool = attrs.field()
@@ -920,9 +918,9 @@ class VoiceStateData(BaseData[voices.VoiceState]):
     is_streaming: bool = attrs.field()
     is_suppressed: bool = attrs.field()
     is_video_enabled: bool = attrs.field()
-    member: typing.Optional[RefCell[MemberData]] = attrs.field()
+    member: RefCell[MemberData] | None = attrs.field()
     session_id: str = attrs.field()
-    requested_to_speak_at: typing.Optional[datetime.datetime] = attrs.field()
+    requested_to_speak_at: datetime.datetime | None = attrs.field()
 
     @typing_extensions.override
     def build_entity(self, app: traits.RESTAware, /) -> voices.VoiceState:
@@ -947,7 +945,7 @@ class VoiceStateData(BaseData[voices.VoiceState]):
     @classmethod
     @typing_extensions.override
     def build_from_entity(
-        cls, voice_state: voices.VoiceState, /, *, member: typing.Optional[RefCell[MemberData]] = None
+        cls, voice_state: voices.VoiceState, /, *, member: RefCell[MemberData] | None = None
     ) -> VoiceStateData:
         return cls(
             channel_id=voice_state.channel_id,

--- a/hikari/internal/collections.py
+++ b/hikari/internal/collections.py
@@ -106,7 +106,7 @@ class FreezableDict(ExtendedMutableMapping[KeyT, ValueT]):
 
     __slots__: typing.Sequence[str] = ("_data",)
 
-    def __init__(self, source: typing.Optional[dict[KeyT, ValueT]] = None, /) -> None:
+    def __init__(self, source: dict[KeyT, ValueT] | None = None, /) -> None:
         self._data = source or {}
 
     @typing_extensions.override
@@ -168,11 +168,11 @@ class LimitedCapacityCacheMap(ExtendedMutableMapping[KeyT, ValueT]):
 
     def __init__(
         self,
-        source: typing.Optional[dict[KeyT, ValueT]] = None,
+        source: dict[KeyT, ValueT] | None = None,
         /,
         *,
         limit: int,
-        on_expire: typing.Optional[typing.Callable[[ValueT], None]] = None,
+        on_expire: typing.Callable[[ValueT], None] | None = None,
     ) -> None:
         self._data: dict[KeyT, ValueT] = source or {}
         self._limit = limit
@@ -339,8 +339,8 @@ class SnowflakeSet(typing.MutableSet[snowflakes.Snowflake]):
 
 
 def get_index_or_slice(
-    mapping: typing.Mapping[KeyT, ValueT], index_or_slice: typing.Union[int, slice]
-) -> typing.Union[ValueT, typing.Sequence[ValueT]]:
+    mapping: typing.Mapping[KeyT, ValueT], index_or_slice: int | slice
+) -> ValueT | typing.Sequence[ValueT]:
     """Get a mapping's entry at a given index as if it's a sequence of it's values.
 
     Parameters

--- a/hikari/internal/data_binding.py
+++ b/hikari/internal/data_binding.py
@@ -106,7 +106,7 @@ default_json_loads: JSONDecoder
 try:
     import orjson
 
-    def default_json_dumps(obj: typing.Union[JSONArray, JSONObject]) -> bytes:
+    def default_json_dumps(obj: JSONArray | JSONObject) -> bytes:
         """Encode a JSON object to [`bytes`][]."""
         return orjson.dumps(obj, option=orjson.OPT_NON_STR_KEYS)
 
@@ -116,7 +116,7 @@ except ModuleNotFoundError:
 
     _json_separators = (",", ":")
 
-    def default_json_dumps(obj: typing.Union[JSONArray, JSONObject]) -> bytes:
+    def default_json_dumps(obj: JSONArray | JSONObject) -> bytes:
         """Encode a JSON object to [`bytes`][]."""
         return json.dumps(obj, separators=_json_separators).encode(_UTF_8)
 
@@ -127,7 +127,7 @@ except ModuleNotFoundError:
 class JSONPayload(aiohttp.BytesPayload):
     """A JSON payload to use in an aiohttp request."""
 
-    def __init__(self, value: typing.Union[JSONArray, JSONObject], dumps: JSONEncoder = default_json_dumps) -> None:
+    def __init__(self, value: JSONArray | JSONObject, dumps: JSONEncoder = default_json_dumps) -> None:
         super().__init__(dumps(value), content_type=_JSON_CONTENT_TYPE, encoding=_UTF_8)
 
 
@@ -138,22 +138,18 @@ class URLEncodedFormBuilder:
     __slots__: typing.Sequence[str] = ("_fields", "_resources")
 
     def __init__(self) -> None:
-        self._fields: list[tuple[str, typing.Union[str, aiohttp.BytesPayload], typing.Optional[str]]] = []
+        self._fields: list[tuple[str, str | aiohttp.BytesPayload, str | None]] = []
         self._resources: list[tuple[str, files.Resource[files.AsyncReader]]] = []
 
-    def add_field(
-        self, name: str, data: typing.Union[str, bytes], *, content_type: typing.Optional[str] = None
-    ) -> None:
-        field_data: typing.Union[str, aiohttp.BytesPayload] = (
-            aiohttp.BytesPayload(data) if isinstance(data, bytes) else data
-        )
+    def add_field(self, name: str, data: str | bytes, *, content_type: str | None = None) -> None:
+        field_data: str | aiohttp.BytesPayload = aiohttp.BytesPayload(data) if isinstance(data, bytes) else data
         self._fields.append((name, field_data, content_type))
 
     def add_resource(self, name: str, resource: files.Resource[files.AsyncReader]) -> None:
         self._resources.append((name, resource))
 
     async def build(
-        self, stack: contextlib.AsyncExitStack, executor: typing.Optional[concurrent.futures.Executor] = None
+        self, stack: contextlib.AsyncExitStack, executor: concurrent.futures.Executor | None = None
     ) -> aiohttp.FormData:
         form = aiohttp.FormData()
 
@@ -204,7 +200,7 @@ class StringMapBuilder(multidict.MultiDict[str]):
         value: undefined.UndefinedOr[typing.Any],
         /,
         *,
-        conversion: typing.Optional[typing.Callable[[typing.Any], typing.Any]] = None,
+        conversion: typing.Callable[[typing.Any], typing.Any] | None = None,
     ) -> None:
         """Add a key and value to the string map.
 
@@ -282,7 +278,7 @@ class JSONObjectBuilder(dict[str, JSONish]):
         value: undefined.UndefinedNoneOr[typing.Any],
         /,
         *,
-        conversion: typing.Optional[typing.Callable[[typing.Any], JSONish]] = None,
+        conversion: typing.Callable[[typing.Any], JSONish] | None = None,
     ) -> None:
         """Put a JSON value.
 
@@ -326,7 +322,7 @@ class JSONObjectBuilder(dict[str, JSONish]):
         values: undefined.UndefinedOr[typing.Iterable[typing.Any]],
         /,
         *,
-        conversion: typing.Optional[typing.Callable[[typing.Any], JSONish]] = None,
+        conversion: typing.Callable[[typing.Any], JSONish] | None = None,
     ) -> None:
         """Put a JSON array.
 

--- a/hikari/internal/enums.py
+++ b/hikari/internal/enums.py
@@ -52,7 +52,7 @@ class _DeprecatedAlias(typing.Generic[_T]):
 
         deprecation.check_if_past_removal(self._name, removal_version=removal_version)
 
-    def __get__(self, instance: typing.Optional[_T], owner_enum: _T) -> _T:
+    def __get__(self, instance: _T | None, owner_enum: _T) -> _T:
         # Import kept in-line due to circular import issues
         from hikari.internal import deprecation
 
@@ -83,7 +83,7 @@ class _EnumNamespace(dict[str, _T]):
         self.values_to_names: dict[_T, str] = {}
         self["__doc__"] = "An enumeration."
 
-    def __getitem__(self, name: str) -> typing.Union[_T, object]:
+    def __getitem__(self, name: str) -> _T | object:
         try:
             return super().__getitem__(name)
         except KeyError:
@@ -171,7 +171,7 @@ class _EnumMeta(type):
         mcls: type[Self],
         cls_name: str,
         bases: tuple[type[typing.Any], ...],
-        namespace: typing.Union[dict[str, typing.Any], _EnumNamespace],
+        namespace: dict[str, typing.Any] | _EnumNamespace,
     ) -> Self:
         global _Enum
 
@@ -228,9 +228,7 @@ class _EnumMeta(type):
         return cls
 
     @classmethod
-    def __prepare__(
-        cls, name: str, bases: tuple[type[typing.Any], ...] = ()
-    ) -> typing.Union[dict[str, typing.Any], _EnumNamespace]:
+    def __prepare__(cls, name: str, bases: tuple[type[typing.Any], ...] = ()) -> dict[str, typing.Any] | _EnumNamespace:
         if _Enum is NotImplemented:
             if name != "Enum":
                 msg = "First instance of _EnumMeta must be Enum"
@@ -423,9 +421,7 @@ class _FlagMeta(type):
         yield from cls._name_to_member_map_.values()
 
     @classmethod
-    def __prepare__(
-        cls, name: str, bases: tuple[type[typing.Any], ...] = ()
-    ) -> typing.Union[dict[str, typing.Any], _EnumNamespace]:
+    def __prepare__(cls, name: str, bases: tuple[type[typing.Any], ...] = ()) -> dict[str, typing.Any] | _EnumNamespace:
         if _Flag is NotImplemented:
             if name != "Flag":
                 msg = "First instance of _FlagMeta must be Flag"
@@ -443,7 +439,7 @@ class _FlagMeta(type):
         mcls: type[Flag],
         cls_name: str,
         bases: tuple[type[typing.Any], ...],
-        namespace: typing.Union[dict[str, typing.Any], _EnumNamespace],
+        namespace: dict[str, typing.Any] | _EnumNamespace,
     ) -> Flag:
         global _Flag
 
@@ -669,7 +665,7 @@ class Flag(metaclass=_FlagMeta):
     __members__: typing.ClassVar[typing.Mapping[str, Flag]]
     __objtype__: typing.ClassVar[type[int]]
     __enumtype__: typing.ClassVar[type[Flag]]
-    _name_: typing.Optional[str]
+    _name_: str | None
     _value_: int
 
     @property
@@ -706,7 +702,7 @@ class Flag(metaclass=_FlagMeta):
         """
         return any((flag & self) == flag for flag in flags)
 
-    def difference(self, other: typing.Union[Self, int]) -> _T:
+    def difference(self, other: Self | int) -> _T:
         """Perform a set difference with the other set.
 
         This will return all flags in this set that are not in the other value.
@@ -715,7 +711,7 @@ class Flag(metaclass=_FlagMeta):
         """
         return self.__class__(self & ~int(other))
 
-    def intersection(self, other: typing.Union[Self, int]) -> _T:
+    def intersection(self, other: Self | int) -> _T:
         """Return a combination of flags that are set for both given values.
 
         Equivalent to using the "AND" `&` operator.
@@ -726,7 +722,7 @@ class Flag(metaclass=_FlagMeta):
         """Return a set of all flags not in the current set."""
         return self.__class__(self.__class__.__everything__._value_ & ~self._value_)
 
-    def is_disjoint(self, other: typing.Union[Self, int]) -> bool:
+    def is_disjoint(self, other: Self | int) -> bool:
         """Return whether two sets have a intersection or not.
 
         If the two sets have an intersection, then this returns
@@ -735,14 +731,14 @@ class Flag(metaclass=_FlagMeta):
         """
         return not (self & other)
 
-    def is_subset(self, other: typing.Union[Self, int]) -> bool:
+    def is_subset(self, other: Self | int) -> bool:
         """Return whether another set contains this set or not.
 
         Equivalent to using the "in" operator.
         """
         return (self & other) == other
 
-    def is_superset(self, other: typing.Union[Self, int]) -> bool:
+    def is_superset(self, other: Self | int) -> bool:
         """Return whether this set contains another set or not."""
         return (self & other) == self
 
@@ -773,7 +769,7 @@ class Flag(metaclass=_FlagMeta):
             key=lambda m: m._name_,
         )
 
-    def symmetric_difference(self, other: typing.Union[_T, int]) -> Self:
+    def symmetric_difference(self, other: _T | int) -> Self:
         """Return a set with the symmetric differences of two flag sets.
 
         Equivalent to using the "XOR" `^` operator.
@@ -782,7 +778,7 @@ class Flag(metaclass=_FlagMeta):
         """
         return self.__class__(self._value_ ^ int(other))
 
-    def union(self, other: typing.Union[_T, int]) -> Self:
+    def union(self, other: _T | int) -> Self:
         """Return a combination of all flags in this set and the other set.
 
         Equivalent to using the "OR" `~` operator.
@@ -815,7 +811,7 @@ class Flag(metaclass=_FlagMeta):
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}.{self.name}: {self.value!r}>"
 
-    def __rsub__(self, other: typing.Union[int, _T]) -> Self:
+    def __rsub__(self, other: int | _T) -> Self:
         # This logic has to be reversed to be correct, since order matters for
         # a subtraction operator. This also ensures `int - _T -> _T` is a valid
         # case for us.

--- a/hikari/internal/mentions.py
+++ b/hikari/internal/mentions.py
@@ -37,8 +37,8 @@ if typing.TYPE_CHECKING:
 def generate_allowed_mentions(
     mentions_everyone: undefined.UndefinedOr[bool],
     mentions_reply: undefined.UndefinedOr[bool],
-    user_mentions: undefined.UndefinedOr[typing.Union[snowflakes.SnowflakeishSequence[users.PartialUser], bool]],
-    role_mentions: undefined.UndefinedOr[typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]],
+    user_mentions: undefined.UndefinedOr[snowflakes.SnowflakeishSequence[users.PartialUser] | bool],
+    role_mentions: undefined.UndefinedOr[snowflakes.SnowflakeishSequence[guilds.PartialRole] | bool],
 ) -> data_binding.JSONObject:
     """Generate an allowed mentions JSON object.
 

--- a/hikari/internal/net.py
+++ b/hikari/internal/net.py
@@ -48,7 +48,7 @@ async def generate_error_response(response: aiohttp.ClientResponse) -> errors.HT
         assert isinstance(json_body, dict)
         args.append(json_body.get("message", ""))
         args.append(json_body.get("code", 0))
-        raw_error_array: typing.Optional[data_binding.JSONObject] = json_body.get("errors")
+        raw_error_array: data_binding.JSONObject | None = json_body.get("errors")
     except ValueError:
         raw_error_array = None
 
@@ -62,7 +62,7 @@ async def generate_error_response(response: aiohttp.ClientResponse) -> errors.HT
         return errors.NotFoundError(*args)
 
     try:
-        status: typing.Union[http.HTTPStatus, int] = http.HTTPStatus(response.status)
+        status: http.HTTPStatus | int = http.HTTPStatus(response.status)
     except ValueError:
         status = response.status
 
@@ -74,7 +74,7 @@ async def generate_error_response(response: aiohttp.ClientResponse) -> errors.HT
 
 
 def create_tcp_connector(
-    http_settings: config.HTTPSettings, *, dns_cache: typing.Union[bool, int] = True, limit: int = 100
+    http_settings: config.HTTPSettings, *, dns_cache: bool | int = True, limit: int = 100
 ) -> aiohttp.TCPConnector:
     """Create a TCP connector and return it.
 

--- a/hikari/internal/routes.py
+++ b/hikari/internal/routes.py
@@ -137,7 +137,7 @@ class Route:
     path_template: str = attrs.field()
     """The template string used for the path."""
 
-    major_params: typing.Optional[frozenset[str]] = attrs.field(hash=False, eq=False, repr=False)
+    major_params: frozenset[str] | None = attrs.field(hash=False, eq=False, repr=False)
     """The optional major parameter name combination for this endpoint."""
 
     has_ratelimits: bool = attrs.field(hash=False, eq=False, repr=False)
@@ -217,7 +217,7 @@ class CDNRoute:
     is_sizable: bool = attrs.field(default=True, kw_only=True, repr=False, hash=False, eq=False)
     """Whether a `size` param can be specified."""
 
-    def compile(self, base_url: str, *, file_format: str, size: typing.Optional[int] = None, **kwargs: object) -> str:
+    def compile(self, base_url: str, *, file_format: str, size: int | None = None, **kwargs: object) -> str:
         """Generate a full CDN url from this endpoint.
 
         Parameters
@@ -284,7 +284,7 @@ class CDNRoute:
         return url
 
     def compile_to_file(
-        self, base_url: str, *, file_format: str, size: typing.Optional[int] = None, **kwargs: object
+        self, base_url: str, *, file_format: str, size: int | None = None, **kwargs: object
     ) -> files.URL:
         """Perform the same as `compile`, but return the URL as a [`hikari.files.URL`][]."""
         return files.URL(self.compile(base_url, file_format=file_format, size=size, **kwargs))

--- a/hikari/internal/signals.py
+++ b/hikari/internal/signals.py
@@ -54,7 +54,7 @@ def _raise_interrupt(signum: int) -> typing.NoReturn:
 def _interrupt_handler(loop: asyncio.AbstractEventLoop) -> _SignalHandlerT:
     loop_thread_id = threading.get_native_id()
 
-    def handler(signum: int, frame: typing.Optional[types.FrameType]) -> None:
+    def handler(signum: int, frame: types.FrameType | None) -> None:
         # The loop may or may not be running, depending on the state of the application when this occurs.
         # Signals on POSIX only occur on the main thread usually, too, so we need to ensure this is
         # threadsafe.
@@ -77,7 +77,7 @@ def _interrupt_handler(loop: asyncio.AbstractEventLoop) -> _SignalHandlerT:
 
 @contextlib.contextmanager
 def handle_interrupts(
-    loop: asyncio.AbstractEventLoop, *, propagate_interrupts: bool, enabled: typing.Optional[bool]
+    loop: asyncio.AbstractEventLoop, *, propagate_interrupts: bool, enabled: bool | None
 ) -> typing.Generator[None, None, None]:
     """Context manager which cleanly exits on signal interrupts.
 
@@ -102,7 +102,7 @@ def handle_interrupts(
         return
 
     interrupt_handler = _interrupt_handler(loop)
-    original_handlers: dict[int, typing.Union[int, _SignalHandlerT, None]] = {}
+    original_handlers: dict[int, int | _SignalHandlerT | None] = {}
 
     for sig in _INTERRUPT_SIGNALS:
         try:

--- a/hikari/internal/time.py
+++ b/hikari/internal/time.py
@@ -83,7 +83,7 @@ def slow_iso8601_datetime_string_to_datetime(datetime_str: str) -> datetime.date
     return datetime.datetime.fromisoformat(datetime_str)
 
 
-fast_iso8601_datetime_string_to_datetime: typing.Optional[typing.Callable[[str], datetime.datetime]]
+fast_iso8601_datetime_string_to_datetime: typing.Callable[[str], datetime.datetime] | None
 try:
     # CISO8601 is around 600x faster than modules like dateutil, which is
     # going to be noticeable on big bots where you are parsing hundreds of

--- a/hikari/internal/ux.py
+++ b/hikari/internal/ux.py
@@ -69,10 +69,7 @@ _LOGGER: typing.Final[logging.Logger] = logging.getLogger("hikari.ux")
 
 
 def init_logging(
-    flavor: typing.Union[None, str, int, dict[str, typing.Any], os.PathLike[str]],
-    *,
-    allow_color: bool,
-    force_color: bool,
+    flavor: None | str | int | dict[str, typing.Any] | os.PathLike[str], *, allow_color: bool, force_color: bool
 ) -> None:
     """Initialize logging for the user.
 
@@ -246,11 +243,7 @@ def _read_banner(package: str) -> str:
 
 
 def print_banner(
-    package: typing.Optional[str],
-    *,
-    allow_color: bool,
-    force_color: bool,
-    extra_args: typing.Optional[dict[str, str]] = None,
+    package: str | None, *, allow_color: bool, force_color: bool, extra_args: dict[str, str] | None = None
 ) -> None:
     """Print a banner of choice to [`sys.stdout`][].
 
@@ -403,7 +396,7 @@ class HikariVersion:
     __slots__: typing.Sequence[str] = ("_cmp", "prerelease", "version")
 
     version: tuple[int, int, int]
-    prerelease: typing.Optional[tuple[str, int]]
+    prerelease: tuple[str, int] | None
 
     def __init__(self, vstring: str) -> None:
         match = _VERSION_REGEX.match(vstring)
@@ -499,7 +492,7 @@ async def check_for_updates(http_settings: config.HTTPSettings, proxy_settings: 
 
         this_version = HikariVersion(about.__version__)
         is_dev = this_version.prerelease is not None
-        newest_version: typing.Optional[HikariVersion] = None
+        newest_version: HikariVersion | None = None
 
         for release_string, artifacts in data["releases"].items():
             if not all(artifact["yanked"] for artifact in artifacts):

--- a/hikari/invites.py
+++ b/hikari/invites.py
@@ -94,44 +94,44 @@ class VanityURL(InviteCode):
 class InviteGuild(guilds.PartialGuild):
     """Represents the partial data of a guild that is attached to invites."""
 
-    features: typing.Sequence[typing.Union[str, guilds.GuildFeature]] = attrs.field(eq=False, hash=False, repr=False)
+    features: typing.Sequence[str | guilds.GuildFeature] = attrs.field(eq=False, hash=False, repr=False)
     """A list of the features in this guild."""
 
-    splash_hash: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    splash_hash: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The hash of the splash for the guild, if there is one."""
 
-    banner_hash: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    banner_hash: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The hash for the guild's banner.
 
     This is only present if [`hikari.guilds.GuildFeature.BANNER`][] is in the
     `features` for this guild. For all other purposes, it is [`None`][].
     """
 
-    description: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    description: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The guild's description."""
 
-    verification_level: typing.Union[guilds.GuildVerificationLevel, int] = attrs.field(eq=False, hash=False, repr=False)
+    verification_level: guilds.GuildVerificationLevel | int = attrs.field(eq=False, hash=False, repr=False)
     """The verification level required for a user to participate in this guild."""
 
-    vanity_url_code: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=True)
+    vanity_url_code: str | None = attrs.field(eq=False, hash=False, repr=True)
     """The vanity URL code for the guild's vanity URL.
 
     This is only present if [`hikari.guilds.GuildFeature.VANITY_URL`][] is in the
     `features` for this guild. If not, this will always be [`None`][].
     """
 
-    welcome_screen: typing.Optional[guilds.WelcomeScreen] = attrs.field(eq=False, hash=False, repr=False)
+    welcome_screen: guilds.WelcomeScreen | None = attrs.field(eq=False, hash=False, repr=False)
     """The welcome screen of a community guild shown to new members, if set."""
 
     nsfw_level: guilds.GuildNSFWLevel = attrs.field(eq=False, hash=False, repr=False)
     """The NSFW level of the guild."""
 
     @property
-    def splash_url(self) -> typing.Optional[files.URL]:
+    def splash_url(self) -> files.URL | None:
         """Splash URL for the guild, if set."""
         return self.make_splash_url()
 
-    def make_splash_url(self, *, ext: str = "png", size: int = 4096) -> typing.Optional[files.URL]:
+    def make_splash_url(self, *, ext: str = "png", size: int = 4096) -> files.URL | None:
         """Generate the guild's splash image URL, if set.
 
         Parameters
@@ -161,11 +161,11 @@ class InviteGuild(guilds.PartialGuild):
         )
 
     @property
-    def banner_url(self) -> typing.Optional[files.URL]:
+    def banner_url(self) -> files.URL | None:
         """Banner URL for the guild, if set."""
         return self.make_banner_url()
 
-    def make_banner_url(self, *, ext: typing.Optional[str] = None, size: int = 4096) -> typing.Optional[files.URL]:
+    def make_banner_url(self, *, ext: str | None = None, size: int = 4096) -> files.URL | None:
         """Generate the guild's banner image URL, if set.
 
         Parameters
@@ -215,20 +215,20 @@ class Invite(InviteCode):
     code: str = attrs.field(hash=True, repr=True)
     """The code for this invite."""
 
-    guild: typing.Optional[InviteGuild] = attrs.field(eq=False, hash=False, repr=False)
+    guild: InviteGuild | None = attrs.field(eq=False, hash=False, repr=False)
     """The partial object of the guild this invite belongs to.
 
     Will be [`None`][] for group DM invites and when attached to a gateway event;
     for invites received over the gateway you should refer to [`hikari.invites.Invite.guild_id`][].
     """
 
-    guild_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=True)
+    guild_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=True)
     """The ID of the guild this invite belongs to.
 
     Will be [`None`][] for group DM invites.
     """
 
-    channel: typing.Optional[channels.PartialChannel] = attrs.field(eq=False, hash=False, repr=False)
+    channel: channels.PartialChannel | None = attrs.field(eq=False, hash=False, repr=False)
     """The partial object of the channel this invite targets.
 
     Will be [`None`][] for invite objects that are attached to gateway events,
@@ -238,31 +238,31 @@ class Invite(InviteCode):
     channel_id: snowflakes.Snowflake = attrs.field(eq=False, hash=False, repr=True)
     """The ID of the channel this invite targets."""
 
-    inviter: typing.Optional[users.User] = attrs.field(eq=False, hash=False, repr=False)
+    inviter: users.User | None = attrs.field(eq=False, hash=False, repr=False)
     """The object of the user who created this invite."""
 
-    target_type: typing.Union[TargetType, int, None] = attrs.field(eq=False, hash=False, repr=False)
+    target_type: TargetType | int | None = attrs.field(eq=False, hash=False, repr=False)
     """The type of the target of this invite, if applicable."""
 
-    target_user: typing.Optional[users.User] = attrs.field(eq=False, hash=False, repr=False)
+    target_user: users.User | None = attrs.field(eq=False, hash=False, repr=False)
     """The object of the user who this invite targets, if set."""
 
-    target_application: typing.Optional[applications.InviteApplication] = attrs.field(eq=False, hash=False, repr=False)
+    target_application: applications.InviteApplication | None = attrs.field(eq=False, hash=False, repr=False)
     """The embedded application this invite targets, if applicable."""
 
-    approximate_active_member_count: typing.Optional[int] = attrs.field(eq=False, hash=False, repr=False)
+    approximate_active_member_count: int | None = attrs.field(eq=False, hash=False, repr=False)
     """The approximate amount of presences in this invite's guild.
 
     This is only returned by the GET REST Invites endpoint.
     """
 
-    approximate_member_count: typing.Optional[int] = attrs.field(eq=False, hash=False, repr=False)
+    approximate_member_count: int | None = attrs.field(eq=False, hash=False, repr=False)
     """The approximate amount of members in this invite's guild.
 
     This is only returned by the GET Invites REST endpoint.
     """
 
-    expires_at: typing.Optional[datetime.datetime] = attrs.field(eq=False, hash=False, repr=False)
+    expires_at: datetime.datetime | None = attrs.field(eq=False, hash=False, repr=False)
     """When this invite will expire.
 
     This field is only returned by the GET Invite REST endpoint and will be
@@ -282,7 +282,7 @@ class InviteWithMetadata(Invite):
     uses: int = attrs.field(eq=False, hash=False, repr=True)
     """The amount of times this invite has been used."""
 
-    max_uses: typing.Optional[int] = attrs.field(eq=False, hash=False, repr=True)
+    max_uses: int | None = attrs.field(eq=False, hash=False, repr=True)
     """The limit for how many times this invite can be used before it expires.
 
     If set to [`None`][] then this is unlimited.
@@ -290,7 +290,7 @@ class InviteWithMetadata(Invite):
 
     # TODO: can we use a non-None value to represent infinity here somehow, or
     # make a timedelta that is infinite for comparisons?
-    max_age: typing.Optional[datetime.timedelta] = attrs.field(eq=False, hash=False, repr=False)
+    max_age: datetime.timedelta | None = attrs.field(eq=False, hash=False, repr=False)
     """The timedelta of how long this invite will be valid for.
 
     If set to [`None`][] then this is unlimited.
@@ -302,14 +302,14 @@ class InviteWithMetadata(Invite):
     created_at: datetime.datetime = attrs.field(eq=False, hash=False, repr=False)
     """When this invite was created."""
 
-    expires_at: typing.Optional[datetime.datetime]
+    expires_at: datetime.datetime | None
     """When this invite will expire.
 
     If this invite doesn't have a set expiry then this will be [`None`][].
     """
 
     @property
-    def uses_left(self) -> typing.Optional[int]:
+    def uses_left(self) -> int | None:
         """Return the number of uses left for this invite.
 
         This will be [`None`][] if the invite has unlimited uses.

--- a/hikari/iterators.py
+++ b/hikari/iterators.py
@@ -146,10 +146,10 @@ class AttrComparator(typing.Generic[ValueT]):
         self,
         attr_name: str,
         expected_value: AnotherValueT,
-        cast: typing.Optional[typing.Callable[[ValueT], AnotherValueT]] = None,
+        cast: typing.Callable[[ValueT], AnotherValueT] | None = None,
     ) -> None:
         self.expected_value: typing.Any = expected_value
-        self.cast: typing.Optional[typing.Callable[[ValueT], typing.Any]] = cast
+        self.cast: typing.Callable[[ValueT], typing.Any] | None = cast
         self.attr_getter: spel.AttrGetter[ValueT, typing.Any] = spel.AttrGetter(attr_name)
 
     def __call__(self, item: ValueT) -> bool:
@@ -232,9 +232,7 @@ class LazyIterator(typing.Generic[ValueT], abc.ABC):
         """
         return _ChunkedLazyIterator(self, chunk_size)
 
-    def map(
-        self, transformation: typing.Union[typing.Callable[[ValueT], AnotherValueT], str]
-    ) -> LazyIterator[AnotherValueT]:
+    def map(self, transformation: typing.Callable[[ValueT], AnotherValueT] | str) -> LazyIterator[AnotherValueT]:
         """Map the values to a different value.
 
         Parameters
@@ -264,7 +262,7 @@ class LazyIterator(typing.Generic[ValueT], abc.ABC):
                 consumer(item)
 
     def filter(
-        self, *predicates: typing.Union[tuple[str, object], typing.Callable[[ValueT], bool]], **attrs: object
+        self, *predicates: tuple[str, object] | typing.Callable[[ValueT], bool], **attrs: object
     ) -> LazyIterator[ValueT]:
         """Filter the items by one or more conditions.
 
@@ -299,7 +297,7 @@ class LazyIterator(typing.Generic[ValueT], abc.ABC):
         return _FilteredLazyIterator(self, conditions)
 
     def take_while(
-        self, *predicates: typing.Union[tuple[str, typing.Any], typing.Callable[[ValueT], bool]], **attrs: object
+        self, *predicates: tuple[str, typing.Any] | typing.Callable[[ValueT], bool], **attrs: object
     ) -> LazyIterator[ValueT]:
         """Return each item until any conditions fail or the end is reached.
 
@@ -327,7 +325,7 @@ class LazyIterator(typing.Generic[ValueT], abc.ABC):
         return _TakeWhileLazyIterator(self, conditions)
 
     def take_until(
-        self, *predicates: typing.Union[tuple[str, typing.Any], typing.Callable[[ValueT], bool]], **attrs: object
+        self, *predicates: tuple[str, typing.Any] | typing.Callable[[ValueT], bool], **attrs: object
     ) -> LazyIterator[ValueT]:
         """Return each item until any conditions pass or the end is reached.
 
@@ -355,7 +353,7 @@ class LazyIterator(typing.Generic[ValueT], abc.ABC):
         return _TakeWhileLazyIterator(self, ~conditions)
 
     def skip_while(
-        self, *predicates: typing.Union[tuple[str, typing.Any], typing.Callable[[ValueT], bool]], **attrs: object
+        self, *predicates: tuple[str, typing.Any] | typing.Callable[[ValueT], bool], **attrs: object
     ) -> LazyIterator[ValueT]:
         """Discard items while all conditions are True.
 
@@ -385,7 +383,7 @@ class LazyIterator(typing.Generic[ValueT], abc.ABC):
         return _DropWhileLazyIterator(self, conditions)
 
     def skip_until(
-        self, *predicates: typing.Union[tuple[str, object], typing.Callable[[ValueT], bool]], **attrs: object
+        self, *predicates: tuple[str, object] | typing.Callable[[ValueT], bool], **attrs: object
     ) -> LazyIterator[ValueT]:
         """Discard items while all conditions are False.
 
@@ -675,9 +673,7 @@ class LazyIterator(typing.Generic[ValueT], abc.ABC):
 
     @staticmethod
     def _map_predicates_and_attr_getters(
-        alg_name: str,
-        *predicates: typing.Union[str, tuple[str, object], typing.Callable[[ValueT], bool]],
-        **attrs: object,
+        alg_name: str, *predicates: str | tuple[str, object] | typing.Callable[[ValueT], bool], **attrs: object
     ) -> All[ValueT]:
         if not predicates and not attrs:
             msg = f"You should provide at least one predicate to {alg_name}()"
@@ -786,10 +782,10 @@ class BufferedLazyIterator(typing.Generic[ValueT], LazyIterator[ValueT], abc.ABC
     __slots__: typing.Sequence[str] = ("_buffer",)
 
     def __init__(self) -> None:
-        self._buffer: typing.Optional[typing.Generator[ValueT, None, None]] = (_ for _ in ())
+        self._buffer: typing.Generator[ValueT, None, None] | None = (_ for _ in ())
 
     @abc.abstractmethod
-    async def _next_chunk(self) -> typing.Optional[typing.Generator[ValueT, None, None]]: ...
+    async def _next_chunk(self) -> typing.Generator[ValueT, None, None] | None: ...
 
     @typing_extensions.override
     async def __anext__(self) -> ValueT:
@@ -947,7 +943,7 @@ class _ReversedLazyIterator(typing.Generic[ValueT], LazyIterator[ValueT]):
 
     def __init__(self, iterator: LazyIterator[ValueT]) -> None:
         self._buffer: typing.MutableSequence[ValueT] = []
-        self._origin: typing.Optional[LazyIterator[ValueT]] = iterator
+        self._origin: LazyIterator[ValueT] | None = iterator
 
     @typing_extensions.override
     async def __anext__(self) -> ValueT:
@@ -1026,7 +1022,7 @@ class _FlatMapLazyIterator(typing.Generic[ValueT, AnotherValueT], LazyIterator[A
     def __init__(self, iterator: LazyIterator[ValueT], flattener: _FlattenerT[ValueT, AnotherValueT]) -> None:
         self._iterator = iterator
         self._flattener = flattener
-        self._result_iterator: typing.Optional[typing.AsyncIterator[AnotherValueT]] = None
+        self._result_iterator: typing.AsyncIterator[AnotherValueT] | None = None
 
     async def _generator(self) -> typing.AsyncIterator[AnotherValueT]:
         async for input_item in self._iterator:

--- a/hikari/messages.py
+++ b/hikari/messages.py
@@ -217,17 +217,17 @@ class Attachment(snowflakes.Unique, files.WebResource):
     filename: str = attrs.field(hash=False, eq=False, repr=True)
     """The filename of the file."""
 
-    title: typing.Optional[str] = attrs.field(hash=False, eq=False, repr=True)
+    title: str | None = attrs.field(hash=False, eq=False, repr=True)
     """The title of the file.
 
     This will be the original filename of the attachment if it contained
     non-unicode characters.
     """
 
-    description: typing.Optional[str] = attrs.field(hash=False, eq=False, repr=True)
+    description: str | None = attrs.field(hash=False, eq=False, repr=True)
     """The description of the file."""
 
-    media_type: typing.Optional[str] = attrs.field(hash=False, eq=False, repr=True)
+    media_type: str | None = attrs.field(hash=False, eq=False, repr=True)
     """The media type of the file."""
 
     size: int = attrs.field(hash=False, eq=False, repr=True)
@@ -236,10 +236,10 @@ class Attachment(snowflakes.Unique, files.WebResource):
     proxy_url: str = attrs.field(hash=False, eq=False, repr=False)
     """The proxied URL of file."""
 
-    height: typing.Optional[int] = attrs.field(hash=False, eq=False, repr=False)
+    height: int | None = attrs.field(hash=False, eq=False, repr=False)
     """The height of the image (if the file is an image)."""
 
-    width: typing.Optional[int] = attrs.field(hash=False, eq=False, repr=False)
+    width: int | None = attrs.field(hash=False, eq=False, repr=False)
     """The width of the image (if the file is an image)."""
 
     is_ephemeral: bool = attrs.field(hash=False, eq=False, repr=True)
@@ -250,10 +250,10 @@ class Attachment(snowflakes.Unique, files.WebResource):
     time (but will exist as long as their relevant message exists).
     """
 
-    duration: typing.Optional[float] = attrs.field(hash=False, eq=False, repr=False)
+    duration: float | None = attrs.field(hash=False, eq=False, repr=False)
     """The duration (in seconds) of the voice message."""
 
-    waveform: typing.Optional[str] = attrs.field(hash=False, eq=False, repr=False)
+    waveform: str | None = attrs.field(hash=False, eq=False, repr=False)
     """A base64 encoded representation of the sampled waveform for the voice message."""
 
     @typing_extensions.override
@@ -269,7 +269,7 @@ class Reaction:
     count: int = attrs.field(eq=False, hash=False, repr=True)
     """The number of times the emoji has been used to react."""
 
-    emoji: typing.Union[emojis_.UnicodeEmoji, emojis_.CustomEmoji] = attrs.field(hash=True, repr=True)
+    emoji: emojis_.UnicodeEmoji | emojis_.CustomEmoji = attrs.field(hash=True, repr=True)
     """The emoji used to react."""
 
     is_me: bool = attrs.field(eq=False, hash=False, repr=False)
@@ -285,10 +285,10 @@ class Reaction:
 class MessageActivity:
     """Represents the activity of a rich presence-enabled message."""
 
-    type: typing.Union[MessageActivityType, int] = attrs.field(repr=True)
+    type: MessageActivityType | int = attrs.field(repr=True)
     """The type of message activity."""
 
-    party_id: typing.Optional[str] = attrs.field(repr=True)
+    party_id: str | None = attrs.field(repr=True)
     """The party ID of the message activity."""
 
 
@@ -306,7 +306,7 @@ class MessageReference:
     )
     """Client application that models may use for procedures."""
 
-    id: typing.Optional[snowflakes.Snowflake] = attrs.field(repr=True)
+    id: snowflakes.Snowflake | None = attrs.field(repr=True)
     """The ID of the original message.
 
     This will be [`None`][] for channel follow add messages. This may
@@ -316,7 +316,7 @@ class MessageReference:
     channel_id: snowflakes.Snowflake = attrs.field(repr=True)
     """The ID of the channel that the original message originated from."""
 
-    guild_id: typing.Optional[snowflakes.Snowflake] = attrs.field(repr=True)
+    guild_id: snowflakes.Snowflake | None = attrs.field(repr=True)
     """The ID of the guild that the message originated from.
 
     This will be [`None`][] when the original message is not from
@@ -324,7 +324,7 @@ class MessageReference:
     """
 
     @property
-    def message_link(self) -> typing.Optional[str]:
+    def message_link(self) -> str | None:
         """Generate a jump link to the referenced message.
 
         This will be [`None`][] for channel follow add messages. This may
@@ -351,15 +351,15 @@ class MessageReference:
 class MessageApplication(guilds.PartialApplication):
     """The representation of an application used in messages."""
 
-    cover_image_hash: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    cover_image_hash: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The CDN's hash of this application's default rich presence invite cover image."""
 
     @property
-    def cover_image_url(self) -> typing.Optional[files.URL]:
+    def cover_image_url(self) -> files.URL | None:
         """Rich presence cover image URL for this application, if set."""
         return self.make_cover_image_url()
 
-    def make_cover_image_url(self, *, ext: str = "png", size: int = 4096) -> typing.Optional[files.URL]:
+    def make_cover_image_url(self, *, ext: str = "png", size: int = 4096) -> files.URL | None:
         """Generate the rich presence cover image URL for this application, if set.
 
         Parameters
@@ -391,7 +391,7 @@ class MessageApplication(guilds.PartialApplication):
 
 
 def _map_cache_maybe_discover(
-    ids: typing.Iterable[snowflakes.Snowflake], cache_call: typing.Callable[[snowflakes.Snowflake], typing.Optional[_T]]
+    ids: typing.Iterable[snowflakes.Snowflake], cache_call: typing.Callable[[snowflakes.Snowflake], _T | None]
 ) -> dict[snowflakes.Snowflake, _T]:
     results: dict[snowflakes.Snowflake, _T] = {}
     for id_ in ids:
@@ -427,7 +427,7 @@ class PartialMessage(snowflakes.Unique):
     channel_id: snowflakes.Snowflake = attrs.field(hash=False, eq=False, repr=True)
     """The ID of the channel that the message was sent in."""
 
-    guild_id: typing.Optional[snowflakes.Snowflake] = attrs.field(hash=False, eq=False, repr=True)
+    guild_id: snowflakes.Snowflake | None = attrs.field(hash=False, eq=False, repr=True)
     """The ID of the guild that the message was sent in or [`None`][] for messages out of guilds.
 
     !!! warning
@@ -537,7 +537,7 @@ class PartialMessage(snowflakes.Unique):
     webhook_id: undefined.UndefinedNoneOr[snowflakes.Snowflake] = attrs.field(hash=False, eq=False, repr=False)
     """If the message was generated by a webhook, the webhook's ID."""
 
-    type: undefined.UndefinedOr[typing.Union[MessageType, int]] = attrs.field(hash=False, eq=False, repr=False)
+    type: undefined.UndefinedOr[MessageType | int] = attrs.field(hash=False, eq=False, repr=False)
     """The message type."""
 
     activity: undefined.UndefinedNoneOr[MessageActivity] = attrs.field(hash=False, eq=False, repr=False)
@@ -593,7 +593,7 @@ class PartialMessage(snowflakes.Unique):
     )
     """Sequence of the components attached to this message."""
 
-    interaction_metadata: typing.Optional[base_interactions.PartialInteractionMetadata] = attrs.field(
+    interaction_metadata: base_interactions.PartialInteractionMetadata | None = attrs.field(
         hash=False, eq=False, repr=False
     )
     """Sent if the message is sent as a result of an interaction."""
@@ -694,7 +694,7 @@ class PartialMessage(snowflakes.Unique):
 
         return {}
 
-    def make_link(self, guild: typing.Optional[snowflakes.SnowflakeishOr[guilds.PartialGuild]]) -> str:
+    def make_link(self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild] | None) -> str:
         """Generate a jump link to this message.
 
         Parameters
@@ -746,10 +746,8 @@ class PartialMessage(snowflakes.Unique):
         self,
         content: undefined.UndefinedOr[typing.Any] = undefined.UNDEFINED,
         *,
-        attachment: undefined.UndefinedNoneOr[typing.Union[files.Resourceish, Attachment]] = undefined.UNDEFINED,
-        attachments: undefined.UndefinedNoneOr[
-            typing.Sequence[typing.Union[files.Resourceish, Attachment]]
-        ] = undefined.UNDEFINED,
+        attachment: undefined.UndefinedNoneOr[files.Resourceish | Attachment] = undefined.UNDEFINED,
+        attachments: undefined.UndefinedNoneOr[typing.Sequence[files.Resourceish | Attachment]] = undefined.UNDEFINED,
         component: undefined.UndefinedNoneOr[special_endpoints.ComponentBuilder] = undefined.UNDEFINED,
         components: undefined.UndefinedNoneOr[
             typing.Sequence[special_endpoints.ComponentBuilder]
@@ -759,10 +757,10 @@ class PartialMessage(snowflakes.Unique):
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[users_.PartialUser], bool]
+            snowflakes.SnowflakeishSequence[users_.PartialUser] | bool
         ] = undefined.UNDEFINED,
         role_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
+            snowflakes.SnowflakeishSequence[guilds.PartialRole] | bool
         ] = undefined.UNDEFINED,
         flags: undefined.UndefinedOr[MessageFlag] = undefined.UNDEFINED,
     ) -> Message:
@@ -934,19 +932,17 @@ class PartialMessage(snowflakes.Unique):
             snowflakes.SnowflakeishSequence[stickers_.PartialSticker]
         ] = undefined.UNDEFINED,
         tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-        reply: typing.Union[
-            undefined.UndefinedType, snowflakes.SnowflakeishOr[PartialMessage], bool
-        ] = undefined.UNDEFINED,
+        reply: undefined.UndefinedType | snowflakes.SnowflakeishOr[PartialMessage] | bool = undefined.UNDEFINED,
         reply_must_exist: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[users_.PartialUser], bool]
+            snowflakes.SnowflakeishSequence[users_.PartialUser] | bool
         ] = undefined.UNDEFINED,
         role_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
+            snowflakes.SnowflakeishSequence[guilds.PartialRole] | bool
         ] = undefined.UNDEFINED,
-        flags: typing.Union[undefined.UndefinedType, int, MessageFlag] = undefined.UNDEFINED,
+        flags: undefined.UndefinedType | int | MessageFlag = undefined.UNDEFINED,
     ) -> Message:
         """Create a message in the channel this message belongs to.
 
@@ -1125,14 +1121,14 @@ class PartialMessage(snowflakes.Unique):
         await self.app.rest.delete_message(self.channel_id, self.id)
 
     @typing.overload
-    async def add_reaction(self, emoji: typing.Union[str, emojis_.Emoji]) -> None: ...
+    async def add_reaction(self, emoji: str | emojis_.Emoji) -> None: ...
 
     @typing.overload
     async def add_reaction(self, emoji: str, emoji_id: snowflakes.SnowflakeishOr[emojis_.CustomEmoji]) -> None: ...
 
     async def add_reaction(
         self,
-        emoji: typing.Union[str, emojis_.Emoji],
+        emoji: str | emojis_.Emoji,
         emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis_.CustomEmoji]] = undefined.UNDEFINED,
     ) -> None:
         r"""Add a reaction to this message.
@@ -1189,7 +1185,7 @@ class PartialMessage(snowflakes.Unique):
     @typing.overload
     async def remove_reaction(
         self,
-        emoji: typing.Union[str, emojis_.Emoji],
+        emoji: str | emojis_.Emoji,
         *,
         user: undefined.UndefinedOr[snowflakes.SnowflakeishOr[users_.PartialUser]] = undefined.UNDEFINED,
     ) -> None: ...
@@ -1205,7 +1201,7 @@ class PartialMessage(snowflakes.Unique):
 
     async def remove_reaction(
         self,
-        emoji: typing.Union[str, emojis_.Emoji],
+        emoji: str | emojis_.Emoji,
         emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis_.CustomEmoji]] = undefined.UNDEFINED,
         *,
         user: undefined.UndefinedOr[snowflakes.SnowflakeishOr[users_.PartialUser]] = undefined.UNDEFINED,
@@ -1278,7 +1274,7 @@ class PartialMessage(snowflakes.Unique):
     async def remove_all_reactions(self) -> None: ...
 
     @typing.overload
-    async def remove_all_reactions(self, emoji: typing.Union[str, emojis_.Emoji]) -> None: ...
+    async def remove_all_reactions(self, emoji: str | emojis_.Emoji) -> None: ...
 
     @typing.overload
     async def remove_all_reactions(
@@ -1287,7 +1283,7 @@ class PartialMessage(snowflakes.Unique):
 
     async def remove_all_reactions(
         self,
-        emoji: undefined.UndefinedOr[typing.Union[str, emojis_.Emoji]] = undefined.UNDEFINED,
+        emoji: undefined.UndefinedOr[str | emojis_.Emoji] = undefined.UNDEFINED,
         emoji_id: undefined.UndefinedOr[snowflakes.SnowflakeishOr[emojis_.CustomEmoji]] = undefined.UNDEFINED,
     ) -> None:
         r"""Remove all users' reactions for a specific emoji from the message.
@@ -1344,16 +1340,16 @@ class Message(PartialMessage):
     author: users_.User = attrs.field(hash=False, eq=False, repr=True)
     """The author of this message."""
 
-    member: typing.Optional[guilds.Member] = attrs.field(hash=False, eq=False, repr=False)
+    member: guilds.Member | None = attrs.field(hash=False, eq=False, repr=False)
     """The member properties for the message's author."""
 
-    content: typing.Optional[str] = attrs.field(hash=False, eq=False, repr=False)
+    content: str | None = attrs.field(hash=False, eq=False, repr=False)
     """The content of the message."""
 
     timestamp: datetime.datetime = attrs.field(hash=False, eq=False, repr=False)
     """The timestamp that the message was sent at."""
 
-    edited_timestamp: typing.Optional[datetime.datetime] = attrs.field(hash=False, eq=False, repr=False)
+    edited_timestamp: datetime.datetime | None = attrs.field(hash=False, eq=False, repr=False)
     """The timestamp that the message was last edited at.
 
     Will be [`None`][] if it wasn't ever edited.
@@ -1368,7 +1364,7 @@ class Message(PartialMessage):
     embeds: typing.Sequence[embeds_.Embed] = attrs.field(hash=False, eq=False, repr=False)
     """The message embeds."""
 
-    poll: typing.Optional[polls_.Poll] = attrs.field(hash=False, eq=False, repr=False)
+    poll: polls_.Poll | None = attrs.field(hash=False, eq=False, repr=False)
     """The message poll."""
 
     reactions: typing.Sequence[Reaction] = attrs.field(hash=False, eq=False, repr=False)
@@ -1377,13 +1373,13 @@ class Message(PartialMessage):
     is_pinned: bool = attrs.field(hash=False, eq=False, repr=False)
     """Whether the message is pinned."""
 
-    webhook_id: typing.Optional[snowflakes.Snowflake] = attrs.field(hash=False, eq=False, repr=False)
+    webhook_id: snowflakes.Snowflake | None = attrs.field(hash=False, eq=False, repr=False)
     """If the message was generated by a webhook, the webhook's id."""
 
-    type: typing.Union[MessageType, int] = attrs.field(hash=False, eq=False, repr=False)
+    type: MessageType | int = attrs.field(hash=False, eq=False, repr=False)
     """The message type."""
 
-    activity: typing.Optional[MessageActivity] = attrs.field(hash=False, eq=False, repr=False)
+    activity: MessageActivity | None = attrs.field(hash=False, eq=False, repr=False)
     """The message activity.
 
     !!! note
@@ -1391,7 +1387,7 @@ class Message(PartialMessage):
         embeds.
     """
 
-    application: typing.Optional[MessageApplication] = attrs.field(hash=False, eq=False, repr=False)
+    application: MessageApplication | None = attrs.field(hash=False, eq=False, repr=False)
     """The message application.
 
     !!! note
@@ -1399,7 +1395,7 @@ class Message(PartialMessage):
         embeds.
     """
 
-    message_reference: typing.Optional[MessageReference] = attrs.field(hash=False, eq=False, repr=False)
+    message_reference: MessageReference | None = attrs.field(hash=False, eq=False, repr=False)
     """The message reference data."""
 
     flags: MessageFlag = attrs.field(hash=False, eq=False, repr=True)
@@ -1408,16 +1404,16 @@ class Message(PartialMessage):
     stickers: typing.Sequence[stickers_.PartialSticker] = attrs.field(hash=False, eq=False, repr=False)
     """The stickers sent with this message."""
 
-    nonce: typing.Optional[str] = attrs.field(hash=False, eq=False, repr=False)
+    nonce: str | None = attrs.field(hash=False, eq=False, repr=False)
     """The message nonce. This is a string used for validating a message was sent."""
 
-    referenced_message: typing.Optional[PartialMessage] = attrs.field(hash=False, eq=False, repr=False)
+    referenced_message: PartialMessage | None = attrs.field(hash=False, eq=False, repr=False)
     """The message that was replied to.
 
     If `type` is [`hikari.messages.MessageType.REPLY`][] and [`None`][], the message was deleted.
     """
 
-    application_id: typing.Optional[snowflakes.Snowflake] = attrs.field(hash=False, eq=False, repr=False)
+    application_id: snowflakes.Snowflake | None = attrs.field(hash=False, eq=False, repr=False)
     """ID of the application this message was sent by.
 
     !!! note
@@ -1429,7 +1425,7 @@ class Message(PartialMessage):
     )
     """Sequence of the components attached to this message."""
 
-    thread: typing.Optional[channels_.GuildThreadChannel] = attrs.field(hash=False, eq=False, repr=False)
+    thread: channels_.GuildThreadChannel | None = attrs.field(hash=False, eq=False, repr=False)
     """The thread that was started from this message.
 
     Will be [`None`][] if the message was not used to start a thread.

--- a/hikari/monetization.py
+++ b/hikari/monetization.py
@@ -99,7 +99,7 @@ class SKU(snowflakes.Unique):
     id: snowflakes.Snowflake = attrs.field(hash=True, repr=True)
     """The ID of the SKU"""
 
-    type: typing.Union[SKUType, int] = attrs.field(eq=False, hash=False, repr=True)
+    type: SKUType | int = attrs.field(eq=False, hash=False, repr=True)
     """The type of the SKU"""
 
     application_id: snowflakes.Snowflake = attrs.field(eq=False, hash=False, repr=True)
@@ -128,26 +128,26 @@ class Entitlement(snowflakes.Unique):
     application_id: snowflakes.Snowflake = attrs.field(eq=False, hash=False, repr=True)
     """ID of the parent application"""
 
-    user_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=True)
+    user_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=True)
     """ID of the user that is granted access to the entitlement's SKU"""
 
-    type: typing.Union[EntitlementType, int] = attrs.field(eq=False, hash=False, repr=True)
+    type: EntitlementType | int = attrs.field(eq=False, hash=False, repr=True)
     """Type of entitlement"""
 
     is_deleted: bool = attrs.field(eq=False, hash=False, repr=False)
     """Whether the entitlement has been deleted"""
 
-    starts_at: typing.Optional[datetime.datetime] = attrs.field(eq=False, hash=False, repr=False)
+    starts_at: datetime.datetime | None = attrs.field(eq=False, hash=False, repr=False)
     """Start date at which the entitlement is valid. Not present when using test entitlements."""
 
-    ends_at: typing.Optional[datetime.datetime] = attrs.field(eq=False, hash=False, repr=False)
+    ends_at: datetime.datetime | None = attrs.field(eq=False, hash=False, repr=False)
     """Date at which the entitlement is no longer valid. Not present when using test entitlements."""
 
-    guild_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    guild_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """ID of the guild that is granted access to the entitlement's SKU"""
 
     # Only partially documented by Discord
-    subscription_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    subscription_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """The ID of the subscription that this entitlement is associated with.
 
     Not present when using test entitlements.

--- a/hikari/polls.py
+++ b/hikari/polls.py
@@ -42,10 +42,10 @@ if typing.TYPE_CHECKING:
 class PollMedia:
     """Common object backing a poll's questions and answers."""
 
-    text: typing.Optional[str] = attrs.field(default=None, repr=True)
+    text: str | None = attrs.field(default=None, repr=True)
     """The text of the element, or [`None`][] if not present."""
 
-    emoji: typing.Optional[emojis.Emoji] = attrs.field(default=None, repr=True)
+    emoji: emojis.Emoji | None = attrs.field(default=None, repr=True)
     """The emoji of the element, or [`None`][] if not present."""
 
 
@@ -106,7 +106,7 @@ class Poll:
     answers: typing.Sequence[PollAnswer] = attrs.field(repr=True)
     """The answers attached to the poll."""
 
-    expiry: typing.Optional[datetime.datetime] = attrs.field(repr=True)
+    expiry: datetime.datetime | None = attrs.field(repr=True)
     """The expiry time for the poll."""
 
     allow_multiselect: bool = attrs.field(repr=True)
@@ -115,5 +115,5 @@ class Poll:
     layout_type: PollLayoutType = attrs.field(repr=True)
     """The type of layout the poll uses."""
 
-    results: typing.Optional[PollResult] = attrs.field(repr=True)
+    results: PollResult | None = attrs.field(repr=True)
     """The results of the poll."""

--- a/hikari/presences.py
+++ b/hikari/presences.py
@@ -95,10 +95,10 @@ class ActivityType(int, enums.Enum):
 class ActivityTimestamps:
     """The datetimes for the start and/or end of an activity session."""
 
-    start: typing.Optional[datetime.datetime] = attrs.field(repr=True)
+    start: datetime.datetime | None = attrs.field(repr=True)
     """When this activity's session was started, if applicable."""
 
-    end: typing.Optional[datetime.datetime] = attrs.field(repr=True)
+    end: datetime.datetime | None = attrs.field(repr=True)
     """When this activity's session will end, if applicable."""
 
 
@@ -107,13 +107,13 @@ class ActivityTimestamps:
 class ActivityParty:
     """Used to represent activity groups of users."""
 
-    id: typing.Optional[str] = attrs.field(hash=True, repr=True)
+    id: str | None = attrs.field(hash=True, repr=True)
     """The string id of this party instance, if set."""
 
-    current_size: typing.Optional[int] = attrs.field(eq=False, hash=False, repr=False)
+    current_size: int | None = attrs.field(eq=False, hash=False, repr=False)
     """Current size of this party, if applicable."""
 
-    max_size: typing.Optional[int] = attrs.field(eq=False, hash=False, repr=False)
+    max_size: int | None = attrs.field(eq=False, hash=False, repr=False)
     """Maximum size of this party, if applicable."""
 
 
@@ -125,21 +125,21 @@ _DYNAMIC_URLS = {"mp": urls.MEDIA_PROXY_URL + "/{}"}
 class ActivityAssets:
     """Used to represent possible assets for an activity."""
 
-    _application_id: typing.Optional[snowflakes.Snowflake] = attrs.field(alias="application_id", repr=False)
+    _application_id: snowflakes.Snowflake | None = attrs.field(alias="application_id", repr=False)
 
-    large_image: typing.Optional[str] = attrs.field(repr=False)
+    large_image: str | None = attrs.field(repr=False)
     """The ID of the asset's large image, if set."""
 
-    large_text: typing.Optional[str] = attrs.field(repr=True)
+    large_text: str | None = attrs.field(repr=True)
     """The text that'll appear when hovering over the large image, if set."""
 
-    small_image: typing.Optional[str] = attrs.field(repr=False)
+    small_image: str | None = attrs.field(repr=False)
     """The ID of the asset's small image, if set."""
 
-    small_text: typing.Optional[str] = attrs.field(repr=True)
+    small_text: str | None = attrs.field(repr=True)
     """The text that'll appear when hovering over the small image, if set."""
 
-    def _make_asset_url(self, asset: typing.Optional[str], ext: str, size: int) -> typing.Optional[files.URL]:
+    def _make_asset_url(self, asset: str | None, ext: str, size: int) -> files.URL | None:
         if asset is None:
             return None
 
@@ -158,7 +158,7 @@ class ActivityAssets:
             )
 
     @property
-    def large_image_url(self) -> typing.Optional[files.URL]:
+    def large_image_url(self) -> files.URL | None:
         """Large image asset URL.
 
         !!! note
@@ -171,7 +171,7 @@ class ActivityAssets:
         except RuntimeError:
             return None
 
-    def make_large_image_url(self, *, ext: str = "png", size: int = 4096) -> typing.Optional[files.URL]:
+    def make_large_image_url(self, *, ext: str = "png", size: int = 4096) -> files.URL | None:
         """Generate the large image asset URL for this application.
 
         !!! note
@@ -203,7 +203,7 @@ class ActivityAssets:
         return self._make_asset_url(self.large_image, ext, size)
 
     @property
-    def small_image_url(self) -> typing.Optional[files.URL]:
+    def small_image_url(self) -> files.URL | None:
         """Small image asset URL.
 
         !!! note
@@ -216,7 +216,7 @@ class ActivityAssets:
         except RuntimeError:
             return None
 
-    def make_small_image_url(self, *, ext: str = "png", size: int = 4096) -> typing.Optional[files.URL]:
+    def make_small_image_url(self, *, ext: str = "png", size: int = 4096) -> files.URL | None:
         """Generate the small image asset URL for this application.
 
         Parameters
@@ -249,13 +249,13 @@ class ActivityAssets:
 class ActivitySecret:
     """The secrets used for interacting with an activity party."""
 
-    join: typing.Optional[str] = attrs.field(repr=False)
+    join: str | None = attrs.field(repr=False)
     """The secret used for joining a party, if applicable."""
 
-    spectate: typing.Optional[str] = attrs.field(repr=False)
+    spectate: str | None = attrs.field(repr=False)
     """The secret used for spectating a party, if applicable."""
 
-    match: typing.Optional[str] = attrs.field(repr=False)
+    match: str | None = attrs.field(repr=False)
     """The secret used for matching a party, if applicable."""
 
 
@@ -303,20 +303,20 @@ class Activity:
     name: str = attrs.field()
     """The activity name."""
 
-    state: typing.Optional[str] = attrs.field(default=None)
+    state: str | None = attrs.field(default=None)
     """The activities state, if set.
 
     This field can be use to set a custom status or provide more information
     on the activity.
     """
 
-    url: typing.Optional[str] = attrs.field(default=None, repr=False)
+    url: str | None = attrs.field(default=None, repr=False)
     """The activity URL, if set.
 
     Only valid for [`hikari.presences.ActivityType.STREAMING`][] activities.
     """
 
-    type: typing.Union[ActivityType, int] = attrs.field(converter=ActivityType, default=ActivityType.PLAYING)
+    type: ActivityType | int = attrs.field(converter=ActivityType, default=ActivityType.PLAYING)
     """The activity type."""
 
     @typing_extensions.override
@@ -331,31 +331,31 @@ class RichActivity(Activity):
     created_at: datetime.datetime = attrs.field(repr=False)
     """When this activity was added to the user's session."""
 
-    timestamps: typing.Optional[ActivityTimestamps] = attrs.field(repr=False)
+    timestamps: ActivityTimestamps | None = attrs.field(repr=False)
     """The timestamps for when this activity's current state will start and end, if applicable."""
 
-    application_id: typing.Optional[snowflakes.Snowflake] = attrs.field(repr=False)
+    application_id: snowflakes.Snowflake | None = attrs.field(repr=False)
     """The ID of the application this activity is for, if applicable."""
 
-    details: typing.Optional[str] = attrs.field(repr=False)
+    details: str | None = attrs.field(repr=False)
     """The text that describes what the activity's target is doing, if set."""
 
-    emoji: typing.Optional[emojis_.Emoji] = attrs.field(repr=False)
+    emoji: emojis_.Emoji | None = attrs.field(repr=False)
     """The emoji of this activity, if it is a custom status and set."""
 
-    party: typing.Optional[ActivityParty] = attrs.field(repr=False)
+    party: ActivityParty | None = attrs.field(repr=False)
     """Information about the party associated with this activity, if set."""
 
-    assets: typing.Optional[ActivityAssets] = attrs.field(repr=False)
+    assets: ActivityAssets | None = attrs.field(repr=False)
     """Images and their hover over text for the activity."""
 
-    secrets: typing.Optional[ActivitySecret] = attrs.field(repr=False)
+    secrets: ActivitySecret | None = attrs.field(repr=False)
     """Secrets for Rich Presence joining and spectating."""
 
-    is_instance: typing.Optional[bool] = attrs.field(repr=False)
+    is_instance: bool | None = attrs.field(repr=False)
     """Whether this activity is an instanced game session."""
 
-    flags: typing.Optional[ActivityFlag] = attrs.field(repr=False)
+    flags: ActivityFlag | None = attrs.field(repr=False)
     """Flags that describe what the activity includes, if present."""
 
     buttons: typing.Sequence[str] = attrs.field(repr=False)
@@ -384,13 +384,13 @@ class Status(str, enums.Enum):
 class ClientStatus:
     """The client statuses for this member."""
 
-    desktop: typing.Union[Status, str] = attrs.field(repr=True)
+    desktop: Status | str = attrs.field(repr=True)
     """The status of the target user's desktop session."""
 
-    mobile: typing.Union[Status, str] = attrs.field(repr=True)
+    mobile: Status | str = attrs.field(repr=True)
     """The status of the target user's mobile session."""
 
-    web: typing.Union[Status, str] = attrs.field(repr=True)
+    web: Status | str = attrs.field(repr=True)
     """The status of the target user's web session."""
 
 
@@ -410,7 +410,7 @@ class MemberPresence:
     guild_id: snowflakes.Snowflake = attrs.field(hash=True, repr=True)
     """The ID of the guild this presence belongs to."""
 
-    visible_status: typing.Union[Status, str] = attrs.field(eq=False, hash=False, repr=True)
+    visible_status: Status | str = attrs.field(eq=False, hash=False, repr=True)
     """This user's current status being displayed by the client."""
 
     activities: typing.Sequence[RichActivity] = attrs.field(eq=False, hash=False, repr=False)

--- a/hikari/scheduled_events.py
+++ b/hikari/scheduled_events.py
@@ -113,13 +113,13 @@ class ScheduledEvent(snowflakes.Unique):
     name: str = attrs.field(hash=False, repr=True)
     """Name of the scheduled event."""
 
-    description: typing.Optional[str] = attrs.field(hash=False, repr=False)
+    description: str | None = attrs.field(hash=False, repr=False)
     """Description of the scheduled event."""
 
     start_time: datetime.datetime = attrs.field(hash=False, repr=False)
     """When the event is scheduled to start."""
 
-    end_time: typing.Optional[datetime.datetime] = attrs.field(hash=False, repr=False)
+    end_time: datetime.datetime | None = attrs.field(hash=False, repr=False)
     """When the event is scheduled to end, if set."""
 
     privacy_level: EventPrivacyLevel = attrs.field(hash=False, repr=False)
@@ -134,28 +134,28 @@ class ScheduledEvent(snowflakes.Unique):
     entity_type: ScheduledEventType = attrs.field(hash=False, repr=True)
     """The type of entity this scheduled event is associated with."""
 
-    creator: typing.Optional[users.User] = attrs.field(hash=False, repr=False)
+    creator: users.User | None = attrs.field(hash=False, repr=False)
     """The user who created the scheduled event.
 
     This will only be set for event created after 2021-10-25.
     """
 
-    user_count: typing.Optional[int] = attrs.field(hash=False, repr=False)
+    user_count: int | None = attrs.field(hash=False, repr=False)
     """The number of users that have subscribed to the event.
 
     This will be [`None`][] on gateway events when creating and
     editing a scheduled event.
     """
 
-    image_hash: typing.Optional[str] = attrs.field(hash=False, repr=False)
+    image_hash: str | None = attrs.field(hash=False, repr=False)
     """Hash of the image used for the scheduled event, if set."""
 
     @property
-    def image_url(self) -> typing.Optional[files.URL]:
+    def image_url(self) -> files.URL | None:
         """Cover image for this scheduled event, if set."""
         return self.make_image_url()
 
-    def make_image_url(self, *, ext: str = "png", size: int = 4096) -> typing.Optional[files.URL]:
+    def make_image_url(self, *, ext: str = "png", size: int = 4096) -> files.URL | None:
         """Generate the cover image for this scheduled event, if set.
 
         Parameters
@@ -231,5 +231,5 @@ class ScheduledEventUser:
     user: users.User = attrs.field(hash=True, repr=True)
     """Object representing the user."""
 
-    member: typing.Optional[guilds.Member] = attrs.field(hash=False, repr=False)
+    member: guilds.Member | None = attrs.field(hash=False, repr=False)
     """Their guild member object if they're in the event's guild."""

--- a/hikari/snowflakes.py
+++ b/hikari/snowflakes.py
@@ -132,9 +132,7 @@ class Unique(abc.ABC):
         return isinstance(other, type(self)) and self.id == other.id
 
 
-def calculate_shard_id(
-    app_or_count: typing.Union[traits.ShardAware, int], guild: SnowflakeishOr[guilds.PartialGuild]
-) -> int:
+def calculate_shard_id(app_or_count: traits.ShardAware | int, guild: SnowflakeishOr[guilds.PartialGuild]) -> int:
     """Calculate the shard ID for a guild based on it's shard aware app or shard count.
 
     Parameters

--- a/hikari/stage_instances.py
+++ b/hikari/stage_instances.py
@@ -73,7 +73,7 @@ class StageInstance(snowflakes.Unique):
     discoverable_disabled: bool = attrs.field(eq=False, hash=False, repr=False)
     """Whether or not stage discovery is disabled."""
 
-    scheduled_event_id: typing.Optional[snowflakes.SnowflakeishOr[scheduled_events.ScheduledEvent]] = attrs.field(
+    scheduled_event_id: snowflakes.SnowflakeishOr[scheduled_events.ScheduledEvent] | None = attrs.field(
         eq=False, hash=False, repr=False
     )
     """The ID of the scheduled event for this stage instance, if it exists."""

--- a/hikari/stickers.py
+++ b/hikari/stickers.py
@@ -77,7 +77,7 @@ class StickerFormatType(int, enums.Enum):
     """A GIF sticker."""
 
 
-_STICKER_EXTENSIONS: dict[typing.Union[StickerFormatType, int], str] = {
+_STICKER_EXTENSIONS: dict[StickerFormatType | int, str] = {
     StickerFormatType.LOTTIE: "json",
     StickerFormatType.GIF: "gif",
 }
@@ -96,7 +96,7 @@ class StickerPack(snowflakes.Unique):
     description: str = attrs.field(eq=False, hash=False, repr=False)
     """The description of the pack."""
 
-    cover_sticker_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    cover_sticker_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """The ID of a sticker in the pack which is shown as the pack's icon."""
 
     stickers: typing.Sequence[StandardSticker] = attrs.field(eq=False, hash=False, repr=False)
@@ -105,15 +105,15 @@ class StickerPack(snowflakes.Unique):
     sku_id: snowflakes.Snowflake = attrs.field(eq=False, hash=False, repr=False)
     """The ID of the packs SKU."""
 
-    banner_asset_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    banner_asset_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """ID of the sticker pack's banner image, if set."""
 
     @property
-    def banner_url(self) -> typing.Optional[files.URL]:
+    def banner_url(self) -> files.URL | None:
         """Banner URL for the pack, if set."""
         return self.make_banner_url()
 
-    def make_banner_url(self, *, ext: str = "png", size: int = 4096) -> typing.Optional[files.URL]:
+    def make_banner_url(self, *, ext: str = "png", size: int = 4096) -> files.URL | None:
         """Generate the pack's banner image URL, if set.
 
         Parameters
@@ -154,7 +154,7 @@ class PartialSticker(snowflakes.Unique):
     name: str = attrs.field(eq=False, hash=False, repr=False)
     """The name of the sticker."""
 
-    format_type: typing.Union[StickerFormatType, int] = attrs.field(eq=False, hash=False, repr=True)
+    format_type: StickerFormatType | int = attrs.field(eq=False, hash=False, repr=True)
     """The format of this sticker's asset."""
 
     @property
@@ -183,7 +183,7 @@ class StandardSticker(PartialSticker):
     type: StickerType = attrs.field(eq=False, hash=False, repr=False, init=False, default=StickerType.STANDARD)
     """The sticker type."""
 
-    description: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    description: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The description of this sticker."""
 
     pack_id: snowflakes.Snowflake = attrs.field(eq=False, hash=False, repr=True)
@@ -204,7 +204,7 @@ class GuildSticker(PartialSticker):
     type: StickerType = attrs.field(eq=False, hash=False, repr=False, init=False, default=StickerType.GUILD)
     """The sticker type."""
 
-    description: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    description: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The description of this sticker."""
 
     guild_id: snowflakes.Snowflake = attrs.field(eq=False, hash=False)
@@ -216,7 +216,7 @@ class GuildSticker(PartialSticker):
     tag: str = attrs.field(eq=False, hash=False)
     """This sticker's tag."""
 
-    user: typing.Optional[users.User] = attrs.field(eq=False, hash=False, repr=False)
+    user: users.User | None = attrs.field(eq=False, hash=False, repr=False)
     """The user that uploaded this sticker.
 
     This will only be available if you have the [`hikari.permissions.Permissions.MANAGE_GUILD_EXPRESSIONS`][]

--- a/hikari/templates.py
+++ b/hikari/templates.py
@@ -76,18 +76,18 @@ class TemplateRole(guilds.PartialRole):
 class TemplateGuild(guilds.PartialGuild):
     """The partial guild object attached to [`hikari.templates.Template`][]."""
 
-    description: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    description: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The guild's description, if set."""
 
-    verification_level: typing.Union[guilds.GuildVerificationLevel, int] = attrs.field(eq=False, hash=False, repr=False)
+    verification_level: guilds.GuildVerificationLevel | int = attrs.field(eq=False, hash=False, repr=False)
     """The verification level needed for a user to participate in this guild."""
 
-    default_message_notifications: typing.Union[guilds.GuildMessageNotificationsLevel, int] = attrs.field(
+    default_message_notifications: guilds.GuildMessageNotificationsLevel | int = attrs.field(
         eq=False, hash=False, repr=False
     )
     """The default setting for message notifications in this guild."""
 
-    explicit_content_filter: typing.Union[guilds.GuildExplicitContentFilterLevel, int] = attrs.field(
+    explicit_content_filter: guilds.GuildExplicitContentFilterLevel | int = attrs.field(
         eq=False, hash=False, repr=False
     )
     """The setting for the explicit content filter in this guild."""
@@ -124,13 +124,13 @@ class TemplateGuild(guilds.PartialGuild):
         the channel objects found attached this template guild.
     """
 
-    afk_channel_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    afk_channel_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """The ID for the channel that AFK voice users get sent to.
 
     If [`None`][], then no AFK channel is set up for this guild.
     """
 
-    system_channel_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    system_channel_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """The ID of the system channel or [`None`][] if it is not enabled.
 
     Welcome messages and Nitro boost messages may be sent to this channel.
@@ -159,7 +159,7 @@ class Template:
     name: str = attrs.field(eq=False, hash=False, repr=True)
     """The template's name."""
 
-    description: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    description: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The template's description."""
 
     usage_count: int = attrs.field(eq=False, hash=False, repr=True)

--- a/hikari/traits.py
+++ b/hikari/traits.py
@@ -132,7 +132,7 @@ class ExecutorAware(fast_protocol.FastProtocolChecking, typing.Protocol):
 
     @property
     @abc.abstractmethod
-    def executor(self) -> typing.Optional[futures.Executor]:
+    def executor(self) -> futures.Executor | None:
         """Executor to use for blocking operations.
 
         This may return [`None`][] if the default [`asyncio`][] thread pool
@@ -258,7 +258,7 @@ class ShardAware(
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_me(self) -> typing.Optional[users_.OwnUser]:
+    def get_me(self) -> users_.OwnUser | None:
         """Return the bot user, if known.
 
         This should be available as soon as the bot has fired the
@@ -326,7 +326,7 @@ class ShardAware(
     async def update_voice_state(
         self,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        channel: typing.Optional[snowflakes.SnowflakeishOr[channels.GuildVoiceChannel]],
+        channel: snowflakes.SnowflakeishOr[channels.GuildVoiceChannel] | None,
         *,
         self_mute: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         self_deaf: undefined.UndefinedOr[bool] = undefined.UNDEFINED,

--- a/hikari/users.py
+++ b/hikari/users.py
@@ -284,13 +284,11 @@ class PartialUser(snowflakes.Unique, abc.ABC):
         reply_must_exist: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-        user_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[PartialUser], bool]
-        ] = undefined.UNDEFINED,
+        user_mentions: undefined.UndefinedOr[snowflakes.SnowflakeishSequence[PartialUser] | bool] = undefined.UNDEFINED,
         role_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
+            snowflakes.SnowflakeishSequence[guilds.PartialRole] | bool
         ] = undefined.UNDEFINED,
-        flags: typing.Union[undefined.UndefinedType, int, messages.MessageFlag] = undefined.UNDEFINED,
+        flags: undefined.UndefinedType | int | messages.MessageFlag = undefined.UNDEFINED,
     ) -> messages.Message:
         """Send a message to this user in DM's.
 
@@ -468,7 +466,7 @@ class User(PartialUser, abc.ABC):
     @property
     @abc.abstractmethod
     @typing_extensions.override
-    def accent_color(self) -> typing.Optional[colors.Color]:
+    def accent_color(self) -> colors.Color | None:
         """The custom banner color for the user, if set else [`None`][].
 
         The official client will decide the default color if not set.
@@ -476,18 +474,18 @@ class User(PartialUser, abc.ABC):
 
     @property
     @typing_extensions.override
-    def accent_colour(self) -> typing.Optional[colors.Color]:
+    def accent_colour(self) -> colors.Color | None:
         """Alias for the [`hikari.users.User.accent_color`][] field."""
         return self.accent_color
 
     @property
     @abc.abstractmethod
     @typing_extensions.override
-    def avatar_hash(self) -> typing.Optional[str]:
+    def avatar_hash(self) -> str | None:
         """Avatar hash for the user, if they have one, otherwise [`None`][]."""
 
     @property
-    def avatar_url(self) -> typing.Optional[files.URL]:
+    def avatar_url(self) -> files.URL | None:
         """Avatar URL for the user, if they have one set.
 
         May be [`None`][] if no custom avatar is set. In this case, you
@@ -498,11 +496,11 @@ class User(PartialUser, abc.ABC):
     @property
     @abc.abstractmethod
     @typing_extensions.override
-    def banner_hash(self) -> typing.Optional[str]:
+    def banner_hash(self) -> str | None:
         """Banner hash for the user, if they have one, otherwise [`None`][]."""
 
     @property
-    def banner_url(self) -> typing.Optional[files.URL]:
+    def banner_url(self) -> files.URL | None:
         """Banner URL for the user, if they have one set.
 
         May be [`None`][] if no custom banner is set.
@@ -527,7 +525,7 @@ class User(PartialUser, abc.ABC):
         return self.make_avatar_url() or self.default_avatar_url
 
     @property
-    def display_banner_url(self) -> typing.Optional[files.URL]:
+    def display_banner_url(self) -> files.URL | None:
         """Display banner URL for this user."""
         return self.make_banner_url()
 
@@ -584,10 +582,10 @@ class User(PartialUser, abc.ABC):
     @property
     @abc.abstractmethod
     @typing_extensions.override
-    def global_name(self) -> typing.Optional[str]:
+    def global_name(self) -> str | None:
         """Global name for the user, if they have one, otherwise [`None`][]."""
 
-    def make_avatar_url(self, *, ext: typing.Optional[str] = None, size: int = 4096) -> typing.Optional[files.URL]:
+    def make_avatar_url(self, *, ext: str | None = None, size: int = 4096) -> files.URL | None:
         """Generate the avatar URL for this user, if set.
 
         If no custom avatar is set, this returns [`None`][]. You can then
@@ -629,7 +627,7 @@ class User(PartialUser, abc.ABC):
             urls.CDN_URL, user_id=self.id, hash=self.avatar_hash, size=size, file_format=ext
         )
 
-    def make_banner_url(self, *, ext: typing.Optional[str] = None, size: int = 4096) -> typing.Optional[files.URL]:
+    def make_banner_url(self, *, ext: str | None = None, size: int = 4096) -> files.URL | None:
         """Generate the banner URL for this user, if set.
 
         If no custom banner is set, this returns [`None`][].
@@ -760,16 +758,16 @@ class UserImpl(PartialUserImpl, User):
     username: str = attrs.field(eq=False, hash=False, repr=True)
     """The user's username."""
 
-    global_name: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=True)
+    global_name: str | None = attrs.field(eq=False, hash=False, repr=True)
     """The user's global name."""
 
-    avatar_hash: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    avatar_hash: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The user's avatar hash, if they have one, otherwise [`None`][]."""
 
-    banner_hash: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    banner_hash: str | None = attrs.field(eq=False, hash=False, repr=False)
     """Banner hash of the user, if they have one, otherwise [`None`][]"""
 
-    accent_color: typing.Optional[colors.Color] = attrs.field(eq=False, hash=False, repr=False)
+    accent_color: colors.Color | None = attrs.field(eq=False, hash=False, repr=False)
     """The custom banner color for the user, if set.
 
     The official client will decide the default color if not set.
@@ -792,27 +790,27 @@ class OwnUser(UserImpl):
     is_mfa_enabled: bool = attrs.field(eq=False, hash=False, repr=False)
     """Whether the user's account has multi-factor authentication enabled."""
 
-    locale: typing.Optional[typing.Union[str, locales.Locale]] = attrs.field(eq=False, hash=False, repr=False)
+    locale: str | locales.Locale | None = attrs.field(eq=False, hash=False, repr=False)
     """The user's set locale.
 
     This is not provided in the `READY` event.
     """
 
-    is_verified: typing.Optional[bool] = attrs.field(eq=False, hash=False, repr=False)
+    is_verified: bool | None = attrs.field(eq=False, hash=False, repr=False)
     """Whether the email for this user's account has been verified.
 
     Will be [`None`][] if retrieved through the OAuth2 flow without the `email`
     scope.
     """
 
-    email: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    email: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The user's set email.
 
     Will be [`None`][] if retrieved through OAuth2 flow without the `email`
     scope. Will always be [`None`][] for bot users.
     """
 
-    premium_type: typing.Union[PremiumType, int, None] = attrs.field(eq=False, hash=False, repr=False)
+    premium_type: PremiumType | int | None = attrs.field(eq=False, hash=False, repr=False)
     """The type of Nitro Subscription this user account had.
 
     This will always be [`None`][] for bots.
@@ -861,13 +859,11 @@ class OwnUser(UserImpl):
         reply_must_exist: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         mentions_reply: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
-        user_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[PartialUser], bool]
-        ] = undefined.UNDEFINED,
+        user_mentions: undefined.UndefinedOr[snowflakes.SnowflakeishSequence[PartialUser] | bool] = undefined.UNDEFINED,
         role_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[guilds.PartialRole], bool]
+            snowflakes.SnowflakeishSequence[guilds.PartialRole] | bool
         ] = undefined.UNDEFINED,
-        flags: typing.Union[undefined.UndefinedType, int, messages.MessageFlag] = undefined.UNDEFINED,
+        flags: undefined.UndefinedType | int | messages.MessageFlag = undefined.UNDEFINED,
     ) -> typing.NoReturn:
         msg = "Unable to send a DM to yourself"
         raise TypeError(msg)

--- a/hikari/voices.py
+++ b/hikari/voices.py
@@ -49,7 +49,7 @@ class VoiceState:
     )
     """Client application that models may use for procedures."""
 
-    channel_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=True)
+    channel_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=True)
     """The ID of the channel this user is connected to.
 
     This will be [`None`][] if they are leaving voice.
@@ -86,7 +86,7 @@ class VoiceState:
     user_id: snowflakes.Snowflake = attrs.field(eq=False, hash=False, repr=True)
     """The ID of the user this voice state is for."""
 
-    member: typing.Optional[guilds.Member] = attrs.field(eq=False, hash=False, repr=False)
+    member: guilds.Member | None = attrs.field(eq=False, hash=False, repr=False)
     """The guild member this voice state is for.
 
     This can be [`None`][] in cases where the Discord backend fails to
@@ -97,7 +97,7 @@ class VoiceState:
     session_id: str = attrs.field(hash=True, repr=True)
     """The string ID of this voice state's session."""
 
-    requested_to_speak_at: typing.Optional[datetime.datetime] = attrs.field(eq=False, hash=False, repr=True)
+    requested_to_speak_at: datetime.datetime | None = attrs.field(eq=False, hash=False, repr=True)
     """When the user requested to speak in a stage channel.
 
     Will be [`None`][] if they have not requested to speak.

--- a/hikari/webhooks.py
+++ b/hikari/webhooks.py
@@ -88,7 +88,7 @@ class ExecutableWebhook(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def token(self) -> typing.Optional[str]:
+    def token(self) -> str | None:
         """Webhook's token.
 
         !!! note
@@ -101,7 +101,7 @@ class ExecutableWebhook(abc.ABC):
         content: undefined.UndefinedOr[typing.Any] = undefined.UNDEFINED,
         *,
         username: undefined.UndefinedOr[str] = undefined.UNDEFINED,
-        avatar_url: typing.Union[undefined.UndefinedType, str, files.URL] = undefined.UNDEFINED,
+        avatar_url: undefined.UndefinedType | str | files.URL = undefined.UNDEFINED,
         tts: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         attachment: undefined.UndefinedOr[files_.Resourceish] = undefined.UNDEFINED,
         attachments: undefined.UndefinedOr[typing.Sequence[files_.Resourceish]] = undefined.UNDEFINED,
@@ -112,12 +112,12 @@ class ExecutableWebhook(abc.ABC):
         poll: undefined.UndefinedOr[special_endpoints.PollBuilder] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[users_.PartialUser], bool]
+            snowflakes.SnowflakeishSequence[users_.PartialUser] | bool
         ] = undefined.UNDEFINED,
         role_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[guilds_.PartialRole], bool]
+            snowflakes.SnowflakeishSequence[guilds_.PartialRole] | bool
         ] = undefined.UNDEFINED,
-        flags: typing.Union[undefined.UndefinedType, int, messages_.MessageFlag] = undefined.UNDEFINED,
+        flags: undefined.UndefinedType | int | messages_.MessageFlag = undefined.UNDEFINED,
     ) -> messages_.Message:
         """Execute the webhook to create a message.
 
@@ -278,11 +278,9 @@ class ExecutableWebhook(abc.ABC):
         message: snowflakes.SnowflakeishOr[messages_.Message],
         content: undefined.UndefinedNoneOr[typing.Any] = undefined.UNDEFINED,
         *,
-        attachment: undefined.UndefinedNoneOr[
-            typing.Union[files.Resourceish, messages_.Attachment]
-        ] = undefined.UNDEFINED,
+        attachment: undefined.UndefinedNoneOr[files.Resourceish | messages_.Attachment] = undefined.UNDEFINED,
         attachments: undefined.UndefinedNoneOr[
-            typing.Sequence[typing.Union[files.Resourceish, messages_.Attachment]]
+            typing.Sequence[files.Resourceish | messages_.Attachment]
         ] = undefined.UNDEFINED,
         component: undefined.UndefinedNoneOr[special_endpoints.ComponentBuilder] = undefined.UNDEFINED,
         components: undefined.UndefinedNoneOr[
@@ -292,10 +290,10 @@ class ExecutableWebhook(abc.ABC):
         embeds: undefined.UndefinedNoneOr[typing.Sequence[embeds_.Embed]] = undefined.UNDEFINED,
         mentions_everyone: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         user_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[users_.PartialUser], bool]
+            snowflakes.SnowflakeishSequence[users_.PartialUser] | bool
         ] = undefined.UNDEFINED,
         role_mentions: undefined.UndefinedOr[
-            typing.Union[snowflakes.SnowflakeishSequence[guilds_.PartialRole], bool]
+            snowflakes.SnowflakeishSequence[guilds_.PartialRole] | bool
         ] = undefined.UNDEFINED,
     ) -> messages_.Message:
         """Edit a message sent by a webhook.
@@ -482,16 +480,16 @@ class PartialWebhook(snowflakes.Unique):
     id: snowflakes.Snowflake = attrs.field(hash=True, repr=True)
     """The ID of this entity."""
 
-    type: typing.Union[WebhookType, int] = attrs.field(eq=False, hash=False, repr=True)
+    type: WebhookType | int = attrs.field(eq=False, hash=False, repr=True)
     """The type of the webhook."""
 
     name: str = attrs.field(eq=False, hash=False, repr=True)
     """The name of the webhook."""
 
-    avatar_hash: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    avatar_hash: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The avatar hash of the webhook."""
 
-    application_id: typing.Optional[snowflakes.Snowflake] = attrs.field(eq=False, hash=False, repr=False)
+    application_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
     """The ID of the application that created this webhook."""
 
     @typing_extensions.override
@@ -517,7 +515,7 @@ class PartialWebhook(snowflakes.Unique):
         return f"<@{self.id}>"
 
     @property
-    def avatar_url(self) -> typing.Optional[files_.URL]:
+    def avatar_url(self) -> files_.URL | None:
         """URL for this webhook's avatar, if set.
 
         May be [`None`][] if no avatar is set. In this case, you should use
@@ -530,7 +528,7 @@ class PartialWebhook(snowflakes.Unique):
         """Default avatar URL for the user."""
         return routes.CDN_DEFAULT_USER_AVATAR.compile_to_file(urls.CDN_URL, style=0, file_format="png")
 
-    def make_avatar_url(self, ext: str = "png", size: int = 4096) -> typing.Optional[files_.URL]:
+    def make_avatar_url(self, ext: str = "png", size: int = 4096) -> files_.URL | None:
         """Generate the avatar URL for this webhook's custom avatar if set.
 
         If no avatar is specified, return [`None`][]. In this case, you should
@@ -580,7 +578,7 @@ class IncomingWebhook(PartialWebhook, ExecutableWebhook):
     guild_id: snowflakes.Snowflake = attrs.field(eq=False, hash=False, repr=True)
     """The guild ID of the webhook."""
 
-    author: typing.Optional[users_.User] = attrs.field(eq=False, hash=False, repr=True)
+    author: users_.User | None = attrs.field(eq=False, hash=False, repr=True)
     """The user that created the webhook.
 
     !!! note
@@ -588,7 +586,7 @@ class IncomingWebhook(PartialWebhook, ExecutableWebhook):
         rather than bot authorization or when received within audit logs.
     """
 
-    token: typing.Optional[str] = attrs.field(eq=False, hash=False, repr=False)
+    token: str | None = attrs.field(eq=False, hash=False, repr=False)
     """The token for the webhook.
 
     !!! note
@@ -793,21 +791,21 @@ class ChannelFollowerWebhook(PartialWebhook):
     guild_id: snowflakes.Snowflake = attrs.field(eq=False, hash=False, repr=True)
     """The guild ID of the webhook."""
 
-    author: typing.Optional[users_.User] = attrs.field(eq=False, hash=False, repr=True)
+    author: users_.User | None = attrs.field(eq=False, hash=False, repr=True)
     """The user that created the webhook.
 
     !!! note
         This will be [`None`][] when received within an audit log.
     """
 
-    source_channel: typing.Optional[channels_.PartialChannel] = attrs.field(eq=False, hash=False, repr=True)
+    source_channel: channels_.PartialChannel | None = attrs.field(eq=False, hash=False, repr=True)
     """The partial object of the channel this webhook is following.
 
     This will be [`None`][] when the user that followed the channel is no
     longer in the source guild or has lost access to the source channel.
     """
 
-    source_guild: typing.Optional[guilds_.PartialGuild] = attrs.field(eq=False, hash=False, repr=True)
+    source_guild: guilds_.PartialGuild | None = attrs.field(eq=False, hash=False, repr=True)
     """The partial object of the guild this webhook is following.
 
     This will be [`None`][] when the user that followed the channel is no

--- a/ruff.toml
+++ b/ruff.toml
@@ -85,9 +85,6 @@ ignore = [
 required-imports = ["from __future__ import annotations"]
 force-single-line = true
 
-[lint.pyupgrade]
-keep-runtime-typing = true # FIXME: Consider removing
-
 [lint.pydocstyle]
 convention = "numpy"
 


### PR DESCRIPTION
### Summary
Forgot to do this as part of the ruff update (was already considering it then), but I do not think we need runtime typechecking and we are already suited to run without it, so this should be fine
