### PR TITLE
Greatly optimize event manager memory management

### DIFF
--- a/changes/2368.optimization.md
+++ b/changes/2368.optimization.md
@@ -1,0 +1,1 @@
+Greatly optimize event managers memory management by avoiding unnecessary tasks creations and reducing lifetime of objects

--- a/hikari/api/event_manager.py
+++ b/hikari/api/event_manager.py
@@ -32,6 +32,7 @@ from hikari.events import base_events
 from hikari.internal import typing_extensions
 
 if typing.TYPE_CHECKING:
+    import asyncio
     import types
 
     from typing_extensions import Self
@@ -183,14 +184,24 @@ class EventManager(abc.ABC):
             If there is no consumer for the event.
         """
 
+    @typing.overload
+    def dispatch(self, event: base_events.EventT, *, wait: typing.Literal[False] = False) -> None: ...
+
+    @typing.overload
+    def dispatch(
+        self, event: base_events.EventT, *, wait: typing.Literal[True] = True
+    ) -> asyncio.Future[typing.Any]: ...
+
     @abc.abstractmethod
-    def dispatch(self, event: base_events.Event) -> None:
+    def dispatch(self, event: base_events.Event, *, wait: bool = False) -> asyncio.Future[typing.Any] | None:
         """Dispatch an event.
 
         Parameters
         ----------
         event
             The event to dispatch.
+        wait
+            Whether to return a asyncio future to wait for the listeners to finish.
 
         Examples
         --------

--- a/hikari/api/event_manager.py
+++ b/hikari/api/event_manager.py
@@ -32,7 +32,6 @@ from hikari.events import base_events
 from hikari.internal import typing_extensions
 
 if typing.TYPE_CHECKING:
-    import asyncio
     import types
 
     from typing_extensions import Self
@@ -185,7 +184,7 @@ class EventManager(abc.ABC):
         """
 
     @abc.abstractmethod
-    def dispatch(self, event: base_events.Event) -> asyncio.Future[typing.Any]:
+    def dispatch(self, event: base_events.Event) -> None:
         """Dispatch an event.
 
         Parameters

--- a/hikari/api/event_manager.py
+++ b/hikari/api/event_manager.py
@@ -185,23 +185,28 @@ class EventManager(abc.ABC):
         """
 
     @typing.overload
-    def dispatch(self, event: base_events.EventT, *, wait: typing.Literal[False] = False) -> None: ...
+    def dispatch(self, event: base_events.Event, *, return_tasks: typing.Literal[False] = False) -> None: ...
 
     @typing.overload
     def dispatch(
-        self, event: base_events.EventT, *, wait: typing.Literal[True] = True
+        self, event: base_events.Event, *, return_tasks: typing.Literal[True] = True
     ) -> asyncio.Future[typing.Any]: ...
 
+    @typing.overload
+    def dispatch(
+        self, event: base_events.Event, *, return_tasks: bool = False
+    ) -> asyncio.Future[typing.Any] | None: ...
+
     @abc.abstractmethod
-    def dispatch(self, event: base_events.Event, *, wait: bool = False) -> asyncio.Future[typing.Any] | None:
+    def dispatch(self, event: base_events.Event, *, return_tasks: bool = False) -> asyncio.Future[typing.Any] | None:
         """Dispatch an event.
 
         Parameters
         ----------
         event
             The event to dispatch.
-        wait
-            Whether to return a asyncio future to wait for the listeners to finish.
+        return_tasks
+            Whether to return an asyncio future to wait for the listeners to finish.
 
         Examples
         --------

--- a/hikari/impl/event_manager.py
+++ b/hikari/impl/event_manager.py
@@ -124,7 +124,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         return self._cache is not None and (self._cache.settings.components & components) == components
 
     @event_manager_base.filtered(shard_events.ShardReadyEvent, config.CacheComponents.ME)
-    async def on_ready(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_ready(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#ready for more info."""
         # TODO: cache unavailable guilds on startup, I didn't bother for the time being.
         event = self._event_factory.deserialize_ready_event(shard, payload)
@@ -132,31 +132,31 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         if self._cache:
             self._cache.update_me(event.my_user)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(shard_events.ShardResumedEvent)
-    async def on_resumed(self, shard: gateway_shard.GatewayShard, _: data_binding.JSONObject) -> None:
+    def on_resumed(self, shard: gateway_shard.GatewayShard, _: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#resumed for more info."""
-        await self.dispatch(self._event_factory.deserialize_resumed_event(shard))
+        self.dispatch(self._event_factory.deserialize_resumed_event(shard))
 
     @event_manager_base.filtered(application_events.ApplicationCommandPermissionsUpdateEvent)
-    async def on_application_command_permissions_update(
+    def on_application_command_permissions_update(
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> None:
-        await self.dispatch(self._event_factory.deserialize_application_command_permission_update_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_application_command_permission_update_event(shard, payload))
 
     @event_manager_base.filtered(channel_events.GuildChannelCreateEvent, config.CacheComponents.GUILD_CHANNELS)
-    async def on_channel_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_channel_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#channel-create for more info."""
         event = self._event_factory.deserialize_guild_channel_create_event(shard, payload)
 
         if self._cache:
             self._cache.set_guild_channel(event.channel)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(channel_events.GuildChannelUpdateEvent, config.CacheComponents.GUILD_CHANNELS)
-    async def on_channel_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_channel_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#channel-update for more info."""
         old = self._cache.get_guild_channel(snowflakes.Snowflake(payload["id"])) if self._cache else None
         event = self._event_factory.deserialize_guild_channel_update_event(shard, payload, old_channel=old)
@@ -164,13 +164,13 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         if self._cache:
             self._cache.update_guild_channel(event.channel)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(
         channel_events.GuildChannelDeleteEvent,
         config.CacheComponents.GUILD_CHANNELS | config.CacheComponents.GUILD_THREADS,
     )
-    async def on_channel_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_channel_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#channel-delete for more info."""
         event = self._event_factory.deserialize_guild_channel_delete_event(shard, payload)
 
@@ -178,19 +178,19 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
             self._cache.delete_guild_channel(event.channel.id)
             self._cache.clear_threads_for_channel(event.guild_id, event.channel.id)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered((channel_events.GuildPinsUpdateEvent, channel_events.DMPinsUpdateEvent))
-    async def on_channel_pins_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_channel_pins_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#channel-pins-update for more info."""
         # TODO: we need a method for this specifically
-        await self.dispatch(self._event_factory.deserialize_channel_pins_update_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_channel_pins_update_event(shard, payload))
 
     @event_manager_base.filtered(
         (channel_events.GuildThreadAccessEvent, channel_events.GuildThreadCreateEvent),
         config.CacheComponents.GUILD_THREADS,
     )
-    async def on_thread_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_thread_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#thread-create for more info."""
         event: channel_events.GuildThreadAccessEvent | channel_events.GuildThreadCreateEvent
         if "newly_created" in payload:
@@ -202,10 +202,10 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         if self._cache:
             self._cache.set_thread(event.thread)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(channel_events.GuildThreadUpdateEvent, config.CacheComponents.GUILD_THREADS)
-    async def on_thread_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_thread_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#thread-update for more info."""
         old = self._cache.get_thread(snowflakes.Snowflake(payload["id"])) if self._cache else None
         event = self._event_factory.deserialize_guild_thread_update_event(shard, payload, old_thread=old)
@@ -213,20 +213,20 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         if self._cache:
             self._cache.update_thread(event.thread)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(channel_events.GuildThreadDeleteEvent, config.CacheComponents.GUILD_THREADS)
-    async def on_thread_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_thread_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#thread-delete for more info."""
         event = self._event_factory.deserialize_guild_thread_delete_event(shard, payload)
 
         if self._cache:
             self._cache.delete_thread(event.thread_id)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(channel_events.ThreadListSyncEvent, config.CacheComponents.GUILD_THREADS)
-    async def on_thread_list_sync(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_thread_list_sync(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#thread-list-sync for more info."""
         event = self._event_factory.deserialize_thread_list_sync_event(shard, payload)
 
@@ -241,12 +241,10 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
             for thread in event.threads.values():
                 self._cache.set_thread(thread)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(channel_events.ThreadMembersUpdateEvent, config.CacheComponents.GUILD_THREADS)
-    async def on_thread_members_update(
-        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
-    ) -> None:
+    def on_thread_members_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#thread-members-update for more info."""
         event = self._event_factory.deserialize_thread_members_update_event(shard, payload)
 
@@ -258,10 +256,10 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
             if user_id in event.removed_member_ids:
                 self._cache.delete_thread(event.thread_id)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     # Internal granularity is preferred for GUILD_CREATE over decorator based filtering due to its large scope.
-    async def on_guild_create(  # noqa: C901, PLR0912, PLR0915 - Function too complex, too many branches and too long
+    def on_guild_create(  # noqa: C901, PLR0912, PLR0915 - Function too complex, too many branches and too long
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-create for more info."""
@@ -421,10 +419,10 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
             task.add_done_callback(self._guild_member_request_tasks.discard)
 
         if event:
-            await self.dispatch(event)
+            self.dispatch(event)
 
     # Internal granularity is preferred for GUILD_UPDATE over decorator based filtering due to its large scope.
-    async def on_guild_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_guild_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-update for more info."""
         event: guild_events.GuildUpdateEvent | None
         if self._enabled_for_event(guild_events.GuildUpdateEvent):
@@ -475,7 +473,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
                     self._cache.set_role(role)
 
         if event:
-            await self.dispatch(event)
+            self.dispatch(event)
 
     @event_manager_base.filtered(
         (guild_events.GuildLeaveEvent, guild_events.GuildUnavailableEvent),
@@ -489,7 +487,7 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         | config.CacheComponents.MEMBERS
         | config.CacheComponents.GUILD_THREADS,
     )
-    async def on_guild_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_guild_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-delete for more info."""
         event: guild_events.GuildUnavailableEvent | guild_events.GuildLeaveEvent
         if payload.get("unavailable"):
@@ -516,20 +514,20 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
             event = self._event_factory.deserialize_guild_leave_event(shard, payload, old_guild=old)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(guild_events.BanCreateEvent)
-    async def on_guild_ban_add(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_guild_ban_add(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-ban-add for more info."""
-        await self.dispatch(self._event_factory.deserialize_guild_ban_add_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_guild_ban_add_event(shard, payload))
 
     @event_manager_base.filtered(guild_events.BanDeleteEvent)
-    async def on_guild_ban_remove(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_guild_ban_remove(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-ban-remove for more info."""
-        await self.dispatch(self._event_factory.deserialize_guild_ban_remove_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_guild_ban_remove_event(shard, payload))
 
     @event_manager_base.filtered(guild_events.EmojisUpdateEvent, config.CacheComponents.EMOJIS)
-    async def on_guild_emojis_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_guild_emojis_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-emojis-update for more info."""
         guild_id = snowflakes.Snowflake(payload["guild_id"])
         old = list(self._cache.clear_emojis_for_guild(guild_id).values()) if self._cache else None
@@ -540,12 +538,10 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
             for emoji in event.emojis:
                 self._cache.set_emoji(emoji)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(guild_events.StickersUpdateEvent, config.CacheComponents.EMOJIS)
-    async def on_guild_stickers_update(
-        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
-    ) -> None:
+    def on_guild_stickers_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-stickers-update for more info."""
         guild_id = snowflakes.Snowflake(payload["guild_id"])
         old = list(self._cache.clear_stickers_for_guild(guild_id).values()) if self._cache else None
@@ -556,42 +552,42 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
             for sticker in event.stickers:
                 self._cache.set_sticker(sticker)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(())  # An empty sequence here means that this method will always be skipped.
-    async def on_guild_integrations_update(self, _: gateway_shard.GatewayShard, __: data_binding.JSONObject) -> None:
+    def on_guild_integrations_update(self, _: gateway_shard.GatewayShard, __: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-integrations-update for more info."""
         # This is only here to stop this being logged or dispatched as an "unknown event".
         # This event is made redundant by INTEGRATION_CREATE/DELETE/UPDATE and is thus not parsed or dispatched.
         raise NotImplementedError
 
     @event_manager_base.filtered(guild_events.IntegrationCreateEvent)
-    async def on_integration_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_integration_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         event = self._event_factory.deserialize_integration_create_event(shard, payload)
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(guild_events.IntegrationUpdateEvent)
-    async def on_integration_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_integration_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         event = self._event_factory.deserialize_integration_update_event(shard, payload)
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(guild_events.IntegrationDeleteEvent)
-    async def on_integration_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_integration_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         event = self._event_factory.deserialize_integration_delete_event(shard, payload)
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(member_events.MemberCreateEvent, config.CacheComponents.MEMBERS)
-    async def on_guild_member_add(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_guild_member_add(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-member-add for more info."""
         event = self._event_factory.deserialize_guild_member_add_event(shard, payload)
 
         if self._cache:
             self._cache.update_member(event.member)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(member_events.MemberDeleteEvent, config.CacheComponents.MEMBERS)
-    async def on_guild_member_remove(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_guild_member_remove(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-member-remove for more info."""
         old: guilds.Member | None = None
         if self._cache:
@@ -600,10 +596,10 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
             )
 
         event = self._event_factory.deserialize_guild_member_remove_event(shard, payload, old_member=old)
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(member_events.MemberUpdateEvent, config.CacheComponents.MEMBERS)
-    async def on_guild_member_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_guild_member_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-member-update for more info."""
         old: guilds.Member | None = None
         if self._cache:
@@ -616,10 +612,10 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         if self._cache:
             self._cache.update_member(event.member)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(shard_events.MemberChunkEvent, config.CacheComponents.MEMBERS)
-    async def on_guild_members_chunk(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_guild_members_chunk(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-members-chunk for more info."""
         event = self._event_factory.deserialize_guild_member_chunk_event(shard, payload)
 
@@ -630,20 +626,20 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
             for presence in event.presences.values():
                 self._cache.set_presence(presence)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(role_events.RoleCreateEvent, config.CacheComponents.ROLES)
-    async def on_guild_role_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_guild_role_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-role-create for more info."""
         event = self._event_factory.deserialize_guild_role_create_event(shard, payload)
 
         if self._cache:
             self._cache.set_role(event.role)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(role_events.RoleUpdateEvent, config.CacheComponents.ROLES)
-    async def on_guild_role_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_guild_role_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-role-update for more info."""
         old = self._cache.get_role(snowflakes.Snowflake(payload["role"]["id"])) if self._cache else None
         event = self._event_factory.deserialize_guild_role_update_event(shard, payload, old_role=old)
@@ -651,10 +647,10 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         if self._cache:
             self._cache.update_role(event.role)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(role_events.RoleDeleteEvent, config.CacheComponents.ROLES)
-    async def on_guild_role_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_guild_role_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-role-delete for more info."""
         old: guilds.Role | None = None
         if self._cache:
@@ -662,20 +658,20 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
         event = self._event_factory.deserialize_guild_role_delete_event(shard, payload, old_role=old)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(channel_events.InviteCreateEvent, config.CacheComponents.INVITES)
-    async def on_invite_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_invite_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#invite-create for more info."""
         event = self._event_factory.deserialize_invite_create_event(shard, payload)
 
         if self._cache:
             self._cache.set_invite(event.invite)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(channel_events.InviteDeleteEvent, config.CacheComponents.INVITES)
-    async def on_invite_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_invite_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#invite-delete for more info."""
         old: invites.InviteWithMetadata | None = None
         if self._cache:
@@ -683,24 +679,24 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
         event = self._event_factory.deserialize_invite_delete_event(shard, payload, old_invite=old)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(
         (message_events.GuildMessageCreateEvent, message_events.DMMessageCreateEvent), config.CacheComponents.MESSAGES
     )
-    async def on_message_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_message_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#message-create for more info."""
         event = self._event_factory.deserialize_message_create_event(shard, payload)
 
         if self._cache:
             self._cache.set_message(event.message)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(
         (message_events.GuildMessageUpdateEvent, message_events.DMMessageUpdateEvent), config.CacheComponents.MESSAGES
     )
-    async def on_message_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_message_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#message-update for more info."""
         old = self._cache.get_message(snowflakes.Snowflake(payload["id"])) if self._cache else None
         event = self._event_factory.deserialize_message_update_event(shard, payload, old_message=old)
@@ -708,12 +704,12 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         if self._cache:
             self._cache.update_message(event.message)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(
         (message_events.GuildMessageDeleteEvent, message_events.DMMessageDeleteEvent), config.CacheComponents.MESSAGES
     )
-    async def on_message_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_message_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#message-delete for more info."""
         if self._cache:
             message_id = snowflakes.Snowflake(payload["id"])
@@ -723,12 +719,12 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
 
         event = self._event_factory.deserialize_message_delete_event(shard, payload, old_message=old_message)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(
         (message_events.GuildMessageDeleteEvent, message_events.DMMessageDeleteEvent), config.CacheComponents.MESSAGES
     )
-    async def on_message_delete_bulk(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_message_delete_bulk(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#message-delete-bulk for more info."""
         old_messages = {}
 
@@ -739,46 +735,42 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
                 if message := self._cache.delete_message(message_id):
                     old_messages[message_id] = message
 
-        await self.dispatch(
+        self.dispatch(
             self._event_factory.deserialize_guild_message_delete_bulk_event(shard, payload, old_messages=old_messages)
         )
 
     @event_manager_base.filtered((reaction_events.GuildReactionAddEvent, reaction_events.DMReactionAddEvent))
-    async def on_message_reaction_add(
-        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
-    ) -> None:
+    def on_message_reaction_add(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#message-reaction-add for more info."""
-        await self.dispatch(self._event_factory.deserialize_message_reaction_add_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_message_reaction_add_event(shard, payload))
 
     # TODO: this is unlikely but reaction cache?
 
     @event_manager_base.filtered((reaction_events.GuildReactionDeleteEvent, reaction_events.DMReactionDeleteEvent))
-    async def on_message_reaction_remove(
-        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
-    ) -> None:
+    def on_message_reaction_remove(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#message-reaction-remove for more info."""
-        await self.dispatch(self._event_factory.deserialize_message_reaction_remove_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_message_reaction_remove_event(shard, payload))
 
     @event_manager_base.filtered(
         (reaction_events.GuildReactionDeleteAllEvent, reaction_events.DMReactionDeleteAllEvent)
     )
-    async def on_message_reaction_remove_all(
+    def on_message_reaction_remove_all(
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#message-reaction-remove-all for more info."""
-        await self.dispatch(self._event_factory.deserialize_message_reaction_remove_all_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_message_reaction_remove_all_event(shard, payload))
 
     @event_manager_base.filtered(
         (reaction_events.GuildReactionDeleteEmojiEvent, reaction_events.DMReactionDeleteEmojiEvent)
     )
-    async def on_message_reaction_remove_emoji(
+    def on_message_reaction_remove_emoji(
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#message-reaction-remove-emoji for more info."""
-        await self.dispatch(self._event_factory.deserialize_message_reaction_remove_emoji_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_message_reaction_remove_emoji_event(shard, payload))
 
     @event_manager_base.filtered(guild_events.PresenceUpdateEvent, config.CacheComponents.PRESENCES)
-    async def on_presence_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_presence_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#presence-update for more info."""
         old: presences_.MemberPresence | None = None
 
@@ -795,15 +787,15 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
             self._cache.update_presence(event.presence)
 
         # TODO: update user here when partial_user is set self._cache.update_user(event.partial_user)
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered((typing_events.GuildTypingEvent, typing_events.DMTypingEvent))
-    async def on_typing_start(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_typing_start(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#typing-start for more info."""
-        await self.dispatch(self._event_factory.deserialize_typing_start_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_typing_start_event(shard, payload))
 
     @event_manager_base.filtered(user_events.OwnUserUpdateEvent, config.CacheComponents.ME)
-    async def on_user_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_user_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#user-update for more info."""
         old = self._cache.get_me() if self._cache else None
         event = self._event_factory.deserialize_own_user_update_event(shard, payload, old_user=old)
@@ -811,10 +803,10 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         if self._cache:
             self._cache.update_me(event.user)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(voice_events.VoiceStateUpdateEvent, config.CacheComponents.VOICE_STATES)
-    async def on_voice_state_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_voice_state_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#voice-state-update for more info."""
         old: voices.VoiceState | None = None
         if self._cache:
@@ -829,17 +821,17 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         elif self._cache:
             self._cache.update_voice_state(event.state)
 
-        await self.dispatch(event)
+        self.dispatch(event)
 
     @event_manager_base.filtered(voice_events.VoiceServerUpdateEvent)
-    async def on_voice_server_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_voice_server_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#voice-server-update for more info."""
-        await self.dispatch(self._event_factory.deserialize_voice_server_update_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_voice_server_update_event(shard, payload))
 
     @event_manager_base.filtered(channel_events.WebhookUpdateEvent)
-    async def on_webhooks_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_webhooks_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#webhooks-update for more info."""
-        await self.dispatch(self._event_factory.deserialize_webhook_update_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_webhook_update_event(shard, payload))
 
     @event_manager_base.filtered(
         (
@@ -849,123 +841,113 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
             interaction_events.ModalInteractionCreateEvent,
         )
     )
-    async def on_interaction_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_interaction_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#interaction-create for more info."""
-        await self.dispatch(self._event_factory.deserialize_interaction_create_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_interaction_create_event(shard, payload))
 
     @event_manager_base.filtered(scheduled_events.ScheduledEventCreateEvent)
-    async def on_guild_scheduled_event_create(
+    def on_guild_scheduled_event_create(
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-create for more info."""
-        await self.dispatch(self._event_factory.deserialize_scheduled_event_create_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_scheduled_event_create_event(shard, payload))
 
     @event_manager_base.filtered(scheduled_events.ScheduledEventDeleteEvent)
-    async def on_guild_scheduled_event_delete(
+    def on_guild_scheduled_event_delete(
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-delete for more info."""
-        await self.dispatch(self._event_factory.deserialize_scheduled_event_delete_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_scheduled_event_delete_event(shard, payload))
 
     @event_manager_base.filtered(scheduled_events.ScheduledEventUpdateEvent)
-    async def on_guild_scheduled_event_update(
+    def on_guild_scheduled_event_update(
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-update for more info."""
-        await self.dispatch(self._event_factory.deserialize_scheduled_event_update_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_scheduled_event_update_event(shard, payload))
 
     @event_manager_base.filtered(scheduled_events.ScheduledEventUserAddEvent)
-    async def on_guild_scheduled_event_user_add(
+    def on_guild_scheduled_event_user_add(
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-user-add for more info."""  # noqa: E501
-        await self.dispatch(self._event_factory.deserialize_scheduled_event_user_add_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_scheduled_event_user_add_event(shard, payload))
 
     @event_manager_base.filtered(scheduled_events.ScheduledEventUserRemoveEvent)
-    async def on_guild_scheduled_event_user_remove(
+    def on_guild_scheduled_event_user_remove(
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-user-remove for more info."""  # noqa: E501
-        await self.dispatch(self._event_factory.deserialize_scheduled_event_user_remove_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_scheduled_event_user_remove_event(shard, payload))
 
     @event_manager_base.filtered(guild_events.AuditLogEntryCreateEvent)
-    async def on_guild_audit_log_entry_create(
+    def on_guild_audit_log_entry_create(
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#guild-audit-log-entry-create for more info."""
-        await self.dispatch(self._event_factory.deserialize_audit_log_entry_create_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_audit_log_entry_create_event(shard, payload))
 
     @event_manager_base.filtered(monetization_events.EntitlementCreateEvent)
-    async def on_entitlement_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_entitlement_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#entitlement-create for more info."""
-        await self.dispatch(self._event_factory.deserialize_entitlement_create_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_entitlement_create_event(shard, payload))
 
     @event_manager_base.filtered(monetization_events.EntitlementDeleteEvent)
-    async def on_entitlement_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_entitlement_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#entitlement-delete for more info."""
-        await self.dispatch(self._event_factory.deserialize_entitlement_delete_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_entitlement_delete_event(shard, payload))
 
     @event_manager_base.filtered(monetization_events.EntitlementUpdateEvent)
-    async def on_entitlement_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+    def on_entitlement_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#entitlement-update for more info."""
-        await self.dispatch(self._event_factory.deserialize_entitlement_update_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_entitlement_update_event(shard, payload))
 
     @event_manager_base.filtered(stage_events.StageInstanceCreateEvent)
-    async def on_stage_instance_create(
-        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
-    ) -> None:
-        await self.dispatch(self._event_factory.deserialize_stage_instance_create_event(shard, payload))
+    def on_stage_instance_create(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+        self.dispatch(self._event_factory.deserialize_stage_instance_create_event(shard, payload))
 
     @event_manager_base.filtered(stage_events.StageInstanceUpdateEvent)
-    async def on_stage_instance_update(
-        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
-    ) -> None:
-        await self.dispatch(self._event_factory.deserialize_stage_instance_update_event(shard, payload))
+    def on_stage_instance_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+        self.dispatch(self._event_factory.deserialize_stage_instance_update_event(shard, payload))
 
     @event_manager_base.filtered(stage_events.StageInstanceDeleteEvent)
-    async def on_stage_instance_delete(
-        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
-    ) -> None:
-        await self.dispatch(self._event_factory.deserialize_stage_instance_delete_event(shard, payload))
+    def on_stage_instance_delete(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
+        self.dispatch(self._event_factory.deserialize_stage_instance_delete_event(shard, payload))
 
     @event_manager_base.filtered(poll_events.PollVoteCreateEvent)
-    async def on_message_poll_vote_add(
-        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
-    ) -> None:
+    def on_message_poll_vote_add(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#message-poll-vote-add for more info."""
-        await self.dispatch(self._event_factory.deserialize_poll_vote_create_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_poll_vote_create_event(shard, payload))
 
     @event_manager_base.filtered(poll_events.PollVoteDeleteEvent)
-    async def on_message_poll_vote_remove(
-        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
-    ) -> None:
+    def on_message_poll_vote_remove(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#message-poll-vote-remove for more info."""
-        await self.dispatch(self._event_factory.deserialize_poll_vote_delete_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_poll_vote_delete_event(shard, payload))
 
     @event_manager_base.filtered(auto_mod_events.AutoModRuleCreateEvent)
-    async def on_auto_moderation_rule_create(
+    def on_auto_moderation_rule_create(
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> None:
         """See https://discord.com/developers/docs/topics/gateway#auto-moderation-rule-create for more info."""
-        await self.dispatch(self._event_factory.deserialize_auto_mod_rule_create_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_auto_mod_rule_create_event(shard, payload))
 
     @event_manager_base.filtered(auto_mod_events.AutoModRuleUpdateEvent)
-    async def on_auto_moderation_rule_update(
+    def on_auto_moderation_rule_update(
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> None:
         """See https://discord.com/developers/docs/topics/gateway#auto-moderation-rule-update for more info."""
-        await self.dispatch(self._event_factory.deserialize_auto_mod_rule_update_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_auto_mod_rule_update_event(shard, payload))
 
     @event_manager_base.filtered(auto_mod_events.AutoModRuleDeleteEvent)
-    async def on_auto_moderation_rule_delete(
+    def on_auto_moderation_rule_delete(
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> None:
         """See https://discord.com/developers/docs/topics/gateway#auto-moderation-rule-delete for more info."""
-        await self.dispatch(self._event_factory.deserialize_auto_mod_rule_delete_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_auto_mod_rule_delete_event(shard, payload))
 
     @event_manager_base.filtered(auto_mod_events.AutoModActionExecutionEvent)
-    async def on_auto_moderation_action_execution(
+    def on_auto_moderation_action_execution(
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> None:
         """See https://discord.com/developers/docs/topics/gateway#auto-moderation-action-execution for more info."""
-        await self.dispatch(self._event_factory.deserialize_auto_mod_action_execution_event(shard, payload))
+        self.dispatch(self._event_factory.deserialize_auto_mod_action_execution_event(shard, payload))

--- a/hikari/impl/event_manager_base.py
+++ b/hikari/impl/event_manager_base.py
@@ -425,9 +425,6 @@ class EventManagerBase(event_manager_.EventManager):
 
         try:
             consumer.callback(shard, payload)
-        except asyncio.CancelledError:
-            # Skip cancelled errors, likely caused by the event loop being shut down.
-            pass
         except errors.UnrecognisedEntityError:
             _LOGGER.debug("Event referenced an unrecognised entity, discarding")
         except Exception as ex:  # noqa: BLE001 - Do not catch blind exception

--- a/hikari/impl/event_manager_base.py
+++ b/hikari/impl/event_manager_base.py
@@ -79,7 +79,7 @@ _LOGGER: typing.Final[logging.Logger] = logging.getLogger("hikari.event_manager"
 class _FilteredMethodT(fast_protocol.FastProtocolChecking, typing.Protocol):
     __slots__: typing.Sequence[str] = ()
 
-    def __call__(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject, /) -> None:
+    def __call__(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         raise NotImplementedError
 
     @property

--- a/hikari/impl/event_manager_base.py
+++ b/hikari/impl/event_manager_base.py
@@ -42,7 +42,6 @@ from hikari.api import config
 from hikari.api import event_manager as event_manager_
 from hikari.events import base_events
 from hikari.events import shard_events
-from hikari.internal import aio
 from hikari.internal import fast_protocol
 from hikari.internal import reflect
 from hikari.internal import typing_extensions
@@ -56,9 +55,7 @@ if typing.TYPE_CHECKING:
     from hikari.api import shard as gateway_shard
     from hikari.internal import data_binding
 
-    _ConsumerT = typing.Callable[
-        [gateway_shard.GatewayShard, data_binding.JSONObject], typing.Coroutine[typing.Any, typing.Any, None]
-    ]
+    _ConsumerT = typing.Callable[[gateway_shard.GatewayShard, data_binding.JSONObject], None]
     _ListenerMapT = dict[type[base_events.EventT], list[event_manager_.CallbackT[base_events.EventT]]]
     _WaiterT = tuple[
         typing.Optional[event_manager_.PredicateT[base_events.EventT]], "asyncio.Future[base_events.EventT]"
@@ -66,10 +63,7 @@ if typing.TYPE_CHECKING:
     _WaiterMapT = dict[type[base_events.EventT], set[_WaiterT[base_events.EventT]]]
 
     _EventManagerBaseT = typing.TypeVar("_EventManagerBaseT", bound="EventManagerBase")
-    _UnboundMethodT = typing.Callable[
-        [_EventManagerBaseT, gateway_shard.GatewayShard, data_binding.JSONObject],
-        typing.Coroutine[typing.Any, typing.Any, None],
-    ]
+    _UnboundMethodT = typing.Callable[[_EventManagerBaseT, gateway_shard.GatewayShard, data_binding.JSONObject], None]
 
 
 if sys.version_info >= (3, 10):
@@ -85,7 +79,7 @@ _LOGGER: typing.Final[logging.Logger] = logging.getLogger("hikari.event_manager"
 class _FilteredMethodT(fast_protocol.FastProtocolChecking, typing.Protocol):
     __slots__: typing.Sequence[str] = ()
 
-    async def __call__(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject, /) -> None:
+    def __call__(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject, /) -> None:
         raise NotImplementedError
 
     @property
@@ -328,8 +322,8 @@ class EventManagerBase(event_manager_.EventManager):
 
     __slots__: typing.Sequence[str] = (
         "_consumers",
+        "_dispatched_tasks",
         "_event_factory",
-        "_handling_dispatch_tasks",
         "_intents",
         "_listeners",
         "_waiters",
@@ -347,7 +341,7 @@ class EventManagerBase(event_manager_.EventManager):
         self._intents = intents
         self._listeners: _ListenerMapT[base_events.Event] = {}
         self._waiters: _WaiterMapT[base_events.Event] = {}
-        self._handling_dispatch_tasks: set[asyncio.Task[None]] = set()
+        self._dispatched_tasks = set()
 
         for name, member in inspect.getmembers(self):
             if name.startswith("on_"):
@@ -420,12 +414,31 @@ class EventManagerBase(event_manager_.EventManager):
         if self._enabled_for_event(shard_events.ShardPayloadEvent):
             payload_event = self._event_factory.deserialize_shard_payload_event(shard, payload, name=event_name)
             self.dispatch(payload_event)
+
         consumer = self._consumers[event_name.lower()]
+        if not consumer.is_enabled:
+            name = consumer.callback.__name__
+            _LOGGER.log(
+                ux.TRACE, "Skipping raw dispatch for %s due to lack of any registered listeners or cache need", name
+            )
+            return
 
-        task = asyncio.create_task(self._handle_dispatch(consumer, shard, payload), name=f"dispatch {event_name}")
-
-        self._handling_dispatch_tasks.add(task)
-        task.add_done_callback(self._handling_dispatch_tasks.discard)
+        try:
+            consumer.callback(shard, payload)
+        except asyncio.CancelledError:
+            # Skip cancelled errors, likely caused by the event loop being shut down.
+            pass
+        except errors.UnrecognisedEntityError:
+            _LOGGER.debug("Event referenced an unrecognised entity, discarding")
+        except Exception as ex:  # noqa: BLE001 - Do not catch blind exception
+            asyncio.get_running_loop().call_exception_handler(
+                {
+                    "message": "Exception occurred in raw event dispatch conduit",
+                    "payload": payload,
+                    "exception": ex,
+                    "task": asyncio.current_task(),
+                }
+            )
 
     # Yes, this is not generic. The reason for this is MyPy complains about
     # using ABCs that are not concrete in generic types passed to functions.
@@ -536,12 +549,19 @@ class EventManagerBase(event_manager_.EventManager):
 
         return decorator
 
+    @typing.overload
+    def dispatch(self, event: base_events.Events, *, wait: bool = False) -> None: ...
+
+    @typing.overload
+    def dispatch(self, event: base_events.Events, *, wait: bool = True) -> asyncio.Future[None]: ...
+
     @typing_extensions.override
-    def dispatch(self, event: base_events.Event) -> asyncio.Future[typing.Any]:
-        tasks: list[typing.Coroutine[None, typing.Any, None]] = []
+    def dispatch(self, event: base_events.Events, *, wait: bool = False) -> asyncio.Future[None] | None:
+        tasks: list[asyncio.Task[None]] = []
 
         for cls in event.dispatches():
-            tasks.extend(self._invoke_callback(c, event) for c in self._listeners.get(cls, ()))
+            if cls in self._listeners:
+                tasks.extend(asyncio.create_task(self._invoke_callback(c, event)) for c in self._listeners[cls])
 
             if cls not in self._waiters:
                 continue
@@ -565,10 +585,13 @@ class EventManagerBase(event_manager_.EventManager):
                 del self._waiters[cls]
                 self._increment_waiter_group_count(cls, -1)
 
-        if tasks:
+        if wait:
             return asyncio.gather(*tasks)
 
-        return aio.completed_future()
+        self._dispatched_tasks.update(tasks)
+        for task in tasks:
+            task.add_done_callback(self._dispatched_tasks.remove)
+        return None
 
     @typing_extensions.override
     def stream(
@@ -610,33 +633,6 @@ class EventManagerBase(event_manager_.EventManager):
 
             raise
 
-    async def _handle_dispatch(
-        self, consumer: _Consumer, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
-    ) -> None:
-        if not consumer.is_enabled:
-            name = consumer.callback.__name__
-            _LOGGER.log(
-                ux.TRACE, "Skipping raw dispatch for %s due to lack of any registered listeners or cache need", name
-            )
-            return
-
-        try:
-            await consumer.callback(shard, payload)
-        except asyncio.CancelledError:
-            # Skip cancelled errors, likely caused by the event loop being shut down.
-            pass
-        except errors.UnrecognisedEntityError:
-            _LOGGER.debug("Event referenced an unrecognised entity, discarding")
-        except Exception as ex:  # noqa: BLE001 - Do not catch blind exception
-            asyncio.get_running_loop().call_exception_handler(
-                {
-                    "message": "Exception occurred in raw event dispatch conduit",
-                    "payload": payload,
-                    "exception": ex,
-                    "task": asyncio.current_task(),
-                }
-            )
-
     async def _invoke_callback(
         self, callback: event_manager_.CallbackT[base_events.EventT], event: base_events.EventT
     ) -> None:
@@ -656,4 +652,4 @@ class EventManagerBase(event_manager_.EventManager):
 
                 log = _LOGGER.debug if self.get_listeners(type(exception_event), polymorphic=True) else _LOGGER.error
                 log("an exception occurred handling an event (%s)", type(event).__name__, exc_info=trio)
-                await self.dispatch(exception_event)
+                self.dispatch(exception_event)

--- a/hikari/impl/event_manager_base.py
+++ b/hikari/impl/event_manager_base.py
@@ -550,15 +550,20 @@ class EventManagerBase(event_manager_.EventManager):
         return decorator
 
     @typing.overload
-    def dispatch(self, event: base_events.Event, *, wait: typing.Literal[False] = False) -> None: ...
+    def dispatch(self, event: base_events.Event, *, return_tasks: typing.Literal[False] = False) -> None: ...
 
     @typing.overload
     def dispatch(
-        self, event: base_events.Event, *, wait: typing.Literal[True] = True
+        self, event: base_events.Event, *, return_tasks: typing.Literal[True] = True
     ) -> asyncio.Future[typing.Any]: ...
 
+    @typing.overload
+    def dispatch(
+        self, event: base_events.Event, *, return_tasks: bool = False
+    ) -> asyncio.Future[typing.Any] | None: ...
+
     @typing_extensions.override
-    def dispatch(self, event: base_events.Event, *, wait: bool = False) -> asyncio.Future[typing.Any] | None:
+    def dispatch(self, event: base_events.Event, *, return_tasks: bool = False) -> asyncio.Future[typing.Any] | None:
         tasks: list[asyncio.Task[None]] = []
 
         for cls in event.dispatches():
@@ -587,7 +592,7 @@ class EventManagerBase(event_manager_.EventManager):
                 del self._waiters[cls]
                 self._increment_waiter_group_count(cls, -1)
 
-        if wait:
+        if return_tasks:
             return asyncio.gather(*tasks)
 
         self._dispatched_tasks.update(tasks)

--- a/hikari/impl/gateway_bot.py
+++ b/hikari/impl/gateway_bot.py
@@ -481,7 +481,7 @@ class GatewayBot(traits.GatewayBotAware):
         _LOGGER.info("bot requested to shut down")
         self._closing_event.set()
 
-        await self._event_manager.dispatch(self._event_factory.deserialize_stopping_event())
+        await self._event_manager.dispatch(self._event_factory.deserialize_stopping_event(), wait=True)
         _LOGGER.log(ux.TRACE, "StoppingEvent dispatch completed, now beginning termination")
 
         await _close_resource("voice handler", self._voice.close())
@@ -497,7 +497,7 @@ class GatewayBot(traits.GatewayBotAware):
         self._cache.clear()
         self._shards.clear()
 
-        await self._event_manager.dispatch(self._event_factory.deserialize_stopped_event())
+        await self._event_manager.dispatch(self._event_factory.deserialize_stopped_event(), wait=True)
 
         self._closed_event.set()
         self._closed_event = None
@@ -505,7 +505,7 @@ class GatewayBot(traits.GatewayBotAware):
 
         _LOGGER.info("bot shut down successfully")
 
-    def dispatch(self, event: base_events.Event) -> asyncio.Future[typing.Any]:
+    def dispatch(self, event: base_events.Event) -> None:
         """Dispatch an event.
 
         Parameters
@@ -588,7 +588,7 @@ class GatewayBot(traits.GatewayBotAware):
         Unsubscribe : [`hikari.impl.gateway_bot.GatewayBot.unsubscribe`][].
         Wait_for : [`hikari.impl.gateway_bot.GatewayBot.wait_for`][].
         """
-        return self._event_manager.dispatch(event)
+        self._event_manager.dispatch(event)
 
     def get_listeners(
         self, event_type: type[base_events.EventT], /, *, polymorphic: bool = True
@@ -951,7 +951,7 @@ class GatewayBot(traits.GatewayBotAware):
         self._rest.start()
         self._voice.start()
 
-        await self._event_manager.dispatch(self._event_factory.deserialize_starting_event())
+        await self._event_manager.dispatch(self._event_factory.deserialize_starting_event(), wait=True)
         requirements = await self._rest.fetch_gateway_bot_info()
 
         if shard_count is None:
@@ -1022,7 +1022,7 @@ class GatewayBot(traits.GatewayBotAware):
 
             await aio.first_completed(self._closing_event.wait(), gather)
 
-        await self._event_manager.dispatch(self._event_factory.deserialize_started_event())
+        await self._event_manager.dispatch(self._event_factory.deserialize_started_event(), wait=True)
 
         _LOGGER.info("started successfully in approx %.2f seconds", time.monotonic() - start_time)
 

--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -934,7 +934,7 @@ class GatewayShardImpl(shard.GatewayShard):
                 if not self._handshake_event.is_set():
                     continue
 
-                self._event_manager.dispatch(self._event_factory.deserialize_connected_event(self))
+                await self._event_manager.dispatch(self._event_factory.deserialize_connected_event(self), wait=True)
                 await aio.first_completed(*lifetime_tasks)
 
                 # Since nothing went wrong, we can reset the backoff and try again
@@ -1004,7 +1004,9 @@ class GatewayShardImpl(shard.GatewayShard):
 
                     if self._handshake_event.is_set():
                         # We dispatched the connected event, so we can dispatch the disconnected one too
-                        self._event_manager.dispatch(self._event_factory.deserialize_disconnected_event(self))
+                        await self._event_manager.dispatch(
+                            self._event_factory.deserialize_disconnected_event(self), wait=True
+                        )
 
     def _serialize_and_store_presence_payload(
         self,

--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -98,7 +98,7 @@ _TOTAL_RATELIMIT: typing.Final[tuple[float, int]] = (60.0, 120)
 # to get around (leaving 3 slots for it).
 _NON_PRIORITY_RATELIMIT: typing.Final[tuple[float, int]] = (60.0, 117)
 # Used to identify the end of a ZLIB payload
-_ZLIB_SUFFIX: typing.Final[bytes] = b"\x00\x00\xff\xff"
+_ZLIB_SYNC_FLUSH: typing.Final[bytes] = b"\x00\x00\xff\xff"
 # Close codes which don't invalidate the current session.
 _RECONNECTABLE_CLOSE_CODES: frozenset[errors.ShardCloseCode] = frozenset(
     (
@@ -191,6 +191,7 @@ class _GatewayTransport:
 
     async def receive_json(self) -> data_binding.JSONObject:
         pl = await self._receive_and_check()
+
         if self._logger.isEnabledFor(ux.TRACE):
             filtered = self._log_filterer(pl)
             self._logger.log(ux.TRACE, "received payload with size %s\n    %s", len(pl), filtered)
@@ -247,7 +248,7 @@ class _GatewayTransport:
         message = await self._ws.receive()
 
         if message.type == aiohttp.WSMsgType.BINARY:
-            if message.data.endswith(_ZLIB_SUFFIX):
+            if message.data.endswith(_ZLIB_SYNC_FLUSH):
                 # Hot and fast path: we already have the full message
                 # in a single frame
                 return self._zlib.decompress(message.data)
@@ -256,7 +257,7 @@ class _GatewayTransport:
             # the whole message. Only then do we create a buffer
             buff = bytearray(message.data)
 
-            while not buff.endswith(_ZLIB_SUFFIX):
+            while not buff.endswith(_ZLIB_SYNC_FLUSH):
                 message = await self._ws.receive()
 
                 if message.type == aiohttp.WSMsgType.BINARY:
@@ -933,7 +934,7 @@ class GatewayShardImpl(shard.GatewayShard):
                 if not self._handshake_event.is_set():
                     continue
 
-                await self._event_manager.dispatch(self._event_factory.deserialize_connected_event(self))
+                self._event_manager.dispatch(self._event_factory.deserialize_connected_event(self))
                 await aio.first_completed(*lifetime_tasks)
 
                 # Since nothing went wrong, we can reset the backoff and try again
@@ -1003,7 +1004,7 @@ class GatewayShardImpl(shard.GatewayShard):
 
                     if self._handshake_event.is_set():
                         # We dispatched the connected event, so we can dispatch the disconnected one too
-                        await self._event_manager.dispatch(self._event_factory.deserialize_disconnected_event(self))
+                        self._event_manager.dispatch(self._event_factory.deserialize_disconnected_event(self))
 
     def _serialize_and_store_presence_payload(
         self,

--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -934,7 +934,9 @@ class GatewayShardImpl(shard.GatewayShard):
                 if not self._handshake_event.is_set():
                     continue
 
-                await self._event_manager.dispatch(self._event_factory.deserialize_connected_event(self), wait=True)
+                await self._event_manager.dispatch(
+                    self._event_factory.deserialize_connected_event(self), return_tasks=True
+                )
                 await aio.first_completed(*lifetime_tasks)
 
                 # Since nothing went wrong, we can reset the backoff and try again
@@ -1005,7 +1007,7 @@ class GatewayShardImpl(shard.GatewayShard):
                     if self._handshake_event.is_set():
                         # We dispatched the connected event, so we can dispatch the disconnected one too
                         await self._event_manager.dispatch(
-                            self._event_factory.deserialize_disconnected_event(self), wait=True
+                            self._event_factory.deserialize_disconnected_event(self), return_tasks=True
                         )
 
     def _serialize_and_store_presence_payload(

--- a/tests/hikari/impl/test_event_manager_base.py
+++ b/tests/hikari/impl/test_event_manager_base.py
@@ -481,13 +481,11 @@ class TestEventManagerBase:
         event_manager._enabled_for_event = mock.Mock(return_value=True)
         mock_payload = {"id": "3123123123"}
         mock_shard = mock.Mock(id=123)
-        event_manager._handle_dispatch = mock.Mock()
         event_manager.dispatch = mock.Mock()
 
         with pytest.raises(LookupError):
             event_manager.consume_raw_event("UNEXISTING_EVENT", mock_shard, mock_payload)
 
-        event_manager._handle_dispatch.assert_not_called()
         event_manager.dispatch.assert_called_once_with(
             event_manager._event_factory.deserialize_shard_payload_event.return_value
         )
@@ -499,20 +497,35 @@ class TestEventManagerBase:
     @pytest.mark.asyncio
     async def test_consume_raw_event_when_found(self, event_manager):
         event_manager._enabled_for_event = mock.Mock(return_value=True)
-        event_manager._handle_dispatch = mock.Mock()
         event_manager.dispatch = mock.Mock()
-        on_existing_event = object()
+        on_existing_event = mock.Mock(is_enabled=True, callback=mock.Mock(__name__="testing"))
         event_manager._consumers = {"existing_event": on_existing_event}
         shard = object()
         payload = {"berp": "baz"}
 
-        with mock.patch("asyncio.create_task") as create_task:
-            event_manager.consume_raw_event("EXISTING_EVENT", shard, payload)
+        event_manager.consume_raw_event("EXISTING_EVENT", shard, payload)
 
-        event_manager._handle_dispatch.assert_called_once_with(on_existing_event, shard, {"berp": "baz"})
-        create_task.assert_called_once_with(
-            event_manager._handle_dispatch(on_existing_event, shard, {"berp": "baz"}), name="dispatch EXISTING_EVENT"
+        on_existing_event.callback.assert_called_once_with(shard, payload)
+        event_manager.dispatch.assert_called_once_with(
+            event_manager._event_factory.deserialize_shard_payload_event.return_value
         )
+        event_manager._event_factory.deserialize_shard_payload_event.assert_called_once_with(
+            shard, payload, name="EXISTING_EVENT"
+        )
+        event_manager._enabled_for_event.assert_called_once_with(shard_events.ShardPayloadEvent)
+
+    @pytest.mark.asyncio
+    async def test_consume_raw_event_skips_consumer_callback_when_not_enabled(self, event_manager):
+        event_manager._enabled_for_event = mock.Mock(return_value=True)
+        event_manager.dispatch = mock.Mock()
+        on_existing_event = mock.Mock(is_enabled=False, callback=mock.Mock(__name__="testing"))
+        event_manager._consumers = {"existing_event": on_existing_event}
+        shard = object()
+        payload = {"berp": "baz"}
+
+        event_manager.consume_raw_event("EXISTING_EVENT", shard, payload)
+
+        on_existing_event.callback.assert_not_called()
         event_manager.dispatch.assert_called_once_with(
             event_manager._event_factory.deserialize_shard_payload_event.return_value
         )
@@ -524,62 +537,28 @@ class TestEventManagerBase:
     @pytest.mark.asyncio
     async def test_consume_raw_event_skips_raw_dispatch_when_not_enabled(self, event_manager):
         event_manager._enabled_for_event = mock.Mock(return_value=False)
-        event_manager._handle_dispatch = mock.Mock()
         event_manager.dispatch = mock.Mock()
-        on_existing_event = object()
+        on_existing_event = mock.Mock(is_enabled=False, callback=mock.Mock(__name__="testing"))
         event_manager._consumers = {"existing_event": on_existing_event}
         shard = object()
         payload = {"berp": "baz"}
 
-        with mock.patch("asyncio.create_task") as create_task:
-            event_manager.consume_raw_event("EXISTING_EVENT", shard, payload)
+        event_manager.consume_raw_event("EXISTING_EVENT", shard, payload)
 
-        event_manager._handle_dispatch.assert_called_once_with(on_existing_event, shard, {"berp": "baz"})
-        create_task.assert_called_once_with(
-            event_manager._handle_dispatch(on_existing_event, shard, {"berp": "baz"}), name="dispatch EXISTING_EVENT"
-        )
         event_manager.dispatch.assert_not_called()
-        event_manager._event_factory.deserialize_shard_payload_event.vassert_not_called()
+        event_manager._event_factory.deserialize_shard_payload_event.assert_not_called()
         event_manager._enabled_for_event.assert_called_once_with(shard_events.ShardPayloadEvent)
 
     @pytest.mark.asyncio
-    async def test_handle_dispatch_invokes_callback(self, event_manager):
-        event_manager._enabled_for_consumer = mock.Mock(return_value=True)
-        consumer = mock.AsyncMock()
-        error_handler = mock.MagicMock()
-        event_loop = asyncio.get_running_loop()
-        event_loop.set_exception_handler(error_handler)
-        shard = object()
-        pl = {"foo": "bar"}
-
-        await event_manager._handle_dispatch(consumer, shard, pl)
-
-        consumer.callback.assert_awaited_once_with(shard, pl)
-        error_handler.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_handle_dispatch_ignores_cancelled_errors(self, event_manager):
-        event_manager._enabled_for_consumer = mock.Mock(return_value=True)
-        consumer = mock.AsyncMock(side_effect=asyncio.CancelledError)
-        error_handler = mock.MagicMock()
-        event_loop = asyncio.get_running_loop()
-        event_loop.set_exception_handler(error_handler)
-        shard = object()
-        pl = {"lorem": "ipsum"}
-
-        await event_manager._handle_dispatch(consumer, shard, pl)
-
-        error_handler.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_handle_dispatch_handles_exceptions(self, event_manager):
+    async def test_consume_raw_event_handles_exceptions(self, event_manager):
         mock_task = mock.Mock()
         # On Python 3.12+ Asyncio uses this to get the task's context if set to call the
         # error handler in. We want to avoid for this test for simplicity.
         mock_task.get_context.return_value = None
-        event_manager._enabled_for_consumer = mock.Mock(return_value=True)
         exc = Exception("aaaa!")
-        consumer = mock.Mock(callback=mock.AsyncMock(side_effect=exc))
+        consumer = mock.Mock(callback=mock.Mock(__name__="testing", side_effect=exc))
+        event_manager._consumers = {"existing_event": consumer}
+
         error_handler = mock.MagicMock()
         event_loop = asyncio.get_running_loop()
         event_loop.set_exception_handler(error_handler)
@@ -587,7 +566,7 @@ class TestEventManagerBase:
         pl = {"i like": "cats"}
 
         with mock.patch.object(asyncio, "current_task", return_value=mock_task):
-            await event_manager._handle_dispatch(consumer, shard, pl)
+            event_manager.consume_raw_event("EXISTING_EVENT", shard, pl)
 
         error_handler.assert_called_once_with(
             event_loop,
@@ -598,20 +577,6 @@ class TestEventManagerBase:
                 "task": mock_task,
             },
         )
-
-    @pytest.mark.asyncio
-    async def test_handle_dispatch_invokes_when_consumer_not_enabled(self, event_manager):
-        consumer = mock.Mock(callback=mock.AsyncMock(__name__="ok"), is_enabled=False)
-        error_handler = mock.MagicMock()
-        event_loop = asyncio.get_running_loop()
-        event_loop.set_exception_handler(error_handler)
-        shard = object()
-        pl = {"foo": "bar"}
-
-        await event_manager._handle_dispatch(consumer, shard, pl)
-
-        consumer.callback.assert_not_called()
-        error_handler.assert_not_called()
 
     def test_subscribe_when_class_call(self, event_manager):
         class Foo:

--- a/tests/hikari/impl/test_gateway_bot.py
+++ b/tests/hikari/impl/test_gateway_bot.py
@@ -443,10 +443,10 @@ class TestGatewayBot:
         assert bot._shards == {}
         cache.clear.assert_called_once_with()
 
-        event_manager.dispatch.assert_has_calls(
+        event_manager.dispatch.assert_has_awaits(
             [
-                mock.call(event_factory.deserialize_stopping_event.return_value),
-                mock.call(event_factory.deserialize_stopped_event.return_value),
+                mock.call(event_factory.deserialize_stopping_event.return_value, wait=True),
+                mock.call(event_factory.deserialize_stopped_event.return_value, wait=True),
             ]
         )
 
@@ -691,8 +691,8 @@ class TestGatewayBot:
         assert event_manager.dispatch.call_count == 2
         event_manager.dispatch.assert_has_awaits(
             [
-                mock.call(event_factory.deserialize_starting_event.return_value),
-                mock.call(event_factory.deserialize_started_event.return_value),
+                mock.call(event_factory.deserialize_starting_event.return_value, wait=True),
+                mock.call(event_factory.deserialize_started_event.return_value, wait=True),
             ]
         )
 

--- a/tests/hikari/impl/test_gateway_bot.py
+++ b/tests/hikari/impl/test_gateway_bot.py
@@ -445,17 +445,17 @@ class TestGatewayBot:
 
         event_manager.dispatch.assert_has_awaits(
             [
-                mock.call(event_factory.deserialize_stopping_event.return_value, wait=True),
-                mock.call(event_factory.deserialize_stopped_event.return_value, wait=True),
+                mock.call(event_factory.deserialize_stopping_event.return_value, return_tasks=True),
+                mock.call(event_factory.deserialize_stopped_event.return_value, return_tasks=True),
             ]
         )
 
     def test_dispatch(self, bot, event_manager):
-        event = object()
+        event = mock.Mock()
 
-        assert bot.dispatch(event) is event_manager.dispatch.return_value
+        assert bot.dispatch(event, return_tasks=True) is event_manager.dispatch.return_value
 
-        event_manager.dispatch.assert_called_once_with(event)
+        event_manager.dispatch.assert_called_once_with(event, return_tasks=True)
 
     def test_get_listeners(self, bot, event_manager):
         event = object()
@@ -691,8 +691,8 @@ class TestGatewayBot:
         assert event_manager.dispatch.call_count == 2
         event_manager.dispatch.assert_has_awaits(
             [
-                mock.call(event_factory.deserialize_starting_event.return_value, wait=True),
-                mock.call(event_factory.deserialize_started_event.return_value, wait=True),
+                mock.call(event_factory.deserialize_starting_event.return_value, return_tasks=True),
+                mock.call(event_factory.deserialize_started_event.return_value, return_tasks=True),
             ]
         )
 


### PR DESCRIPTION
Instead of creating tasks that keep references to soon to be deleted objects (ie, payloads) we can optimize the lifetime of each of these objects and have them be marked for removal by the GC as soon as possible
