### PR TITLE
Allow setting HTTP concurrent connection limit

### DIFF
--- a/changes/2395.feature.md
+++ b/changes/2395.feature.md
@@ -1,0 +1,1 @@
+Allow setting HTTP concurrent connection limit through `HTTPSettings.connection_limit`

--- a/hikari/impl/config.py
+++ b/hikari/impl/config.py
@@ -240,6 +240,12 @@ class HTTPSettings(config.HTTPSettings):
         by any value set here.
     """
 
+    connection_limit: int = attrs.field(default=100)
+    """The maximum number of concurrent connections to allow per connector.
+
+    If `0`, then there will be no limit.
+    """
+
     @max_redirects.validator
     def _(self, _: attrs.Attribute[int | None], value: object) -> None:
         # This error won't occur until some time in the future where it will be annoying to

--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -292,7 +292,7 @@ class _GatewayTransport:
 
         try:
             try:
-                connector = net.create_tcp_connector(http_settings=http_settings, dns_cache=False, limit=1)
+                connector = net.create_tcp_connector(http_settings=http_settings, dns_cache=False)
                 client_session = await exit_stack.enter_async_context(
                     net.create_client_session(
                         connector=connector,

--- a/hikari/internal/net.py
+++ b/hikari/internal/net.py
@@ -73,9 +73,7 @@ async def generate_error_response(response: aiohttp.ClientResponse) -> errors.HT
     return errors.HTTPResponseError(real_url, status, response.headers, raw_body)
 
 
-def create_tcp_connector(
-    http_settings: config.HTTPSettings, *, dns_cache: bool | int = True, limit: int = 100
-) -> aiohttp.TCPConnector:
+def create_tcp_connector(http_settings: config.HTTPSettings, *, dns_cache: bool | int = True) -> aiohttp.TCPConnector:
     """Create a TCP connector and return it.
 
     Parameters
@@ -101,7 +99,7 @@ def create_tcp_connector(
     return aiohttp.TCPConnector(
         enable_cleanup_closed=http_settings.enable_cleanup_closed,
         force_close=http_settings.force_close_transports,
-        limit=limit,
+        limit=http_settings.connection_limit,
         ssl=http_settings.ssl,
         ttl_dns_cache=dns_cache if not isinstance(dns_cache, bool) else 10,
         use_dns_cache=dns_cache is not False,

--- a/hikari/internal/ux.py
+++ b/hikari/internal/ux.py
@@ -473,7 +473,7 @@ async def check_for_updates(http_settings: config.HTTPSettings, proxy_settings: 
     try:
         async with (
             net.create_client_session(
-                connector=net.create_tcp_connector(dns_cache=False, limit=1, http_settings=http_settings),
+                connector=net.create_tcp_connector(dns_cache=False, http_settings=http_settings),
                 connector_owner=True,
                 http_settings=http_settings,
                 raise_for_status=True,

--- a/tests/hikari/impl/test_shard.py
+++ b/tests/hikari/impl/test_shard.py
@@ -387,7 +387,7 @@ class TestGatewayTransport:
             [mock.call(create_client_session.return_value), mock.call(client_session.ws_connect.return_value)]
         )
 
-        create_tcp_connector.assert_called_once_with(http_settings=http_settings, dns_cache=False, limit=1)
+        create_tcp_connector.assert_called_once_with(http_settings=http_settings, dns_cache=False)
         create_client_session.assert_called_once_with(
             connector=create_tcp_connector.return_value,
             connector_owner=True,

--- a/tests/hikari/internal/test_ux.py
+++ b/tests/hikari/internal/test_ux.py
@@ -665,7 +665,7 @@ class TestCheckForUpdates:
             await ux.check_for_updates(http_settings=http_settings, proxy_settings=proxy_settings)
 
         logger.warning.assert_called_once_with("Failed to fetch hikari version details", exc_info=ex)
-        create_tcp_connector.assert_called_once_with(dns_cache=False, limit=1, http_settings=http_settings)
+        create_tcp_connector.assert_called_once_with(dns_cache=False, http_settings=http_settings)
         create_client_session.assert_called_once_with(
             connector=create_tcp_connector(),
             connector_owner=True,
@@ -704,7 +704,7 @@ class TestCheckForUpdates:
         logger.info.assert_not_called()
 
         json_loads.assert_called_once_with(_request.read.return_value)
-        create_tcp_connector.assert_called_once_with(dns_cache=False, limit=1, http_settings=http_settings)
+        create_tcp_connector.assert_called_once_with(dns_cache=False,  http_settings=http_settings)
         create_client_session.assert_called_once_with(
             connector=create_tcp_connector(),
             connector_owner=True,
@@ -753,7 +753,7 @@ class TestCheckForUpdates:
             "A newer version of hikari is available, consider upgrading to %s", ux.HikariVersion(v)
         )
         json_loads.assert_called_once_with(_request.read.return_value)
-        create_tcp_connector.assert_called_once_with(dns_cache=False, limit=1, http_settings=http_settings)
+        create_tcp_connector.assert_called_once_with(dns_cache=False, http_settings=http_settings)
         create_client_session.assert_called_once_with(
             connector=create_tcp_connector(),
             connector_owner=True,


### PR DESCRIPTION
This allows increasing the limit for large shard clusters, where there will be a lot of continuous requests being made, provided that the underlying architecture can handle it