### PR TITLE
Add `application_id` to guild channels & make group DM deserializer null-safe

### DIFF
--- a/changes/2771.feature.md
+++ b/changes/2771.feature.md
@@ -1,0 +1,1 @@
+Add the `application_id` field to guild channels, which Discord now documents on the channel object for future guild channel use cases

--- a/hikari/channels.py
+++ b/hikari/channels.py
@@ -946,6 +946,13 @@ class GuildChannel(PartialChannel):
     guild_id: snowflakes.Snowflake = attrs.field(eq=False, hash=False, repr=True)
     """The ID of the guild the channel belongs to."""
 
+    application_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=False)
+    """The ID of the application associated with this channel.
+
+    This will be [`None`][] for channels which are not associated with an
+    application.
+    """
+
     parent_id: snowflakes.Snowflake | None = attrs.field(eq=False, hash=False, repr=True)
     """The ID of the parent channel the channel belongs to.
 

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -121,6 +121,7 @@ class _GuildChannelFields:
     name: str | None = attrs.field()
     type: channel_models.ChannelType | int = attrs.field()
     guild_id: snowflakes.Snowflake = attrs.field()
+    application_id: snowflakes.Snowflake | None = attrs.field()
     parent_id: snowflakes.Snowflake | None = attrs.field()
 
 
@@ -1136,6 +1137,10 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         else:
             nicknames = {}
 
+        application_id: snowflakes.Snowflake | None = None
+        if (raw_application_id := payload.get("application_id")) is not None:
+            application_id = snowflakes.Snowflake(raw_application_id)
+
         recipients = {snowflakes.Snowflake(user["id"]): self.deserialize_user(user) for user in payload["recipients"]}
 
         return channel_models.GroupDMChannel(
@@ -1147,7 +1152,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             owner_id=snowflakes.Snowflake(payload["owner_id"]),
             icon_hash=payload["icon"],
             nicknames=nicknames,
-            application_id=snowflakes.Snowflake(payload["application_id"]) if "application_id" in payload else None,
+            application_id=application_id,
             recipients=recipients,
         )
 
@@ -1161,11 +1166,16 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
         if (raw_parent_id := payload.get("parent_id")) is not None:
             parent_id = snowflakes.Snowflake(raw_parent_id)
 
+        application_id: snowflakes.Snowflake | None = None
+        if (raw_application_id := payload.get("application_id")) is not None:
+            application_id = snowflakes.Snowflake(raw_application_id)
+
         return _GuildChannelFields(
             id=snowflakes.Snowflake(payload["id"]),
             name=payload.get("name"),
             type=channel_models.ChannelType(payload["type"]),
             guild_id=guild_id,
+            application_id=application_id,
             parent_id=parent_id,
         )
 
@@ -1187,6 +1197,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             name=channel_fields.name,
             type=channel_fields.type,
             guild_id=channel_fields.guild_id,
+            application_id=channel_fields.application_id,
             permission_overwrites=permission_overwrites,
             is_nsfw=payload.get("nsfw", False),
             parent_id=None,
@@ -1223,6 +1234,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             name=channel_fields.name,
             type=channel_fields.type,
             guild_id=channel_fields.guild_id,
+            application_id=channel_fields.application_id,
             permission_overwrites=permission_overwrites,
             is_nsfw=payload.get("nsfw", False),
             parent_id=channel_fields.parent_id,
@@ -1267,6 +1279,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             name=channel_fields.name,
             type=channel_fields.type,
             guild_id=channel_fields.guild_id,
+            application_id=channel_fields.application_id,
             permission_overwrites=permission_overwrites,
             is_nsfw=payload.get("nsfw", False),
             parent_id=channel_fields.parent_id,
@@ -1298,6 +1311,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             name=channel_fields.name,
             type=channel_fields.type,
             guild_id=channel_fields.guild_id,
+            application_id=channel_fields.application_id,
             permission_overwrites={
                 snowflakes.Snowflake(overwrite["id"]): self.deserialize_permission_overwrite(overwrite)
                 for overwrite in payload["permission_overwrites"]
@@ -1336,6 +1350,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             name=channel_fields.name,
             type=channel_fields.type,
             guild_id=channel_fields.guild_id,
+            application_id=channel_fields.application_id,
             permission_overwrites={
                 snowflakes.Snowflake(overwrite["id"]): self.deserialize_permission_overwrite(overwrite)
                 for overwrite in payload["permission_overwrites"]
@@ -1408,6 +1423,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             name=channel_fields.name,
             type=channel_fields.type,
             guild_id=channel_fields.guild_id,
+            application_id=channel_fields.application_id,
             permission_overwrites=permission_overwrites,
             is_nsfw=payload.get("nsfw", False),
             parent_id=channel_fields.parent_id,
@@ -1515,6 +1531,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             name=channel_fields.name,
             type=channel_fields.type,
             guild_id=channel_fields.guild_id,
+            application_id=channel_fields.application_id,
             parent_id=channel_fields.parent_id,
             last_message_id=last_message_id,
             last_pin_timestamp=last_pin_timestamp,
@@ -1561,6 +1578,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             name=channel_fields.name,
             type=channel_fields.type,
             guild_id=channel_fields.guild_id,
+            application_id=channel_fields.application_id,
             parent_id=channel_fields.parent_id,
             last_message_id=last_message_id,
             last_pin_timestamp=last_pin_timestamp,
@@ -1603,6 +1621,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             name=channel_fields.name,
             type=channel_fields.type,
             guild_id=channel_fields.guild_id,
+            application_id=channel_fields.application_id,
             parent_id=channel_fields.parent_id,
             last_message_id=last_message_id,
             last_pin_timestamp=last_pin_timestamp,
@@ -1671,6 +1690,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             name=channel_fields.name,
             type=channel_fields.type,
             guild_id=channel_fields.guild_id,
+            application_id=channel_fields.application_id,
             permission_overwrites=permission_overwrites,
             is_nsfw=payload.get("nsfw", False),
             parent_id=channel_fields.parent_id,

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -73,6 +73,7 @@ def guild_text_channel_payload(permission_overwrite_payload):
     return {
         "id": "123",
         "guild_id": "567",
+        "application_id": "323123123",
         "name": "general",
         "type": 0,
         "position": 6,
@@ -1868,6 +1869,13 @@ class TestEntityFactoryImpl:
         assert group_dm.application_id is None
         assert group_dm.last_message_id is None
 
+    def test_deserialize_group_dm_channel_with_null_application_id(self, entity_factory_impl, group_dm_channel_payload):
+        group_dm_channel_payload["application_id"] = None
+
+        group_dm = entity_factory_impl.deserialize_group_dm(group_dm_channel_payload)
+
+        assert group_dm.application_id is None
+
     @pytest.fixture
     def guild_category_payload(self, permission_overwrite_payload):
         return {
@@ -1937,6 +1945,7 @@ class TestEntityFactoryImpl:
         assert guild_text_channel.name == "general"
         assert guild_text_channel.type == channel_models.ChannelType.GUILD_TEXT
         assert guild_text_channel.guild_id == 567
+        assert guild_text_channel.application_id == 323123123
         assert guild_text_channel.position == 6
         assert guild_text_channel.permission_overwrites == {
             4242: entity_factory_impl.deserialize_permission_overwrite(permission_overwrite_payload)
@@ -1968,6 +1977,7 @@ class TestEntityFactoryImpl:
         assert guild_text_channel.rate_limit_per_user.total_seconds() == 0
         assert guild_text_channel.last_pin_timestamp is None
         assert guild_text_channel.parent_id is None
+        assert guild_text_channel.application_id is None
         assert guild_text_channel.last_message_id is None
         assert guild_text_channel.default_auto_archive_duration == datetime.timedelta(minutes=1440)
 
@@ -1986,12 +1996,14 @@ class TestEntityFactoryImpl:
                 "last_message_id": None,
                 "last_pin_timestamp": None,
                 "parent_id": None,
+                "application_id": None,
             }
         )
         assert guild_text_channel.topic is None
         assert guild_text_channel.last_message_id is None
         assert guild_text_channel.last_pin_timestamp is None
         assert guild_text_channel.parent_id is None
+        assert guild_text_channel.application_id is None
 
     def test_deserialize_guild_news_channel(
         self, entity_factory_impl, mock_app, guild_news_channel_payload, permission_overwrite_payload

--- a/tests/hikari/test_channels.py
+++ b/tests/hikari/test_channels.py
@@ -328,6 +328,7 @@ class TestGuildChannel:
             name="foo1",
             type=channels.ChannelType.GUILD_VOICE,
             guild_id=snowflakes.Snowflake(123456789),
+            application_id=None,
             parent_id=None,
         )
 
@@ -408,6 +409,7 @@ class TestPermissibleGuildChannel:
             name="foo1",
             type=channels.ChannelType.GUILD_VOICE,
             guild_id=snowflakes.Snowflake(123456789),
+            application_id=None,
             is_nsfw=True,
             parent_id=None,
             position=54,


### PR DESCRIPTION
### Summary
https://github.com/discord/discord-api-docs/commit/08b39ffb5b3682cc266996b4b0a120317b1cf0e8

Discord updated the docs today to make the channel `application_id` field nullable and no longer group DM specific ("application id associated with the channel", with a changelog note that future guild channels can serialize it as null). This adds the field to `GuildChannel` so it's available on all guild channel types, and makes the group DM deserializer null-safe to match the new `?snowflake` contract.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
