### PR TITLE
Default to unsigned in Color.to_bytes

### DIFF
--- a/changes/2764.bugfix.md
+++ b/changes/2764.bugfix.md
@@ -1,0 +1,1 @@
+Default to unsigned in `Color.to_bytes`, fixing an `OverflowError` when converting colors with a red channel of `0x80` or higher to their natural three bytes

--- a/hikari/colors.py
+++ b/hikari/colors.py
@@ -527,7 +527,7 @@ class Color(int):
 
     @typing_extensions.override
     def to_bytes(
-        self, length: typing.SupportsIndex, byteorder: typing.Literal["little", "big"], *, signed: bool = True
+        self, length: typing.SupportsIndex, byteorder: typing.Literal["little", "big"], *, signed: bool = False
     ) -> bytes:
         """Convert the color code to bytes.
 

--- a/tests/hikari/test_colors.py
+++ b/tests/hikari/test_colors.py
@@ -272,6 +272,12 @@ class TestColor:
         b = c.to_bytes(10, "little")
         assert b == b"\xff\xaa\xff\x00\x00\x00\x00\x00\x00\x00"
 
+    def test_Color_to_bytes_with_three_bytes(self):
+        c = colors.Color(0xFF0000)
+        b = c.to_bytes(3, "big")
+        assert b == b"\xff\x00\x00"
+        assert colors.Color.from_bytes(b, "big") == c
+
     @pytest.mark.parametrize(
         ("input", "expected_result"),
         [


### PR DESCRIPTION
### Summary
`Color` is constrained to the unsigned range 0..0xFFFFFF, but `to_bytes` defaulted to `signed=True`, raising `OverflowError` for any color with a red channel of 0x80 or higher at the documented three byte length and disagreeing with the inherited from_bytes default.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
