### PR TITLE
Add the `after` parameter to fetch_audit_log

### DIFF
--- a/changes/2793.breaking.md
+++ b/changes/2793.breaking.md
@@ -1,0 +1,1 @@
+The `before`, `user` and `action_type` parameters of `AuditLogIterator.__init__` are now keyword-only and optional

--- a/changes/2793.feature.md
+++ b/changes/2793.feature.md
@@ -1,0 +1,1 @@
+Add the missing `after` parameter to `RESTClient.fetch_audit_log`, allowing the audit log to be iterated in ascending order

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -3695,7 +3695,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Raises
         ------
-        TypeError
+        ValueError
             If both `before` and `after` are specified.
         hikari.errors.BadRequestError
             If any of the fields that are passed have an invalid value.

--- a/hikari/api/rest.py
+++ b/hikari/api/rest.py
@@ -3651,6 +3651,7 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
         *,
         before: undefined.UndefinedOr[snowflakes.SearchableSnowflakeishOr[snowflakes.Unique]] = undefined.UNDEFINED,
+        after: undefined.UndefinedOr[snowflakes.SearchableSnowflakeishOr[snowflakes.Unique]] = undefined.UNDEFINED,
         user: undefined.UndefinedOr[snowflakes.SnowflakeishOr[users_.PartialUser]] = undefined.UNDEFINED,
         event_type: undefined.UndefinedOr[audit_logs.AuditLogEventType | int] = undefined.UNDEFINED,
     ) -> iterators.LazyIterator[audit_logs.AuditLog]:
@@ -3673,6 +3674,15 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
             a datetime object, it will be transformed into a snowflake. This
             may be any other Discord entity that has an ID. In this case, the
             date the object was first created will be used.
+
+            The entries will be returned in descending order (newest first).
+        after
+            If provided, filter to only actions after this snowflake. If you provide
+            a datetime object, it will be transformed into a snowflake. This
+            may be any other Discord entity that has an ID. In this case, the
+            date the object was first created will be used.
+
+            The entries will be returned in ascending order (oldest first).
         user
             If provided, the user to filter for.
         event_type
@@ -3685,6 +3695,8 @@ class RESTClient(traits.NetworkSettingsAware, abc.ABC):
 
         Raises
         ------
+        TypeError
+            If both `before` and `after` are specified.
         hikari.errors.BadRequestError
             If any of the fields that are passed have an invalid value.
         hikari.errors.ForbiddenError

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -500,7 +500,15 @@ def _transform_emoji_to_url_format(
     return emoji
 
 
-def _to_audit_log_timestamp(
+@typing.overload
+def _to_searchable_snowflake_str(value: undefined.UndefinedType, /) -> undefined.UndefinedType: ...
+
+
+@typing.overload
+def _to_searchable_snowflake_str(value: snowflakes.SearchableSnowflakeishOr[snowflakes.Unique], /) -> str: ...
+
+
+def _to_searchable_snowflake_str(
     value: undefined.UndefinedOr[snowflakes.SearchableSnowflakeishOr[snowflakes.Unique]], /
 ) -> undefined.UndefinedOr[str]:
     if value is undefined.UNDEFINED:
@@ -1401,22 +1409,13 @@ class RESTClientImpl(rest_api.RESTClient):
 
         if before is not undefined.UNDEFINED:
             direction = "before"
-            if isinstance(before, datetime.datetime):
-                timestamp = str(snowflakes.Snowflake.from_datetime(before))
-            else:
-                timestamp = str(int(before))
+            timestamp = _to_searchable_snowflake_str(before)
         elif after is not undefined.UNDEFINED:
             direction = "after"
-            if isinstance(after, datetime.datetime):
-                timestamp = str(snowflakes.Snowflake.from_datetime(after))
-            else:
-                timestamp = str(int(after))
+            timestamp = _to_searchable_snowflake_str(after)
         elif around is not undefined.UNDEFINED:
             direction = "around"
-            if isinstance(around, datetime.datetime):
-                timestamp = str(snowflakes.Snowflake.from_datetime(around))
-            else:
-                timestamp = str(int(around))
+            timestamp = _to_searchable_snowflake_str(around)
         else:
             direction = "before"
             timestamp = undefined.UNDEFINED
@@ -2396,16 +2395,12 @@ class RESTClientImpl(rest_api.RESTClient):
     ) -> iterators.LazyIterator[applications.OwnGuild]:
         if start_at is undefined.UNDEFINED:
             start_at = snowflakes.Snowflake.max() if newest_first else snowflakes.Snowflake.min()
-        elif isinstance(start_at, datetime.datetime):
-            start_at = snowflakes.Snowflake.from_datetime(start_at)
-        else:
-            start_at = int(start_at)
 
         return special_endpoints_impl.OwnGuildIterator(
             entity_factory=self._entity_factory,
             request_call=self._request,
             newest_first=newest_first,
-            first_id=str(start_at),
+            first_id=_to_searchable_snowflake_str(start_at),
         )
 
     @typing_extensions.override
@@ -2730,8 +2725,8 @@ class RESTClientImpl(rest_api.RESTClient):
             entity_factory=self._entity_factory,
             request_call=self._request,
             guild=guild,
-            before=_to_audit_log_timestamp(before),
-            after=_to_audit_log_timestamp(after),
+            before=_to_searchable_snowflake_str(before),
+            after=_to_searchable_snowflake_str(after),
             user=user,
             action_type=event_type,
         )
@@ -3712,14 +3707,7 @@ class RESTClientImpl(rest_api.RESTClient):
             snowflakes.SearchableSnowflakeishOr[channels_.GuildThreadChannel]
         ] = undefined.UNDEFINED,
     ) -> iterators.LazyIterator[channels_.GuildPrivateThread]:
-        if before is undefined.UNDEFINED:
-            start: undefined.UndefinedOr[str] = undefined.UNDEFINED
-
-        elif isinstance(before, datetime.datetime):
-            start = str(snowflakes.Snowflake.from_datetime(before))
-
-        else:
-            start = str(snowflakes.Snowflake(before))
+        start = _to_searchable_snowflake_str(before)
 
         return special_endpoints_impl.GuildThreadIterator(
             deserialize=self._entity_factory.deserialize_guild_private_thread,
@@ -3762,14 +3750,11 @@ class RESTClientImpl(rest_api.RESTClient):
         *,
         start_at: undefined.UndefinedOr[snowflakes.SearchableSnowflakeishOr[users_.PartialUser]] = undefined.UNDEFINED,
     ) -> iterators.LazyIterator[guilds.Member]:
-        first_id: undefined.UndefinedOr[str] = undefined.UNDEFINED
-        if isinstance(start_at, datetime.datetime):
-            first_id = str(snowflakes.Snowflake.from_datetime(start_at))
-        elif start_at is not undefined.UNDEFINED:
-            first_id = str(int(start_at))
-
         return special_endpoints_impl.MemberIterator(
-            entity_factory=self._entity_factory, request_call=self._request, guild=guild, first_id=first_id
+            entity_factory=self._entity_factory,
+            request_call=self._request,
+            guild=guild,
+            first_id=_to_searchable_snowflake_str(start_at),
         )
 
     @typing_extensions.override
@@ -4008,13 +3993,13 @@ class RESTClientImpl(rest_api.RESTClient):
     ) -> iterators.LazyIterator[guilds.GuildBan]:
         if start_at is undefined.UNDEFINED:
             start_at = snowflakes.Snowflake.max() if newest_first else snowflakes.Snowflake.min()
-        elif isinstance(start_at, datetime.datetime):
-            start_at = snowflakes.Snowflake.from_datetime(start_at)
-        else:
-            start_at = int(start_at)
 
         return special_endpoints_impl.GuildBanIterator(
-            self._entity_factory, self._request, guild, newest_first=newest_first, first_id=str(start_at)
+            self._entity_factory,
+            self._request,
+            guild,
+            newest_first=newest_first,
+            first_id=_to_searchable_snowflake_str(start_at),
         )
 
     @typing_extensions.override
@@ -5176,13 +5161,14 @@ class RESTClientImpl(rest_api.RESTClient):
     ) -> iterators.LazyIterator[scheduled_events.ScheduledEventUser]:
         if start_at is undefined.UNDEFINED:
             start_at = snowflakes.Snowflake.max() if newest_first else snowflakes.Snowflake.min()
-        elif isinstance(start_at, datetime.datetime):
-            start_at = snowflakes.Snowflake.from_datetime(start_at)
-        else:
-            start_at = int(start_at)
 
         return special_endpoints_impl.ScheduledEventUserIterator(
-            self._entity_factory, self._request, guild, event, first_id=str(start_at), newest_first=newest_first
+            self._entity_factory,
+            self._request,
+            guild,
+            event,
+            first_id=_to_searchable_snowflake_str(start_at),
+            newest_first=newest_first,
         )
 
     @typing_extensions.override

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -500,6 +500,18 @@ def _transform_emoji_to_url_format(
     return emoji
 
 
+def _to_audit_log_timestamp(
+    value: undefined.UndefinedOr[snowflakes.SearchableSnowflakeishOr[snowflakes.Unique]], /
+) -> undefined.UndefinedOr[str]:
+    if value is undefined.UNDEFINED:
+        return undefined.UNDEFINED
+
+    if isinstance(value, datetime.datetime):
+        return str(snowflakes.Snowflake.from_datetime(value))
+
+    return str(int(value))
+
+
 def _build_prompts(
     prompts: typing.Sequence[special_endpoints.GuildOnboardingPromptBuilder],
 ) -> list[typing.MutableMapping[str, typing.Any]]:
@@ -2706,22 +2718,20 @@ class RESTClientImpl(rest_api.RESTClient):
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
         *,
         before: undefined.UndefinedOr[snowflakes.SearchableSnowflakeishOr[snowflakes.Unique]] = undefined.UNDEFINED,
+        after: undefined.UndefinedOr[snowflakes.SearchableSnowflakeishOr[snowflakes.Unique]] = undefined.UNDEFINED,
         user: undefined.UndefinedOr[snowflakes.SnowflakeishOr[users_.PartialUser]] = undefined.UNDEFINED,
         event_type: undefined.UndefinedOr[audit_logs.AuditLogEventType | int] = undefined.UNDEFINED,
     ) -> iterators.LazyIterator[audit_logs.AuditLog]:
-        timestamp: undefined.UndefinedOr[str]
-        if before is undefined.UNDEFINED:
-            timestamp = undefined.UNDEFINED
-        elif isinstance(before, datetime.datetime):
-            timestamp = str(snowflakes.Snowflake.from_datetime(before))
-        else:
-            timestamp = str(int(before))
+        if not undefined.any_undefined(before, after):
+            msg = "Can not specify 'before' and 'after' together."
+            raise TypeError(msg)
 
         return special_endpoints_impl.AuditLogIterator(
             entity_factory=self._entity_factory,
             request_call=self._request,
             guild=guild,
-            before=timestamp,
+            before=_to_audit_log_timestamp(before),
+            after=_to_audit_log_timestamp(after),
             user=user,
             action_type=event_type,
         )

--- a/hikari/impl/rest.py
+++ b/hikari/impl/rest.py
@@ -2724,7 +2724,7 @@ class RESTClientImpl(rest_api.RESTClient):
     ) -> iterators.LazyIterator[audit_logs.AuditLog]:
         if not undefined.any_undefined(before, after):
             msg = "Can not specify 'before' and 'after' together."
-            raise TypeError(msg)
+            raise ValueError(msg)
 
         return special_endpoints_impl.AuditLogIterator(
             entity_factory=self._entity_factory,

--- a/hikari/impl/shard.py
+++ b/hikari/impl/shard.py
@@ -68,6 +68,7 @@ if typing.TYPE_CHECKING:
         def decompress(self, data: bytes, max_length: int = ...) -> bytes:
             raise NotImplementedError
 
+
 if sys.version_info >= (3, 14):
     _DEFAULT_COMPRESS_TYPE = shard.GatewayCompression.TRANSPORT_ZSTD_STREAM
 else:
@@ -368,8 +369,6 @@ class _GatewayZlibStreamTransport(_GatewayTransport):
             return self._inflator.decompress(buff)
 
         self._handle_other_message(message)  # type: ignore[arg-type]
-
-
 
 
 class _GatewayZstdStreamTransport(_GatewayTransport):

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -732,11 +732,11 @@ class AuditLogIterator(iterators.LazyIterator["audit_logs.AuditLog"]):
         entity_factory: entity_factory_.EntityFactory,
         request_call: _RequestCallSig,
         guild: snowflakes.SnowflakeishOr[guilds.PartialGuild],
-        before: undefined.UndefinedOr[str],
-        user: undefined.UndefinedOr[snowflakes.SnowflakeishOr[users.PartialUser]],
-        action_type: undefined.UndefinedOr[audit_logs.AuditLogEventType | int],
         *,
+        before: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         after: undefined.UndefinedOr[str] = undefined.UNDEFINED,
+        user: undefined.UndefinedOr[snowflakes.SnowflakeishOr[users.PartialUser]] = undefined.UNDEFINED,
+        action_type: undefined.UndefinedOr[audit_logs.AuditLogEventType | int] = undefined.UNDEFINED,
     ) -> None:
         self._action_type = action_type
         self._entity_factory = entity_factory

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -771,10 +771,8 @@ class AuditLogIterator(iterators.LazyIterator["audit_logs.AuditLog"]):
         # Since deserialize_audit_log may skip entries it doesn't recognise,
         # first_id has to be calculated based on the raw payload as log.entries
         # may be missing entries.
-        if self._direction == "before":
-            self._first_id = str(min(int(entry["id"]) for entry in audit_log_entries))
-        else:
-            self._first_id = str(max(int(entry["id"]) for entry in audit_log_entries))
+        aggregate = min if self._direction == "before" else max
+        self._first_id = str(aggregate(int(entry["id"]) for entry in audit_log_entries))
         return log
 
 

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -718,6 +718,7 @@ class AuditLogIterator(iterators.LazyIterator["audit_logs.AuditLog"]):
 
     __slots__: typing.Sequence[str] = (
         "_action_type",
+        "_direction",
         "_entity_factory",
         "_first_id",
         "_guild_id",
@@ -734,10 +735,18 @@ class AuditLogIterator(iterators.LazyIterator["audit_logs.AuditLog"]):
         before: undefined.UndefinedOr[str],
         user: undefined.UndefinedOr[snowflakes.SnowflakeishOr[users.PartialUser]],
         action_type: undefined.UndefinedOr[audit_logs.AuditLogEventType | int],
+        *,
+        after: undefined.UndefinedOr[str] = undefined.UNDEFINED,
     ) -> None:
         self._action_type = action_type
         self._entity_factory = entity_factory
-        self._first_id = before
+        self._first_id: undefined.UndefinedOr[str]
+        if after is not undefined.UNDEFINED:
+            self._direction = "after"
+            self._first_id = after
+        else:
+            self._direction = "before"
+            self._first_id = before
         self._guild_id = snowflakes.Snowflake(guild)
         self._request_call = request_call
         self._route = routes.GET_GUILD_AUDIT_LOGS.compile(guild=guild)
@@ -749,7 +758,7 @@ class AuditLogIterator(iterators.LazyIterator["audit_logs.AuditLog"]):
         query.put("limit", 100)
         query.put("user_id", self._user)
         query.put("action_type", self._action_type, conversion=int)
-        query.put("before", self._first_id)
+        query.put(self._direction, self._first_id)
 
         response = await self._request_call(compiled_route=self._route, query=query)
         assert isinstance(response, dict)
@@ -762,7 +771,10 @@ class AuditLogIterator(iterators.LazyIterator["audit_logs.AuditLog"]):
         # Since deserialize_audit_log may skip entries it doesn't recognise,
         # first_id has to be calculated based on the raw payload as log.entries
         # may be missing entries.
-        self._first_id = str(min(entry["id"] for entry in audit_log_entries))
+        if self._direction == "before":
+            self._first_id = str(min(int(entry["id"]) for entry in audit_log_entries))
+        else:
+            self._first_id = str(max(int(entry["id"]) for entry in audit_log_entries))
         return log
 
 

--- a/tests/hikari/events/test_base_events.py
+++ b/tests/hikari/events/test_base_events.py
@@ -81,7 +81,6 @@ def test_inherited_is_no_recursive_throw_event():
     assert not base_events.is_no_recursive_throw_event(DummyGuildDerivedEvent)
 
 
-
 @pytest.fixture(scope="session")  # we don't modify this so make it once.
 def error():
     # Raise and catch to fill in the traceback attribute.
@@ -90,11 +89,13 @@ def error():
     except RuntimeError as ex:
         return ex
 
+
 @pytest.fixture
 def event(error):
     return base_events.ExceptionEvent(
         exception=error, failed_event=mock.Mock(base_events.Event), failed_callback=mock.AsyncMock()
     )
+
 
 class TestExceptionEvent:
     def test_app_property(self, event):

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -1076,7 +1076,7 @@ class TestRESTClientImpl:
             )
 
     def test_fetch_audit_log_when_before_and_after_specified(self, rest_client):
-        with pytest.raises(TypeError, match=r"Can not specify 'before' and 'after' together."):
+        with pytest.raises(ValueError, match=r"Can not specify 'before' and 'after' together."):
             rest_client.fetch_audit_log(StubModel(123), before=StubModel(456), after=StubModel(789))
 
     def test_fetch_public_archived_threads(self, rest_client: rest.RESTClientImpl):

--- a/tests/hikari/impl/test_rest.py
+++ b/tests/hikari/impl/test_rest.py
@@ -996,6 +996,7 @@ class TestRESTClientImpl:
                 request_call=rest_client._request,
                 guild=guild,
                 before=undefined.UNDEFINED,
+                after=undefined.UNDEFINED,
                 user=undefined.UNDEFINED,
                 action_type=undefined.UNDEFINED,
             )
@@ -1017,6 +1018,7 @@ class TestRESTClientImpl:
                 request_call=rest_client._request,
                 guild=guild,
                 before="735757641938108416",
+                after=undefined.UNDEFINED,
                 user=user,
                 action_type=audit_logs.AuditLogEventType.GUILD_UPDATE,
             )
@@ -1033,9 +1035,49 @@ class TestRESTClientImpl:
                 request_call=rest_client._request,
                 guild=guild,
                 before="456",
+                after=undefined.UNDEFINED,
                 user=undefined.UNDEFINED,
                 action_type=undefined.UNDEFINED,
             )
+
+    def test_fetch_audit_log_when_after_datetime(self, rest_client):
+        guild = StubModel(123)
+        stub_iterator = mock.Mock()
+        datetime_obj = datetime.datetime(2020, 7, 23, 7, 18, 11, 554023, tzinfo=datetime.timezone.utc)
+
+        with mock.patch.object(special_endpoints, "AuditLogIterator", return_value=stub_iterator) as iterator:
+            assert rest_client.fetch_audit_log(guild, after=datetime_obj) == stub_iterator
+
+            iterator.assert_called_once_with(
+                entity_factory=rest_client._entity_factory,
+                request_call=rest_client._request,
+                guild=guild,
+                before=undefined.UNDEFINED,
+                after="735757641938108416",
+                user=undefined.UNDEFINED,
+                action_type=undefined.UNDEFINED,
+            )
+
+    def test_fetch_audit_log_when_after_is_else(self, rest_client):
+        guild = StubModel(123)
+        stub_iterator = mock.Mock()
+
+        with mock.patch.object(special_endpoints, "AuditLogIterator", return_value=stub_iterator) as iterator:
+            assert rest_client.fetch_audit_log(guild, after=StubModel(456)) == stub_iterator
+
+            iterator.assert_called_once_with(
+                entity_factory=rest_client._entity_factory,
+                request_call=rest_client._request,
+                guild=guild,
+                before=undefined.UNDEFINED,
+                after="456",
+                user=undefined.UNDEFINED,
+                action_type=undefined.UNDEFINED,
+            )
+
+    def test_fetch_audit_log_when_before_and_after_specified(self, rest_client):
+        with pytest.raises(TypeError, match=r"Can not specify 'before' and 'after' together."):
+            rest_client.fetch_audit_log(StubModel(123), before=StubModel(456), after=StubModel(789))
 
     def test_fetch_public_archived_threads(self, rest_client: rest.RESTClientImpl):
         mock_datetime = time.utc_datetime()

--- a/tests/hikari/impl/test_special_endpoints.py
+++ b/tests/hikari/impl/test_special_endpoints.py
@@ -222,9 +222,7 @@ class TestAuditLogIterator:
                 {"audit_log_entries": []},
             ]
         )
-        iterator = special_endpoints.AuditLogIterator(
-            mock_entity_factory, mock_request, 123, undefined.UNDEFINED, undefined.UNDEFINED, undefined.UNDEFINED
-        )
+        iterator = special_endpoints.AuditLogIterator(mock_entity_factory, mock_request, 123)
 
         result = await iterator
 
@@ -249,15 +247,7 @@ class TestAuditLogIterator:
                 {"audit_log_entries": []},
             ]
         )
-        iterator = special_endpoints.AuditLogIterator(
-            mock_entity_factory,
-            mock_request,
-            123,
-            undefined.UNDEFINED,
-            undefined.UNDEFINED,
-            undefined.UNDEFINED,
-            after="0",
-        )
+        iterator = special_endpoints.AuditLogIterator(mock_entity_factory, mock_request, 123, after="0")
 
         result = await iterator
 

--- a/tests/hikari/impl/test_special_endpoints.py
+++ b/tests/hikari/impl/test_special_endpoints.py
@@ -210,6 +210,73 @@ class TestReactorIterator:
         mock_request.assert_awaited_once_with(compiled_route=expected_route, query={"limit": "100", "type": "1"})
 
 
+class TestAuditLogIterator:
+    @pytest.mark.asyncio
+    async def test_aiter_when_before(self):
+        expected_route = routes.GET_GUILD_AUDIT_LOGS.compile(guild=123)
+        mock_entity_factory = mock.Mock()
+        mock_request = mock.AsyncMock(
+            side_effect=[
+                {"audit_log_entries": [{"id": "1000"}, {"id": "99"}, {"id": "100"}]},
+                {"audit_log_entries": [{"id": "50"}]},
+                {"audit_log_entries": []},
+            ]
+        )
+        iterator = special_endpoints.AuditLogIterator(
+            mock_entity_factory, mock_request, 123, undefined.UNDEFINED, undefined.UNDEFINED, undefined.UNDEFINED
+        )
+
+        result = await iterator
+
+        assert result == [mock_entity_factory.deserialize_audit_log.return_value] * 2
+        mock_request.assert_has_awaits(
+            [
+                mock.call(compiled_route=expected_route, query={"limit": "100"}),
+                # Entry IDs must be compared numerically, not lexicographically ("99" > "100" as strings).
+                mock.call(compiled_route=expected_route, query={"limit": "100", "before": "99"}),
+                mock.call(compiled_route=expected_route, query={"limit": "100", "before": "50"}),
+            ]
+        )
+
+    @pytest.mark.asyncio
+    async def test_aiter_when_after(self):
+        expected_route = routes.GET_GUILD_AUDIT_LOGS.compile(guild=123)
+        mock_entity_factory = mock.Mock()
+        mock_request = mock.AsyncMock(
+            side_effect=[
+                {"audit_log_entries": [{"id": "99"}, {"id": "1000"}, {"id": "100"}]},
+                {"audit_log_entries": [{"id": "2000"}]},
+                {"audit_log_entries": []},
+            ]
+        )
+        iterator = special_endpoints.AuditLogIterator(
+            mock_entity_factory,
+            mock_request,
+            123,
+            undefined.UNDEFINED,
+            undefined.UNDEFINED,
+            undefined.UNDEFINED,
+            after="0",
+        )
+
+        result = await iterator
+
+        assert result == [mock_entity_factory.deserialize_audit_log.return_value] * 2
+        mock_entity_factory.deserialize_audit_log.assert_has_calls(
+            [
+                mock.call({"audit_log_entries": [{"id": "99"}, {"id": "1000"}, {"id": "100"}]}, guild_id=123),
+                mock.call({"audit_log_entries": [{"id": "2000"}]}, guild_id=123),
+            ]
+        )
+        mock_request.assert_has_awaits(
+            [
+                mock.call(compiled_route=expected_route, query={"limit": "100", "after": "0"}),
+                mock.call(compiled_route=expected_route, query={"limit": "100", "after": "1000"}),
+                mock.call(compiled_route=expected_route, query={"limit": "100", "after": "2000"}),
+            ]
+        )
+
+
 class TestOwnGuildIterator:
     @pytest.mark.asyncio
     async def test_aiter(self):


### PR DESCRIPTION
### Summary
Also fixes the iterator comparing audit log entry IDs as strings when calculating the next page cursor, which is wrong for IDs of different lengths.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
