### PR TITLE
Add SEND_POLLS and USE_EXTERNAL_APPS permissions

### DIFF
--- a/hikari/permissions.py
+++ b/hikari/permissions.py
@@ -302,6 +302,17 @@ class Permissions(enums.Flag):
     SEND_VOICE_MESSAGES = 1 << 46
     """Allows sending voice messages."""
 
+    SEND_POLLS = 1 << 49
+    """Allows sending polls."""
+
+    USE_EXTERNAL_APPS = 1 << 50
+    """Allows user-installed apps to send public responses.
+
+    When disabled, users will still be allowed to use their apps but the responses will be ephemeral.
+
+    This only applies to apps not also installed to the server.
+    """
+
     @classmethod
     def all_permissions(cls) -> Permissions:
         """Get an instance of [`hikari.permissions.Permissions`][] with all the known permissions.

--- a/tests/hikari/test_permissions.py
+++ b/tests/hikari/test_permissions.py
@@ -28,4 +28,4 @@ class TestPermissions:
         all_perms = permissions.Permissions.all_permissions()
 
         assert isinstance(all_perms, permissions.Permissions)
-        assert all_perms == 140737488355327
+        assert all_perms == 1829587348619263


### PR DESCRIPTION
### Summary
The Discord Developer Documentation [specifies](https://discord.com/developers/docs/topics/permissions#permissions-bitwise-permission-flags) the ``SEND_POLLS`` and ``USE_EXTERNAL_APPS``. These permissions have been added to the ``Permissions`` enum, and the permission test function was updated to include the permissions.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
None found.
