### PR TITLE
Use `--locked` instead of `--frozen` when syncing nox pipelines

### DIFF
--- a/pipelines/nox.py
+++ b/pipelines/nox.py
@@ -60,5 +60,5 @@ def sync(
         args.extend((group_flag, group))
 
     session.run_install(
-        "uv", "sync", "--frozen", *args, silent=True, env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location}
+        "uv", "sync", "--locked", *args, silent=True, env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location}
     )


### PR DESCRIPTION
This should avoid errors where adding or updating new dependencies will silently not install them, leading to confusion