### PR TITLE
documentation: fix typo in colors.py

### DIFF
--- a/hikari/colors.py
+++ b/hikari/colors.py
@@ -128,13 +128,13 @@ class Color(int):
     Color(r=0xff, g=0x5, b=0x1a)
 
     >>> c = Color.of((255, 5, 26))
-    Color(r=0xff, g=0x5, b=1xa)
+    Color(r=0xff, g=0x5, b=0x1a)
 
     >>> c = Color.of(255, 5, 26)
-    Color(r=0xff, g=0x5, b=1xa)
+    Color(r=0xff, g=0x5, b=0x1a)
 
     >>> c = Color.of([0xFF, 0x5, 0x1a])
-    Color(r=0xff, g=0x5, b=1xa)
+    Color(r=0xff, g=0x5, b=0x1a)
 
     >>> c = Color.of("#1a2b3c")
     Color(r=0x1a, g=0x2b, b=0x3c)
@@ -156,7 +156,7 @@ class Color(int):
     Color(r=0xff, g=0x5, b=0x1a)
 
     >>> c = Color.from_rgb(255, 5, 26)
-    Color(r=0xff, g=0x5, b=1xa)
+    Color(r=0xff, g=0x5, b=0x1a)
 
     >>> c = Color.from_hex_code("#1a2b3c")
     Color(r=0x1a, g=0x2b, b=0x3c)
@@ -467,10 +467,10 @@ class Color(int):
         Color(r=0xff, g=0x5, b=0x1a)
 
         >>> c = Color.of((255, 5, 26))
-        Color(r=0xff, g=0x5, b=1xa)
+        Color(r=0xff, g=0x5, b=0x1a)
 
         >>> c = Color.of([0xFF, 0x5, 0x1a])
-        Color(r=0xff, g=0x5, b=1xa)
+        Color(r=0xff, g=0x5, b=0x1a)
 
         >>> c = Color.of("#1a2b3c")
         Color(r=0x1a, g=0x2b, b=0x3c)


### PR DESCRIPTION
### Summary
Fix typo in `hikari/colors.py` (invalid syntax in docstring example)

Multiple instances of the below where the `b`lue channel is weirdly written as `1xa`:
```py
"""
>>> Color.of([0xff, 0x5, 0x1a])
Color(r=0xff, g=0x5, b=1xa)
""" #                ^^^^^
```

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
