### PR TITLE
Optimize internal enums

### DIFF
--- a/changes/2789.breaking.md
+++ b/changes/2789.breaking.md
@@ -1,0 +1,1 @@
+The `Flag` set-predicate methods (`all`, `any`, `none`, `is_subset`, `is_superset`, `is_disjoint` and the `in` operator) now validate their operand with `operator.index`, raising `TypeError` for floats, strings and other non-integer values instead of returning an unspecified result

--- a/changes/2789.breaking.md
+++ b/changes/2789.breaking.md
@@ -1,1 +1,0 @@
-The `Flag` set-predicate methods (`all`, `any`, `none`, `is_subset`, `is_superset`, `is_disjoint` and the `in` operator) now validate their operand with `operator.index`, raising `TypeError` for floats, strings and other non-integer values instead of returning an unspecified result

--- a/changes/2789.optimization.md
+++ b/changes/2789.optimization.md
@@ -1,0 +1,6 @@
+Speed up the internal enum/flag implementation:
+- `Flag.split` (and iteration) now walks the set bits of the value instead of scanning every defined member (~12x faster on `Permissions`)
+- `len(flag)` now counts bits without building a list, which also makes `list(flag)` stop exploding the value twice
+- The set-predicate methods (`all`, `any`, `none`, `is_subset`, `is_superset`, `is_disjoint`, `difference` and `in`) no longer allocate intermediate flag instances
+- `bool(flag)` now uses the C-level `int.__bool__`
+- `EnumType["NAME"]` now hits the member map directly instead of going through `getattr`

--- a/changes/2789.optimization.md
+++ b/changes/2789.optimization.md
@@ -1,6 +1,6 @@
 Speed up the internal enum/flag implementation:
-- `Flag.split` (and iteration) now walks the set bits of the value instead of scanning every defined member (~3-6x faster on `Permissions` for typical permission sets, up to ~20x for sparse values)
+- `Flag.split` (and iteration) now walks the set bits of the value instead of scanning every defined member
 - `len(flag)` now counts bits without building a list, which also makes `list(flag)` stop exploding the value twice
-- The set-predicate methods (`all`, `any`, `none`, `is_subset`, `is_superset`, `is_disjoint`, `difference` and `in`) no longer allocate intermediate flag instances
+- The set-predicate methods (`all`, `any`, `none`, `is_subset`, `is_superset`, `is_disjoint`, `difference` and `in`) no longer allocate intermediate flag instances.
 - `bool(flag)` now uses the C-level `int.__bool__`
 - `EnumType["NAME"]` now hits the member map directly instead of going through `getattr`

--- a/changes/2789.optimization.md
+++ b/changes/2789.optimization.md
@@ -1,5 +1,5 @@
 Speed up the internal enum/flag implementation:
-- `Flag.split` (and iteration) now walks the set bits of the value instead of scanning every defined member (~12x faster on `Permissions`)
+- `Flag.split` (and iteration) now walks the set bits of the value instead of scanning every defined member (~3-6x faster on `Permissions` for typical permission sets, up to ~20x for sparse values)
 - `len(flag)` now counts bits without building a list, which also makes `list(flag)` stop exploding the value twice
 - The set-predicate methods (`all`, `any`, `none`, `is_subset`, `is_superset`, `is_disjoint`, `difference` and `in`) no longer allocate intermediate flag instances
 - `bool(flag)` now uses the C-level `int.__bool__`

--- a/hikari/internal/enums.py
+++ b/hikari/internal/enums.py
@@ -504,6 +504,7 @@ class _FlagMeta(type):
         all_bits_member._name_ = None
         all_bits_member._value_ = all_bits
         cls.__everything__ = all_bits_member
+        cls._powers_of_2_mask_ = functools.reduce(operator.or_, powers_of_2_map.keys(), 0)
 
         return cls
 
@@ -660,6 +661,7 @@ class Flag(metaclass=_FlagMeta):
     _name_to_member_map_: typing.ClassVar[typing.Mapping[str, Flag]]
     _value_to_member_map_: typing.ClassVar[typing.Mapping[int, Flag]]
     _powers_of_2_to_member_map_: typing.ClassVar[typing.Mapping[int, Flag]]
+    _powers_of_2_mask_: typing.ClassVar[int]
     _temp_members_: typing.ClassVar[typing.Mapping[int, Flag]]
     _member_names_: typing.ClassVar[typing.Sequence[str]]
     __members__: typing.ClassVar[typing.Mapping[str, Flag]]
@@ -763,11 +765,18 @@ class Flag(metaclass=_FlagMeta):
 
         The result will be a name-sorted [`typing.Sequence`][] of each member
         """
-        return sorted(
-            (member for member in self.__class__._powers_of_2_to_member_map_.values() if member.value & self),
-            # Assumption: powers of 2 already have a cached value.
-            key=lambda m: m._name_,
-        )
+        members = self.__class__._powers_of_2_to_member_map_
+        # Masking drops any unrecognised bits upfront, so every remaining bit
+        # is guaranteed to have a member in the map.
+        value = self._value_ & self.__class__._powers_of_2_mask_
+        out = []
+        while value:
+            bit = value & -value
+            value ^= bit
+            out.append(members[bit])
+
+        out.sort(key=lambda m: m._name_)
+        return out
 
     def symmetric_difference(self, other: _T | int) -> Self:
         """Return a set with the symmetric differences of two flag sets.

--- a/hikari/internal/enums.py
+++ b/hikari/internal/enums.py
@@ -156,10 +156,16 @@ class _EnumMeta(type):
         return cls._value_to_member_map_.get(value, value)
 
     def __getitem__(cls, name: str) -> Enum:
-        if (member := getattr(cls, name, None)) is not None:
-            return member
+        try:
+            return cls._name_to_member_map_[name]
+        # AttributeError can only happen on the base Enum class, which has no member map.
+        except (AttributeError, KeyError):
+            # Fall back to attribute access so that deprecated aliases and any
+            # other descriptor-provided names still resolve.
+            if (member := getattr(cls, name, None)) is not None:
+                return member
 
-        raise KeyError(name)
+            raise KeyError(name) from None
 
     def __contains__(cls, item: object) -> bool:
         return item in cls._value_to_member_map_
@@ -412,10 +418,16 @@ class _FlagMeta(type):
                 return pseudomember
 
     def __getitem__(cls, name: str) -> Flag:
-        if (member := getattr(cls, name, None)) is not None:
-            return member
+        try:
+            return cls._name_to_member_map_[name]
+        # AttributeError can only happen on the base Flag class, which has no member map.
+        except (AttributeError, KeyError):
+            # Fall back to attribute access so that deprecated aliases and any
+            # other descriptor-provided names still resolve.
+            if (member := getattr(cls, name, None)) is not None:
+                return member
 
-        raise KeyError(name)
+            raise KeyError(name) from None
 
     def __iter__(cls) -> typing.Iterator[typing.Any]:
         yield from cls._name_to_member_map_.values()

--- a/hikari/internal/enums.py
+++ b/hikari/internal/enums.py
@@ -704,7 +704,7 @@ class Flag(metaclass=_FlagMeta):
             Otherwise, return [`False`][].
         """
         value = self._value_
-        return all(((flag_value := int(flag)) & value) == flag_value for flag in flags)
+        return all(((flag_value := operator.index(flag)) & value) == flag_value for flag in flags)
 
     def any(self, *flags: Self) -> bool:
         """Check if any of the given flags are part of this value.
@@ -716,7 +716,7 @@ class Flag(metaclass=_FlagMeta):
             Otherwise, return [`False`][].
         """
         value = self._value_
-        return any(((flag_value := int(flag)) & value) == flag_value for flag in flags)
+        return any(((flag_value := operator.index(flag)) & value) == flag_value for flag in flags)
 
     def difference(self, other: Self | int) -> _T:
         """Perform a set difference with the other set.
@@ -745,19 +745,20 @@ class Flag(metaclass=_FlagMeta):
         [`False`][]. If no common flag values exist between them, then
         this returns [`True`][].
         """
-        return not self._value_ & int(other)
+        return not self._value_ & operator.index(other)
 
     def is_subset(self, other: Self | int) -> bool:
         """Return whether another set contains this set or not.
 
         Equivalent to using the "in" operator.
         """
-        other_value = int(other)
+        other_value = operator.index(other)
         return (self._value_ & other_value) == other_value
 
     def is_superset(self, other: Self | int) -> bool:
         """Return whether this set contains another set or not."""
-        return (self._value_ & int(other)) == self._value_
+        value = self._value_
+        return (value & operator.index(other)) == value
 
     def none(self, *flags: Self) -> bool:
         """Check if none of the given flags are part of this value.

--- a/hikari/internal/enums.py
+++ b/hikari/internal/enums.py
@@ -815,7 +815,8 @@ class Flag(metaclass=_FlagMeta):
         return iter(self.split())
 
     def __len__(self) -> int:
-        return len(self.split())
+        # Masking drops any unrecognised bits, matching what split returns.
+        return (self._value_ & self._powers_of_2_mask_).bit_count()
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}.{self.name}: {self.value!r}>"

--- a/hikari/internal/enums.py
+++ b/hikari/internal/enums.py
@@ -691,7 +691,8 @@ class Flag(metaclass=_FlagMeta):
             [`True`][] if any of the given flags are part of this value.
             Otherwise, return [`False`][].
         """
-        return all((flag & self) == flag for flag in flags)
+        value = self._value_
+        return all(((flag_value := int(flag)) & value) == flag_value for flag in flags)
 
     def any(self, *flags: Self) -> bool:
         """Check if any of the given flags are part of this value.
@@ -702,7 +703,8 @@ class Flag(metaclass=_FlagMeta):
             [`True`][] if any of the given flags are part of this value.
             Otherwise, return [`False`][].
         """
-        return any((flag & self) == flag for flag in flags)
+        value = self._value_
+        return any(((flag_value := int(flag)) & value) == flag_value for flag in flags)
 
     def difference(self, other: Self | int) -> _T:
         """Perform a set difference with the other set.
@@ -711,7 +713,7 @@ class Flag(metaclass=_FlagMeta):
 
         Equivalent to using the subtraction `-` operator.
         """
-        return self.__class__(self & ~int(other))
+        return self.__class__(self._value_ & ~int(other))
 
     def intersection(self, other: Self | int) -> _T:
         """Return a combination of flags that are set for both given values.
@@ -731,18 +733,19 @@ class Flag(metaclass=_FlagMeta):
         [`False`][]. If no common flag values exist between them, then
         this returns [`True`][].
         """
-        return not (self & other)
+        return not self._value_ & int(other)
 
     def is_subset(self, other: Self | int) -> bool:
         """Return whether another set contains this set or not.
 
         Equivalent to using the "in" operator.
         """
-        return (self & other) == other
+        other_value = int(other)
+        return (self._value_ & other_value) == other_value
 
     def is_superset(self, other: Self | int) -> bool:
         """Return whether this set contains another set or not."""
-        return (self & other) == self
+        return (self._value_ & int(other)) == self._value_
 
     def none(self, *flags: Self) -> bool:
         """Check if none of the given flags are part of this value.

--- a/hikari/internal/enums.py
+++ b/hikari/internal/enums.py
@@ -824,9 +824,7 @@ class Flag(metaclass=_FlagMeta):
     # so this is being defined anyway.
     symmetricdifference = symmetric_difference
 
-    # __bool__ is deliberately not defined: every construction path guarantees
-    # the underlying int value has the same truthiness as _value_, so the
-    # C-level int.__bool__ is both correct and faster.
+    # __bool__ is intentionally not defined: the inherited C-level int.__bool__ is equivalent and faster.
 
     def __int__(self) -> int:
         return self._value_

--- a/hikari/internal/enums.py
+++ b/hikari/internal/enums.py
@@ -37,6 +37,7 @@ if typing.TYPE_CHECKING:
 
 _T = typing.TypeVar("_T")
 _MAX_CACHED_MEMBERS: typing.Final[int] = 1 << 12
+_get_name = operator.attrgetter("_name_")
 
 
 class _DeprecatedAlias(typing.Generic[_T]):
@@ -791,7 +792,7 @@ class Flag(metaclass=_FlagMeta):
             value ^= bit
             out.append(members[bit])
 
-        out.sort(key=lambda m: m._name_)
+        out.sort(key=_get_name)
         return out
 
     def symmetric_difference(self, other: _T | int) -> Self:

--- a/hikari/internal/enums.py
+++ b/hikari/internal/enums.py
@@ -808,8 +808,9 @@ class Flag(metaclass=_FlagMeta):
     # so this is being defined anyway.
     symmetricdifference = symmetric_difference
 
-    def __bool__(self) -> bool:
-        return bool(self._value_)
+    # __bool__ is deliberately not defined: every construction path guarantees
+    # the underlying int value has the same truthiness as _value_, so the
+    # C-level int.__bool__ is both correct and faster.
 
     def __int__(self) -> int:
         return self._value_

--- a/hikari/internal/enums.py
+++ b/hikari/internal/enums.py
@@ -491,6 +491,7 @@ class _FlagMeta(type):
 
         cls = super().__new__(mcls, cls_name, (int, *bases), new_namespace)
 
+        powers_of_2_mask = 0
         for name, value in namespace.names_to_values.items():
             if isinstance(new_namespace.get(name), _DeprecatedAlias):
                 continue
@@ -511,13 +512,14 @@ class _FlagMeta(type):
 
             if not (value & value - 1):
                 powers_of_2_map[value] = member
+                powers_of_2_mask |= value
 
         all_bits = functools.reduce(operator.or_, value_to_member.keys())
         all_bits_member = cls.__new__(cls, all_bits)
         all_bits_member._name_ = None
         all_bits_member._value_ = all_bits
         cls.__everything__ = all_bits_member
-        cls._powers_of_2_mask_ = functools.reduce(operator.or_, powers_of_2_map.keys(), 0)
+        cls._powers_of_2_mask_ = powers_of_2_mask
 
         return cls
 

--- a/tests/hikari/internal/test_enums.py
+++ b/tests/hikari/internal/test_enums.py
@@ -239,7 +239,7 @@ class TestEnum:
                 foo = 9
                 old_foo = enums.deprecated(9, removal_version="4.0.0")
 
-        with mock.patch.object(warnings, "warn") as warn:
+        with mock.patch.object(deprecation, "check_if_past_removal"), mock.patch.object(warnings, "warn") as warn:
             assert Enum["old_foo"] is Enum.foo
 
         warn.assert_called_once()
@@ -1345,7 +1345,7 @@ class TestIntFlag:
                 FOO = 0x1
                 OLD_FOO = enums.deprecated(0x1, removal_version="4.0.0")
 
-        with mock.patch.object(warnings, "warn") as warn:
+        with mock.patch.object(deprecation, "check_if_past_removal"), mock.patch.object(warnings, "warn") as warn:
             assert TestFlag["OLD_FOO"] is TestFlag.FOO
 
         warn.assert_called_once()

--- a/tests/hikari/internal/test_enums.py
+++ b/tests/hikari/internal/test_enums.py
@@ -1099,6 +1099,31 @@ class TestIntFlag:
         # Baz is a combined field technically, so we don't expect it to be output here
         assert val.split() == [TestFlag.BAR, TestFlag.BORK, TestFlag.FOO]
 
+    def test_split_with_unrecognised_bits(self):
+        class TestFlag(enums.Flag):
+            FOO = 0x1
+            BAR = 0x2
+            QUX = 0x10
+
+        val = TestFlag(0x1 | 0x2 | 0x4 | 0x8 | 0x20)
+
+        # 0x4, 0x8 and 0x20 are not defined members, so they must be omitted.
+        assert val.split() == [TestFlag.BAR, TestFlag.FOO]
+
+    def test_split_with_only_unrecognised_bits(self):
+        class TestFlag(enums.Flag):
+            FOO = 0x1
+            BAR = 0x2
+
+        assert TestFlag(0x4 | 0x8).split() == []
+
+    def test_split_on_empty_value(self):
+        class TestFlag(enums.Flag):
+            FOO = 0x1
+            BAR = 0x2
+
+        assert TestFlag(0).split() == []
+
     def test_str_operator(self):
         class TestFlag(enums.Flag):
             FOO = 0x1

--- a/tests/hikari/internal/test_enums.py
+++ b/tests/hikari/internal/test_enums.py
@@ -1022,6 +1022,16 @@ class TestIntFlag:
         assert len(val3) == 3
         assert len(val3_comb) == 3
 
+    def test_len_with_unrecognised_bits(self):
+        class TestFlag(enums.Flag):
+            FOO = 0x1
+            BAR = 0x2
+            QUX = 0x10
+
+        # 0x4 and 0x8 are not defined members, so they must not be counted.
+        assert len(TestFlag(0x1 | 0x4 | 0x8 | 0x10)) == 2
+        assert len(TestFlag(0x4 | 0x8)) == 0
+
     def test_or(self):
         class TestFlag(enums.Flag):
             FOO = 0x1

--- a/tests/hikari/internal/test_enums.py
+++ b/tests/hikari/internal/test_enums.py
@@ -1128,6 +1128,28 @@ class TestIntFlag:
         # Baz is a combined field technically, so we don't expect it to be output here
         assert val.split() == [TestFlag.BAR, TestFlag.BORK, TestFlag.FOO]
 
+    def test_set_predicates_reject_non_integer_operands(self):
+        class TestFlag(enums.Flag):
+            FOO = 0x1
+            BAR = 0x2
+
+        val = TestFlag.FOO | TestFlag.BAR
+
+        with pytest.raises(TypeError):
+            val.is_subset(1.5)
+        with pytest.raises(TypeError):
+            val.is_superset("1")
+        with pytest.raises(TypeError):
+            val.is_disjoint(1.5)
+        with pytest.raises(TypeError):
+            val.all(1.5)
+        with pytest.raises(TypeError):
+            val.any("1")
+        with pytest.raises(TypeError):
+            val.none(1.5)
+        with pytest.raises(TypeError):
+            1.5 in val
+
     def test_split_with_unrecognised_bits(self):
         class TestFlag(enums.Flag):
             FOO = 0x1

--- a/tests/hikari/internal/test_enums.py
+++ b/tests/hikari/internal/test_enums.py
@@ -225,6 +225,25 @@ class TestEnum:
         assert returned == Enum.foo
         assert type(returned) is Enum
 
+    def test_getitem_when_name_unknown(self):
+        class Enum(int, enums.Enum):
+            foo = 9
+
+        with pytest.raises(KeyError):
+            Enum["missing"]
+
+    def test_getitem_when_deprecated_alias(self):
+        with mock.patch.object(deprecation, "check_if_past_removal"):
+
+            class Enum(int, enums.Enum):
+                foo = 9
+                old_foo = enums.deprecated(9, removal_version="4.0.0")
+
+        with mock.patch.object(warnings, "warn") as warn:
+            assert Enum["old_foo"] is Enum.foo
+
+        warn.assert_called_once()
+
     def test_contains(self):
         class Enum(int, enums.Enum):
             foo = 9
@@ -1289,6 +1308,25 @@ class TestIntFlag:
         returned = TestFlag["FOO"]
         assert returned == TestFlag.FOO
         assert type(returned) is TestFlag
+
+    def test_getitem_when_name_unknown(self):
+        class TestFlag(enums.Flag):
+            FOO = 0x1
+
+        with pytest.raises(KeyError):
+            TestFlag["MISSING"]
+
+    def test_getitem_when_deprecated_alias(self):
+        with mock.patch.object(deprecation, "check_if_past_removal"):
+
+            class TestFlag(enums.Flag):
+                FOO = 0x1
+                OLD_FOO = enums.deprecated(0x1, removal_version="4.0.0")
+
+        with mock.patch.object(warnings, "warn") as warn:
+            assert TestFlag["OLD_FOO"] is TestFlag.FOO
+
+        warn.assert_called_once()
 
     def test_repr(self):
         class TestFlag(enums.Flag):


### PR DESCRIPTION
### Summary
Small disclaimer, I did not find these improvements on my own. I was talking to claude about the future plan to migrate to msgspec and claude was saying that we should move to stdlib enums, i was pushing against that, saying that our enums are faster. To which claude replied something along the lines of „yes you are right thats is important, btw I can make them faster.“ 

Yeah and here we are. I did implement everything on my own, all that claude did was tell me what could be improved and reviewed the changes. (The last review round isnt pushed and im not home right now, i will keep this a draft until then.)

I hope this sort of „AI“ contribution is okay.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
