### PR TITLE
Add support for voice channel statuses

### DIFF
--- a/changes/2774.feature.md
+++ b/changes/2774.feature.md
@@ -1,0 +1,1 @@
+Add support for voice channel statuses: `RESTClient.set_voice_channel_status`, the `VoiceChannelStatusUpdateEvent` event, the `Permissions.SET_VOICE_CHANNEL_STATUS` permission and the `VOICE_CHANNEL_STATUS_CREATE`/`VOICE_CHANNEL_STATUS_DELETE` audit log events with their entry info models

--- a/hikari/api/event_factory.py
+++ b/hikari/api/event_factory.py
@@ -1394,6 +1394,25 @@ class EventFactory(abc.ABC):
         """
 
     @abc.abstractmethod
+    def deserialize_voice_channel_status_update_event(
+        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
+    ) -> voice_events.VoiceChannelStatusUpdateEvent:
+        """Parse a raw payload from Discord into a voice channel status update event object.
+
+        Parameters
+        ----------
+        shard
+            The shard that emitted this event.
+        payload
+            The dict payload to parse.
+
+        Returns
+        -------
+        hikari.events.voice_events.VoiceChannelStatusUpdateEvent
+            The parsed voice channel status update event object.
+        """
+
+    @abc.abstractmethod
     def deserialize_auto_mod_rule_create_event(
         self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
     ) -> auto_mod_events.AutoModRuleCreateEvent:

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -435,6 +435,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Raises
         ------
+        hikari.errors.BadRequestError
+            If the provided status is longer than 500 characters.
         hikari.errors.ForbiddenError
             If you are missing the [`hikari.permissions.Permissions.SET_VOICE_CHANNEL_STATUS`][]
             permission, or the [`hikari.permissions.Permissions.MANAGE_CHANNELS`][] permission

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -412,6 +412,45 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         """
 
     @abc.abstractmethod
+    async def set_voice_channel_status(
+        self,
+        channel: snowflakes.SnowflakeishOr[channels_.GuildVoiceChannel],
+        status: str | None,
+        *,
+        reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
+    ) -> None:
+        """Set the status of a voice channel.
+
+        Parameters
+        ----------
+        channel
+            The voice channel to set the status of. This may be the object
+            or the ID of an existing channel.
+        status
+            The new voice channel status (up to 500 characters) or
+            [`None`][] to remove it.
+        reason
+            If provided, the reason that will be recorded in the audit logs.
+            Maximum of 512 characters.
+
+        Raises
+        ------
+        hikari.errors.ForbiddenError
+            If you are missing the [`hikari.permissions.Permissions.SET_VOICE_CHANNEL_STATUS`][]
+            permission, or the [`hikari.permissions.Permissions.MANAGE_CHANNELS`][] permission
+            when not connected to the voice channel.
+        hikari.errors.NotFoundError
+            If the channel is not found.
+        hikari.errors.UnauthorizedError
+            If you are unauthorized to make the request (invalid/missing token).
+        hikari.errors.RateLimitTooLongError
+            Raised in the event that a rate limit occurs that is
+            longer than `max_rate_limit` when making a request.
+        hikari.errors.InternalServerError
+            If an internal error occurs on Discord while handling the request.
+        """
+
+    @abc.abstractmethod
     async def fetch_my_voice_state(self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild]) -> voices.VoiceState:
         """Fetch the current user's voice state.
 

--- a/hikari/audit_logs.py
+++ b/hikari/audit_logs.py
@@ -36,6 +36,8 @@ __all__: typing.Sequence[str] = (
     "MessageBulkDeleteEntryInfo",
     "MessageDeleteEntryInfo",
     "MessagePinEntryInfo",
+    "VoiceChannelStatusCreateEntryInfo",
+    "VoiceChannelStatusDeleteEntryInfo",
 )
 
 import typing
@@ -498,6 +500,12 @@ class AuditLogEventType(int, enums.Enum):
     HOME_SETTINGS_UPDATE = 191
     """Indicates that guild server guide was updated."""
 
+    VOICE_CHANNEL_STATUS_CREATE = 192
+    """Indicates that a voice channel status was set by a user."""
+
+    VOICE_CHANNEL_STATUS_DELETE = 193
+    """Indicates that a voice channel status was deleted by a user."""
+
 
 @attrs.define(kw_only=True, weakref_slot=False)
 class BaseAuditLogEntryInfo:
@@ -690,6 +698,24 @@ class MemberMoveEntryInfo(MemberDisconnectEntryInfo):
         channel = await self.app.rest.fetch_channel(self.channel_id)
         assert isinstance(channel, channels.GuildVoiceChannel)
         return channel
+
+
+@attrs_extensions.with_copy
+@attrs.define(kw_only=True, weakref_slot=False)
+class VoiceChannelStatusDeleteEntryInfo(BaseAuditLogEntryInfo):
+    """Extra information for the voice channel status delete entry."""
+
+    channel_id: snowflakes.Snowflake = attrs.field(repr=True)
+    """The channel the voice channel status was deleted from."""
+
+
+@attrs_extensions.with_copy
+@attrs.define(kw_only=True, weakref_slot=False)
+class VoiceChannelStatusCreateEntryInfo(VoiceChannelStatusDeleteEntryInfo):
+    """Extra information for the voice channel status create entry."""
+
+    status: str = attrs.field(repr=True)
+    """The new voice channel status."""
 
 
 @attrs_extensions.with_copy

--- a/hikari/events/voice_events.py
+++ b/hikari/events/voice_events.py
@@ -146,6 +146,7 @@ class VoiceServerUpdateEvent(VoiceEvent):
         return f"wss://{self.raw_endpoint}"
 
 
+@base_events.requires_intents(intents.Intents.GUILDS)
 @attrs_extensions.with_copy
 @attrs.define(kw_only=True, weakref_slot=False)
 class VoiceChannelStartTimeUpdateEvent(VoiceEvent):
@@ -173,6 +174,7 @@ class VoiceChannelStartTimeUpdateEvent(VoiceEvent):
     """
 
 
+@base_events.requires_intents(intents.Intents.GUILDS)
 @attrs_extensions.with_copy
 @attrs.define(kw_only=True, weakref_slot=False)
 class VoiceChannelStatusUpdateEvent(VoiceEvent):

--- a/hikari/events/voice_events.py
+++ b/hikari/events/voice_events.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 __all__: typing.Sequence[str] = (
     "VoiceChannelStartTimeUpdateEvent",
+    "VoiceChannelStatusUpdateEvent",
     "VoiceEvent",
     "VoiceServerUpdateEvent",
     "VoiceStateUpdateEvent",
@@ -169,4 +170,28 @@ class VoiceChannelStartTimeUpdateEvent(VoiceEvent):
     """When the ongoing voice session started.
 
     This will be [`None`][] if there is no ongoing voice session.
+    """
+
+
+@attrs_extensions.with_copy
+@attrs.define(kw_only=True, weakref_slot=False)
+class VoiceChannelStatusUpdateEvent(VoiceEvent):
+    """Event fired when the status of a voice channel changes."""
+
+    app: traits.RESTAware = attrs.field(metadata={attrs_extensions.SKIP_DEEP_COPY: True})
+    # <<inherited docstring from Event>>.
+
+    shard: gateway_shard.GatewayShard = attrs.field(metadata={attrs_extensions.SKIP_DEEP_COPY: True})
+    # <<inherited docstring from ShardEvent>>.
+
+    guild_id: snowflakes.Snowflake = attrs.field(repr=True)
+    # <<inherited docstring from VoiceEvent>>
+
+    channel_id: snowflakes.Snowflake = attrs.field(repr=True)
+    """ID of the voice channel this event is for."""
+
+    status: str | None = attrs.field(repr=True)
+    """The new voice channel status.
+
+    This will be [`None`][] if the status was removed.
     """

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -533,6 +533,8 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             audit_log_models.AuditLogEventType.MESSAGE_DELETE: self._deserialize_message_delete_entry_info,
             audit_log_models.AuditLogEventType.MEMBER_DISCONNECT: self._deserialize_member_disconnect_entry_info,
             audit_log_models.AuditLogEventType.MEMBER_MOVE: self._deserialize_member_move_entry_info,
+            audit_log_models.AuditLogEventType.VOICE_CHANNEL_STATUS_CREATE: self._deserialize_voice_channel_status_create_entry_info,  # noqa: E501
+            audit_log_models.AuditLogEventType.VOICE_CHANNEL_STATUS_DELETE: self._deserialize_voice_channel_status_delete_entry_info,  # noqa: E501
         }
         self._auto_mod_action_mapping = {
             auto_mod_models.AutoModActionType.BLOCK_MESSAGE: self._deserialize_auto_mod_block_message,
@@ -943,6 +945,20 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
     ) -> audit_log_models.MemberMoveEntryInfo:
         return audit_log_models.MemberMoveEntryInfo(
             app=self._app, channel_id=snowflakes.Snowflake(payload["channel_id"]), count=int(payload["count"])
+        )
+
+    def _deserialize_voice_channel_status_create_entry_info(
+        self, payload: data_binding.JSONObject
+    ) -> audit_log_models.VoiceChannelStatusCreateEntryInfo:
+        return audit_log_models.VoiceChannelStatusCreateEntryInfo(
+            app=self._app, channel_id=snowflakes.Snowflake(payload["channel_id"]), status=payload["status"]
+        )
+
+    def _deserialize_voice_channel_status_delete_entry_info(
+        self, payload: data_binding.JSONObject
+    ) -> audit_log_models.VoiceChannelStatusDeleteEntryInfo:
+        return audit_log_models.VoiceChannelStatusDeleteEntryInfo(
+            app=self._app, channel_id=snowflakes.Snowflake(payload["channel_id"])
         )
 
     @typing_extensions.override

--- a/hikari/impl/event_factory.py
+++ b/hikari/impl/event_factory.py
@@ -1055,6 +1055,18 @@ class EventFactoryImpl(event_factory.EventFactory):
             voice_start_time=voice_start_time,
         )
 
+    @typing_extensions.override
+    def deserialize_voice_channel_status_update_event(
+        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
+    ) -> voice_events.VoiceChannelStatusUpdateEvent:
+        return voice_events.VoiceChannelStatusUpdateEvent(
+            app=self._app,
+            shard=shard,
+            guild_id=snowflakes.Snowflake(payload["guild_id"]),
+            channel_id=snowflakes.Snowflake(payload["id"]),
+            status=payload["status"],
+        )
+
     ################
     # MONETIZATION #
     ################

--- a/hikari/impl/event_manager.py
+++ b/hikari/impl/event_manager.py
@@ -840,6 +840,13 @@ class EventManagerImpl(event_manager_base.EventManagerBase):
         """See https://docs.discord.com/developers/events/gateway-events#voice-channel-start-time-update."""
         self.dispatch(self._event_factory.deserialize_voice_channel_start_time_update_event(shard, payload))
 
+    @event_manager_base.filtered(voice_events.VoiceChannelStatusUpdateEvent)
+    def on_voice_channel_status_update(
+        self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject
+    ) -> None:
+        """See https://docs.discord.com/developers/events/gateway-events#voice-channel-status-update."""
+        self.dispatch(self._event_factory.deserialize_voice_channel_status_update_event(shard, payload))
+
     @event_manager_base.filtered(channel_events.WebhookUpdateEvent)
     def on_webhooks_update(self, shard: gateway_shard.GatewayShard, payload: data_binding.JSONObject) -> None:
         """See https://discord.com/developers/docs/topics/gateway-events#webhooks-update for more info."""

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -1183,6 +1183,19 @@ class RESTClientImpl(rest_api.RESTClient):
         return self._entity_factory.deserialize_channel(response)
 
     @typing_extensions.override
+    async def set_voice_channel_status(
+        self,
+        channel: snowflakes.SnowflakeishOr[channels_.GuildVoiceChannel],
+        status: str | None,
+        *,
+        reason: undefined.UndefinedOr[str] = undefined.UNDEFINED,
+    ) -> None:
+        route = routes.PUT_CHANNEL_VOICE_STATUS.compile(channel=channel)
+        body = data_binding.JSONObjectBuilder()
+        body.put("status", status)
+        await self._request(route, json=body, reason=reason)
+
+    @typing_extensions.override
     async def fetch_my_voice_state(self, guild: snowflakes.SnowflakeishOr[guilds.PartialGuild]) -> voices.VoiceState:
         route = routes.GET_MY_GUILD_VOICE_STATE.compile(guild=guild)
 

--- a/hikari/internal/routes.py
+++ b/hikari/internal/routes.py
@@ -368,6 +368,7 @@ PUT_CHANNEL_PINS: typing.Final[Route] = Route(PUT, "/channels/{channel}/messages
 DELETE_CHANNEL_PIN: typing.Final[Route] = Route(DELETE, "/channels/{channel}/messages/pins/{message}")
 
 POST_CHANNEL_TYPING: typing.Final[Route] = Route(POST, "/channels/{channel}/typing")
+PUT_CHANNEL_VOICE_STATUS: typing.Final[Route] = Route(PUT, "/channels/{channel}/voice-status")
 
 POST_CHANNEL_WEBHOOKS: typing.Final[Route] = Route(POST, "/channels/{channel}/webhooks")
 GET_CHANNEL_WEBHOOKS: typing.Final[Route] = Route(GET, "/channels/{channel}/webhooks")

--- a/hikari/permissions.py
+++ b/hikari/permissions.py
@@ -302,6 +302,9 @@ class Permissions(enums.Flag):
     SEND_VOICE_MESSAGES = 1 << 46
     """Allows sending voice messages."""
 
+    SET_VOICE_CHANNEL_STATUS = 1 << 48
+    """Allows setting voice channel status."""
+
     SEND_POLLS = 1 << 49
     """Allows sending polls."""
 

--- a/tests/hikari/impl/test_entity_factory.py
+++ b/tests/hikari/impl/test_entity_factory.py
@@ -1489,6 +1489,33 @@ class TestEntityFactoryImpl:
         assert isinstance(member_move_entry_info, audit_log_models.MemberMoveEntryInfo)
 
     @pytest.fixture
+    def voice_channel_status_create_info_payload(self):
+        return {"channel_id": "22222222", "status": "very cool status"}
+
+    def test__deserialize_voice_channel_status_create_entry_info(
+        self, entity_factory_impl, voice_channel_status_create_info_payload
+    ):
+        info = entity_factory_impl._deserialize_voice_channel_status_create_entry_info(
+            voice_channel_status_create_info_payload
+        )
+        assert info.channel_id == 22222222
+        assert info.status == "very cool status"
+        assert isinstance(info, audit_log_models.VoiceChannelStatusCreateEntryInfo)
+
+    @pytest.fixture
+    def voice_channel_status_delete_info_payload(self):
+        return {"channel_id": "22222222"}
+
+    def test__deserialize_voice_channel_status_delete_entry_info(
+        self, entity_factory_impl, voice_channel_status_delete_info_payload
+    ):
+        info = entity_factory_impl._deserialize_voice_channel_status_delete_entry_info(
+            voice_channel_status_delete_info_payload
+        )
+        assert info.channel_id == 22222222
+        assert isinstance(info, audit_log_models.VoiceChannelStatusDeleteEntryInfo)
+
+    @pytest.fixture
     def audit_log_entry_payload(self):
         return {
             "action_type": 14,

--- a/tests/hikari/impl/test_event_factory.py
+++ b/tests/hikari/impl/test_event_factory.py
@@ -1570,6 +1570,25 @@ class TestEventFactoryImpl:
 
         assert event.voice_start_time is None
 
+    def test_deserialize_voice_channel_status_update_event(self, event_factory, mock_app, mock_shard):
+        mock_payload = {"id": "5513123", "guild_id": "54123123", "status": "very cool status"}
+
+        event = event_factory.deserialize_voice_channel_status_update_event(mock_shard, mock_payload)
+
+        assert isinstance(event, voice_events.VoiceChannelStatusUpdateEvent)
+        assert event.app is mock_app
+        assert event.shard is mock_shard
+        assert event.channel_id == 5513123
+        assert event.guild_id == 54123123
+        assert event.status == "very cool status"
+
+    def test_deserialize_voice_channel_status_update_event_with_null_status(self, event_factory, mock_app, mock_shard):
+        mock_payload = {"id": "5513123", "guild_id": "54123123", "status": None}
+
+        event = event_factory.deserialize_voice_channel_status_update_event(mock_shard, mock_payload)
+
+        assert event.status is None
+
     ##################
     #  MONETIZATION  #
     ##################

--- a/tests/hikari/impl/test_event_manager.py
+++ b/tests/hikari/impl/test_event_manager.py
@@ -1488,6 +1488,17 @@ class TestEventManagerImpl:
         event_factory.deserialize_voice_channel_start_time_update_event.assert_called_once_with(shard, payload)
         event_manager_impl.dispatch.assert_called_once_with(event)
 
+    def test_on_voice_channel_status_update(self, event_manager_impl, shard, event_factory):
+        payload = {}
+        event = mock.Mock()
+
+        event_factory.deserialize_voice_channel_status_update_event.return_value = event
+
+        event_manager_impl.on_voice_channel_status_update(shard, payload)
+
+        event_factory.deserialize_voice_channel_status_update_event.assert_called_once_with(shard, payload)
+        event_manager_impl.dispatch.assert_called_once_with(event)
+
     def test_on_webhooks_update(self, event_manager_impl, shard, event_factory):
         payload = {}
         event = mock.Mock()

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -2517,6 +2517,24 @@ class TestRESTClientImplAsync:
         rest_client._request.assert_awaited_once_with(expected_route, json={}, reason=undefined.UNDEFINED)
         rest_client._entity_factory.deserialize_channel.assert_called_once_with(rest_client._request.return_value)
 
+    async def test_set_voice_channel_status(self, rest_client):
+        expected_route = routes.PUT_CHANNEL_VOICE_STATUS.compile(channel=123)
+        rest_client._request = mock.AsyncMock()
+
+        await rest_client.set_voice_channel_status(StubModel(123), "very cool status", reason="because")
+
+        rest_client._request.assert_awaited_once_with(
+            expected_route, json={"status": "very cool status"}, reason="because"
+        )
+
+    async def test_set_voice_channel_status_with_null_status(self, rest_client):
+        expected_route = routes.PUT_CHANNEL_VOICE_STATUS.compile(channel=123)
+        rest_client._request = mock.AsyncMock()
+
+        await rest_client.set_voice_channel_status(StubModel(123), None)
+
+        rest_client._request.assert_awaited_once_with(expected_route, json={"status": None}, reason=undefined.UNDEFINED)
+
     async def test_delete_channel(self, rest_client):
         expected_route = routes.DELETE_CHANNEL.compile(channel=123)
         rest_client._request = mock.AsyncMock(return_value={"id": "NNNNN"})

--- a/tests/hikari/test_permissions.py
+++ b/tests/hikari/test_permissions.py
@@ -28,4 +28,4 @@ class TestPermissions:
         all_perms = permissions.Permissions.all_permissions()
 
         assert isinstance(all_perms, permissions.Permissions)
-        assert all_perms == 8584986789675007
+        assert all_perms == 8866461766385663


### PR DESCRIPTION
### Summary
Add support for voice channel statuses: `RESTClient.set_voice_channel_status`, the `VoiceChannelStatusUpdateEvent` event, the `Permissions.SET_VOICE_CHANNEL_STATUS` permission and the `VOICE_CHANNEL_STATUS_CREATE`/`VOICE_CHANNEL_STATUS_DELETE` audit log events with their entry info models

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
