### PR TITLE
Fix `end_poll` method in `RESTClient`.

### DIFF
--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -8672,7 +8672,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         /,
-    ) -> None:
+    ) -> messages_.Message:
         """End a poll.
 
         Parameters
@@ -8681,6 +8681,11 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             The channel the poll is in.
         message
             The message the poll is in.
+
+        Returns
+        -------
+        hikari.messages.Message
+            The message that had its poll ended.
 
         Raises
         ------

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -4803,7 +4803,9 @@ class RESTClientImpl(rest_api.RESTClient):
         channel: snowflakes.SnowflakeishOr[channels_.TextableChannel],
         message: snowflakes.SnowflakeishOr[messages_.PartialMessage],
         /,
-    ) -> None:
+    ) -> messages_.Message:
         route = routes.POST_EXPIRE_POLL.compile(channel=channel, message=message)
 
-        await self._request(route)
+        response = await self._request(route)
+        assert isinstance(response, dict)
+        return self._entity_factory.deserialize_message(response)

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -6741,8 +6741,15 @@ class TestRESTClientImplAsync:
         expected_route = routes.POST_EXPIRE_POLL.compile(
             channel=StubModel(45874392), message=StubModel(398475938475), answer=StubModel(4)
         )
-        rest_client._request = mock.AsyncMock()
 
-        await rest_client.end_poll(StubModel(45874392), StubModel(398475938475))
+        message_obj = mock.Mock()
+
+        rest_client._request = mock.AsyncMock(return_value={"id": "398475938475"})
+
+        rest_client._entity_factory.deserialize_message = mock.Mock(return_value=message_obj)
+
+        response = await rest_client.end_poll(StubModel(45874392), StubModel(398475938475))
 
         rest_client._request.assert_awaited_once_with(expected_route)
+
+        assert response is message_obj


### PR DESCRIPTION
### Summary
Fix `end_poll` method in `RESTClient` to return a message object instead of `None`.

### Checklist
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
