### PR TITLE
Add approximate_user_install_count attribute to hikari.Application

### DIFF
--- a/changes/2303.bugfix.md
+++ b/changes/2303.bugfix.md
@@ -1,0 +1,1 @@
+Add ``approximate_user_install_count`` attribute to ``Application``.

--- a/hikari/applications.py
+++ b/hikari/applications.py
@@ -662,6 +662,9 @@ class Application(guilds.PartialApplication):
     approximate_guild_count: int = attrs.field(eq=False, hash=False, repr=False)
     """The approximate number of guilds this application is part of."""
 
+    approximate_user_install_count: int = attrs.field(eq=False, hash=False, repr=False)
+    """The approximate number of users that have installed this application."""
+
     integration_types_config: typing.Mapping[ApplicationIntegrationType, ApplicationIntegrationConfiguration] = (
         attrs.field(eq=False, hash=False, repr=False)
     )

--- a/hikari/applications.py
+++ b/hikari/applications.py
@@ -659,10 +659,10 @@ class Application(guilds.PartialApplication):
     install_parameters: ApplicationInstallParameters | None = attrs.field(eq=False, hash=False, repr=False)
     """Settings for the application's default in-app authorization link, if enabled."""
 
-    approximate_guild_count: int = attrs.field(eq=False, hash=False, repr=False)
+    approximate_guild_count: int | None = attrs.field(eq=False, hash=False, repr=False)
     """The approximate number of guilds this application is part of."""
 
-    approximate_user_install_count: int = attrs.field(eq=False, hash=False, repr=False)
+    approximate_user_install_count: int | None = attrs.field(eq=False, hash=False, repr=False)
     """The approximate number of users that have installed this application."""
 
     integration_types_config: typing.Mapping[ApplicationIntegrationType, ApplicationIntegrationConfiguration] = (

--- a/hikari/applications.py
+++ b/hikari/applications.py
@@ -659,10 +659,10 @@ class Application(guilds.PartialApplication):
     install_parameters: ApplicationInstallParameters | None = attrs.field(eq=False, hash=False, repr=False)
     """Settings for the application's default in-app authorization link, if enabled."""
 
-    approximate_guild_count: int | None = attrs.field(eq=False, hash=False, repr=False)
-    """The approximate number of guilds this application is part of."""
-
-    approximate_user_install_count: int | None = attrs.field(eq=False, hash=False, repr=False)
+    approximate_guild_count: int = attrs.field(eq=False, hash=False, repr=False)
+     """The approximate number of guilds this application is part of."""
+ 
+    approximate_user_install_count: int = attrs.field(eq=False, hash=False, repr=False)
     """The approximate number of users that have installed this application."""
 
     integration_types_config: typing.Mapping[ApplicationIntegrationType, ApplicationIntegrationConfiguration] = (

--- a/hikari/applications.py
+++ b/hikari/applications.py
@@ -660,7 +660,7 @@ class Application(guilds.PartialApplication):
     """Settings for the application's default in-app authorization link, if enabled."""
 
     approximate_guild_count: int = attrs.field(eq=False, hash=False, repr=False)
-     """The approximate number of guilds this application is part of."""
+    """The approximate number of guilds this application is part of."""
  
     approximate_user_install_count: int = attrs.field(eq=False, hash=False, repr=False)
     """The approximate number of users that have installed this application."""

--- a/hikari/applications.py
+++ b/hikari/applications.py
@@ -661,7 +661,7 @@ class Application(guilds.PartialApplication):
 
     approximate_guild_count: int = attrs.field(eq=False, hash=False, repr=False)
     """The approximate number of guilds this application is part of."""
- 
+
     approximate_user_install_count: int = attrs.field(eq=False, hash=False, repr=False)
     """The approximate number of users that have installed this application."""
 

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -700,8 +700,8 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             custom_install_url=payload.get("custom_install_url"),
             tags=payload.get("tags") or [],
             install_parameters=install_parameters,
-            approximate_guild_count=payload.get("approximate_guild_count"),
-            approximate_user_install_count=payload.get("approximate_user_install_count"),
+            approximate_guild_count=payload["approximate_guild_count"],
+            approximate_user_install_count=payload["approximate_user_install_count"],
             integration_types_config=integration_types_config,
         )
 

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -700,8 +700,8 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             custom_install_url=payload.get("custom_install_url"),
             tags=payload.get("tags") or [],
             install_parameters=install_parameters,
-            approximate_guild_count=payload["approximate_guild_count"],
-            approximate_user_install_count=payload["approximate_user_install_count"],
+            approximate_guild_count=payload.get("approximate_guild_count"),
+            approximate_user_install_count=payload.get("approximate_user_install_count"),
             integration_types_config=integration_types_config,
         )
 

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -701,6 +701,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             tags=payload.get("tags") or [],
             install_parameters=install_parameters,
             approximate_guild_count=payload["approximate_guild_count"],
+            approximate_user_install_count=payload["approximate_user_install_count"],
             integration_types_config=integration_types_config,
         )
 

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -1098,6 +1098,7 @@ class TestEntityFactoryImpl:
                 "flags": 0,
                 "owner": owner_payload,
                 "approximate_guild_count": 10000,
+                "approximate_user_install_count": 10001,
             }
         )
 
@@ -1123,6 +1124,7 @@ class TestEntityFactoryImpl:
                 "verify_key": "1232313223",
                 "flags": 0,
                 "approximate_guild_count": 10000,
+                "approximate_user_install_count": 10001,
             }
         )
 

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -1008,6 +1008,7 @@ class TestEntityFactoryImpl:
             "tags": ["i", "like", "hikari"],
             "install_params": {"scopes": ["bot", "applications.commands"], "permissions": 8},
             "approximate_guild_count": 10000,
+            "approximate_user_install_count": 10001,
             "integration_types_config": {
                 "0": {"oauth2_install_params": {"scopes": ["applications.commands", "bot"], "permissions": "0"}},
                 "1": {},

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -1040,6 +1040,7 @@ class TestEntityFactoryImpl:
         assert application.tags == ["i", "like", "hikari"]
         assert application.icon_hash == "iwiwiwiwiw"
         assert application.approximate_guild_count == 10000
+        assert application.approximate_user_install_count == 10001
         # Install Parameters
         assert application.install_parameters.scopes == [
             application_models.OAuth2Scope.BOT,


### PR DESCRIPTION
### Summary
The [Discord documentation for the Application object](https://discord.com/developers/docs/resources/application#application-object-application-structure) specifies an optional ``approximate_user_install_count`` field.

Also, I noticed that the ``approximate_guild_count`` field is optional in Discord's specification, but is required for the Application class.

This pull request:
- Adds the ``approximate_user_install_count`` attribute to the ``hikari.Application`` class.
- Modifies the ``hikari.Application.approximate_guild_count`` attribute type hint to reflect the Discord documentation (can be None).
- Modifies the ``deserialize_application`` function to read fields ``approximate_user_install_count`` and ``approximate_guild_count`` as optional.
- Modifies test_entity_factory to include the ``approximate_user_install_count`` in the sample application payload.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
