### PR TITLE
Add missing voice message docstrings

### DIFF
--- a/changes/2355.bugfix.md
+++ b/changes/2355.bugfix.md
@@ -1,2 +1,1 @@
-Added partial missing documentation for `RESTClient.edit_interaction_voice_message_response` and `RESTClient.
-create_interaction_voice_message_response`.
+Added partial missing documentation for rest voice-message interaction methods.

--- a/changes/2355.bugfix.md
+++ b/changes/2355.bugfix.md
@@ -1,0 +1,2 @@
+Added partial missing documentation for `RESTClient.edit_interaction_voice_message_response` and `RESTClient.
+create_interaction_voice_message_response`.

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -1260,7 +1260,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
                 the application (default is a thread pool which supports this
                 behaviour).
         waveform
-            The waveform of the entire message, with 1 byte
+            The waveform of the entire voice message, with 1 byte
             per datapoint encoded in base64.
 
             Official clients sample the recording at most once per 100
@@ -2205,11 +2205,13 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
                 the application (default is a thread pool which supports this
                 behaviour).
         waveform
-            The waveform of the entire message, with 1 byte
+            The waveform of the entire voice message, with 1 byte
             per datapoint encoded in base64.
+
             Official clients sample the recording at most once per 100
             milliseconds, but will downsample so that no more than 256
             datapoints are in the waveform.
+
             !!! note
                 Discord states that this is implementation detail and might
                 change without notice. You have been warned!
@@ -7809,6 +7811,20 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             This can be a resource, or string of a path on your computer
             or a URL. The Content-Type of the attachment has to start with
             `audio/`.
+        waveform
+            The waveform of the entire voice message, with 1 byte
+            per datapoint encoded in base64.
+
+            Official clients sample the recording at most once per 100
+            milliseconds, but will downsample so that no more than 256
+            datapoints are in the waveform.
+
+            !!! note
+                Discord states that this is implementation detail and might
+                change without notice. You have been warned!
+        duration
+            The duration of the voice message in seconds. This is intended to be
+            a float.
         flags
             If provided, the message flags this response should have.
 
@@ -8005,6 +8021,20 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             This can be a resource, or string of a path on your computer
             or a URL. The Content-Type of the attachment has to start with
             `audio/`.
+        waveform
+            The waveform of the entire voice message, with 1 byte
+            per datapoint encoded in base64.
+
+            Official clients sample the recording at most once per 100
+            milliseconds, but will downsample so that no more than 256
+            datapoints are in the waveform.
+
+            !!! note
+                Discord states that this is implementation detail and might
+                change without notice. You have been warned!
+        duration
+            The duration of the voice message in seconds. This is intended to be
+            a float.
 
 
         Returns


### PR DESCRIPTION
Added missing docstrings for voice messages in the rest API. Updated the waveform description for voice messages.

fix/missing-voice-message-docstrings

### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
