### PR TITLE
Always send allowed_mentions

### DIFF
--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -1530,14 +1530,12 @@ class RESTClientImpl(rest_api.RESTClient):
         body.put("embeds", serialized_embeds)
         body.put("components", serialized_components)
         body.put("poll", poll, conversion=lambda p: p.build())
+        body.put(
+            "allowed_mentions",
+            mentions.generate_allowed_mentions(mentions_everyone, mentions_reply, user_mentions, role_mentions),
+        )
 
         body.put_snowflake_array("sticker_ids", (sticker,) if sticker else stickers)
-
-        if not edit or not undefined.all_undefined(mentions_everyone, mentions_reply, user_mentions, role_mentions):
-            body.put(
-                "allowed_mentions",
-                mentions.generate_allowed_mentions(mentions_everyone, mentions_reply, user_mentions, role_mentions),
-            )
 
         form_builder: data_binding.URLEncodedFormBuilder | None = None
         if resources or final_attachments:


### PR DESCRIPTION
We used to differenciate between sending them or not depending on whether the message was edited, but this is wrong and we should always include it

### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
