### PR TITLE
Add missing tests for components V2

### DIFF
--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -1642,6 +1642,18 @@ class TestRESTClientImpl:
 
         assert payload.get("flags") is message_models.MessageFlag.IS_COMPONENTS_V2
 
+    def test__build_message_payload_with_components_v2_and_flags(self, rest_client):
+        component_1 = mock.Mock(type=components.ComponentType.ACTION_ROW, build=mock.Mock(return_value=({}, ())))
+        component_2 = mock.Mock(type=components.ComponentType.CONTAINER, build=mock.Mock(return_value=({}, ())))
+
+        payload, _ = rest_client._build_message_payload(
+            components=[component_1, component_2], flags=message_models.MessageFlag.EPHEMERAL
+        )
+
+        assert (
+            payload.get("flags") is message_models.MessageFlag.IS_COMPONENTS_V2 | message_models.MessageFlag.EPHEMERAL
+        )
+
     def test_interaction_deferred_builder(self, rest_client):
         result = rest_client.interaction_deferred_builder(5)
 


### PR DESCRIPTION
### Summary
Added the missing tests for the code that automatically adds the `IS_COMPONENTS_V2` flag to a message payload if the user adds a V2 component.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
