### PR TITLE
chore: bump required uv version to ~=0.12.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ types = [
 ]
 
 [tool.uv]
-required-version = "~=0.11.28"
+required-version = "~=0.12.1"
 
 [tool.coverage.run]
 relative_files = true


### PR DESCRIPTION
### Summary
bump required uv version to `~=0.12.1`

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
