### PR TITLE
Remove the changelog fragment for the unreleased aiohttp regression

### DIFF
--- a/changes/2751.bugfix.md
+++ b/changes/2751.bugfix.md
@@ -1,1 +1,0 @@
-Bump the minimum required aiohttp version to 3.14, fixing a `TypeError` when connecting to the gateway with aiohttp 3.13 installed


### PR DESCRIPTION
### Summary
The `decode_text` `TypeError` only ever existed on master and was never part of a release, so it doesn't need an entry in the released changelog.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
#2751 