### PR TITLE
Temporarily pin 3.13 tests to 3.13.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9, "3.10", 3.11, 3.12, 3.13]
+        python-version: [3.9, "3.10", 3.11, 3.12, 3.13.5]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Fixes an issue when installing ciso8601

See: https://github.com/python/cpython/issues/135151