### PR TITLE
Make the `TextSelectMenuBuilder` parent type parameter covariant

### DIFF
--- a/changes/2796.bugfix.md
+++ b/changes/2796.bugfix.md
@@ -1,0 +1,1 @@
+Make the `TextSelectMenuBuilder` parent type parameter covariant, fixing spurious typing errors when a builder parameterized with a concrete action row type is used where one parameterized with its abstract counterpart is expected

--- a/hikari/api/special_endpoints.py
+++ b/hikari/api/special_endpoints.py
@@ -98,7 +98,7 @@ if typing.TYPE_CHECKING:
     from hikari.api import rest as rest_api
     from hikari.interactions import base_interactions
 
-_ParentT = typing.TypeVar("_ParentT")
+_ParentT_co = typing.TypeVar("_ParentT_co", covariant=True)
 
 
 class TypingIndicator(abc.ABC):
@@ -1842,14 +1842,14 @@ class SelectMenuBuilder(ComponentBuilder, abc.ABC):
         """
 
 
-class TextSelectMenuBuilder(SelectMenuBuilder, abc.ABC, typing.Generic[_ParentT]):
+class TextSelectMenuBuilder(SelectMenuBuilder, abc.ABC, typing.Generic[_ParentT_co]):
     """Builder class for a text select menu."""
 
     __slots__: typing.Sequence[str] = ()
 
     @property
     @abc.abstractmethod
-    def parent(self) -> _ParentT:
+    def parent(self) -> _ParentT_co:
         """Parent object which initialised this builder."""
 
     @property

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -145,7 +145,7 @@ if typing.TYPE_CHECKING:
             raise NotImplementedError
 
 
-_ParentT = typing.TypeVar("_ParentT")
+_ParentT_co = typing.TypeVar("_ParentT_co", covariant=True)
 _GuildThreadChannelT = typing.TypeVar("_GuildThreadChannelT", bound=channels.GuildThreadChannel)
 
 
@@ -2097,11 +2097,11 @@ class SelectMenuBuilder(special_endpoints.SelectMenuBuilder):
 
 
 @attrs.define(init=False, weakref_slot=False)
-class TextSelectMenuBuilder(SelectMenuBuilder, special_endpoints.TextSelectMenuBuilder[_ParentT]):
+class TextSelectMenuBuilder(SelectMenuBuilder, special_endpoints.TextSelectMenuBuilder[_ParentT_co]):
     """Builder class for text select menus."""
 
     _options: list[special_endpoints.SelectOptionBuilder] = attrs.field()
-    _parent: _ParentT | None = attrs.field()
+    _parent: _ParentT_co | None = attrs.field()
     _type: typing.Literal[component_models.ComponentType.TEXT_SELECT_MENU] = attrs.field()
 
     if not typing.TYPE_CHECKING:
@@ -2115,7 +2115,7 @@ class TextSelectMenuBuilder(SelectMenuBuilder, special_endpoints.TextSelectMenuB
         *,
         id: undefined.UndefinedOr[int] = undefined.UNDEFINED,
         custom_id: str,
-        parent: _ParentT,
+        parent: _ParentT_co,
         options: typing.Sequence[special_endpoints.SelectOptionBuilder] = (),
         placeholder: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         min_values: int = 0,
@@ -2141,7 +2141,7 @@ class TextSelectMenuBuilder(SelectMenuBuilder, special_endpoints.TextSelectMenuB
         *,
         id: undefined.UndefinedOr[int] = undefined.UNDEFINED,
         custom_id: str,
-        parent: _ParentT | None = None,
+        parent: _ParentT_co | None = None,
         options: typing.Sequence[special_endpoints.SelectOptionBuilder] = (),
         placeholder: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         min_values: int = 0,
@@ -2162,7 +2162,7 @@ class TextSelectMenuBuilder(SelectMenuBuilder, special_endpoints.TextSelectMenuB
 
     @property
     @typing_extensions.override
-    def parent(self) -> _ParentT:
+    def parent(self) -> _ParentT_co:
         if self._parent is None:
             msg = "This menu has no parent"
             raise RuntimeError(msg)

--- a/pipelines/pyright.nox.py
+++ b/pipelines/pyright.nox.py
@@ -28,7 +28,12 @@ from pipelines import nox
 
 @nox.session()
 def pyright(session: nox.Session) -> None:
-    """Perform static type analysis on Python source code using pyright."""
+    """Perform static type analysis on Python source code using pyright.
+
+    At the time of writing this, this pipeline will not run successfully,
+    as hikari does not have 100% compatibility with pyright just yet. This
+    exists to make it easier to test and eventually reach that 100% compatibility.
+    """
     nox.sync(session, self=True, extras=["speedups", "server"], groups=["pyright"])
     session.run("pyright")
 

--- a/pipelines/pyright.nox.py
+++ b/pipelines/pyright.nox.py
@@ -28,12 +28,7 @@ from pipelines import nox
 
 @nox.session()
 def pyright(session: nox.Session) -> None:
-    """Perform static type analysis on Python source code using pyright.
-
-    At the time of writing this, this pipeline will not run successfully,
-    as hikari does not have 100% compatibility with pyright just yet. This
-    exists to make it easier to test and eventually reach that 100% compatibility.
-    """
+    """Perform static type analysis on Python source code using pyright."""
     nox.sync(session, self=True, extras=["speedups", "server"], groups=["pyright"])
     session.run("pyright")
 


### PR DESCRIPTION
### Summary
I found this while trying [ty](https://docs.astral.sh/ty/) just for fun on hikari. This did not get caught before because we don't use pyright yet for the internals, and mypy doesnt catch it.

The type variable is only used in output position, so declaring it invariant needlessly made differently-parameterized builders mutually incompatible and caused the `add_text_menu` overrides to violate LSP on paper. 

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
