### PR TITLE
Default to unsigned in Color.to_bytes

### DIFF
--- a/changes/2742.bugfix.md
+++ b/changes/2742.bugfix.md
@@ -1,0 +1,1 @@
+`Color.to_bytes` now defaults to `signed=False`, matching `Color.from_bytes` and `Color`'s unsigned domain, so encoding a color into 3 bytes (e.g. `Color(0xFF0000).to_bytes(3, "big")`) no longer raises `OverflowError`.

--- a/changes/2742.bugfix.md
+++ b/changes/2742.bugfix.md
@@ -1,1 +1,1 @@
-`Color.to_bytes` now defaults to `signed=False`, matching `Color.from_bytes` and `Color`'s unsigned domain, so encoding a color into 3 bytes (e.g. `Color(0xFF0000).to_bytes(3, "big")`) no longer raises `OverflowError`.
+`Color.to_bytes` now defaults to `signed=False`, so encoding a color into 3 bytes no longer raises `OverflowError`.

--- a/hikari/colors.py
+++ b/hikari/colors.py
@@ -527,7 +527,7 @@ class Color(int):
 
     @typing_extensions.override
     def to_bytes(
-        self, length: typing.SupportsIndex, byteorder: typing.Literal["little", "big"], *, signed: bool = True
+        self, length: typing.SupportsIndex, byteorder: typing.Literal["little", "big"], *, signed: bool = False
     ) -> bytes:
         """Convert the color code to bytes.
 

--- a/tests/hikari/test_colors.py
+++ b/tests/hikari/test_colors.py
@@ -272,6 +272,13 @@ class TestColor:
         b = c.to_bytes(10, "little")
         assert b == b"\xff\xaa\xff\x00\x00\x00\x00\x00\x00\x00"
 
+    def test_Color_to_bytes_three_bytes(self):
+        # A color with a red channel >= 0x80 must fit in 3 bytes (Color is
+        # unsigned), and must round-trip through the inherited from_bytes.
+        c = colors.Color(0xFF0000)
+        assert c.to_bytes(3, "big") == b"\xff\x00\x00"
+        assert colors.Color.from_bytes(c.to_bytes(3, "big"), "big") == c
+
     @pytest.mark.parametrize(
         ("input", "expected_result"),
         [


### PR DESCRIPTION
### Summary

`Color.to_bytes` overrides `int.to_bytes` but flips the default of `signed` from `False` to `True`:

```python
def to_bytes(self, length, byteorder, *, signed: bool = True) -> bytes:
    return int(self).to_bytes(length, byteorder, signed=signed)
```

`Color` is an unsigned value, constrained to `0 <= raw_rgb <= 0xFFFFFF`. With `signed=True`, encoding a color whose red channel is `>= 0x80` into the natural 3 bytes overflows:

```python
Color(0xFF0000).to_bytes(3, "big")   # OverflowError: int too big to convert
```

(0xFF0000 = 16,711,680 exceeds the signed 3-byte max of 8,388,607.) This breaks roughly half of all colors for the documented use (`length` "should be around 3").

Its inverse, `Color.from_bytes`, is not overridden, so it inherits `int.from_bytes` with `signed=False`. The encode/decode pair therefore disagrees on `signed`, and a `to_bytes` → `from_bytes` round-trip at length 3 fails to even encode.

### Fix

Default `signed` to `False`, matching `int.to_bytes`, the inherited `from_bytes`, and `Color`'s unsigned domain:

```python
def to_bytes(self, length, byteorder, *, signed: bool = False) -> bytes:
```

Now `Color(0xFF0000).to_bytes(3, "big")` returns `b"\xff\x00\x00"` and round-trips. Passing `signed=True` explicitly is still available.

### Tests

Added `test_Color_to_bytes_three_bytes`, asserting a red-channel `>= 0x80` color encodes to 3 bytes and round-trips through `from_bytes`. It fails on `master` (`OverflowError`) and passes with the fix. The existing `test_Color_to_bytes` (length 10) is unaffected.