### PR TITLE
documentation: fix typo in docstring in audit_logs.py

### DIFF
--- a/changes/2741.documentation.md
+++ b/changes/2741.documentation.md
@@ -1,0 +1,1 @@
+fix typo in audit_logs.py AuditLogEventType docstring

--- a/changes/2741.documentation.md
+++ b/changes/2741.documentation.md
@@ -1,1 +1,0 @@
-fix typo in audit_logs.py AuditLogEventType docstring

--- a/hikari/audit_logs.py
+++ b/hikari/audit_logs.py
@@ -490,7 +490,7 @@ class AuditLogEventType(int, enums.Enum):
     """Indicates that guild server guide was created."""
 
     HOME_SETTINGS_UPDATE = 191
-    """Indicates that guild server guide was uodated."""
+    """Indicates that guild server guide was updated."""
 
 
 @attrs.define(kw_only=True, weakref_slot=False)


### PR DESCRIPTION
### Summary
fix typo in `audit_logs.py` in `AuditLogEventType`

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
