### PR TITLE
Add attachment size limit parameter and tests

### DIFF
--- a/changes/2729.feature.md
+++ b/changes/2729.feature.md
@@ -1,0 +1,1 @@
+Add `attachment_size_limit` parameter to `PartialInteraction` object

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -2942,6 +2942,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             entitlements=entitlements,
             authorizing_integration_owners=authorizing_integration_owners,
             context=application_models.ApplicationContextType(payload["context"]),
+            attachment_size_limit=payload["attachment_size_limit"],
         )
 
     @typing_extensions.override
@@ -2996,6 +2997,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             entitlements=[self.deserialize_entitlement(entitlement) for entitlement in payload.get("entitlements", ())],
             authorizing_integration_owners=authorizing_integration_owners,
             context=application_models.ApplicationContextType(payload["context"]),
+            attachment_size_limit=payload["attachment_size_limit"],
         )
 
     @typing_extensions.override
@@ -3048,6 +3050,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             entitlements=[self.deserialize_entitlement(entitlement) for entitlement in payload.get("entitlements", ())],
             authorizing_integration_owners=authorizing_integration_owners,
             context=application_models.ApplicationContextType(payload["context"]),
+            attachment_size_limit=payload["attachment_size_limit"],
         )
 
     @typing_extensions.override
@@ -3197,6 +3200,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             entitlements=[self.deserialize_entitlement(entitlement) for entitlement in payload.get("entitlements", ())],
             authorizing_integration_owners=authorizing_integration_owners,
             context=application_models.ApplicationContextType(payload["context"]),
+            attachment_size_limit=payload["attachment_size_limit"],
         )
 
     ##################

--- a/hikari/interactions/base_interactions.py
+++ b/hikari/interactions/base_interactions.py
@@ -339,6 +339,9 @@ class PartialInteraction(snowflakes.Unique, webhooks.ExecutableWebhook):
     entitlements: typing.Sequence[monetization.Entitlement] = attrs.field(eq=False, hash=False, repr=True)
     """For monetized apps, any entitlements for the invoking user, represents access to SKUs."""
 
+    attachment_size_limit: int = attrs.field(eq=False, hash=False, repr=True)
+    """The size limit of the attachments for both the bot and user."""
+
     @property
     def channel_id(self) -> snowflakes.Snowflake:
         """The ID of the channel this interaction was invoked in."""

--- a/hikari/interactions/base_interactions.py
+++ b/hikari/interactions/base_interactions.py
@@ -340,7 +340,7 @@ class PartialInteraction(snowflakes.Unique, webhooks.ExecutableWebhook):
     """For monetized apps, any entitlements for the invoking user, represents access to SKUs."""
 
     attachment_size_limit: int = attrs.field(eq=False, hash=False, repr=True)
-    """The size limit of the attachments for both the bot and user."""
+    """The size limit of the attachments that can be uploaded."""
 
     @property
     def channel_id(self) -> snowflakes.Snowflake:

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -4711,6 +4711,7 @@ class TestEntityFactoryImpl:
             ],
             "authorizing_integration_owners": {"0": "123", "1": "456"},
             "context": 2,
+            "attachment_size_limit": 12345,
         }
 
     def test_deserialize_command_interaction(
@@ -4755,6 +4756,7 @@ class TestEntityFactoryImpl:
             application_models.ApplicationIntegrationType.USER_INSTALL
         ] == snowflakes.Snowflake(456)
         assert interaction.context == application_models.ApplicationContextType.PRIVATE_CHANNEL
+        assert interaction.attachment_size_limit == 12345
 
         # CommandInteractionOption
         assert len(interaction.options) == 1
@@ -4822,6 +4824,7 @@ class TestEntityFactoryImpl:
             ],
             "authorizing_integration_owners": {"0": "123", "1": "456"},
             "context": 2,
+            "attachment_size_limit": 12345,
         }
 
     def test_deserialize_command_interaction_with_context_menu_field(
@@ -4907,6 +4910,7 @@ class TestEntityFactoryImpl:
             ],
             "authorizing_integration_owners": {"0": "123", "1": "456"},
             "context": 2,
+            "attachment_size_limit": 12345,
         }
 
     def test_deserialize_autocomplete_interaction(
@@ -4941,6 +4945,7 @@ class TestEntityFactoryImpl:
             application_models.ApplicationIntegrationType.USER_INSTALL
         ] == snowflakes.Snowflake(456)
         assert interaction.context == application_models.ApplicationContextType.PRIVATE_CHANNEL
+        assert interaction.attachment_size_limit == 12345
 
         # AutocompleteInteractionOption
         assert len(interaction.options) == 1
@@ -5199,6 +5204,7 @@ class TestEntityFactoryImpl:
             ],
             "authorizing_integration_owners": {"0": "123", "1": "456"},
             "context": 2,
+            "attachment_size_limit": 12345,
         }
 
     def test_deserialize_component_interaction(
@@ -5250,6 +5256,8 @@ class TestEntityFactoryImpl:
         assert len(interaction.entitlements) == 1
         assert interaction.entitlements[0].id == 696969696969696
 
+        assert interaction.attachment_size_limit == 12345
+
     def test_deserialize_component_interaction_with_undefined_fields(
         self, entity_factory_impl, user_payload, message_payload, guild_text_channel_payload
     ):
@@ -5283,6 +5291,7 @@ class TestEntityFactoryImpl:
                 ],
                 "authorizing_integration_owners": {"0": "123", "1": "456"},
                 "context": 0,
+                "attachment_size_limit": 12345,
             }
         )
 
@@ -5336,6 +5345,7 @@ class TestEntityFactoryImpl:
             ],
             "authorizing_integration_owners": {"0": "123", "1": "456"},
             "context": 2,
+            "attachment_size_limit": 12345,
         }
 
     def test_deserialize_modal_interaction(
@@ -5361,6 +5371,7 @@ class TestEntityFactoryImpl:
             interaction_member_payload, guild_id=290926798626357999
         )
         assert interaction.user is interaction.member.user
+        assert interaction.attachment_size_limit == 12345
         assert isinstance(interaction, modal_interactions.ModalInteraction)
 
         assert len(interaction.entitlements) == 1

--- a/tests/hikari/impl/test_interaction_server.py
+++ b/tests/hikari/impl/test_interaction_server.py
@@ -683,6 +683,7 @@ class TestInteractionServer:
             guild_locale="en-GB",
             locale="es-ES",
             entitlements=[],
+            attachment_size_limit=12345,
         )
         mock_builder = mock.Mock(build=mock.Mock(return_value=({"ok": "No boomer"}, [mock_file_1, mock_file_2])))
         mock_listener = mock.AsyncMock(return_value=mock_builder)
@@ -739,6 +740,7 @@ class TestInteractionServer:
             guild_locale="en-GB",
             locale="es-ES",
             entitlements=[],
+            attachment_size_limit=12345,
         )
         mock_builder = mock.Mock(build=mock.Mock(return_value=({"ok": "No boomer"}, [mock_file_1, mock_file_2])))
         g_called = False
@@ -794,6 +796,7 @@ class TestInteractionServer:
             guild_locale="en-GB",
             locale="es-ES",
             entitlements=[],
+            attachment_size_limit=12345,
         )
 
         mock_listener = mock.AsyncMock(return_value=None)
@@ -958,6 +961,7 @@ class TestInteractionServer:
             guild_locale="en-GB",
             locale="es-ES",
             entitlements=[],
+            attachment_size_limit=12345,
         )
         mock_interaction_server.set_listener(
             base_interactions.PartialInteraction, mock.Mock(side_effect=mock_exception)
@@ -1002,6 +1006,7 @@ class TestInteractionServer:
             guild_locale="en-GB",
             locale="es-ES",
             entitlements=[],
+            attachment_size_limit=12345,
         )
         mock_builder = mock.Mock(build=mock.Mock(side_effect=mock_exception))
         mock_interaction_server.set_listener(
@@ -1048,6 +1053,7 @@ class TestInteractionServer:
             guild_locale="en-GB",
             locale="es-ES",
             entitlements=[],
+            attachment_size_limit=12345,
         )
         mock_builder = mock.Mock(build=mock.Mock(return_value=({"ok": "No"}, [])))
         mock_interaction_server.set_listener(

--- a/tests/hikari/interactions/test_base_interactions.py
+++ b/tests/hikari/interactions/test_base_interactions.py
@@ -71,6 +71,7 @@ class TestPartialInteraction:
                 )
             ],
             context=applications.ApplicationContextType.PRIVATE_CHANNEL,
+            attachment_size_limit=12345,
         )
 
     def test_webhook_id_property(self, mock_partial_interaction):
@@ -150,6 +151,7 @@ class TestMessageResponseMixin:
                     subscription_id=None,
                 )
             ],
+            attachment_size_limit=12345,
         )
 
     @pytest.mark.asyncio
@@ -328,6 +330,7 @@ class TestModalResponseMixin:
                     subscription_id=None,
                 )
             ],
+            attachment_size_limit=12345,
         )
 
     @pytest.mark.asyncio

--- a/tests/hikari/interactions/test_command_interactions.py
+++ b/tests/hikari/interactions/test_command_interactions.py
@@ -78,6 +78,7 @@ class TestCommandInteraction:
                 applications.ApplicationIntegrationType.GUILD_INSTALL: snowflakes.Snowflake(123)
             },
             context=applications.ApplicationContextType.PRIVATE_CHANNEL,
+            attachment_size_limit=12345,
         )
 
     def test_channel_id_property(self, mock_command_interaction):
@@ -140,6 +141,7 @@ class TestAutocompleteInteraction:
                 applications.ApplicationIntegrationType.GUILD_INSTALL: snowflakes.Snowflake(123)
             },
             context=applications.ApplicationContextType.PRIVATE_CHANNEL,
+            attachment_size_limit=12345,
         )
 
     @pytest.fixture

--- a/tests/hikari/interactions/test_component_interactions.py
+++ b/tests/hikari/interactions/test_component_interactions.py
@@ -75,6 +75,7 @@ class TestComponentInteraction:
                 applications.ApplicationIntegrationType.GUILD_INSTALL: snowflakes.Snowflake(123)
             },
             context=applications.ApplicationContextType.PRIVATE_CHANNEL,
+            attachment_size_limit=12345,
         )
 
     def test_build_response(self, mock_component_interaction, mock_app):

--- a/tests/hikari/interactions/test_modal_interactions.py
+++ b/tests/hikari/interactions/test_modal_interactions.py
@@ -83,6 +83,7 @@ class TestModalInteraction:
                 applications.ApplicationIntegrationType.GUILD_INSTALL: snowflakes.Snowflake(123)
             },
             context=applications.ApplicationContextType.PRIVATE_CHANNEL,
+            attachment_size_limit=12345,
         )
 
     def test_build_response(self, mock_modal_interaction, mock_app):


### PR DESCRIPTION
### Summary
Add attachment size limit parameter to interaction partial interaction payload.

### Checklist
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
