### PR TITLE
Remove unused POST_GUILDS route

### DIFF
--- a/hikari/internal/routes.py
+++ b/hikari/internal/routes.py
@@ -396,7 +396,6 @@ DELETE_REACTION_USER: typing.Final[Route] = Route(
 
 # Guilds
 GET_GUILD: typing.Final[Route] = Route(GET, "/guilds/{guild}")
-POST_GUILDS: typing.Final[Route] = Route(POST, "/guilds")
 PATCH_GUILD: typing.Final[Route] = Route(PATCH, "/guilds/{guild}")
 DELETE_GUILD: typing.Final[Route] = Route(DELETE, "/guilds/{guild}")
 


### PR DESCRIPTION
### Summary
Removes the `POST_GUILDS` route from `hikari/internal/routes.py`.

### Checklist
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
N/A