### PR TITLE
Fix enum `__getitem__` not properly returning items with a falsy value

### DIFF
--- a/changes/2434.bugfix.md
+++ b/changes/2434.bugfix.md
@@ -1,0 +1,1 @@
+Fix enum `__getitem__` not properly returning items with a falsy value

--- a/hikari/internal/enums.py
+++ b/hikari/internal/enums.py
@@ -412,7 +412,7 @@ class _FlagMeta(type):
                 return pseudomember
 
     def __getitem__(cls, name: str) -> Flag:
-        if member := getattr(cls, name, None):
+        if (member := getattr(cls, name, None)) is not None:
             return member
 
         raise KeyError(name)


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
